### PR TITLE
Fix raise of syntax errors for unmatched braces

### DIFF
--- a/jerry-core/parser/js/lexer.cpp
+++ b/jerry-core/parser/js/lexer.cpp
@@ -1218,6 +1218,19 @@ lexer_next_token (void)
     goto end;
   }
 
+  /**
+   * FIXME:
+   *       The way to raise syntax errors for unexpected EOF
+   *       should be reworked so that EOF would be checked by
+   *       caller of the routine, and the following condition
+   *       would be checked as assertion in the routine.
+   */
+  if (prev_token.type == TOK_EOF
+      && sent_token.type == TOK_EOF)
+  {
+    PARSE_ERROR ("Unexpected EOF", buffer - buffer_start);
+  }
+
   prev_token = sent_token;
   sent_token = lexer_next_token_private ();
 

--- a/tests/jerry/regression-test-issues-43-183.js
+++ b/tests/jerry/regression-test-issues-43-183.js
@@ -1,0 +1,56 @@
+// Copyright 2015 Samsung Electronics Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function check_syntax_error (script)
+{
+  try
+  {
+    eval (script);
+    assert (false);
+  }
+  catch (e)
+  {
+    assert (e instanceof SyntaxError);
+  }
+}
+
+check_syntax_error ('{');
+check_syntax_error ('}');
+check_syntax_error ('[');
+check_syntax_error (']');
+check_syntax_error ('(');
+check_syntax_error (')');
+
+check_syntax_error ('function f (');
+check_syntax_error ('function f ()');
+check_syntax_error ('function f () {');
+check_syntax_error ('function f () }');
+check_syntax_error ('function f ({) }');
+check_syntax_error ('function f { }');
+check_syntax_error ('function f {');
+check_syntax_error ('function f }');
+
+check_syntax_error ('a = [[];');
+
+check_syntax_error ('a = {;');
+check_syntax_error ('a = };');
+check_syntax_error ('a = {{};');
+
+check_syntax_error ('a = {get q {} };');
+check_syntax_error ('a = {get q ( {} };');
+check_syntax_error ('a = {get q ) {} };');
+check_syntax_error ('a = {get q () };');
+check_syntax_error ('a = {get q () { };');
+check_syntax_error ('a = {get q () };');
+check_syntax_error ('a = {get q () { };');


### PR DESCRIPTION
Related issues: #43, #183

The pull request proposes a temporary solution for handling unmatched braces.
Handling of unmatched braces should be moved from lexer to parser, when parse infrastructure would be updated to make it possible.
