### PR TITLE
Introducing getters and setters for compressed pointers in 'mem' component

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -38,12 +38,12 @@
  * The offset is shifted right by MEM_ALIGNMENT_LOG.
  * Least significant MEM_ALIGNMENT_LOG bits of non-shifted offset are zeroes.
  */
-#define ECMA_POINTER_FIELD_WIDTH MEM_COMPRESSED_POINTER_WIDTH
+#define ECMA_POINTER_FIELD_WIDTH MEM_CP_WIDTH
 
 /**
  * The NULL value for compressed pointers
  */
-#define ECMA_NULL_POINTER MEM_COMPRESSED_POINTER_NULL
+#define ECMA_NULL_POINTER MEM_CP_NULL
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -27,44 +27,27 @@
 #include "mem-allocator.h"
 
 /**
- * Get value of pointer from specified non-null compressed pointer field.
+ * Get value of pointer from specified non-null compressed pointer.
  */
-#define ECMA_GET_NON_NULL_POINTER(type, field) \
-  ((type *) mem_decompress_pointer (field))
+#define ECMA_GET_NON_NULL_POINTER(type, field) MEM_CP_GET_NON_NULL_POINTER (type, field)
 
 /**
- * Get value of pointer from specified compressed pointer field.
+ * Get value of pointer from specified compressed pointer.
  */
-#define ECMA_GET_POINTER(type, field) \
-  (((unlikely (field == ECMA_NULL_POINTER)) ? NULL : ECMA_GET_NON_NULL_POINTER (type, field)))
+#define ECMA_GET_POINTER(type, field) MEM_CP_GET_POINTER (type, field)
 
 /**
- * Set value of non-null compressed pointer field so that it will correspond
+ * Set value of non-null compressed pointer so that it will correspond
  * to specified non_compressed_pointer.
  */
-#define ECMA_SET_NON_NULL_POINTER(field, non_compressed_pointer) \
-  (field) = (mem_compress_pointer (non_compressed_pointer) & \
-             ((((mem_cpointer_t) 1u) << ECMA_POINTER_FIELD_WIDTH) - 1))
+#define ECMA_SET_NON_NULL_POINTER(field, non_compressed_pointer) MEM_CP_SET_NON_NULL_POINTER (field, \
+                                                                                              non_compressed_pointer)
 
 /**
- * Set value of compressed pointer field so that it will correspond
+ * Set value of compressed pointer so that it will correspond
  * to specified non_compressed_pointer.
  */
-#define ECMA_SET_POINTER(field, non_compressed_pointer) \
-  do \
-  { \
-    auto __temp_pointer = non_compressed_pointer; \
-    non_compressed_pointer = __temp_pointer; \
-  } while (0); \
-  \
-  if (unlikely ((non_compressed_pointer) == NULL)) \
-  { \
-    (field) = ECMA_NULL_POINTER; \
-  } \
-  else \
-  { \
-    ECMA_SET_NON_NULL_POINTER (field, non_compressed_pointer); \
-  }
+#define ECMA_SET_POINTER(field, non_compressed_pointer) MEM_CP_SET_POINTER (field, non_compressed_pointer)
 
 /* ecma-helpers-value.c */
 extern bool ecma_is_value_empty (ecma_value_t value);

--- a/jerry-core/mem/mem-allocator.cpp
+++ b/jerry-core/mem/mem-allocator.cpp
@@ -109,7 +109,7 @@ mem_compress_pointer (const void *pointer) /**< pointer to compress */
 
   JERRY_ASSERT((int_ptr & ~((1u << MEM_HEAP_OFFSET_LOG) - 1)) == 0);
 
-  JERRY_ASSERT(int_ptr != MEM_COMPRESSED_POINTER_NULL);
+  JERRY_ASSERT (int_ptr != MEM_CP_NULL);
 
   return int_ptr;
 } /* mem_compress_pointer */
@@ -120,7 +120,7 @@ mem_compress_pointer (const void *pointer) /**< pointer to compress */
 void*
 mem_decompress_pointer (uintptr_t compressed_pointer) /**< pointer to decompress */
 {
-  JERRY_ASSERT(compressed_pointer != MEM_COMPRESSED_POINTER_NULL);
+  JERRY_ASSERT (compressed_pointer != MEM_CP_NULL);
 
   uintptr_t int_ptr = compressed_pointer;
 

--- a/jerry-core/mem/mem-allocator.h
+++ b/jerry-core/mem/mem-allocator.h
@@ -36,7 +36,7 @@ typedef uint16_t mem_cpointer_t;
 /**
  * Representation of NULL value for compressed pointers
  */
-#define MEM_COMPRESSED_POINTER_NULL 0
+#define MEM_CP_NULL 0
 
 /**
  * Required alignment for allocated units/blocks
@@ -46,12 +46,12 @@ typedef uint16_t mem_cpointer_t;
 /**
  * Width of compressed memory pointer
  */
-#define MEM_COMPRESSED_POINTER_WIDTH (MEM_HEAP_OFFSET_LOG - MEM_ALIGNMENT_LOG)
+#define MEM_CP_WIDTH (MEM_HEAP_OFFSET_LOG - MEM_ALIGNMENT_LOG)
 
 /**
  * Compressed pointer value mask
  */
-#define MEM_COMPRESSED_POINTER_MASK ((1ull << MEM_COMPRESSED_POINTER_WIDTH) - 1)
+#define MEM_CP_MASK ((1ull << MEM_CP_WIDTH) - 1)
 
 /**
  * Heap offset value mask
@@ -79,6 +79,45 @@ typedef enum
  * A 'try give memory back' callback routine type.
  */
 typedef void (*mem_try_give_memory_back_callback_t) (mem_try_give_memory_back_severity_t);
+
+/**
+ * Get value of pointer from specified non-null compressed pointer value
+ */
+#define MEM_CP_GET_NON_NULL_POINTER(type, cp_value) \
+  ((type *) mem_decompress_pointer (cp_value))
+
+/**
+ * Get value of pointer from specified compressed pointer value
+ */
+#define MEM_CP_GET_POINTER(type, cp_value) \
+  (((unlikely ((cp_value) == MEM_CP_NULL)) ? NULL : MEM_CP_GET_NON_NULL_POINTER (type, cp_value)))
+
+/**
+ * Set value of non-null compressed pointer so that it will correspond
+ * to specified non_compressed_pointer
+ */
+#define MEM_CP_SET_NON_NULL_POINTER(cp_value, non_compressed_pointer) \
+  (cp_value) = (mem_compress_pointer (non_compressed_pointer) & MEM_CP_MASK)
+
+/**
+ * Set value of compressed pointer so that it will correspond
+ * to specified non_compressed_pointer
+ */
+#define MEM_CP_SET_POINTER(cp_value, non_compressed_pointer) \
+  do \
+  { \
+    auto __temp_pointer = non_compressed_pointer; \
+    non_compressed_pointer = __temp_pointer; \
+  } while (0); \
+  \
+  if (unlikely ((non_compressed_pointer) == NULL)) \
+  { \
+    (cp_value) = MEM_CP_NULL; \
+  } \
+  else \
+  { \
+    MEM_CP_SET_NON_NULL_POINTER (cp_value, non_compressed_pointer); \
+  }
 
 extern void mem_init (void);
 extern void mem_finalize (bool is_show_mem_stats);

--- a/jerry-core/mem/mem-pool.h
+++ b/jerry-core/mem/mem-pool.h
@@ -65,7 +65,7 @@ typedef struct __attribute__ ((aligned (MEM_ALIGNMENT))) mem_pool_state_t
   mem_pool_chunk_index_t free_chunks_number : MEM_POOL_MAX_CHUNKS_NUMBER_LOG;
 
   /** Pointer to the next pool with same chunk size */
-  mem_cpointer_t next_pool_cp : MEM_COMPRESSED_POINTER_WIDTH;
+  mem_cpointer_t next_pool_cp : MEM_CP_WIDTH;
 } mem_pool_state_t;
 
 extern void mem_pool_init (mem_pool_state_t *pool_p, size_t pool_size);


### PR DESCRIPTION
Adding MEM_CP_{GET_[NON_NULL_]POINTER, SET_[NON_NULL_]POINTER} interfaces similar to ECMA_{GET, SET}_[NON_NULL_]POINTER in ecma, that can be used throughout the engine.
