### PR TITLE
Use __func__ instead of __FUNCTION__

### DIFF
--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -88,7 +88,7 @@ extern void __noreturn jerry_unimplemented (const char *comment, const char *fil
 
 #ifndef JERRY_NDEBUG
 #define JERRY_ASSERT(x) do { if (__builtin_expect (!(x), 0)) { \
-    jerry_assert_fail (#x, __FILE__, __FUNCTION__, __LINE__); } } while (0)
+    jerry_assert_fail (#x, __FILE__, __func__, __LINE__); } } while (0)
 #else /* !JERRY_NDEBUG */
 #define JERRY_ASSERT(x) do { if (false) { (void)(x); } } while (0)
 #endif /* !JERRY_NDEBUG */
@@ -132,19 +132,19 @@ template<typename... values> extern void jerry_ref_unused_variables (const value
 #define JERRY_UNREACHABLE() \
   do \
   { \
-    jerry_unreachable (NULL, __FILE__, __FUNCTION__, __LINE__); \
+    jerry_unreachable (NULL, __FILE__, __func__, __LINE__); \
   } while (0)
 
 #define JERRY_UNIMPLEMENTED(comment) \
   do \
   { \
-    jerry_unimplemented (comment, __FILE__, __FUNCTION__, __LINE__); \
+    jerry_unimplemented (comment, __FILE__, __func__, __LINE__); \
   } while (0)
 
 #define JERRY_UNIMPLEMENTED_REF_UNUSED_VARS(comment, ...) \
   do \
   { \
-    jerry_unimplemented (comment, __FILE__, __FUNCTION__, __LINE__); \
+    jerry_unimplemented (comment, __FILE__, __func__, __LINE__); \
     if (false) \
     { \
       jerry_ref_unused_variables (0, __VA_ARGS__); \

--- a/jerry-libc/jerry-libc-defs.h
+++ b/jerry-libc/jerry-libc-defs.h
@@ -39,11 +39,11 @@ libc_fatal (const char *msg,
 
 #ifndef LIBC_NDEBUG
 # define LIBC_ASSERT(x) do { if (__builtin_expect (!(x), 0)) { \
-     libc_fatal (#x, __FILE__, __FUNCTION__, __LINE__); } } while (0)
+     libc_fatal (#x, __FILE__, __func__, __LINE__); } } while (0)
 # define LIBC_UNREACHABLE() \
    do \
    { \
-     libc_fatal ("Code is unreachable", __FILE__, __FUNCTION__, __LINE__); \
+     libc_fatal ("Code is unreachable", __FILE__, __func__, __LINE__); \
    } while (0)
 #else /* !LIBC_NDEBUG */
 # define LIBC_ASSERT(x) do { if (false) { (void) (x); } } while (0)

--- a/jerry-libc/target/linux/jerry-libc-target.c
+++ b/jerry-libc/target/linux/jerry-libc-target.c
@@ -48,7 +48,7 @@ LIBC_UNREACHABLE_STUB_FOR (int raise (int sig_no __attr_unused___))
 #define LIBC_EXIT_ON_ERROR(syscall_ret_val) \
   if ((syscall_ret_val) < 0) \
 { \
-  libc_fatal ("Syscall", __FILE__, __FUNCTION__, __LINE__); \
+  libc_fatal ("Syscall", __FILE__, __func__, __LINE__); \
 }
 
 static long int syscall_0 (long int syscall_no);


### PR DESCRIPTION
The **FUNCTION** is not part of the C99/C++11 standard.
So replace all occurrences with the standard **func**.

Side note: GCC 5.1 warns when using -Wpedantic -std=c99
and **FUNCTION**.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com
