### PR TITLE
Remove unnecessary jerry internal header file.

### DIFF
--- a/jerry-core/jerry-snapshot.h
+++ b/jerry-core/jerry-snapshot.h
@@ -17,8 +17,6 @@
 #ifndef JERRY_SNAPSHOT_H
 #define JERRY_SNAPSHOT_H
 
-#include "ecma-globals.h"
-
 /**
  * Snapshot header
  */


### PR DESCRIPTION
For developers who want to check version numbers of jerry snapshot binaries, it is nature to include "jerry-snapshot.h" and use macro `JERRY_SNAPSHOT_VERSION`. Therefore "jerry-snapshot.h" should not rely on any jerry internal stuff.
