### PR TITLE
Make exit behaviour of `jerry_fatal` flag-dependent

### DIFF
--- a/jerry-core/jerry-internal.h
+++ b/jerry-core/jerry-internal.h
@@ -34,4 +34,7 @@ extern void
 jerry_dispatch_object_free_callback (ecma_external_pointer_t freecb_p,
                                      ecma_external_pointer_t native_p);
 
+extern bool
+jerry_is_abort_on_fail (void);
+
 #endif /* !JERRY_INTERNAL_H */

--- a/jerry-core/jerry.cpp
+++ b/jerry-core/jerry.cpp
@@ -1186,6 +1186,18 @@ jerry_get_memory_limits (size_t *out_data_bss_brk_limit_p, /**< out: Jerry's max
 } /* jerry_get_memory_limits */
 
 /**
+ * Check whether 'abort' should be called instead of 'exit' upon exiting with non-zero exit code.
+ *
+ * @return true - if 'abort on fail' flag is set,
+ *         false - otherwise.
+ */
+bool
+jerry_is_abort_on_fail (void)
+{
+  return ((jerry_flags & JERRY_FLAG_ABORT_ON_FAIL) != 0);
+} /* jerry_is_abort_on_fail */
+
+/**
  * Register Jerry's fatal error callback
  */
 void

--- a/jerry-core/jerry.h
+++ b/jerry-core/jerry.h
@@ -40,6 +40,7 @@ typedef uint32_t jerry_flag_t;
 #define JERRY_FLAG_PARSE_ONLY             (1u << 4) /**< parse only, prevents script execution (only for testing)
                                                      *   FIXME: Remove. */
 #define JERRY_FLAG_ENABLE_LOG             (1u << 5) /**< enable logging */
+#define JERRY_FLAG_ABORT_ON_FAIL          (1u << 6) /**< abort instead of exit in case of failure */
 
 /**
  * Error codes

--- a/jerry-core/jrt/jrt-fatals.cpp
+++ b/jerry-core/jrt/jrt-fatals.cpp
@@ -20,6 +20,9 @@
 #include "jrt.h"
 #include "jrt-libc-includes.h"
 
+#define JERRY_INTERNAL
+#include "jerry-internal.h"
+
 /*
  * Exit with specified status code.
  *
@@ -62,7 +65,7 @@ jerry_fatal (jerry_fatal_code_t code) /**< status code */
   }
 #endif /* !JERRY_NDEBUG */
 
-  if (code == ERR_FAILED_INTERNAL_ASSERTION)
+  if (code != 0 && jerry_is_abort_on_fail ())
   {
     abort ();
   }

--- a/main-linux.cpp
+++ b/main-linux.cpp
@@ -193,6 +193,10 @@ main (int argc,
         return JERRY_STANDALONE_EXIT_CODE_FAIL;
       }
     }
+    else if (!strcmp ("--abort-on-fail", argv[i]))
+    {
+      flags |= JERRY_FLAG_ABORT_ON_FAIL;
+    }
     else
     {
       file_names[files_counter++] = argv[i];

--- a/main-nuttx.cpp
+++ b/main-nuttx.cpp
@@ -166,6 +166,10 @@ int jerry_main (int argc, char *argv[])
     {
       flags |= JERRY_FLAG_SHOW_OPCODES;
     }
+    else if (!strcmp ("--abort-on-fail", argv[i]))
+    {
+      flags |= JERRY_FLAG_ABORT_ON_FAIL;
+    }
     else
     {
       file_names[files_counter++] = argv[i];


### PR DESCRIPTION
- Added new flag `JERRY_FLAG_ABORT_ON_FAIL`.
- Added new internal api function `jerry_is_abort_on_fail` to
  check the status of the flag.
- Changed `jerry_fatal` bail-out function to call `abort` when the
  flag is set and exit code is non-zero (i.e., not only for
  assertion failures).
- Added `--abort-on-fail` command line option to linux and nuttx
  apps to set the flag.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
