### PR TITLE
target: mbedos5: Allow jerry_port_console and jerry_port_log to be overriden by user code

### DIFF
--- a/targets/mbedos5/source/jerry_port_mbed.c
+++ b/targets/mbedos5/source/jerry_port_mbed.c
@@ -22,6 +22,7 @@
 
 #include "us_ticker_api.h"
 
+#ifndef JSMBED_OVERRIDE_JERRY_PORT_CONSOLE
 /**
  * Provide console message implementation for the engine.
  */
@@ -39,7 +40,9 @@ jerry_port_console (const char *format, /**< format string */
     printf ("\r"); /* add CR for proper display in serial monitors */
   }
 } /* jerry_port_console */
+#endif /* JSMBED_OVERRIDE_JERRY_PORT_CONSOLE */
 
+#ifndef JSMBED_OVERRIDE_JERRY_PORT_LOG
 /**
  * Provide log message implementation for the engine.
  */
@@ -58,8 +61,9 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
   if (strlen (format) == 1 && format[0] == 0x0a) /* line feed (\n) */
   {
     printf ("\r"); /* add CR for proper display in serial monitors */
-  } 
+  }
 } /* jerry_port_log */
+#endif /* JSMBED_OVERRIDE_JERRY_PORT_LOG */
 
 /**
  * Implementation of jerry_port_fatal.


### PR DESCRIPTION
We're building a REPL (as user-space program) on top of mbedos5 target. For this I need to override the jerry_port_console and jerry_port_log functions from the REPL. This commit wraps these functions in an ifndef, so we can define macros to not include these files.

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com

/cc @matthewelse @thegecko 