### PR TITLE
target: mbedos5: Add PwmOut and AnalogIn interfaces

### DIFF
--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/AnalogIn-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/AnalogIn-js.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _JERRYSCRIPT_MBED_DRIVERS_ANALOGIN_H
+#define _JERRYSCRIPT_MBED_DRIVERS_ANALOGIN_H
+
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+DECLARE_CLASS_CONSTRUCTOR(AnalogIn);
+
+#endif  // _JERRYSCRIPT_MBED_DRIVERS_ANALOGIN_H

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/PwmOut-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/PwmOut-js.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _JERRYSCRIPT_MBED_DRIVERS_PWMOUT_H
+#define _JERRYSCRIPT_MBED_DRIVERS_PWMOUT_H
+
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+DECLARE_CLASS_CONSTRUCTOR(PwmOut);
+
+#endif  // _JERRYSCRIPT_MBED_DRIVERS_PWMOUT_H

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
@@ -22,6 +22,8 @@
 #include "jerryscript-mbed-drivers/assert-js.h"
 #include "jerryscript-mbed-drivers/I2C-js.h"
 #include "jerryscript-mbed-drivers/gc-js.h"
+#include "jerryscript-mbed-drivers/AnalogIn-js.h"
+#include "jerryscript-mbed-drivers/PwmOut-js.h"
 
 DECLARE_JS_WRAPPER_REGISTRATION (base) {
     REGISTER_GLOBAL_FUNCTION(assert);
@@ -31,6 +33,8 @@ DECLARE_JS_WRAPPER_REGISTRATION (base) {
     REGISTER_CLASS_CONSTRUCTOR(DigitalOut);
     REGISTER_CLASS_CONSTRUCTOR(I2C);
     REGISTER_CLASS_CONSTRUCTOR(InterruptIn);
+    REGISTER_CLASS_CONSTRUCTOR(AnalogIn);
+    REGISTER_CLASS_CONSTRUCTOR(PwmOut);
 }
 
 #endif  // _JERRYSCRIPT_MBED_DRIVERS_LIB_DRIVERS_H

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn.cpp
@@ -1,0 +1,93 @@
+/* Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "jerryscript-mbed-util/logging.h"
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+#include "mbed.h"
+
+/**
+ * AnalogIn#read (native JavaScript method)
+ *
+ * Read the input voltage, represented as a float in the range [0.0, 1.0]
+ *
+ * @returns A floating-point value representing the current input voltage, measured as a percentage
+ */
+DECLARE_CLASS_FUNCTION(AnalogIn, read) {
+    CHECK_ARGUMENT_COUNT(AnalogIn, read, (args_count == 0));
+
+    // Extract native AnalogIn pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    AnalogIn* native_ptr = reinterpret_cast<AnalogIn*>(ptr_val);
+
+    float result = native_ptr->read();
+    return jerry_create_number(result);
+}
+
+/**
+ * AnalogIn#read_u16 (native JavaScript method)
+ *
+ * Read the input voltage, represented as an unsigned short in the range [0x0, 0xFFFF]
+ *
+ * @returns 16-bit unsigned short representing the current input voltage, normalised to a 16-bit value
+ */
+DECLARE_CLASS_FUNCTION(AnalogIn, read_u16) {
+    CHECK_ARGUMENT_COUNT(AnalogIn, read_u16, (args_count == 0));
+
+    // Extract native AnalogIn pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    AnalogIn* native_ptr = reinterpret_cast<AnalogIn*>(ptr_val);
+
+    uint16_t result = native_ptr->read_u16();
+    return jerry_create_number(result);
+}
+
+/**
+ * AnalogIn#destructor
+ *
+ * Called if/when the AnalogIn is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(AnalogIn)(const uintptr_t native_handle) {
+    delete reinterpret_cast<AnalogIn*>(native_handle);
+}
+
+/**
+ * AnalogIn (native JavaScript constructor)
+ *
+ * @param pin_name mbed pin to connect the AnalogIn to.
+ * @returns a JavaScript object representing a AnalogIn.
+ */
+DECLARE_CLASS_CONSTRUCTOR(AnalogIn) {
+    CHECK_ARGUMENT_COUNT(AnalogIn, __constructor, args_count == 1);
+    CHECK_ARGUMENT_TYPE_ALWAYS(AnalogIn, __constructor, 0, number);
+
+    PinName pin_name = PinName(jerry_get_number_value(args[0]));
+
+    // create native object
+    uintptr_t native_ptr = (uintptr_t) new AnalogIn(pin_name);
+
+    // create the jerryscript object
+    jerry_value_t js_object = jerry_create_object();
+    jerry_set_object_native_handle(js_object, native_ptr, NAME_FOR_CLASS_NATIVE_DESTRUCTOR(AnalogIn));
+
+    // attach methods
+    ATTACH_CLASS_FUNCTION(js_object, AnalogIn, read);
+    ATTACH_CLASS_FUNCTION(js_object, AnalogIn, read_u16);
+
+    return js_object;
+}

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut.cpp
@@ -1,0 +1,242 @@
+/* Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "jerryscript-mbed-util/logging.h"
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+#include "mbed.h"
+
+/**
+ * PwmOut#write (native JavaScript method)
+ *
+ * Set the ouput duty-cycle, specified as a percentage (float)
+ *
+ * @param value A floating-point value representing the output duty-cycle,
+ *    specified as a percentage. The value should lie between
+ *    0.0 (representing on 0%) and 1.0 (representing on 100%).
+ *    Values outside this range will be saturated to 0.0f or 1.0f
+ * @returns undefined
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, write) {
+    CHECK_ARGUMENT_COUNT(PwmOut, write, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, write, 0, number);
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    double arg0 = jerry_get_number_value(args[0]);
+    native_ptr->write(static_cast<float>(arg0));
+
+    return jerry_create_undefined();
+}
+
+/**
+ * PwmOut#read (native JavaScript method)
+ *
+ * Return the current output duty-cycle setting, measured as a percentage (float)
+ *
+ * @returns
+ *    A floating-point value representing the current duty-cycle being output on the pin,
+ *    measured as a percentage. The returned value will lie between
+ *    0.0 (representing on 0%) and 1.0 (representing on 100%).
+ *
+ * @note
+ * This value may not match exactly the value set by a previous <write>.
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, read) {
+    CHECK_ARGUMENT_COUNT(PwmOut, read, (args_count == 0));
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    float result = native_ptr->read();
+    return jerry_create_number(result);
+}
+
+/**
+ * PwmOut#period (native JavaScript method)
+ *
+ * Set the PWM period, specified in seconds (float), keeping the duty cycle the same.
+ *
+ * @note
+ *   The resolution is currently in microseconds; periods smaller than this
+ *   will be set to zero.
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, period) {
+    CHECK_ARGUMENT_COUNT(PwmOut, period, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, period, 0, number);
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    double arg0 = jerry_get_number_value(args[0]);
+    native_ptr->period(static_cast<float>(arg0));
+
+    return jerry_create_undefined();
+}
+
+/**
+ * PwmOut#period_ms (native JavaScript method)
+ *
+ * Set the PWM period, specified in milli-seconds (int), keeping the duty cycle the same.
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, period_ms) {
+    CHECK_ARGUMENT_COUNT(PwmOut, period_ms, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, period_ms, 0, number);
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    double arg0 = jerry_get_number_value(args[0]);
+    native_ptr->period_ms(static_cast<int>(arg0));
+
+    return jerry_create_undefined();
+}
+
+/**
+ * PwmOut#period_us (native JavaScript method)
+ *
+ * Set the PWM period, specified in micro-seconds (int), keeping the duty cycle the same.
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, period_us) {
+    CHECK_ARGUMENT_COUNT(PwmOut, period_us, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, period_us, 0, number);
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    double arg0 = jerry_get_number_value(args[0]);
+    native_ptr->period_us(static_cast<int>(arg0));
+
+    return jerry_create_undefined();
+}
+
+/**
+ * PwmOut#pulsewidth (native JavaScript method)
+ *
+ * Set the PWM pulsewidth, specified in seconds (float), keeping the period the same.
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth) {
+    CHECK_ARGUMENT_COUNT(PwmOut, pulsewidth, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, pulsewidth, 0, number);
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    double arg0 = jerry_get_number_value(args[0]);
+    native_ptr->pulsewidth(static_cast<float>(arg0));
+
+    return jerry_create_undefined();
+}
+
+/**
+ * PwmOut#pulsewidth_ms (native JavaScript method)
+ *
+ * Set the PWM pulsewidth, specified in milli-seconds (int), keeping the period the same.
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth_ms) {
+    CHECK_ARGUMENT_COUNT(PwmOut, pulsewidth_ms, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, pulsewidth_ms, 0, number);
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    double arg0 = jerry_get_number_value(args[0]);
+    native_ptr->pulsewidth_ms(static_cast<int>(arg0));
+
+    return jerry_create_undefined();
+}
+
+/**
+ * PwmOut#pulsewidth_us (native JavaScript method)
+ *
+ * Set the PWM pulsewidth, specified in micro-seconds (int), keeping the period the same.
+ */
+DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth_us) {
+    CHECK_ARGUMENT_COUNT(PwmOut, pulsewidth_us, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, pulsewidth_us, 0, number);
+
+    // Extract native PwmOut pointer
+    uintptr_t ptr_val;
+    jerry_get_object_native_handle(this_obj, &ptr_val);
+
+    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+
+    double arg0 = jerry_get_number_value(args[0]);
+    native_ptr->pulsewidth_us(static_cast<int>(arg0));
+
+    return jerry_create_undefined();
+}
+
+/**
+ * PwmOut#destructor
+ *
+ * Called if/when the PwmOut is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut)(const uintptr_t native_handle) {
+    delete reinterpret_cast<PwmOut*>(native_handle);
+}
+
+/**
+ * PwmOut (native JavaScript constructor)
+ *
+ * @param pin_name mbed pin to connect the PwmOut to.
+ * @returns a JavaScript object representing a PwmOut.
+ */
+DECLARE_CLASS_CONSTRUCTOR(PwmOut) {
+    CHECK_ARGUMENT_COUNT(PwmOut, __constructor, args_count == 1);
+    CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, __constructor, 0, number);
+
+    PinName pin_name = PinName(jerry_get_number_value(args[0]));
+
+    // Create the native object
+    uintptr_t native_ptr = (uintptr_t) new PwmOut(pin_name);
+
+    // create the jerryscript object
+    jerry_value_t js_object = jerry_create_object();
+    jerry_set_object_native_handle(js_object, native_ptr, NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut));
+
+    // attach methods
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, write);
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, read);
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, period);
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, period_ms);
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, period_us);
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, pulsewidth);
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, pulsewidth_ms);
+    ATTACH_CLASS_FUNCTION(js_object, PwmOut, pulsewidth_us);
+
+    return js_object;
+}


### PR DESCRIPTION
mbed OS 5 target is currently missing wrappers around PwmOut and AnalogIn interface, which are part of the standard library of mbed OS. This commit adds them. Tested with mbed CI test shield. I've followed the coding style in jerryscript-mbed, rather than JerryScript coding style.

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com

Partial fix for #1454.

/cc @thegecko @matthewelse 