### PR TITLE
Add literal registration in parse_member_expression (TOK_KEYWORD case)

### DIFF
--- a/jerry-core/parser/js/parser.cpp
+++ b/jerry-core/parser/js/parser.cpp
@@ -773,7 +773,7 @@ parse_member_expression (operand *this_arg, operand *prop_gl)
       else if (token_is (TOK_KEYWORD))
       {
         const char *s = lexer_keyword_to_string ((keyword) token_data ());
-        literal_t lit = lit_find_literal_by_charset ((const ecma_char_t *) s, (ecma_length_t) strlen (s));
+        literal_t lit = lit_find_or_create_literal_from_charset ((const ecma_char_t *) s, (ecma_length_t) strlen (s));
         if (lit == NULL)
         {
           EMIT_ERROR ("Expected identifier");

--- a/tests/jerry/regression-test-issue-116.js
+++ b/tests/jerry/regression-test-issue-116.js
@@ -1,0 +1,24 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try
+{
+  Symbol.for.length.toString.length.toExponential.length.valueOf.length.toExponential.length.valueOf.length.toFixed.name.anchor.name.bold.length.toExponential.caller;
+  assert (false);
+}
+catch (e)
+{
+  assert (e instanceof ReferenceError);
+}


### PR DESCRIPTION
Related issue: #116
