### PR TITLE
Terminate with signal in case of an assert

### DIFF
--- a/jerry-core/jrt/jrt-fatals.cpp
+++ b/jerry-core/jrt/jrt-fatals.cpp
@@ -62,7 +62,14 @@ jerry_fatal (jerry_fatal_code_t code) /**< status code */
   }
 #endif /* !JERRY_NDEBUG */
 
-  exit (code);
+  if (code == ERR_FAILED_INTERNAL_ASSERTION)
+  {
+    abort ();
+  }
+  else
+  {
+    exit (code);
+  }
 } /* jerry_fatal */
 
 /**


### PR DESCRIPTION
Automated debugging is easier if the process terminates with a
signal instead of a regular `exit (code);` call, since in this
latter case the cause of error cannot be automatically backtraced.

Care has been taken to ensure that the exit code after the signal
is the same as what we would get with `exit`.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
