### PR TITLE
Improvements for ecma_op_general_object_define_own_property

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects-general.cpp
+++ b/jerry-core/ecma/operations/ecma-objects-general.cpp
@@ -747,6 +747,9 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
       return ecma_reject (is_throw);
     }
 
+    bool was_enumerable = ecma_is_property_enumerable (current_p);
+    bool was_configurable = ecma_is_property_configurable (current_p);
+
     ecma_delete_property (obj_p, current_p);
 
     if (is_current_data_descriptor)
@@ -757,8 +760,8 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
                                                        property_name_p,
                                                        NULL,
                                                        NULL,
-                                                       ecma_is_property_enumerable (current_p),
-                                                       ecma_is_property_configurable (current_p));
+                                                       was_enumerable,
+                                                       was_configurable);
     }
     else
     {
@@ -767,8 +770,8 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
       current_p = ecma_create_named_data_property (obj_p,
                                                    property_name_p,
                                                    false,
-                                                   ecma_is_property_enumerable (current_p),
-                                                   ecma_is_property_configurable (current_p));
+                                                   was_enumerable,
+                                                   was_configurable);
     }
   }
   else if (is_property_desc_data_descriptor && is_current_data_descriptor)
@@ -819,28 +822,28 @@ ecma_op_general_object_define_own_property (ecma_object_t *obj_p, /**< the objec
   // 12.
   if (property_desc_p->is_value_defined)
   {
-    JERRY_ASSERT (is_current_data_descriptor);
+    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDDATA);
 
     ecma_named_data_property_assign_value (obj_p, current_p, property_desc_p->value);
   }
 
   if (property_desc_p->is_writable_defined)
   {
-    JERRY_ASSERT (is_current_data_descriptor);
+    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDDATA);
 
     ecma_set_property_writable_attr (current_p, property_desc_p->is_writable);
   }
 
   if (property_desc_p->is_get_defined)
   {
-    JERRY_ASSERT (is_current_accessor_descriptor);
+    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
 
     ecma_set_named_accessor_property_getter (obj_p, current_p, property_desc_p->get_p);
   }
 
   if (property_desc_p->is_set_defined)
   {
-    JERRY_ASSERT (is_current_accessor_descriptor);
+    JERRY_ASSERT (current_p->type == ECMA_PROPERTY_NAMEDACCESSOR);
 
     ecma_set_named_accessor_property_setter (obj_p, current_p, property_desc_p->set_p);
   }

--- a/tests/jerry/regression-test-issue-115.js
+++ b/tests/jerry/regression-test-issue-115.js
@@ -1,0 +1,19 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var v_1 = [,];
+Object.defineProperty(v_1, "0", {
+    set: function() {},
+});

--- a/tests/jerry/regression-test-issue-132.js
+++ b/tests/jerry/regression-test-issue-132.js
@@ -1,0 +1,42 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test raised by fuzzer
+v_0 = [,];
+v_1 = [,];
+v_2 = Object.defineProperties([,], { '0': {  get: function() { } } });
+
+// Test change from data to accessor type
+var a = { x:2 };
+Object.defineProperty(a, "x", {
+      enumerable: true,
+      configurable: true,
+      get: function() { return 0; }
+});
+
+// Test change from accessor to data type
+var obj = {test: 2};
+
+Object.defineProperty(obj, "test", {
+      enumerable: true,
+      configurable: true,
+      get: function() { return 0; }
+});
+
+Object.defineProperty(obj, "x", {
+      enumerable: true,
+      configurable: true,
+      value: -2
+});


### PR DESCRIPTION
List of improvements:
- Get the [[Enumerable]] and [[Configurable]] attributes before removing a property.
- Directly check the type of the property in asserts.

Related issues: #115 and #132

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com
