### PR TITLE
[WIP] Emscripten implementation of jerry-api.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS )
 set(JERRY_LIBC    ON  CACHE BOOL "Build and use jerry-libc?")
 set(JERRY_LIBM    ON  CACHE BOOL "Build and use jerry-libm?")
 set(JERRY_CMDLINE ON  CACHE BOOL "Build jerry command line tool?")
+set(JERRY_EMSCRIPTEN_SIMULATOR ON CACHE BOOL "Build and use jerry-emscripten-simulator?")
 set(UNITTESTS     OFF CACHE BOOL "Build unit tests?")
 
 # Optional build settings
@@ -49,18 +50,19 @@ if("${PLATFORM}" STREQUAL "DARWIN")
 endif()
 
 # Status messages
-message(STATUS "CMAKE_SYSTEM_NAME         " ${CMAKE_SYSTEM_NAME})
-message(STATUS "CMAKE_SYSTEM_PROCESSOR    " ${CMAKE_SYSTEM_PROCESSOR})
-message(STATUS "CMAKE_BUILD_TYPE          " ${CMAKE_BUILD_TYPE})
-message(STATUS "JERRY_LIBC                " ${JERRY_LIBC})
-message(STATUS "JERRY_LIBM                " ${JERRY_LIBM})
-message(STATUS "JERRY_CMDLINE             " ${JERRY_CMDLINE})
-message(STATUS "UNITTESTS                 " ${UNITTESTS})
-message(STATUS "PORT_DIR                  " ${PORT_DIR})
-message(STATUS "ENABLE_LTO                " ${ENABLE_LTO})
-message(STATUS "ENABLE_ALL_IN_ONE         " ${ENABLE_ALL_IN_ONE})
-message(STATUS "ENABLE_STRIP              " ${ENABLE_STRIP})
-message(STATUS "ENABLE_STATIC_LINK        " ${ENABLE_STATIC_LINK})
+message(STATUS "CMAKE_SYSTEM_NAME          " ${CMAKE_SYSTEM_NAME})
+message(STATUS "CMAKE_SYSTEM_PROCESSOR     " ${CMAKE_SYSTEM_PROCESSOR})
+message(STATUS "CMAKE_BUILD_TYPE           " ${CMAKE_BUILD_TYPE})
+message(STATUS "JERRY_LIBC                 " ${JERRY_LIBC})
+message(STATUS "JERRY_LIBM                 " ${JERRY_LIBM})
+message(STATUS "JERRY_CMDLINE              " ${JERRY_CMDLINE})
+message(STATUS "JERRY_EMSCRIPTEN_SIMULATOR " ${JERRY_EMSCRIPTEN_SIMULATOR})
+message(STATUS "UNITTESTS                  " ${UNITTESTS})
+message(STATUS "PORT_DIR                   " ${PORT_DIR})
+message(STATUS "ENABLE_LTO                 " ${ENABLE_LTO})
+message(STATUS "ENABLE_ALL_IN_ONE          " ${ENABLE_ALL_IN_ONE})
+message(STATUS "ENABLE_STRIP               " ${ENABLE_STRIP})
+message(STATUS "ENABLE_STATIC_LINK         " ${ENABLE_STATIC_LINK})
 
 # Setup directories
 # Project binary dir
@@ -127,16 +129,18 @@ if(ENABLE_LTO)
 endif()
 
 # Define _BSD_SOURCE if we use default port and compiler default libc
-if(${PORT_DIR} STREQUAL "${CMAKE_SOURCE_DIR}/targets/default" AND NOT JERRY_LIBC)
+if(${PORT_DIR} STREQUAL "${CMAKE_SOURCE_DIR}/targets/default" AND (NOT JERRY_LIBC OR JERRY_EMSCRIPTEN_SIMULATOR))
   set(DEFINES_JERRY ${DEFINES_JERRY} _BSD_SOURCE)
 endif()
 
 # Compiler / Linker flags
 jerry_add_compile_flags(-fno-builtin)
-if(("${PLATFORM}" STREQUAL "DARWIN"))
-  jerry_add_link_flags(-lSystem)
-else()
-  jerry_add_link_flags(-Wl,-z,noexecstack)
+if(NOT JERRY_EMSCRIPTEN_SIMULATOR)
+  if(("${PLATFORM}" STREQUAL "DARWIN"))
+    jerry_add_link_flags(-lSystem)
+  else()
+    jerry_add_link_flags(-Wl,-z,noexecstack)
+  endif()
 endif()
 
 # Turn off linking to compiler's default libc, in case jerry-libc is used
@@ -167,7 +171,7 @@ endif()
 jerry_add_compile_flags(-std=c99 -pedantic)
 
 # Strip binary
-if(ENABLE_STRIP AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(ENABLE_STRIP AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT JERRY_EMSCRIPTEN_SIMULATOR)
   jerry_add_link_flags(-s)
 endif()
 
@@ -180,18 +184,22 @@ if(DEFINED EXTERNAL_LINKER_FLAGS)
   jerry_add_link_flags(${EXTERNAL_LINKER_FLAGS})
 endif()
 
-# Jerry's libc
-if(JERRY_LIBC)
-  add_subdirectory(jerry-libc)
-endif()
+if(NOT JERRY_EMSCRIPTEN_SIMULATOR)
+  # Jerry's libc
+  if(JERRY_LIBC)
+    add_subdirectory(jerry-libc)
+  endif()
 
-# Jerry's libm
-if(JERRY_LIBM)
-  add_subdirectory(jerry-libm)
-endif()
+  # Jerry's libm
+  if(JERRY_LIBM)
+    add_subdirectory(jerry-libm)
+  endif()
 
-# Jerry's core
-add_subdirectory(jerry-core)
+  # Jerry's core
+  add_subdirectory(jerry-core)
+else()
+  add_subdirectory(jerry-emscripten-simulator)
+endif()
 
 # Jerry command line tool
 if(JERRY_CMDLINE)

--- a/cmake/toolchain_emscripten.cmake
+++ b/cmake/toolchain_emscripten.cmake
@@ -1,0 +1,21 @@
+# Copyright 2016 Pebble Technology Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_C_COMPILER emcc)
+
+set(CMAKE_EXECUTABLE_SUFFIX_C ".js")
+
+set(FLAGS_COMMON_ARCH -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s RESERVED_FUNCTION_POINTERS=1000 -s SAFE_HEAP=1 -s ASSERTIONS=1)

--- a/jerry-emscripten-simulator/CMakeLists.txt
+++ b/jerry-emscripten-simulator/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright 2016 Pebble Technology Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+cmake_minimum_required (VERSION 2.8.12)
+set(JERRY_CORE_SIMULATOR_NAME jerry-core)
+project (${JERRY_CORE_SIMULATOR_NAME} C)
+
+set(INCLUDE_CORE "${CMAKE_SOURCE_DIR}/jerry-core")
+
+file(GLOB SOURCE_JERRY_EMSCRIPTEN_SIMULATOR *.c)
+file(GLOB SOURCE_PORT_FILES "${PORT_DIR}/*.c")
+set(SOURCE_CORE ${SOURCE_JERRY_EMSCRIPTEN_SIMULATOR} ${SOURCE_PORT_FILES})
+
+jerry_add_compile_warnings(no-dollar-in-identifier-extension)
+
+add_library(${JERRY_CORE_SIMULATOR_NAME} STATIC ${SOURCE_CORE})
+
+# Provides stdin through Node.js' process.stdin:
+file(GLOB MODULE_JS module.js)
+
+file(GLOB JERRY_JS jerry.js)
+
+# Adds global.print() function:
+file(GLOB PRINT_JS print.js)
+
+# Work-around for https://public.kitware.com/Bug/view.php?id=15826
+set(PRE_JS_OPTIONS "--pre-js ${MODULE_JS}" "--pre-js ${JERRY_JS}" "--pre-js ${PRINT_JS}")
+
+target_compile_definitions(${JERRY_CORE_SIMULATOR_NAME} PUBLIC ${DEFINES_JERRY})
+target_include_directories(${JERRY_CORE_SIMULATOR_NAME} PUBLIC ${INCLUDE_CORE})
+target_link_libraries(${JERRY_CORE_SIMULATOR_NAME} ${EXTERNAL_LINK_LIBS} ${PRE_JS_OPTIONS})
+
+install(TARGETS ${JERRY_CORE_SIMULATOR_NAME} DESTINATION lib)
+install(FILES "${INCLUDE_CORE}/jerry-api.h" "${INCLUDE_CORE}/jerry-port.h" DESTINATION include)

--- a/jerry-emscripten-simulator/jerry.c
+++ b/jerry-emscripten-simulator/jerry.c
@@ -1,0 +1,792 @@
+/* Copyright 2016 Pebble Technology Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerry-api.h"
+
+#include <emscripten/emscripten.h>
+
+#include <string.h>
+
+#define TYPE_ERROR \
+    jerry_create_error(JERRY_ERROR_TYPE, NULL);
+
+#define TYPE_ERROR_ARG \
+    jerry_create_error( \
+      JERRY_ERROR_TYPE, (const jerry_char_t *)"wrong type of argument");
+
+#define TYPE_ERROR_FLAG \
+    jerry_create_error( \
+        JERRY_ERROR_TYPE, \
+        (const jerry_char_t *)"argument cannot have an error flag");
+
+////////////////////////////////////////////////////////////////////////////////
+// Parser and Executor Function
+////////////////////////////////////////////////////////////////////////////////
+
+// Note that `is_strict` is currently unsupported by emscripten
+jerry_value_t jerry_eval(const jerry_char_t *source_p, size_t source_size,
+                         bool is_strict) {
+  // FIXME: use is_strict
+  (void)is_strict;
+
+  return (jerry_value_t)EM_ASM_INT({
+      // jerry_eval() uses an indirect eval() call,
+      // so the global execution context is used.
+      // Also see ECMA 5.1 -- 10.4.2 Entering Eval Code.
+      var indirectEval = eval;
+      try {
+        return __jerryRefs.ref(indirectEval(Module.Pointer_stringify($0, $1)));
+      } catch (e) {
+        var error_ref = __jerryRefs.ref(e);
+        __jerryRefs.setError(error_ref, true);
+        return error_ref;
+      }
+    }, source_p, source_size);
+}
+
+size_t jerry_parse_and_save_snapshot(const jerry_char_t *source_p,
+                                     size_t source_size,
+                                     bool is_for_global, bool is_strict,
+                                     uint8_t *buffer_p, size_t buffer_size) {
+  EM_ASM(throw new Error('Not implemented'));
+  (void)source_p;
+  (void)source_size;
+  (void)is_for_global;
+  (void)is_strict;
+  (void)buffer_p;
+  (void)buffer_size;
+  return 0;
+}
+
+jerry_value_t jerry_parse(const jerry_char_t *source_p, size_t source_size,
+                          bool is_strict) {
+  EM_ASM(throw new Error('Not implemented'));
+  (void)source_p;
+  (void)source_size;
+  (void)is_strict;
+  return 0;
+}
+
+jerry_value_t jerry_run(const jerry_value_t func_val) {
+  EM_ASM(throw new Error('Not implemented'));
+  (void)func_val;
+  return 0;
+}
+
+jerry_value_t jerry_exec_snapshot(const void *snapshot_p, size_t snapshot_size,
+                                  bool copy_bytecode) {
+  EM_ASM(throw new Error('Not implemented'));
+  (void)snapshot_p;
+  (void)snapshot_size;
+  (void)copy_bytecode;
+  return 0;
+}
+
+jerry_value_t jerry_acquire_value(jerry_value_t value) {
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.acquire($0);
+    }, value);
+}
+
+void jerry_release_value(jerry_value_t value) {
+  EM_ASM_INT({
+      __jerryRefs.release($0);
+    }, value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Get the global context
+////////////////////////////////////////////////////////////////////////////////
+jerry_value_t jerry_get_global_object(void) {
+  return ((jerry_value_t)EM_ASM_INT_V({ \
+      return __jerryRefs.ref(Function('return this;')()); \
+    }));
+}
+
+jerry_value_t jerry_get_global_builtin(const jerry_char_t *builtin_name) {
+  return ((jerry_value_t)EM_ASM_INT({ \
+      var global = Function('return this;')();
+      return __jerryRefs.ref(global[Module.Pointer_stringify($0)]); \
+    }, builtin_name));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Jerry Value Type Checking
+////////////////////////////////////////////////////////////////////////////////
+
+#define JERRY_VALUE_HAS_TYPE(ref, typename) \
+    ((bool)EM_ASM_INT({ \
+             return typeof __jerryRefs.get($0) === (typename); \
+           }, (ref)))
+
+#define JERRY_VALUE_IS_INSTANCE(ref, type) \
+    ((bool)EM_ASM_INT({ \
+             return __jerryRefs.get($0) instanceof (type); \
+           }, (ref)))
+
+bool jerry_value_is_array(const jerry_value_t value) {
+  return JERRY_VALUE_IS_INSTANCE(value, Array);
+}
+
+bool jerry_value_is_boolean(const jerry_value_t value) {
+  return JERRY_VALUE_HAS_TYPE(value, 'boolean');
+}
+
+bool jerry_value_is_constructor(const jerry_value_t value) {
+  return jerry_value_is_function(value);
+}
+
+bool jerry_value_is_function(const jerry_value_t value) {
+  return JERRY_VALUE_HAS_TYPE(value, 'function');
+}
+
+bool jerry_value_is_number(const jerry_value_t value) {
+  return JERRY_VALUE_HAS_TYPE(value, 'number');
+}
+
+bool jerry_value_is_null(const jerry_value_t value) {
+  return ((bool)EM_ASM_INT({
+      return __jerryRefs.get($0) === null;
+    }, value));
+}
+
+bool jerry_value_is_object(const jerry_value_t value) {
+  return !jerry_value_is_null(value) &&
+          (JERRY_VALUE_HAS_TYPE(value, 'object') ||
+           jerry_value_is_function(value));
+}
+
+bool jerry_value_is_string(const jerry_value_t value) {
+  return JERRY_VALUE_HAS_TYPE(value, 'string');
+}
+
+bool jerry_value_is_undefined(const jerry_value_t value) {
+  return JERRY_VALUE_HAS_TYPE(value, 'undefined');
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Jerry Value Getter Functions
+////////////////////////////////////////////////////////////////////////////////
+
+bool jerry_get_boolean_value(const jerry_value_t value) {
+  if (!jerry_value_is_boolean(value)) {
+    return false;
+  }
+  return (bool)EM_ASM_INT({
+      return (__jerryRefs.get($0) === true);
+    }, value);
+}
+
+double jerry_get_number_value(const jerry_value_t value) {
+  if (!jerry_value_is_number(value)) {
+    return 0.0;
+  }
+  return EM_ASM_DOUBLE({
+      return __jerryRefs.get($0);
+    }, value);
+}
+////////////////////////////////////////////////////////////////////////////////
+// Functions for UTF-8 encoded string values
+////////////////////////////////////////////////////////////////////////////////
+jerry_size_t jerry_get_utf8_string_size(const jerry_value_t value) {
+  if (!jerry_value_is_string(value)) {
+    return 0;
+  }
+  return (jerry_size_t)EM_ASM_INT({
+      return Module.lengthBytesUTF8(__jerryRefs.get($0));
+    }, value);
+}
+
+jerry_size_t jerry_string_to_utf8_char_buffer(const jerry_value_t value,
+                                              jerry_char_t *buffer_p,
+                                              jerry_size_t buffer_size) {
+  const jerry_size_t str_size = jerry_get_utf8_string_size(value);
+  if (str_size == 0 || buffer_size < str_size || buffer_p == NULL) {
+    return 0;
+  }
+
+  EM_ASM_INT({
+      var str = __jerryRefs.get($0);
+      // Add one onto the buffer size, since Module.stringToUTF8 adds a null
+      // character at the end. This will lead to truncation if we just use
+      // buffer_size. Since the actual jerry-api does not do this, we are
+      // always careful to allocate space for a null character at the end.
+      // Allow stringToUTF8 to write that extra null beyond the passed in
+      // buffer_length.
+      Module.stringToUTF8(str, $1, $2 + 1);
+    }, value, buffer_p, buffer_size);
+  return strlen((const char *)buffer_p);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Functions for array object values
+////////////////////////////////////////////////////////////////////////////////
+uint32_t jerry_get_array_length(const jerry_value_t value) {
+  if (!jerry_value_is_array(value)) {
+    return 0;
+  }
+  return (uint32_t)EM_ASM_INT({
+      return __jerryRefs.get($0).length;
+    }, value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Jerry Value Creation API
+////////////////////////////////////////////////////////////////////////////////
+#define JERRY_CREATE_VALUE(value) \
+    ((jerry_value_t)EM_ASM_INT_V({ \
+        return __jerryRefs.ref((value)); \
+      }))
+
+jerry_value_t jerry_create_array(uint32_t size) {
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(new Array($0));
+    }, size);
+}
+
+jerry_value_t jerry_create_boolean(bool value) {
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(Boolean($0));
+    }, value);
+}
+
+jerry_value_t jerry_create_error(jerry_error_t error_type,
+                                 const jerry_char_t *message_p) {
+  return jerry_create_error_sz(error_type,
+                               message_p, strlen((const char *)message_p));
+}
+
+#define JERRY_ERROR(type, msg, sz) (jerry_value_t)(EM_ASM_INT({ \
+      return __jerryRefs.ref(new (type)(Module.Pointer_stringify($0, $1))) \
+    }, (msg), (sz)))
+
+jerry_value_t jerry_create_error_sz(jerry_error_t error_type,
+                                    const jerry_char_t *message_p,
+                                    jerry_size_t message_size) {
+  jerry_value_t error_ref = 0;
+  switch (error_type) {
+    case JERRY_ERROR_COMMON:
+      error_ref = JERRY_ERROR(Error, message_p, message_size);
+      break;
+    case JERRY_ERROR_EVAL:
+      error_ref = JERRY_ERROR(EvalError, message_p, message_size);
+      break;
+    case JERRY_ERROR_RANGE:
+      error_ref = JERRY_ERROR(RangeError, message_p, message_size);
+      break;
+    case JERRY_ERROR_REFERENCE:
+      error_ref = JERRY_ERROR(ReferenceError, message_p, message_size);
+      break;
+    case JERRY_ERROR_SYNTAX:
+      error_ref = JERRY_ERROR(SyntaxError, message_p, message_size);
+      break;
+    case JERRY_ERROR_TYPE:
+      error_ref = JERRY_ERROR(TypeError, message_p, message_size);
+      break;
+    case JERRY_ERROR_URI:
+      error_ref = JERRY_ERROR(URIError, message_p, message_size);
+      break;
+    default:
+      EM_ASM_INT({
+          abort('Cannot create error type: ' + $0);
+        }, error_type);
+      break;
+  }
+  jerry_value_set_error_flag(&error_ref);
+  return error_ref;
+}
+
+jerry_value_t jerry_create_external_function(jerry_external_handler_t handler_p) {
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerry_create_external_function($0);
+    }, handler_p);
+}
+
+jerry_value_t jerry_create_number(double value) {
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref($0);
+    }, value);
+}
+
+jerry_value_t jerry_create_number_infinity(bool negative) {
+  if (negative) {
+    return JERRY_CREATE_VALUE(-Infinity);
+  } else {
+    return JERRY_CREATE_VALUE(Infinity);
+  }
+}
+
+jerry_value_t jerry_create_number_nan(void) {
+  return JERRY_CREATE_VALUE(NaN);
+}
+
+jerry_value_t jerry_create_null(void) {
+  return JERRY_CREATE_VALUE(null);
+}
+
+jerry_value_t jerry_create_object(void) {
+  return JERRY_CREATE_VALUE(new Object());
+}
+
+jerry_value_t jerry_create_string_sz(const jerry_char_t *str_p,
+                                     jerry_size_t str_size) {
+  if (!str_p) {
+    return jerry_create_undefined();
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(Module.Pointer_stringify($0, $1));
+    }, str_p, str_size);
+}
+
+jerry_value_t jerry_create_string(const jerry_char_t *str_p) {
+  if (!str_p) {
+    return jerry_create_undefined();
+  }
+  return jerry_create_string_sz(str_p, strlen((const char *)str_p));
+}
+
+jerry_size_t jerry_get_string_size(const jerry_value_t value) {
+  if (!jerry_value_is_string(value)) {
+    return 0;
+  }
+  return (jerry_size_t)EM_ASM_INT({
+      return Module.lengthBytesUTF8(__jerryRefs.get($0));
+    }, value);
+}
+
+jerry_value_t jerry_create_undefined(void) {
+  return JERRY_CREATE_VALUE(undefined);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// General API Functions of JS Objects
+////////////////////////////////////////////////////////////////////////////////
+
+bool jerry_has_property(const jerry_value_t obj_val,
+                        const jerry_value_t prop_name_val) {
+  if (!jerry_value_is_object(obj_val) ||
+      !jerry_value_is_string(prop_name_val)) {
+    return false;
+  }
+  return (bool)EM_ASM_INT({
+      var obj = __jerryRefs.get($0);
+      var name = __jerryRefs.get($1);
+      return (name in obj);
+    }, obj_val, prop_name_val);
+}
+
+bool jerry_has_own_property(const jerry_value_t obj_val,
+                            const jerry_value_t prop_name_val) {
+  if (!jerry_value_is_object(obj_val) ||
+      !jerry_value_is_string(prop_name_val)) {
+    return false;
+  }
+  return (bool)EM_ASM_INT({
+      var obj = __jerryRefs.get($0);
+      var name = __jerryRefs.get($1);
+      return obj.hasOwnProperty(name);
+    }, obj_val, prop_name_val);
+}
+
+bool jerry_delete_property(const jerry_value_t obj_val,
+                           const jerry_value_t prop_name_val) {
+  if (!jerry_value_is_object(obj_val) ||
+      !jerry_value_is_string(prop_name_val)) {
+    return false;
+  }
+  return (bool)EM_ASM_INT({
+      var obj = __jerryRefs.get($0);
+      var name = __jerryRefs.get($1);
+      try {
+        return delete obj[name];
+      } catch (e) {
+        // In strict mode, delete throws SyntaxError if the property is an
+        // own non-configurable property.
+        return false;
+      }
+      return true;
+    }, obj_val, prop_name_val);
+}
+
+jerry_value_t jerry_get_property(const jerry_value_t obj_val,
+                                 const jerry_value_t prop_name_val) {
+  if (!jerry_value_is_object(obj_val) ||
+      !jerry_value_is_string(prop_name_val)) {
+    return TYPE_ERROR_ARG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      var obj = __jerryRefs.get($0);
+      var name = __jerryRefs.get($1);
+      return __jerryRefs.ref(obj[name]);
+    }, obj_val, prop_name_val);
+}
+
+jerry_value_t jerry_get_property_by_index(const jerry_value_t obj_val,
+                                          uint32_t index) {
+  if (!jerry_value_is_object(obj_val)) {
+    return TYPE_ERROR;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      var obj = __jerryRefs.get($0);
+      return __jerryRefs.ref(obj[$1]);
+    }, obj_val, index);
+}
+
+jerry_value_t jerry_set_property(const jerry_value_t obj_val,
+                                 const jerry_value_t prop_name_val,
+                                 const jerry_value_t value_to_set) {
+  if (jerry_value_has_error_flag(value_to_set) ||
+      !jerry_value_is_object(obj_val) ||
+      !jerry_value_is_string(prop_name_val)) {
+    return TYPE_ERROR_ARG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      var obj = __jerryRefs.get($0);
+      var name = __jerryRefs.get($1);
+      var to_set = __jerryRefs.get($2);
+      obj[name] = to_set;
+      return __jerryRefs.ref(true);
+    }, obj_val, prop_name_val, value_to_set);
+}
+
+jerry_value_t jerry_set_property_by_index(const jerry_value_t obj_val,
+                                          uint32_t index,
+                                          const jerry_value_t value_to_set) {
+  if (jerry_value_has_error_flag(value_to_set) ||
+      !jerry_value_is_object(obj_val)) {
+    return TYPE_ERROR_ARG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      var obj = __jerryRefs.get($0);
+      var to_set = __jerryRefs.get($2);
+      obj[$1] = to_set;
+      return __jerryRefs.ref(true);
+    }, obj_val, index, value_to_set);
+}
+
+void jerry_init_property_descriptor_fields(jerry_property_descriptor_t *prop_desc_p) {
+  *prop_desc_p = (jerry_property_descriptor_t) {
+    .value = jerry_create_undefined(),
+    .getter = jerry_create_undefined(),
+    .setter = jerry_create_undefined(),
+  };
+}
+
+jerry_value_t jerry_define_own_property(const jerry_value_t obj_val,
+                                        const jerry_value_t prop_name_val,
+                                        const jerry_property_descriptor_t *pdp) {
+  if (!jerry_value_is_object(obj_val) && !jerry_value_is_string(obj_val)) {
+    return TYPE_ERROR_ARG;
+  }
+  if ((pdp->is_writable_defined || pdp->is_value_defined)
+      && (pdp->is_get_defined || pdp->is_set_defined)) {
+    return TYPE_ERROR_ARG;
+  }
+  if (pdp->is_get_defined && !jerry_value_is_function(pdp->getter)) {
+    return TYPE_ERROR_ARG;
+  }
+  if (pdp->is_set_defined && !jerry_value_is_function(pdp->setter)) {
+    return TYPE_ERROR_ARG;
+  }
+
+  return (jerry_value_t)(EM_ASM_INT({
+      var obj = __jerryRefs.get($12 /* obj_val */);
+      var name = __jerryRefs.get($13 /* prop_name_val */);
+      var desc = {};
+      if ($0 /* is_value_defined */) {
+        desc.value = __jerryRefs.get($9);
+      }
+      if ($1 /* is_get_defined */) {
+        desc.get = __jerryRefs.get($10);
+      }
+      if ($2 /* is_set_defined */) {
+        desc.set = __jerryRefs.get($11);
+      }
+      if ($3 /* is_writable_defined */) {
+        desc.writable = Boolean($4 /* is_writable */);
+      }
+      if ($5 /* is_enumerable_defined */) {
+        desc.enumerable = Boolean($6 /* is_enumerable */);
+      }
+      if ($7 /* is_configurable */) {
+        desc.configurable = Boolean($8 /* is_configurable */);
+      }
+
+      Object.defineProperty(obj, name, desc);
+      return __jerryRefs.ref(Boolean(true));
+    }, pdp->is_value_defined,    /* $0 */
+       pdp->is_get_defined,      /* $1 */
+       pdp->is_set_defined,      /* $2 */
+       pdp->is_writable_defined, /* $3 */
+       pdp->is_writable,         /* $4 */
+       pdp->is_enumerable_defined,   /* $5 */
+       pdp->is_enumerable,           /* $6 */
+       pdp->is_configurable_defined, /* $7 */
+       pdp->is_configurable,         /* $8 */
+       pdp->value,   /* $9  */
+       pdp->getter,  /* $10 */
+       pdp->setter,  /* $11 */
+       obj_val,      /* $12 */
+       prop_name_val /* $13 */
+    ));
+}
+
+jerry_value_t emscripten_call_jerry_function(jerry_external_handler_t func_obj_p,
+                                             const jerry_value_t func_obj_val,
+                                             const jerry_value_t this_val,
+                                             const jerry_value_t args_p[],
+                                             jerry_size_t args_count) {
+  return (func_obj_p)(func_obj_val, this_val, args_p, args_count);
+}
+
+jerry_value_t jerry_call_function(const jerry_value_t func_obj_val,
+                                  const jerry_value_t this_val,
+                                  const jerry_value_t args_p[],
+                                  jerry_size_t args_count) {
+  if (!jerry_value_is_function(func_obj_val)) {
+    return TYPE_ERROR_ARG;
+  }
+
+  return (jerry_value_t)EM_ASM_INT({
+        var func_obj = __jerryRefs.get($0);
+        var this_val = __jerryRefs.get($1);
+        var args = [];
+        for (var i = 0; i < $3; ++i) {
+          args.push(__jerryRefs.get(getValue($2 + i*4, 'i32')));
+        }
+        try {
+          var rv = func_obj.apply(this_val, args);
+        } catch (e) {
+          var error_ref = __jerryRefs.ref(e);
+          __jerryRefs.setError(error_ref, true);
+          return error_ref;
+        }
+        return __jerryRefs.ref(rv);
+    }, func_obj_val, this_val, args_p, args_count);
+}
+
+jerry_value_t jerry_construct_object(const jerry_value_t func_obj_val,
+                                     const jerry_value_t args_p[],
+                                     jerry_size_t args_count) {
+  if (!jerry_value_is_constructor(func_obj_val)) {
+    return TYPE_ERROR_ARG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+        var func_obj = __jerryRefs.get($0);
+        var args = [];
+        for (var i = 0; i < $2; ++i) {
+          args.push(__jerryRefs.get(getValue($1 + i*4, 'i32')));
+        }
+        // Call the constructor with new object as `this`
+        var bindArgs = [null].concat(args);
+        var boundConstructor = func_obj.bind.apply(func_obj, bindArgs);
+        var rv = new boundConstructor();
+        return __jerryRefs.ref(rv);
+    }, func_obj_val, args_p, args_count);
+}
+
+jerry_size_t jerry_string_to_char_buffer(const jerry_value_t value,
+                                         jerry_char_t *buffer_p,
+                                         jerry_size_t buffer_size) {
+  return jerry_string_to_utf8_char_buffer(value, buffer_p, buffer_size);
+}
+
+jerry_size_t jerry_object_to_string_to_utf8_char_buffer(const jerry_value_t object,
+                                                        jerry_char_t *buffer_p,
+                                                        jerry_size_t buffer_size) {
+  jerry_value_t str_ref = (jerry_value_t)EM_ASM_INT({
+    var str = __jerryRefs.ref(String(__jerryRefs.get($0)));
+    return str;
+  }, object);
+  jerry_size_t len = jerry_string_to_utf8_char_buffer(str_ref, buffer_p, buffer_size);
+  jerry_release_value(str_ref);
+
+  return len;
+}
+
+// FIXME: Propery do CESU-8 => UTF-8 conversion.
+jerry_size_t jerry_object_to_string_to_char_buffer(const jerry_value_t object,
+                                                   jerry_char_t *buffer_p,
+                                                   jerry_size_t buffer_size) {
+  return jerry_object_to_string_to_utf8_char_buffer(object,
+                                                    buffer_p,
+                                                    buffer_size);
+}
+
+jerry_value_t jerry_get_object_keys(const jerry_value_t value) {
+  if (!jerry_value_is_object(value)) {
+    return TYPE_ERROR_ARG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(Object.keys(__jerryRefs.get($0)));
+    }, value);
+}
+
+jerry_value_t jerry_get_prototype(const jerry_value_t value) {
+  if (!jerry_value_is_object(value)) {
+    return TYPE_ERROR_ARG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(__jerryRefs.get($0).prototype);
+    }, value);
+}
+
+jerry_value_t jerry_set_prototype(const jerry_value_t obj_val,
+                                  const jerry_value_t proto_obj_val) {
+  // FIXME: Not sure what to do here, perhaps assign __prototype___?
+  EM_ASM(throw new Error('Not implemented'));
+  (void)obj_val;
+  (void)proto_obj_val;
+  return 0;
+}
+
+bool jerry_get_object_native_handle(const jerry_value_t obj_val,
+                                    uintptr_t *out_handle_p) {
+  return EM_ASM_INT({
+    var ptr = __jerryRefs.getNativeHandle($0);
+    if (ptr === undefined) {
+      return false;
+    }
+    Module.setValue($1, ptr, '*');
+    return true;
+  }, obj_val, out_handle_p);
+}
+
+void jerry_set_object_native_handle(const jerry_value_t obj_val,
+                                    uintptr_t handle_p,
+                                    jerry_object_free_callback_t freecb_p) {
+  EM_ASM_INT({
+    __jerryRefs.setNativeHandle($0, $1, $2);
+  }, obj_val, handle_p, freecb_p);
+}
+
+void emscripten_call_jerry_object_free_callback(jerry_object_free_callback_t freecb_p,
+                                                uintptr_t handle_p) {
+  if (freecb_p) {
+    freecb_p(handle_p);
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Error flag manipulation functions
+////////////////////////////////////////////////////////////////////////////////
+//
+// The error flag is stored alongside the value in __jerryRefs.
+// This allows for us to keep a valid value, like jerryscript does, and be able
+// to add / remove a flag specifying whether there was an error or not.
+
+bool jerry_value_has_error_flag(const jerry_value_t value) {
+  return (bool)(EM_ASM_INT({
+      return __jerryRefs.getError($0);
+    }, value));
+}
+
+void jerry_value_clear_error_flag(jerry_value_t *value_p) {
+  EM_ASM_INT({
+      return __jerryRefs.setError($0, false);
+    }, *value_p);
+}
+
+void jerry_value_set_error_flag(jerry_value_t *value_p) {
+  EM_ASM_INT({
+      return __jerryRefs.setError($0, true);
+    }, *value_p);
+}
+////////////////////////////////////////////////////////////////////////////////
+// Converters of `jerry_value_t`
+////////////////////////////////////////////////////////////////////////////////
+
+bool jerry_value_to_boolean(const jerry_value_t value) {
+  if (jerry_value_has_error_flag(value)) {
+    return false;
+  }
+  return (bool)EM_ASM_INT({
+      return Boolean(__jerryRefs.get($0));
+    }, value);
+}
+
+
+
+jerry_value_t jerry_value_to_number(const jerry_value_t value) {
+  if (jerry_value_has_error_flag(value)) {
+    return TYPE_ERROR_FLAG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(Number(__jerryRefs.get($0)));
+    }, value);
+}
+
+jerry_value_t jerry_value_to_object(const jerry_value_t value) {
+  if (jerry_value_has_error_flag(value)) {
+    return TYPE_ERROR_FLAG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(new Object(__jerryRefs.get($0)));
+    }, value);
+}
+
+jerry_value_t jerry_value_to_primitive(const jerry_value_t value) {
+  if (jerry_value_has_error_flag(value)) {
+    return TYPE_ERROR_FLAG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      var val = __jerryRefs.get($0);
+      var rv;
+      if ((typeof val === 'object' && val != null)
+          || (typeof val === 'function')) {
+        rv = val.valueOf(); // unbox
+      } else {
+        rv = val; // already a primitive
+      }
+      return __jerryRefs.ref(rv);
+    }, value);
+}
+
+jerry_value_t jerry_value_to_string(const jerry_value_t value) {
+  if (jerry_value_has_error_flag(value)) {
+    return TYPE_ERROR_FLAG;
+  }
+  return (jerry_value_t)EM_ASM_INT({
+      return __jerryRefs.ref(String(__jerryRefs.get($0)));
+    }, value);
+}
+
+int jerry_obj_refcount(jerry_value_t o) {
+  return EM_ASM_INT({
+    try {
+      return __jerryRefs.getRefCount($0);
+    } catch (e) {
+      return 0;
+    }
+  }, o);
+}
+
+void jerry_get_memory_limits(size_t *out_data_bss_brk_limit_p,
+                             size_t *out_stack_limit_p) {
+  *out_data_bss_brk_limit_p = 0;
+  *out_stack_limit_p = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//
+////////////////////////////////////////////////////////////////////////////////
+
+void jerry_init(jerry_init_flag_t flags) {
+  EM_ASM(__jerryRefs.reset());
+  (void)flags;
+}
+
+void jerry_cleanup(void) {
+}

--- a/jerry-emscripten-simulator/jerry.js
+++ b/jerry-emscripten-simulator/jerry.js
@@ -1,0 +1,184 @@
+/* Copyright 2016 Pebble Technology Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var __jerryRefs = {
+
+  // Jerryscript values (jerry_value_t) are integers which contain information
+  // about some javascript value that has been internally created.
+  // Create _objMap which will allow us to store and retrieve javascript values
+  // from a jerry_value_t, and perform refcounts on values that we still need an
+  // internal reference to, and avoid them from being garbage collected.
+
+  _objMap : {},
+  _nextObjectRef : 1,
+  _findValue : function(value) {
+    if (Number.isNaN(value)) {
+      // Special case to find NaN
+      for (var jerry_val in this._objMap) {
+        if (Number.isNaN(this._objMap[jerry_val].value)) {
+          return jerry_val;
+        }
+      }
+    } else {
+      for (var jerry_val in this._objMap) {
+        if (this._objMap[jerry_val].value === value) {
+          return jerry_val;
+        }
+      }
+    }
+    return 0;
+  },
+  _getEntry : function(jerry_value) {
+    var entry = this._objMap[jerry_value];
+    if (!entry) {
+      throw new Error('Entry at ' + jerry_value + ' does not exist');
+    }
+    return entry;
+  },
+
+  reset: function() {
+    this._objMap = {};
+    this._nextObjectRef = 1;
+  },
+
+  // Given a jerry value, return the stored javascript value.
+  get : function(jerry_value) {
+    return this._getEntry(jerry_value).value;
+  },
+
+  // Given a javascript value, return a jerry value that refers to it.
+  // If the value already exists in the map, increment its refcount and return
+  // the jerry value.
+  // Otherwise, create a new entry and return the jerry value.
+  ref : function(value) {
+    var jerry_value = this._findValue(value);
+    if (jerry_value) {
+      this._getEntry(jerry_value).refCount++;
+      return jerry_value;
+    }
+
+    jerry_value = this._nextObjectRef++;
+    this._objMap[jerry_value] = {
+      refCount : 1,
+      value : value,
+      error : false,
+    };
+    // console.log('created entry ' + jerry_value + ' for ' + value + ' at ' + stackTrace());
+    return jerry_value;
+  },
+
+  getRefCount : function(jerry_value) {
+    return this._getEntry(jerry_value).refCount;
+  },
+
+  // Increase the reference count of the given jerry value
+  acquire : function(jerry_value) {
+    this._getEntry(jerry_value).refCount++;
+    return jerry_value;
+  },
+
+  // Decrease the reference count of the given jerry value and delete it if
+  // there are no more internal references.
+  release : function(ref) {
+    var entry = this._getEntry(ref);
+    entry.refCount--;
+
+    if (entry.refCount <= 0) {
+      if (entry.freeCallbackPtr) {
+        Module.ccall(
+          'emscripten_call_jerry_object_free_callback',
+          null,
+          ['number', 'number'],
+          [entry.freeCallbackPtr, entry.nativeHandlePtr]);
+      }
+      // console.log('deleting ' + ref + ' at ' + stackTrace());
+      delete this._objMap[ref];
+    }
+  },
+
+  setError : function(ref, state) {
+    this._getEntry(ref).error = state;
+  },
+
+  getError : function(ref) {
+    return this._getEntry(ref).error;
+  },
+
+  setNativeHandle : function(jerryValue, nativeHandlePtr, freeCallbackPtr) {
+    var entry = this._getEntry(jerryValue);
+    entry.nativeHandlePtr = nativeHandlePtr;
+    entry.freeCallbackPtr = freeCallbackPtr;
+  },
+
+  getNativeHandle : function(jerryValue) {
+    return this._getEntry(jerryValue).nativeHandlePtr;
+  }
+};
+
+function __jerry_create_external_function(function_ptr) {
+  var f = function() {
+    var nativeHandlerArgs = [
+        function_ptr, /* the function pointer for us to call */
+        __jerryRefs.ref(f), /* ref to the actual js function */
+        __jerryRefs.ref(this) /* our this object */
+    ];
+
+    var numArgs = arguments.length;
+    var jsRefs = [];
+    for (var i = 0; i < numArgs; i++) {
+      jsRefs.push(__jerryRefs.ref(arguments[i]));
+    }
+
+    // Arg 4 is a uint32 array of jerry_value_t arguments
+    var jsArgs = Module._malloc(numArgs * 4);
+    for (var i = 0; i < numArgs; i++) {
+      Module.setValue(jsArgs + i*4, jsRefs[i], 'i32');
+    }
+    nativeHandlerArgs.push(jsArgs);
+    nativeHandlerArgs.push(numArgs);
+
+    // this is just the classy Emscripten calling. function_ptr is a C-pointer here
+    // and we know the signature of the C function as it needs to follow
+    var result_ref = Module.ccall('emscripten_call_jerry_function',
+        'number',
+        ['number', 'number', 'number', 'number', 'number'],
+        nativeHandlerArgs);
+
+    // Free and release all js args
+    Module._free(jsArgs);
+    while (jsRefs.length > 0) {
+      __jerryRefs.release(jsRefs.pop());
+    }
+
+    // decrease refcount of native handler arguments
+    __jerryRefs.release(nativeHandlerArgs[1]); // jsFunctionRef
+    __jerryRefs.release(nativeHandlerArgs[2]); // our this object
+
+    // delete native handler arguments
+    nativeHandlerArgs.length = 0;
+
+    var result_val = __jerryRefs.get(result_ref);
+    var has_error = __jerryRefs.getError(result_ref);
+    __jerryRefs.release(result_ref);
+
+    if (has_error) {
+      throw result_val;
+    }
+
+    return result_val;
+  };
+
+  return __jerryRefs.ref(f);
+}

--- a/jerry-emscripten-simulator/module.js
+++ b/jerry-emscripten-simulator/module.js
@@ -1,0 +1,28 @@
+/* Copyright 2016 Pebble Technology Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Module = {
+  preRun: function() {
+    if (typeof(process) === 'undefined') {
+      throw new Error('Make sure to run this code in Node.js');
+    }
+    var nodeStdinCallback = process.stdin.read.bind(process.stdin);
+    var stdin = function() {
+      console.log('stdin called');
+      return null;
+    };
+    FS.init(stdin);
+  }
+};

--- a/jerry-emscripten-simulator/print.js
+++ b/jerry-emscripten-simulator/print.js
@@ -1,0 +1,21 @@
+/* Copyright 2016 Pebble Technology Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(function() {
+  var global = Function('return this;')();
+  global.print = function(str) {
+    console.log(str);
+  }
+})();

--- a/tools/build.py
+++ b/tools/build.py
@@ -62,6 +62,7 @@ def get_arguments():
     parser.add_argument('--jerry-libc', metavar='X', choices=['on', 'off'], default='on', help='build and use jerry-libc (%(choices)s; default: %(default)s)')
     parser.add_argument('--jerry-libm', metavar='X', choices=['on', 'off'], default='on', help='build and use jerry-libm (%(choices)s; default: %(default)s)')
     parser.add_argument('--jerry-cmdline', metavar='X', choices=['on', 'off'], default='on', help='build jerry command line tool (%(choices)s; default: %(default)s)')
+    parser.add_argument('--jerry-emscripten-simulator', metavar='X', choices=['on', 'off'], default='off', help='build and use jerry-emscripten-simulator (%(choices)s; default: %(default)s)')
     parser.add_argument('--static-link', metavar='X', choices=['on', 'off'], default='on', help='enable static linking of binaries (%(choices)s; default: %(default)s)')
     parser.add_argument('--strip', metavar='X', choices=['on', 'off'], default='on', help='strip release binaries (%(choices)s; default: %(default)s)')
     parser.add_argument('--unittests', action='store_const', const='ON', default='OFF', help='build unittests')
@@ -88,6 +89,7 @@ def generate_build_options(arguments):
     build_options.append('-DJERRY_LIBC=%s' % arguments.jerry_libc.upper())
     build_options.append('-DJERRY_LIBM=%s' % arguments.jerry_libm.upper())
     build_options.append('-DJERRY_CMDLINE=%s' % arguments.jerry_cmdline.upper())
+    build_options.append('-DJERRY_EMSCRIPTEN_SIMULATOR=%s' % arguments.jerry_emscripten_simulator.upper())
     build_options.append('-DCMAKE_VERBOSE_MAKEFILE=%s' % arguments.verbose)
     build_options.append('-DCMAKE_BUILD_TYPE=%s' % arguments.build_type)
     build_options.append('-DFEATURE_PROFILE=%s' % arguments.profile)
@@ -113,6 +115,12 @@ def generate_build_options(arguments):
     build_options.append('-DEXTERNAL_COMPILE_FLAGS=' + ' '.join(arguments.compile_flag))
     build_options.append('-DEXTERNAL_LINKER_FLAGS=' + ' '.join(arguments.linker_flag))
     build_options.append('-DEXTERNAL_LINK_LIBS=' + ' '.join(arguments.link_lib))
+
+    if arguments.jerry_emscripten_simulator == 'on':
+        if arguments.toolchain:
+            print('Cannot use --toolchain when using --jerry-emscripten-simulator')
+            sys.exit(-1)
+        build_options.append('-DCMAKE_TOOLCHAIN_FILE=cmake/toolchain_emscripten.cmake')
 
     if arguments.toolchain:
         build_options.append('-DCMAKE_TOOLCHAIN_FILE=%s' % arguments.toolchain)


### PR DESCRIPTION
Partial implementation of the JerryScript API targeting the Emscripten transpiler.

To build:
```
tools/build.py --jerry-emscripten=on
```
This will build the command line tool into `build/bin/jerry.js`.
Once built, `cd build/bin && node jerry.js` to run it.

TODO:
- There is an issue with the way Emscripten deals with `stdin`, so the REPL functionality doesn't work correctly (the tool exists immediately).
- Clean up