### PR TITLE
Fix of checksum check in tools/prerequisites.sh

### DIFF
--- a/tools/prerequisites.sh
+++ b/tools/prerequisites.sh
@@ -79,7 +79,7 @@ function setup_from_zip() {
 
   wget --no-check-certificate -O "$TMP_DIR/$NAME.zip" "$URL" || fail_msg "$FAIL_MSG. Cannot download '$URL' zip archive."
 
-  echo "$CHECKSUM $TMP_DIR/$NAME.zip" | sha256sum --check --strict || fail_msg "$FAIL_MSG. Archive's checksum doesn't match."
+  echo "$CHECKSUM  $TMP_DIR/$NAME.zip" | sha256sum --check --strict || fail_msg "$FAIL_MSG. Archive's checksum doesn't match."
 
   unzip "$TMP_DIR/$NAME.zip" -d "$TMP_DIR/$NAME" || fail_msg "$FAIL_MSG. Failed to unpack zip archive."
   mkdir "$DEST" || fail_msg "$FAIL_MSG. Failed to create '$DEST' directory."
@@ -166,7 +166,7 @@ function setup_cppcheck() {
 
   wget --no-check-certificate -O "$TMP_DIR/$NAME.tar.bz2" "$URL" || fail_msg "$FAIL_MSG. Cannot download '$URL' archive."
 
-  echo "$CHECKSUM $TMP_DIR/$NAME.tar.bz2" | sha256sum --check --strict || fail_msg "$FAIL_MSG. Archive's checksum doesn't match."
+  echo "$CHECKSUM  $TMP_DIR/$NAME.tar.bz2" | sha256sum --check --strict || fail_msg "$FAIL_MSG. Archive's checksum doesn't match."
 
   tar xjvf "$TMP_DIR/$NAME.tar.bz2" -C "$TMP_DIR" || fail_msg "$FAIL_MSG. Failed to unpack archive."
 
@@ -213,7 +213,7 @@ function setup_vera() {
 
   wget --no-check-certificate -O "$TMP_DIR/$NAME.tar.gz" "$URL" || fail_msg "$FAIL_MSG. Cannot download '$URL' archive."
 
-  echo "$CHECKSUM $TMP_DIR/$NAME.tar.gz" | sha256sum --check --strict || fail_msg "$FAIL_MSG. Archive's checksum doesn't match."
+  echo "$CHECKSUM  $TMP_DIR/$NAME.tar.gz" | sha256sum --check --strict || fail_msg "$FAIL_MSG. Archive's checksum doesn't match."
 
   tar xzvf "$TMP_DIR/$NAME.tar.gz" -C "$TMP_DIR" || fail_msg "$FAIL_MSG. Failed to unpack archive."
 


### PR DESCRIPTION
Checksum string with a single space isn't processed correctly by `sha256sum` from Ubuntu 12.04
