### PR TITLE
Fix exception handling in opfunc_native_call (OPCODE_NATIVE_CALL_PRINT case)

### DIFF
--- a/jerry-core/vm/opcodes-native-call.cpp
+++ b/jerry-core/vm/opcodes-native-call.cpp
@@ -69,7 +69,7 @@ opfunc_native_call (opcode_t opdata, /**< operation data */
       case OPCODE_NATIVE_CALL_PRINT:
       {
         for (ecma_length_t arg_index = 0;
-             arg_index < args_read;
+             ecma_is_completion_value_empty (ret_value) && arg_index < args_read;
              arg_index++)
         {
           ECMA_TRY_CATCH (str_value,

--- a/tests/jerry/regression-test-issue-122.js
+++ b/tests/jerry/regression-test-issue-122.js
@@ -1,0 +1,24 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try
+{
+  print(this, []);
+  assert (false);
+}
+catch (e)
+{
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
Related issue: #122
