### PR TITLE
Remove invalid assertion in `ecma_builtin_global_object_eval`

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.cpp
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.cpp
@@ -54,14 +54,12 @@
  *         Returned value must be freed with ecma_free_completion_value.
  */
 static ecma_completion_value_t
-ecma_builtin_global_object_eval (ecma_value_t this_arg, /**< this argument */
+ecma_builtin_global_object_eval (ecma_value_t this_arg __attr_unused___, /**< this argument */
                                  ecma_value_t x) /**< routine's first argument */
 {
   ecma_completion_value_t ret_value = ecma_make_empty_completion_value ();
 
   bool is_direct_eval = vm_is_direct_eval_form_call ();
-  JERRY_ASSERT (!(is_direct_eval
-                  && !ecma_is_value_undefined (this_arg)));
 
   /* See also: ECMA-262 v5, 10.1.1 */
   bool is_called_from_strict_mode_code;

--- a/tests/jerry/regression-test-issue-212.js
+++ b/tests/jerry/regression-test-issue-212.js
@@ -1,0 +1,17 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright 2015 University of Szeged.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+with(0xB276)
+  eval("foo = true;");


### PR DESCRIPTION
The removed assertion checked that `this` argument can't be equal to `undefined` in direct call to eval.
Actually, `this` can be not equal to `undefined` in case direct call to eval is performed from `with` block.

Related issue: #212
