### PR TITLE
Fix property lookup in Object.getOwnPropertyDescriptor.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.cpp
@@ -279,7 +279,7 @@ ecma_builtin_object_object_get_own_property_descriptor (ecma_value_t this_arg __
   ecma_string_t *name_str_p = ecma_get_string_from_value (name_str_value);
 
   // 3.
-  ecma_property_t *prop_p = ecma_op_general_object_get_own_property (obj_p, name_str_p);
+  ecma_property_t *prop_p = ecma_op_object_get_own_property (obj_p, name_str_p);
 
   if (prop_p != NULL)
   {

--- a/tests/jerry/object_get_own_property_descriptor.js
+++ b/tests/jerry/object_get_own_property_descriptor.js
@@ -70,3 +70,16 @@ assert (typeof(desc.set) === 'function');
 assert (desc.configurable);
 assert (desc.enumerable);
 assert (obj.foo === 0)
+
+var array_desc = Object.getOwnPropertyDescriptor(Array, "prototype");
+assert (array_desc.configurable === false);
+assert (array_desc.writable === false);
+assert (array_desc.enumerable === false);
+
+var obj_undef;
+try {
+    Object.getOwnPropertyDescriptor (obj_undef, "fail");
+    assert (false);
+} catch (e) {
+    assert (e instanceof TypeError);
+}


### PR DESCRIPTION
The ecma_op_general_object_get_own_property call does not find all
properties, we need to use the ecma_op_object_get_own_property method
for correct property lookup.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com
