### PR TITLE
Add logging support for linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ project (Jerry CXX C ASM)
 # Determining platform and defining options
  option(ENABLE_VALGRIND "Enable valgrind helpers in memory allocators" OFF)
  option(ENABLE_LTO      "Enable LTO build" ON)
+ option(ENABLE_LOG      "Enable LOG build" OFF)
 
  set(PLATFORM "${CMAKE_SYSTEM_NAME}")
  string(TOUPPER "${PLATFORM}" PLATFORM)
@@ -337,6 +338,10 @@ project (Jerry CXX C ASM)
                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
      add_custom_target(mcu_header_with_script_to_run.${TARGET_NAME} DEPENDS ${MCU_SCRIPT_GENERATED_HEADER})
      set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_MCU_SCRIPT_HEADER="${MCU_SCRIPT_GENERATED_HEADER}")
+    elseif("${PLATFORM}" STREQUAL "LINUX")
+     if("${ENABLE_LOG}" STREQUAL "ON")
+      set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_ENABLE_LOG)
+     endif()
     endif()
 
     set_property(TARGET ${TARGET_NAME}

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@
    LTO := OFF
   endif
 
+ # LOG
+  LOG ?= OFF
+  ifneq ($(LOG),ON)
+   LOG := OFF
+  endif
+
 # External build configuration
  # List of include paths for external libraries (semicolon-separated)
   EXTERNAL_LIBS_INTERFACE ?=
@@ -151,7 +157,7 @@ $(BUILD_DIRS_NATIVE): prerequisites
           fi; \
 	  mkdir -p $@ && \
           cd $@ && \
-          cmake -DENABLE_VALGRIND=$(VALGRIND) -DENABLE_LTO=$(LTO) -DCMAKE_TOOLCHAIN_FILE=build/configs/toolchain_linux_$$arch.cmake ../../.. &>cmake.log || \
+          cmake -DENABLE_VALGRIND=$(VALGRIND) -DENABLE_LOG=$(LOG) -DENABLE_LTO=$(LTO) -DCMAKE_TOOLCHAIN_FILE=build/configs/toolchain_linux_$$arch.cmake ../../.. &>cmake.log || \
           (echo "CMake run failed. See "`pwd`"/cmake.log for details."; exit 1;)
 
 $(BUILD_DIRS_NUTTX): prerequisites

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -140,6 +140,11 @@ project (JerryCore CXX C ASM)
   set(INCLUDE_CORE ${INCLUDE_CORE} ${INCLUDE_THIRD_PARTY_VALGRIND})
  endif()
 
+ # Log
+  if("${ENABLE_LOG}" STREQUAL "ON")
+   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_ENABLE_LOG)
+  endif()
+
 # Platform-specific configuration
  set(DEFINES_JERRY ${DEFINES_JERRY} ${DEFINES_JERRY_${PLATFORM_EXT}})
 

--- a/jerry-core/jerry.cpp
+++ b/jerry-core/jerry.cpp
@@ -71,6 +71,11 @@ static bool jerry_api_available;
  */
 char jerry_extension_characters_buffer[CONFIG_EXTENSION_CHAR_BUFFER_SIZE];
 
+#ifdef JERRY_ENABLE_LOG
+int jerry_debug_level = 0;
+FILE *jerry_log_file = nullptr;
+#endif
+
 /**
  * Assert that it is correct to call API in current state.
  *
@@ -1119,6 +1124,13 @@ jerry_api_eval (const char *source_p, /**< source code */
 void
 jerry_init (jerry_flag_t flags) /**< combination of Jerry flags */
 {
+  if (flags & (JERRY_FLAG_ENABLE_LOG))
+  {
+#ifndef JERRY_ENABLE_LOG
+    JERRY_WARNING_MSG ("Ignoring log options because of '!JERRY_ENABLE_LOG' build configuration.\n");
+#endif
+  }
+
   if (flags & (JERRY_FLAG_MEM_STATS))
   {
 #ifndef MEM_STATS
@@ -1126,14 +1138,15 @@ jerry_init (jerry_flag_t flags) /**< combination of Jerry flags */
                | JERRY_FLAG_MEM_STATS_PER_OPCODE
                | JERRY_FLAG_MEM_STATS_SEPARATE);
 
-    printf ("Ignoring memory statistics option because of '!MEM_STATS' build configuration.\n");
+    JERRY_WARNING_MSG ("Ignoring memory statistics option because of '!MEM_STATS' build configuration.\n");
 #endif /* !MEM_STATS */
   }
   else if (flags & (JERRY_FLAG_MEM_STATS_PER_OPCODE | JERRY_FLAG_MEM_STATS_SEPARATE))
   {
     flags &= ~(JERRY_FLAG_MEM_STATS_PER_OPCODE | JERRY_FLAG_MEM_STATS_SEPARATE);
 
-    printf ("Ignoring detailed memory statistics options because memory statistics dump mode is not enabled.\n");
+    JERRY_WARNING_MSG (
+      "Ignoring detailed memory statistics options because memory statistics dump mode is not enabled.\n");
   }
 
   jerry_flags = flags;

--- a/jerry-core/jerry.h
+++ b/jerry-core/jerry.h
@@ -39,6 +39,7 @@ typedef uint32_t jerry_flag_t;
 #define JERRY_FLAG_MEM_STATS_SEPARATE     (1u << 3) /**< dump memory statistics and reset peak values after parse */
 #define JERRY_FLAG_PARSE_ONLY             (1u << 4) /**< parse only, prevents script execution (only for testing)
                                                      *   FIXME: Remove. */
+#define JERRY_FLAG_ENABLE_LOG             (1u << 5) /**< enable logging */
 
 /**
  * Error codes
@@ -66,6 +67,11 @@ extern const char *jerry_commit_hash;
  * Jerry engine build branch name
  */
 extern const char *jerry_branch_name;
+
+#ifdef JERRY_ENABLE_LOG
+extern int jerry_debug_level;
+extern FILE *jerry_log_file;
+#endif /* JERRY_ENABLE_LOG */
 
 /**
  * Jerry error callback type

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -16,6 +16,7 @@
 #ifndef JERRY_GLOBALS_H
 #define JERRY_GLOBALS_H
 
+#include <stdio.h>
 #include "jerry.h"
 #include "jrt-types.h"
 
@@ -91,6 +92,36 @@ extern void __noreturn jerry_unimplemented (const char *comment, const char *fil
 #else /* !JERRY_NDEBUG */
 #define JERRY_ASSERT(x) do { if (false) { (void)(x); } } while (0)
 #endif /* !JERRY_NDEBUG */
+
+#ifdef JERRY_ENABLE_LOG
+#define JERRY_LOG(lvl, ...) \
+  do \
+  { \
+    if (lvl <= jerry_debug_level && jerry_log_file) \
+    { \
+      fprintf (jerry_log_file, __VA_ARGS__); \
+    } \
+  } \
+  while (0)
+
+#define JERRY_DLOG(...) JERRY_LOG (1, __VA_ARGS__)
+#define JERRY_DDLOG(...) JERRY_LOG (2, __VA_ARGS__)
+#define JERRY_DDDLOG(...) JERRY_LOG (3, __VA_ARGS__)
+#else /* !JERRY_ENABLE_LOG */
+#define JERRY_DLOG(...) \
+  do \
+  { \
+    if (false) \
+    { \
+      jerry_ref_unused_variables (0, __VA_ARGS__); \
+    } \
+  } while (0)
+#define JERRY_DDLOG(...) JERRY_DLOG (__VA_ARGS__)
+#define JERRY_DDDLOG(...) JERRY_DLOG (__VA_ARGS__)
+#endif /* !JERRY_ENABLE_LOG */
+
+#define JERRY_ERROR_MSG(...) fprintf (stderr, __VA_ARGS__)
+#define JERRY_WARNING_MSG(...) JERRY_ERROR_MSG (__VA_ARGS__)
 
 /**
  * Mark for unreachable points and unimplemented cases


### PR DESCRIPTION
Added three macros:

```
#define JERRY_DLOG(...) 
#define JERRY_DDLOG(...) 
#define JERRY_DDDLOG(...) 
```

which take the same arguments as `printf` and log information with debug levels 1, 2, and 3 accordingly.

To build the engine with logging support pass LOG=ON option to make (could be passed only to linux targets):

```
make release.linux LOG=ON
make debug.linux LOG=ON
```

To enable logging, run the engine with --log-level option:
`jerry --log-level 1 test.js`
Supported values of --debug-level:
- 0 - no logging
- 1 - log level 1 (least detailed)
- 2 - log level 2
- 3 - log level 3 (most detailed)

By default, log messages are dumped to stdout. To specify log file, use --log-file option:
`jerry --log-level 1 --log-file jerry.log test.js`
