### PR TITLE
Add `abort ()` to jerry-libc

### DIFF
--- a/jerry-libc/include/stdlib.h
+++ b/jerry-libc/include/stdlib.h
@@ -23,5 +23,6 @@
 #endif /* !__cplusplus */
 
 extern EXTERN_C void __attribute__ ((noreturn)) exit (int);
+extern EXTERN_C void __attribute__ ((noreturn)) abort (void);
 
 #endif /* !JERRY_LIBC_STDLIB_H */

--- a/jerry-libc/jerry-libc-defs.h
+++ b/jerry-libc/jerry-libc-defs.h
@@ -29,11 +29,6 @@
 #define __attr_noinline___ __attribute__((noinline))
 
 /**
- * Constants
- */
-#define LIBC_FATAL_ERROR_EXIT_CODE (2)
-
-/**
  * Assertions
  */
 extern void __attr_noreturn___

--- a/jerry-libc/jerry-libc-fatals.c
+++ b/jerry-libc/jerry-libc-fatals.c
@@ -41,5 +41,5 @@ libc_fatal (const char *msg, /**< fatal error description */
             msg, function_name, file_name, line_number);
   }
 
-  exit (LIBC_FATAL_ERROR_EXIT_CODE);
+  abort ();
 } /* libc_fatal */

--- a/jerry-libc/jerry-libc.c
+++ b/jerry-libc/jerry-libc.c
@@ -31,8 +31,6 @@ FILE *stdin  = (FILE*) 0;
 FILE *stdout = (FILE*) 1;
 FILE *stderr = (FILE*) 2;
 
-LIBC_UNREACHABLE_STUB_FOR (void abort (void))
-
 #ifdef __GNUC__
 /*
  * Making GCC not to replace:

--- a/jerry-libc/target/linux/asm_arm.h
+++ b/jerry-libc/target/linux/asm_arm.h
@@ -18,6 +18,19 @@
 
 /*
  * mov syscall_no (%r0) -> %r7
+ * svc #0
+ */
+#define SYSCALL_0 \
+  push {r4-r12, lr}; \
+  \
+  mov r7, r0; \
+  \
+  svc #0; \
+  \
+  pop {r4-r12, pc};
+
+/*
+ * mov syscall_no (%r0) -> %r7
  * mov arg1 (%r1) -> %r0
  * svc #0
  */

--- a/jerry-libc/target/linux/asm_x64.h
+++ b/jerry-libc/target/linux/asm_x64.h
@@ -18,6 +18,15 @@
 
 /*
  * mov syscall_no (%rdi) -> %rax
+ * syscall
+ */
+#define SYSCALL_0 \
+  mov %rdi, %rax; \
+  syscall; \
+  ret;
+
+/*
+ * mov syscall_no (%rdi) -> %rax
  * mov arg1 (%rsi) -> %rdi
  * syscall
  */

--- a/jerry-libc/target/linux/asm_x86.h
+++ b/jerry-libc/target/linux/asm_x86.h
@@ -18,6 +18,22 @@
 
 /*
  * mov syscall_no -> %eax
+ * int $0x80
+ * mov %eax -> ret
+ */
+#define SYSCALL_0 \
+  push %edi;               \
+  push %esi;               \
+  push %ebx;               \
+  mov 0x10 (%esp), %eax;   \
+  int $0x80;               \
+  pop %ebx;                \
+  pop %esi;                \
+  pop %edi;                \
+  ret;
+
+/*
+ * mov syscall_no -> %eax
  * mov arg1 -> %ebx
  * int $0x80
  * mov %eax -> ret

--- a/jerry-libc/target/linux/jerry-asm.S
+++ b/jerry-libc/target/linux/jerry-asm.S
@@ -14,6 +14,12 @@ _start:
   _START
 .size _start, . - _start
 
+.global syscall_0_asm
+.type syscall_0_asm, %function
+syscall_0_asm:
+  SYSCALL_0
+.size syscall_0_asm, . - syscall_0_asm
+
 .global syscall_1_asm
 .type syscall_1_asm, %function
 syscall_1_asm:

--- a/jerry-libc/target/mcu-stubs/jerry-libc-target.c
+++ b/jerry-libc/target/mcu-stubs/jerry-libc-target.c
@@ -38,6 +38,15 @@ exit (int status __attr_unused___)
   }
 } /* exit */
 
+/** abort - cause abnormal process termination  */
+void __attr_noreturn___ __attr_used___
+abort (void)
+{
+  while (true)
+  {
+  }
+} /* abort */
+
 /**
  * fwrite
  *


### PR DESCRIPTION
Added declaration and implementations of `void abort (void)` to
jerry-libc. As the linux implementation relies on the `getpid`
syscall - which has no arguments - `syscall_0` implementations
have been added as well.

`libc_fatal` has been adapted to use the new `abort` function
instead of `exit`. This also made the definition of
`LIBC_FATAL_ERROR_EXIT_CODE` unnecessary.

Finally, the syscall fatal error message was fixed.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
