### PR TITLE
new Date error solved

### DIFF
--- a/tests/jerry/regression-test-issue-1386.js
+++ b/tests/jerry/regression-test-issue-1386.js
@@ -1,0 +1,24 @@
+// Copyright 2016 Hayun Lee (lhy920806@gmail.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+for (var y = 1950; y < 2050; y++) {
+  for (var m = 0; m < 12; m++) {
+    var last_date = new Date(y, m, 1).getDay ();
+    assert (!isNaN (last_date));
+    for (var d = 1; d < 32; d++) {
+      assert (last_date == new Date(y, m, d).getDay ());
+      last_date = (last_date + 1) % 7;
+    }
+  }
+}

--- a/tests/unit/test-date-helpers.c
+++ b/tests/unit/test-date-helpers.c
@@ -162,6 +162,8 @@ main ()
   TEST_ASSERT (ecma_date_make_day (1970, 1, 35) == 65);
   TEST_ASSERT (ecma_date_make_day (1970, 13, 35) == 430);
   TEST_ASSERT (ecma_date_make_day (2016, 2, 1) == 16861);
+  TEST_ASSERT (ecma_date_make_day (2016, 8, 31) == 17075);
+  TEST_ASSERT (ecma_date_make_day (2016, 9, 1) == 17075);
 
   /* ecma_number_t ecma_date_make_date (day, time) */
 


### PR DESCRIPTION
I solved the problem mentioned in issue #1386 .
(new Date() fails for any date in October on leap years)
The issue was raised long time before, 
but the problem was not solved for a long time.

Therefore, i solved the problem, and
In addition, i enhanced the algorithm. (Change binary search to simple algorithm)
The algorithm uses ecma standard api. 

I did two unit tests (bug fix, performance).
Following is code is used for unit tests on IoT.js.

```javascript
fail_count=0;
for (y=1950; y<2050; y++) {
  for (m=0; m<12; m++) {
    for (d=1; d<32; d++) {
      var date = new Date(y, m, d);
      if (isNaN(date)) {
        fail_count++;
      }
    }
  }
}
console.log(fail_count);
```

```javascript
var t0 = new Date().getTime();
for (y=1950; y<2050; y++) {
  for (m=0; m<12; m++) {
    for (d=1; d<32; d++) {
      var date = new Date(y, m, d);
    }
  }
}
var t1 = new Date().getTime();
var delay = t1 - t0;
console.log(delay + "ms");
```

This table is results of unit tests.

  /  | Original JerryScript | Modified JerryScript
--- | -------------------- | ---------------------
fail_count | 775 | 0
delay (ms) | 33275 | 16823