### PR TITLE
Fix test search in run-test-pass.sh

### DIFF
--- a/tools/runners/run-test-pass.sh
+++ b/tools/runners/run-test-pass.sh
@@ -59,7 +59,7 @@ rm -f $JS_FILES $JERRY_ERROR
 
 if [ -d $TESTS ];
 then
- find $TESTS -path $TESTS/fail -prune -o -name [^N]*.js -print | sort > $JS_FILES
+ find $TESTS -path $TESTS/fail -prune -o -name "[^N]*.js" -print | sort > $JS_FILES
 else
  if [ -f $TESTS ];
  then


### PR DESCRIPTION
Using the find program with an argument "*" could lead to problems.
If there are ".js" files in the executing directory then the
shell replaces the asterisk with that filenames.

The fix is simple: quote the argument which has the asterisk.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com
