### PR TITLE
Checking for equality to magic string in ecma_new_ecma_string_from_number

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.cpp
+++ b/jerry-core/ecma/base/ecma-helpers-string.cpp
@@ -459,6 +459,12 @@ ecma_new_ecma_string_from_number (ecma_number_t num) /**< ecma-number */
                                                    str_buf,
                                                    sizeof (str_buf));
 
+  ecma_magic_string_id_t magic_string_id;
+  if (ecma_is_zt_string_magic (str_buf, &magic_string_id))
+  {
+    return ecma_get_magic_string (magic_string_id);
+  }
+
   ecma_string_t* string_desc_p = ecma_alloc_string ();
   string_desc_p->refs = 1;
   string_desc_p->is_stack_var = false;

--- a/tests/jerry/regression-test-issue-113.js
+++ b/tests/jerry/regression-test-issue-113.js
@@ -1,0 +1,16 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+v_1 = [];
+v_1 * v_1[v_1 % v_1];


### PR DESCRIPTION
Changing ecma_new_ecma_string_from_number to check if the string to create is equal to a magic string, and, if so, to invoke corresponding magic string construction.

Related issue: #113
