### PR TITLE
Fix object free callback.

### DIFF
--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -155,10 +155,8 @@ extern EXTERN_C
 bool jerry_api_get_object_native_handle (jerry_api_object_t *object_p, uintptr_t* out_handle_p);
 
 extern EXTERN_C
-void jerry_api_set_object_native_handle (jerry_api_object_t *object_p, uintptr_t handle);
-
-extern EXTERN_C
-bool jerry_api_set_object_free_callback (jerry_api_object_t *object_p,
+void jerry_api_set_object_native_handle (jerry_api_object_t *object_p,
+                                         uintptr_t handle,
                                          jerry_object_free_callback_t freecb_p);
 
 extern EXTERN_C

--- a/tests/unit/test_api.cpp
+++ b/tests/unit/test_api.cpp
@@ -144,10 +144,9 @@ handler_construct (const jerry_api_object_t *function_obj_p,
 
   jerry_api_set_object_field_value (this_p->v_object, "value_field", &args_p [0]);
 
-  jerry_api_set_object_native_handle (this_p->v_object, (uintptr_t) 0x0012345678abcdefull);
-
-  bool is_set = jerry_api_set_object_free_callback (this_p->v_object, handler_construct_freecb);
-  assert (is_set);
+  jerry_api_set_object_native_handle (this_p->v_object,
+                                      (uintptr_t) 0x0012345678abcdefull,
+                                      handler_construct_freecb);
 
   return true;
 } /* handler_construct */
@@ -348,6 +347,8 @@ main (void)
   jerry_api_release_value (&res);
 
   jerry_cleanup ();
+
+  assert(test_api_is_free_callback_was_called);
 
   return 0;
 }


### PR DESCRIPTION
- remove jerry_set_object_free_callback()
- change jerry_api_set_object_native_handle() with object_free_callback
- related issue: https://github.com/Samsung/jerryscript/issues/17

JerryScript-DCO-1.0-Signed-off-by: SaeHie Park saehie.park@samsung.com
