### PR TITLE
Fast search of data space start for one-chunked blocks

### DIFF
--- a/jerry-core/mem/mem-allocator.cpp
+++ b/jerry-core/mem/mem-allocator.cpp
@@ -30,7 +30,8 @@
 /**
  * Area for heap
  */
-static uint8_t mem_heap_area[ MEM_HEAP_AREA_SIZE ] __attribute__ ((aligned (MEM_ALIGNMENT)));
+static uint8_t mem_heap_area[ MEM_HEAP_AREA_SIZE ] __attribute__ ((aligned (JERRY_MAX (MEM_ALIGNMENT,
+                                                                                       MEM_HEAP_CHUNK_SIZE))));
 
 /**
  * The 'try to give memory back' callback

--- a/jerry-core/mem/mem-heap.h
+++ b/jerry-core/mem/mem-heap.h
@@ -44,7 +44,7 @@ extern void mem_heap_finalize (void);
 extern void* mem_heap_alloc_block (size_t size_in_bytes, mem_heap_alloc_term_t alloc_term);
 extern void* mem_heap_alloc_chunked_block (mem_heap_alloc_term_t alloc_term);
 extern void mem_heap_free_block (void *ptr);
-extern void* mem_heap_get_block_start (void *ptr);
+extern void* mem_heap_get_chunked_block_start (void *ptr);
 extern size_t mem_heap_get_chunked_block_data_size (void);
 extern size_t __attr_pure___ mem_heap_recommend_allocation_size (size_t minimum_allocation_size);
 extern void mem_heap_print (bool dump_block_headers, bool dump_block_data, bool dump_stats);


### PR DESCRIPTION
- heap area is now aligned on heap chunk size;
- mem_heap_get_block_start is renamed to mem_heap_get_chunked_block_start,
  now this interface is applicable only to one-chunked blocks,
  and is significantly faster - instead of iterating list of heap blocks
  to find block header, it just aligns value of pointer to heap chunk size.

Related issue: #44
