### PR TITLE
Streamline copyright notices across the codebase.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchain_external.cmake
+++ b/cmake/toolchain_external.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchain_linux_armv7l-el.cmake
+++ b/cmake/toolchain_linux_armv7l-el.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchain_linux_armv7l.cmake
+++ b/cmake/toolchain_linux_armv7l.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchain_linux_i686.cmake
+++ b/cmake/toolchain_linux_i686.cmake
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchain_mcu_stm32f3.cmake
+++ b/cmake/toolchain_mcu_stm32f3.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchain_mcu_stm32f4.cmake
+++ b/cmake/toolchain_mcu_stm32f4.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/toolchain_openwrt_mips.cmake
+++ b/cmake/toolchain_openwrt_mips.cmake
@@ -1,4 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jerry-core/config.h
+++ b/jerry-core/config.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-gc.h
+++ b/jerry-core/ecma/base/ecma-gc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers-errol.c
+++ b/jerry-core/ecma/base/ecma-helpers-errol.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers-external-pointers.c
+++ b/jerry-core/ecma/base/ecma-helpers-external-pointers.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers-values-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-values-collection.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-init-finalize.h
+++ b/jerry-core/ecma/base/ecma-init-finalize.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-lcache.h
+++ b/jerry-core/ecma/base/ecma-lcache.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-literal-storage.c
+++ b/jerry-core/ecma/base/ecma-literal-storage.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-literal-storage.h
+++ b/jerry-core/ecma/base/ecma-literal-storage.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/base/ecma-property-hashmap.h
+++ b/jerry-core/ecma/base/ecma-property-hashmap.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror-prototype.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-error.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-error.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror-prototype.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror-prototype.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
- * Copyright 2015 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror-prototype.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror-prototype.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror-prototype.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror-prototype.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.inc.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-boolean-object.h
+++ b/jerry-core/ecma/operations/ecma-boolean-object.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-comparison.c
+++ b/jerry-core/ecma/operations/ecma-comparison.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-comparison.h
+++ b/jerry-core/ecma/operations/ecma-comparison.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-eval.c
+++ b/jerry-core/ecma/operations/ecma-eval.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-eval.h
+++ b/jerry-core/ecma/operations/ecma-eval.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-exceptions.h
+++ b/jerry-core/ecma/operations/ecma-exceptions.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-lex-env.h
+++ b/jerry-core/ecma/operations/ecma-lex-env.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-number-arithmetic.c
+++ b/jerry-core/ecma/operations/ecma-number-arithmetic.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-number-arithmetic.h
+++ b/jerry-core/ecma/operations/ecma-number-arithmetic.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-number-object.h
+++ b/jerry-core/ecma/operations/ecma-number-object.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-reference.h
+++ b/jerry-core/ecma/operations/ecma-reference.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/ecma/operations/ecma-try-catch-macro.h
+++ b/jerry-core/ecma/operations/ecma-try-catch-macro.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jcontext/jcontext.c
+++ b/jerry-core/jcontext/jcontext.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jerry-internal.h
+++ b/jerry-core/jerry-internal.h
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jerry-port.h
+++ b/jerry-core/jerry-port.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jerry-snapshot.c
+++ b/jerry-core/jerry-snapshot.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jerry-snapshot.h
+++ b/jerry-core/jerry-snapshot.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 University of Szeged.
- * Copyright 2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-allocator-internal.h
+++ b/jerry-core/jmem/jmem-allocator-internal.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-allocator.h
+++ b/jerry-core/jmem/jmem-allocator.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-config.h
+++ b/jerry-core/jmem/jmem-config.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-heap.h
+++ b/jerry-core/jmem/jmem-heap.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jmem/jmem-poolman.h
+++ b/jerry-core/jmem/jmem-poolman.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jrt/jrt-bit-fields.h
+++ b/jerry-core/jrt/jrt-bit-fields.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jrt/jrt-fatals.c
+++ b/jerry-core/jrt/jrt-fatals.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jrt/jrt-libc-includes.h
+++ b/jerry-core/jrt/jrt-libc-includes.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jrt/jrt-types.h
+++ b/jerry-core/jrt/jrt-types.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-globals.h
+++ b/jerry-core/lit/lit-globals.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-magic-strings.inc.h
+++ b/jerry-core/lit/lit-magic-strings.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/lit/lit-unicode-ranges.inc.h
+++ b/jerry-core/lit/lit-unicode-ranges.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/byte-code.c
+++ b/jerry-core/parser/js/byte-code.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/common.c
+++ b/jerry-core/parser/js/common.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/common.h
+++ b/jerry-core/parser/js/common.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser-limits.h
+++ b/jerry-core/parser/js/js-parser-limits.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser-mem.c
+++ b/jerry-core/parser/js/js-parser-mem.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser-scanner.c
+++ b/jerry-core/parser/js/js-parser-scanner.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/regexp/re-bytecode.c
+++ b/jerry-core/parser/regexp/re-bytecode.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/regexp/re-bytecode.h
+++ b/jerry-core/parser/regexp/re-bytecode.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/regexp/re-compiler.h
+++ b/jerry-core/parser/regexp/re-compiler.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/parser/regexp/re-parser.h
+++ b/jerry-core/parser/regexp/re-parser.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/opcodes-ecma-arithmetics.c
+++ b/jerry-core/vm/opcodes-ecma-arithmetics.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/opcodes-ecma-bitwise.c
+++ b/jerry-core/vm/opcodes-ecma-bitwise.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/opcodes-ecma-equality.c
+++ b/jerry-core/vm/opcodes-ecma-equality.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/opcodes-ecma-relational.c
+++ b/jerry-core/vm/opcodes-ecma-relational.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/opcodes.h
+++ b/jerry-core/vm/opcodes.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/vm-defines.h
+++ b/jerry-core/vm/vm-defines.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/vm-stack.c
+++ b/jerry-core/vm/vm-stack.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/vm-stack.h
+++ b/jerry-core/vm/vm-stack.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/CMakeLists.txt
+++ b/jerry-libc/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jerry-libc/arch/arm-v7.h
+++ b/jerry-libc/arch/arm-v7.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/arch/x86-32.h
+++ b/jerry-libc/arch/x86-32.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/arch/x86-64.h
+++ b/jerry-libc/arch/x86-64.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/include/assert.h
+++ b/jerry-libc/include/assert.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/include/setjmp.h
+++ b/jerry-libc/include/setjmp.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/include/stdio.h
+++ b/jerry-libc/include/stdio.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/include/stdlib.h
+++ b/jerry-libc/include/stdlib.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/include/string.h
+++ b/jerry-libc/include/string.h
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/include/sys/time.h
+++ b/jerry-libc/include/sys/time.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/jerry-libc-defs.h
+++ b/jerry-libc/jerry-libc-defs.h
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/jerry-libc-printf.c
+++ b/jerry-libc/jerry-libc-printf.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/jerry-libc.c
+++ b/jerry-libc/jerry-libc.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/target/posix/jerry-asm.S
+++ b/jerry-libc/target/posix/jerry-asm.S
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libc/target/posix/jerry-libc-target.c
+++ b/jerry-libc/target/posix/jerry-libc-target.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/CMakeLists.txt
+++ b/jerry-libm/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2015-2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jerry-libm/acos.c
+++ b/jerry-libm/acos.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/asin.c
+++ b/jerry-libm/asin.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/atan.c
+++ b/jerry-libm/atan.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/atan2.c
+++ b/jerry-libm/atan2.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/ceil.c
+++ b/jerry-libm/ceil.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/copysign.c
+++ b/jerry-libm/copysign.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/exp.c
+++ b/jerry-libm/exp.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/fabs.c
+++ b/jerry-libm/fabs.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/finite.c
+++ b/jerry-libm/finite.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/floor.c
+++ b/jerry-libm/floor.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/fmod.c
+++ b/jerry-libm/fmod.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/include/math.h
+++ b/jerry-libm/include/math.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/isnan.c
+++ b/jerry-libm/isnan.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/jerry-libm-internal.h
+++ b/jerry-libm/jerry-libm-internal.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/log.c
+++ b/jerry-libm/log.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/nextafter.c
+++ b/jerry-libm/nextafter.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/pow.c
+++ b/jerry-libm/pow.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/scalbn.c
+++ b/jerry-libm/scalbn.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/sqrt.c
+++ b/jerry-libm/sqrt.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-libm/trig.c
+++ b/jerry-libm/trig.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/include/inttypes.h
+++ b/targets/curie_bsp/include/inttypes.h
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/include/setjmp.h
+++ b/targets/curie_bsp/include/setjmp.h
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/jerry_app/arc/main.c
+++ b/targets/curie_bsp/jerry_app/arc/main.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/jerry_app/arc/memory_pool_list.def
+++ b/targets/curie_bsp/jerry_app/arc/memory_pool_list.def
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/jerry_app/include/project_mapping.h
+++ b/targets/curie_bsp/jerry_app/include/project_mapping.h
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/jerry_app/quark/main.c
+++ b/targets/curie_bsp/jerry_app/quark/main.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/jerry_app/quark/memory_pool_list.def
+++ b/targets/curie_bsp/jerry_app/quark/memory_pool_list.def
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/setup.py
+++ b/targets/curie_bsp/setup.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016 Intel Corporation
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/source/curie-bsp-port.c
+++ b/targets/curie_bsp/source/curie-bsp-port.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/curie_bsp/source/setjmp.S
+++ b/targets/curie_bsp/source/setjmp.S
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/default/jerry-port-default-date.c
+++ b/targets/default/jerry-port-default-date.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/default/jerry-port-default-fatal.c
+++ b/targets/default/jerry-port-default-fatal.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/default/jerry-port-default-io.c
+++ b/targets/default/jerry-port-default-io.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/default/jerry-port-default.h
+++ b/targets/default/jerry-port-default.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/Makefile
+++ b/targets/esp8266/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/esp8266/Makefile.esp8266
+++ b/targets/esp8266/Makefile.esp8266
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/esp8266/include/esp8266_gpio.h
+++ b/targets/esp8266/include/esp8266_gpio.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/include/esp8266_uart.h
+++ b/targets/esp8266/include/esp8266_uart.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/include/jerry_extapi.h
+++ b/targets/esp8266/include/jerry_extapi.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/include/jerry_run.h
+++ b/targets/esp8266/include/jerry_run.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/include/native_esp8266.h
+++ b/targets/esp8266/include/native_esp8266.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/include/user_config.h
+++ b/targets/esp8266/include/user_config.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/source/jerry_extapi.c
+++ b/targets/esp8266/source/jerry_extapi.c
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/source/jerry_run.c
+++ b/targets/esp8266/source/jerry_run.c
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/user/jerry_port.c
+++ b/targets/esp8266/user/jerry_port.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/user/native_esp8266.c
+++ b/targets/esp8266/user/native_esp8266.c
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/user/user_gpio.c
+++ b/targets/esp8266/user/user_gpio.c
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/esp8266/user/user_main.c
+++ b/targets/esp8266/user/user_main.c
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/Makefile.mbed
+++ b/targets/mbed/Makefile.mbed
@@ -1,5 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/mbed/js/blink.js
+++ b/targets/mbed/js/blink.js
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/js/main.js
+++ b/targets/mbed/js/main.js
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/jerry_extapi.cpp
+++ b/targets/mbed/source/jerry_extapi.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/jerry_extapi.h
+++ b/targets/mbed/source/jerry_extapi.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/jerry_run.cpp
+++ b/targets/mbed/source/jerry_run.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/jerry_run.h
+++ b/targets/mbed/source/jerry_run.h
@@ -1,4 +1,4 @@
-/* Copyright 2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/main.cpp
+++ b/targets/mbed/source/main.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/makejerry.cmake
+++ b/targets/mbed/source/makejerry.cmake
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/mbed/source/native_mbed.cpp
+++ b/targets/mbed/source/native_mbed.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/native_mbed.h
+++ b/targets/mbed/source/native_mbed.h
@@ -1,4 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbed/source/port/jerry_port.c
+++ b/targets/mbed/source/port/jerry_port.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/Makefile
+++ b/targets/mbedos5/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 ARM Limited
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/AnalogIn-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/AnalogIn-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/DigitalOut-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/DigitalOut-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/I2C-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/I2C-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/InterruptIn-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/InterruptIn-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/PwmOut-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/PwmOut-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/assert-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/assert-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/gc-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/gc-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/setInterval-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/setInterval-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/setTimeout-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/setTimeout-js.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/assert.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/assert.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/gc.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/gc.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setInterval.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setInterval.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setTimeout.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setTimeout.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/BoundCallback.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/BoundCallback.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/EventLoop.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/EventLoop.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/source/EventLoop.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/source/EventLoop.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/launcher.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/launcher.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/setup.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/setup.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/setup.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/setup.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/registry.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/registry.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/source/registry.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/source/registry.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/source/wrap_tools.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/source/wrap_tools.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2014-2015 Samsung Electronics Co., Ltd.
- * Copyright (c) 2016 ARM Limited.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/wrap_tools.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-library-registry/wrap_tools.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/js_source.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/js_source.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/logging.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/logging.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/wrappers.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/wrappers.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/js/flash_leds.js
+++ b/targets/mbedos5/js/flash_leds.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/js/main.js
+++ b/targets/mbedos5/js/main.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/source/jerry_port_mbed.c
+++ b/targets/mbedos5/source/jerry_port_mbed.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/source/main.cpp
+++ b/targets/mbedos5/source/main.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/tools/check_pins.sh
+++ b/targets/mbedos5/tools/check_pins.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2016 ARM Limited.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/mbedos5/tools/cmsis.h
+++ b/targets/mbedos5/tools/cmsis.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 ARM Limited.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/mbedos5/tools/generate_pins.py
+++ b/targets/mbedos5/tools/generate_pins.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2016 ARM Limited
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -178,7 +178,7 @@ if __name__ == "__main__":
     out_file = '\r\n'.join(['var %s = %s;' % pin for pin in pins.iteritems()])
     args.o.write(out_file)
 
-    LICENSE = '''/* Copyright 2016 ARM, Ltd.
+    LICENSE = '''/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");
  * you may not use this file except in compliance with the License.

--- a/targets/nuttx-stm32f4/Make.defs
+++ b/targets/nuttx-stm32f4/Make.defs
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/nuttx-stm32f4/Makefile
+++ b/targets/nuttx-stm32f4/Makefile
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/particle/Makefile.particle
+++ b/targets/particle/Makefile.particle
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/particle/source/main.cpp
+++ b/targets/particle/source/main.cpp
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/riot-stm32f4/Makefile
+++ b/targets/riot-stm32f4/Makefile
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/riot-stm32f4/Makefile.riot
+++ b/targets/riot-stm32f4/Makefile.riot
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/riot-stm32f4/source/main-riotos.c
+++ b/targets/riot-stm32f4/source/main-riotos.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/tools/js2c.py
+++ b/targets/tools/js2c.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ def removeWhitespaces(code):
     return re.sub('\n+', '\n', re.sub('\n +', '\n', code))
 
 
-LICENSE = '''/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+LICENSE = '''/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the \"License\");
  * you may not use this file except in compliance with the License.

--- a/targets/zephyr/Makefile
+++ b/targets/zephyr/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2016 Intel Corporation
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -1,4 +1,4 @@
-# Copyright © 2016 Intel Corporation
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/zephyr/src/Makefile
+++ b/targets/zephyr/src/Makefile
@@ -1,4 +1,4 @@
-# Copyright © 2016 Intel Corporation
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/targets/zephyr/src/getline-zephyr.c
+++ b/targets/zephyr/src/getline-zephyr.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Linaro
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/zephyr/src/getline-zephyr.h
+++ b/targets/zephyr/src/getline-zephyr.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 Linaro
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/zephyr/src/jerry-port.c
+++ b/targets/zephyr/src/jerry-port.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Intel Corporation
- * Copyright 2016 Linaro Limited
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/targets/zephyr/src/main-zephyr.c
+++ b/targets/zephyr/src/main-zephyr.c
@@ -1,4 +1,4 @@
-/* Copyright 2016 Intel Corporation
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/benchmarks/jerry/fill-array-with-numbers-3-times-5000-elements.js
+++ b/tests/benchmarks/jerry/fill-array-with-numbers-3-times-5000-elements.js
@@ -1,4 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/benchmarks/jerry/function_loop.js
+++ b/tests/benchmarks/jerry/function_loop.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/benchmarks/jerry/gc.js
+++ b/tests/benchmarks/jerry/gc.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/benchmarks/jerry/loop_arithmetics_10kk.js
+++ b/tests/benchmarks/jerry/loop_arithmetics_10kk.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/benchmarks/jerry/loop_arithmetics_1kk.js
+++ b/tests/benchmarks/jerry/loop_arithmetics_1kk.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/hello.js
+++ b/tests/hello.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/06/06-001.js
+++ b/tests/jerry-test-suite/06/06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/06/06-002.js
+++ b/tests/jerry-test-suite/06/06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/06/06-003.js
+++ b/tests/jerry-test-suite/06/06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/06/06-004.js
+++ b/tests/jerry-test-suite/06/06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/06/06-005.js
+++ b/tests/jerry-test-suite/06/06-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.06/07.06.01/07.06.01-001.js
+++ b/tests/jerry-test-suite/07/07.06/07.06.01/07.06.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.08/07.08.05/07.08.05-001.js
+++ b/tests/jerry-test-suite/07/07.08/07.08.05/07.08.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-001.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-002.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-003.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-004.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-005.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-006.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-007.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-008.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-009.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/07/07.09/07.09-010.js
+++ b/tests/jerry-test-suite/07/07.09/07.09-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-001.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-002.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-003.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-004.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-005.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-006.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-007.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-008.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-009.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-010.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.01/08.01-011.js
+++ b/tests/jerry-test-suite/08/08.01/08.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.02/08.02-001.js
+++ b/tests/jerry-test-suite/08/08.02/08.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.02/08.02-002.js
+++ b/tests/jerry-test-suite/08/08.02/08.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.03/08.03-001.js
+++ b/tests/jerry-test-suite/08/08.03/08.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.03/08.03-002.js
+++ b/tests/jerry-test-suite/08/08.03/08.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.03/08.03-003.js
+++ b/tests/jerry-test-suite/08/08.03/08.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.03/08.03-004.js
+++ b/tests/jerry-test-suite/08/08.03/08.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-001.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-002.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-003.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-004.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-005.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-006.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-007.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-008.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-009.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-010.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-011.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-012.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-013.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-014.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-015.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-016.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.04/08.04-017.js
+++ b/tests/jerry-test-suite/08/08.04/08.04-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.05/08.05-001.js
+++ b/tests/jerry-test-suite/08/08.05/08.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.05/08.05-002.js
+++ b/tests/jerry-test-suite/08/08.05/08.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.05/08.05-003.js
+++ b/tests/jerry-test-suite/08/08.05/08.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/08/08.12/08.12.02/08.12.02-001.js
+++ b/tests/jerry-test-suite/08/08.12/08.12.02/08.12.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/10/10.03/10.03.01/10.03.01-001.js
+++ b/tests/jerry-test-suite/10/10.03/10.03.01/10.03.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-001.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-002.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-003.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-004.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-005.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-006.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-007.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-008.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.05/11.01.05-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-001.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-002.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-003.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-004.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-005.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-006.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-009.js
+++ b/tests/jerry-test-suite/11/11.01/11.01.06/11.01.06-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-001.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-002.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-003.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-004.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-007.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-008.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-009.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-010.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-011.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.01/11.02.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-001.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-002.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-003.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-004.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-005.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-006.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-007.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-008.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-009.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.02/11.02.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-006.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-007.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-008.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-017.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-021.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.03/11.02.03-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-001.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-002.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-003.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-004.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-005.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-006.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-007.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-008.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-009.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-010.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-011.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-012.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-013.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-014.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-016.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-017.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-018.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-019.js
+++ b/tests/jerry-test-suite/11/11.02/11.02.04/11.02.04-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-005.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-006.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-007.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-008.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-009.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-010.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-011.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-012.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-013.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-014.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-015.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-016.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.01/11.03.01-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-005.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-006.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-007.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-008.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-009.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-010.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-011.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-012.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-013.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-014.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-015.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-016.js
+++ b/tests/jerry-test-suite/11/11.03/11.03.02/11.03.02-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-003.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-013.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-017.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.01/11.04.01-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.02/11.04.02-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.02/11.04.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.02/11.04.02-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.02/11.04.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-003.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-013.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-016.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.03/11.04.03-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.04/11.04.04-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.05/11.04.05-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-003.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-013.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-014.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-015.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-016.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-017.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-018.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-019.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-020.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-021.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-022.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-023.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-024.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-025.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-026.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-027.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-028.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.06/11.04.06-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-003.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-013.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-014.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-015.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-016.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-017.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-018.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-019.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-020.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-021.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-022.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-023.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-024.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-025.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-026.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-027.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-028.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-029.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-030.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-030.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-031.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-031.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-032.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-032.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-033.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.07/11.04.07-033.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-003.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-013.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-014.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-015.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-016.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-017.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-018.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-019.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-020.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-021.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-022.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.08/11.04.08-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-001.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-002.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-003.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-004.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-005.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-006.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-007.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-008.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-009.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-010.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-011.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-012.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-013.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-014.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-015.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-016.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-017.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-018.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-019.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-020.js
+++ b/tests/jerry-test-suite/11/11.04/11.04.09/11.04.09-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-001.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-002.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-003.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-004.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-005.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-006.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-007.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-008.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-009.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-010.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-011.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-012.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-013.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-014.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-015.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-016.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-017.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-018.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-019.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-020.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-021.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-022.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-023.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-024.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-025.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-026.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-027.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-028.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-029.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-030.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-030.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-031.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-031.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-032.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-032.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-033.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-033.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-034.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-034.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-035.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-035.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-036.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-036.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-037.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-037.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-038.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-038.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-039.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-039.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-040.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-040.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-041.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-041.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-042.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-042.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-043.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-043.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-044.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-044.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-045.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-045.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-046.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-046.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-047.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-047.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-048.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-048.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-049.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-049.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-050.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-050.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-051.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-051.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-052.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-052.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-053.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-053.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-054.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-054.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-055.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-055.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-056.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-056.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-057.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-057.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-058.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-058.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-059.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-059.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-060.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-060.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-061.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-061.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-062.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-062.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-063.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-063.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-064.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-064.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-065.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-065.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-066.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-066.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-067.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-067.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-068.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-068.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-069.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-069.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-070.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-070.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-071.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-071.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-072.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-072.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-073.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-073.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-074.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-074.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-075.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-075.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-076.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-076.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-077.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-077.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-078.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-078.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-079.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-079.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-080.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-080.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-081.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-081.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-082.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-082.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-083.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-083.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-084.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-084.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-085.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-085.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-086.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-086.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-087.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-087.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-088.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-088.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-089.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-089.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-090.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.01/11.05.01-090.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-001.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-002.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-003.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-004.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-005.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-006.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-007.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-008.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-009.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-010.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-011.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-012.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-013.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-014.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-015.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-016.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-017.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-018.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-019.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-020.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-021.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-022.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-023.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-024.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-025.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-026.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-027.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-028.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-029.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-030.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-030.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-031.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-031.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-032.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-032.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-033.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-033.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-034.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-034.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-035.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-035.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-036.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-036.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-037.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-037.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-038.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-038.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-039.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-039.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-040.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-040.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-041.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-041.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-042.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-042.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-043.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-043.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-044.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-044.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-045.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-045.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-046.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-046.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-047.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-047.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-048.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-048.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-049.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-049.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-050.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-050.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-051.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-051.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-052.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-052.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-053.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-053.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-054.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-054.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-055.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-055.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-056.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-056.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-057.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-057.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-058.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-058.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-059.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-059.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-060.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-060.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-061.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-061.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-062.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-062.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-063.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-063.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-064.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-064.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-065.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-065.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-066.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-066.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-067.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-067.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-068.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-068.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-069.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-069.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-070.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-070.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-071.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-071.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-072.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-072.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-073.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-073.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-074.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-074.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-075.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-075.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-076.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-076.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-077.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-077.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-078.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-078.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-079.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-079.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-080.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-080.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-081.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-081.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-082.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-082.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-083.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-083.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-084.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-084.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-085.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-085.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-086.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-086.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-087.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-087.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-088.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-088.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-089.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-089.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-090.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.02/11.05.02-090.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-001.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-002.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-003.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-004.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-005.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-006.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-007.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-008.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-009.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-010.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-011.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-012.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-013.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-014.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-015.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-016.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-017.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-018.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-019.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-020.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-021.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-022.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-023.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-024.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-025.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-026.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-027.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-028.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-029.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-030.js
+++ b/tests/jerry-test-suite/11/11.05/11.05.03/11.05.03-030.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-001.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-002.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-003.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-004.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-005.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-006.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-007.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-008.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-009.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-010.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-011.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-012.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-013.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-014.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-015.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-016.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-017.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-018.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.01/11.06.01-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-001.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-002.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-003.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-004.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-005.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-006.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-007.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-008.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-009.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-010.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-011.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-012.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-013.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-014.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-015.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-016.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-017.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.02/11.06.02-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-001.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-002.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-003.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-004.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-005.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-006.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-007.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-008.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-009.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-010.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-011.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-012.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-013.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-014.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-015.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-016.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-017.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-018.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-019.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-020.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-021.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-022.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-023.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-024.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-025.js
+++ b/tests/jerry-test-suite/11/11.06/11.06.03/11.06.03-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-001.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-003.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-004.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-005.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-006.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-007.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-008.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-009.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.01/11.07.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-001.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-002.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-003.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-004.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-005.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-006.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-007.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-008.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-009.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.02/11.07.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-001.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-002.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-003.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-004.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-005.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-006.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-007.js
+++ b/tests/jerry-test-suite/11/11.07/11.07.03/11.07.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-001.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-002.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-003.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-004.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-005.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-006.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.01/11.08.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-001.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-002.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-003.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-004.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-005.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-006.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.02/11.08.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-001.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-002.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-003.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-004.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-005.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-006.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-007.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-008.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-009.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-010.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-011.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.03/11.08.03-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-001.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-002.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-003.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-004.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-005.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-006.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-007.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-008.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-009.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.04/11.08.04-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-001.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-002.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-003.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-004.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-005.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-006.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-007.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.06/11.08.06-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-001.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-002.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-003.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-004.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-005.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-007.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-008.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-009.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-010.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-011.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-012.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-013.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-014.js
+++ b/tests/jerry-test-suite/11/11.08/11.08.07/11.08.07-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-001.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-002.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-003.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-004.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-005.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-006.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-007.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-008.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-009.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-010.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-011.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-012.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-013.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-014.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-015.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-016.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-017.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-018.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-019.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-020.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-021.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-022.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-023.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-024.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-025.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-026.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-027.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-028.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-029.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-030.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-030.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-031.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-031.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-032.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-032.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-033.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-033.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-034.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-034.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-035.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-035.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-036.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-036.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-037.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-037.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-038.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.01/11.09.01-038.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-001.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-002.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-003.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-004.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-005.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-006.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-007.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-008.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-009.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-010.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-011.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-012.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-013.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-014.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-015.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-016.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-017.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-018.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-019.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-020.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-021.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-022.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-023.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-024.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-025.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-026.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-027.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-028.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-029.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-030.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-030.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-031.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-031.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-032.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-032.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-033.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-033.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-034.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-034.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-035.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-035.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-036.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-036.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-037.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-037.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-038.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.02/11.09.02-038.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-001.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-002.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-003.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-004.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-005.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-006.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-007.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-008.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-009.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-010.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-011.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-012.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-013.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-014.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-015.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-016.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-017.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-018.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-019.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-020.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-021.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-022.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-023.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-024.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-025.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.04/11.09.04-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-001.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-002.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-003.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-004.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-005.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-006.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-007.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-008.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-009.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-010.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-011.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-012.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-013.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-014.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-015.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-016.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-017.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-018.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-019.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-020.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-021.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-022.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-023.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-024.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-025.js
+++ b/tests/jerry-test-suite/11/11.09/11.09.05/11.09.05-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-001.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-002.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-003.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-004.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-005.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-006.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-007.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-008.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-009.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-010.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-011.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-012.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-013.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-014.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-015.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-016.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-017.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.10/11.10-018.js
+++ b/tests/jerry-test-suite/11/11.10/11.10-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-001.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-002.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-003.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-004.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-005.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-006.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-007.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-008.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-009.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-010.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-011.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-012.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-013.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-014.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-015.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-016.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-017.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-018.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-019.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-020.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-021.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-022.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-023.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-024.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-025.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-026.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.11/11.11-027.js
+++ b/tests/jerry-test-suite/11/11.11/11.11-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.12/11.12-001.js
+++ b/tests/jerry-test-suite/11/11.12/11.12-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.12/11.12-002.js
+++ b/tests/jerry-test-suite/11/11.12/11.12-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.12/11.12-003.js
+++ b/tests/jerry-test-suite/11/11.12/11.12-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.12/11.12-004.js
+++ b/tests/jerry-test-suite/11/11.12/11.12-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.12/11.12-005.js
+++ b/tests/jerry-test-suite/11/11.12/11.12-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.12/11.12-008.js
+++ b/tests/jerry-test-suite/11/11.12/11.12-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.12/11.12-012.js
+++ b/tests/jerry-test-suite/11/11.12/11.12-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.01/11.13.01-001.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.01/11.13.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-001.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-002.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-003.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-004.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-005.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-006.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-007.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-008.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-009.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-010.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-011.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-012.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-013.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-014.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-039.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-039.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-040.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-040.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-041.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-041.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-042.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-042.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-043.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-043.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-044.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-044.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-045.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-045.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-046.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-046.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-047.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-047.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-048.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-048.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-049.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-049.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-050.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-050.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-051.js
+++ b/tests/jerry-test-suite/11/11.13/11.13.02/11.13.02-051.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.14/11.14-001.js
+++ b/tests/jerry-test-suite/11/11.14/11.14-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/11/11.14/11.14-002.js
+++ b/tests/jerry-test-suite/11/11.14/11.14-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.01/12.01-001.js
+++ b/tests/jerry-test-suite/12/12.01/12.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.01/12.01-002.js
+++ b/tests/jerry-test-suite/12/12.01/12.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.01/12.01-003.js
+++ b/tests/jerry-test-suite/12/12.01/12.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.01/12.01-004.js
+++ b/tests/jerry-test-suite/12/12.01/12.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.01/12.01-005.js
+++ b/tests/jerry-test-suite/12/12.01/12.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-001.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-002.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-003.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-004.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-005.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-006.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-007.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-008.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-009.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-010.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-011.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-012.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-013.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-014.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-015.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-016.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-018.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-019.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-020.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-021.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02-022.js
+++ b/tests/jerry-test-suite/12/12.02/12.02-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02.01/12.02.01-001.js
+++ b/tests/jerry-test-suite/12/12.02/12.02.01/12.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.02/12.02.01/12.02.01-002.js
+++ b/tests/jerry-test-suite/12/12.02/12.02.01/12.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.03/12.03-001.js
+++ b/tests/jerry-test-suite/12/12.03/12.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.03/12.03-002.js
+++ b/tests/jerry-test-suite/12/12.03/12.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.03/12.03-003.js
+++ b/tests/jerry-test-suite/12/12.03/12.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.04/12.04-001.js
+++ b/tests/jerry-test-suite/12/12.04/12.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.04/12.04-002.js
+++ b/tests/jerry-test-suite/12/12.04/12.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.04/12.04-003.js
+++ b/tests/jerry-test-suite/12/12.04/12.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.04/12.04-004.js
+++ b/tests/jerry-test-suite/12/12.04/12.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-001.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-002.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-003.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-004.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-005.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-006.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-007.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.05/12.05-008.js
+++ b/tests/jerry-test-suite/12/12.05/12.05-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-001.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-002.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-003.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-004.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-005.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-006.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-007.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-008.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-009.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-010.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.01/12.06.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-001.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-002.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-003.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-004.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-005.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-006.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-007.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-008.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.02/12.06.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-001.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-002.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-003.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-004.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-005.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-006.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-007.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-008.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-009.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-010.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-011.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.03/12.06.03-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-001.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-002.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-003.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-004.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-005.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-006.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-007.js
+++ b/tests/jerry-test-suite/12/12.06/12.06.04/12.06.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-001.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-002.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-003.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-004.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-005.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-006.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-007.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-008.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-009.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-010.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-011.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-012.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-013.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-014.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-015.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.07/12.07-016.js
+++ b/tests/jerry-test-suite/12/12.07/12.07-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-001.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-002.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-003.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-004.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-005.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-006.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-007.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-008.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-009.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-010.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-011.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-012.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-013.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-014.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-015.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-016.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-017.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.08/12.08-018.js
+++ b/tests/jerry-test-suite/12/12.08/12.08-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.09/12.09-001.js
+++ b/tests/jerry-test-suite/12/12.09/12.09-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.09/12.09-002.js
+++ b/tests/jerry-test-suite/12/12.09/12.09-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.09/12.09-003.js
+++ b/tests/jerry-test-suite/12/12.09/12.09-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.09/12.09-004.js
+++ b/tests/jerry-test-suite/12/12.09/12.09-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.09/12.09-005.js
+++ b/tests/jerry-test-suite/12/12.09/12.09-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.09/12.09-006.js
+++ b/tests/jerry-test-suite/12/12.09/12.09-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.10/12.10-001.js
+++ b/tests/jerry-test-suite/12/12.10/12.10-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.10/12.10-002.js
+++ b/tests/jerry-test-suite/12/12.10/12.10-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.10/12.10-003.js
+++ b/tests/jerry-test-suite/12/12.10/12.10-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.10/12.10-004.js
+++ b/tests/jerry-test-suite/12/12.10/12.10-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.10/12.10-005.js
+++ b/tests/jerry-test-suite/12/12.10/12.10-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.10/12.10-006.js
+++ b/tests/jerry-test-suite/12/12.10/12.10-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.10/12.10-007.js
+++ b/tests/jerry-test-suite/12/12.10/12.10-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.11/12.11-001.js
+++ b/tests/jerry-test-suite/12/12.11/12.11-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.11/12.11-002.js
+++ b/tests/jerry-test-suite/12/12.11/12.11-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.11/12.11-003.js
+++ b/tests/jerry-test-suite/12/12.11/12.11-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.11/12.11-004.js
+++ b/tests/jerry-test-suite/12/12.11/12.11-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.11/12.11-005.js
+++ b/tests/jerry-test-suite/12/12.11/12.11-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.11/12.11-006.js
+++ b/tests/jerry-test-suite/12/12.11/12.11-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.11/12.11-007.js
+++ b/tests/jerry-test-suite/12/12.11/12.11-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-001.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-002.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-003.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-004.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-005.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-006.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-007.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-008.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-009.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.12/12.12-010.js
+++ b/tests/jerry-test-suite/12/12.12/12.12-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.13/12.13-001.js
+++ b/tests/jerry-test-suite/12/12.13/12.13-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.13/12.13-002.js
+++ b/tests/jerry-test-suite/12/12.13/12.13-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.13/12.13-003.js
+++ b/tests/jerry-test-suite/12/12.13/12.13-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.14/12.14-001.js
+++ b/tests/jerry-test-suite/12/12.14/12.14-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.14/12.14-002.js
+++ b/tests/jerry-test-suite/12/12.14/12.14-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.14/12.14-003.js
+++ b/tests/jerry-test-suite/12/12.14/12.14-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.14/12.14-004.js
+++ b/tests/jerry-test-suite/12/12.14/12.14-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.14/12.14-005.js
+++ b/tests/jerry-test-suite/12/12.14/12.14-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/12/12.14/12.14-006.js
+++ b/tests/jerry-test-suite/12/12.14/12.14-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-001.js
+++ b/tests/jerry-test-suite/13/13-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-002.js
+++ b/tests/jerry-test-suite/13/13-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-003.js
+++ b/tests/jerry-test-suite/13/13-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-004.js
+++ b/tests/jerry-test-suite/13/13-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-005.js
+++ b/tests/jerry-test-suite/13/13-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-006.js
+++ b/tests/jerry-test-suite/13/13-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-007.js
+++ b/tests/jerry-test-suite/13/13-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-008.js
+++ b/tests/jerry-test-suite/13/13-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-009.js
+++ b/tests/jerry-test-suite/13/13-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-010.js
+++ b/tests/jerry-test-suite/13/13-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-011.js
+++ b/tests/jerry-test-suite/13/13-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-012.js
+++ b/tests/jerry-test-suite/13/13-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13-013.js
+++ b/tests/jerry-test-suite/13/13-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.01/13.01-001.js
+++ b/tests/jerry-test-suite/13/13.01/13.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-001.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-002.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-003.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-004.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-005.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-006.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-007.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/13/13.02/13.02-008.js
+++ b/tests/jerry-test-suite/13/13.02/13.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-004.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-005.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-006.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-007.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-008.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-009.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-010.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.01/15.02.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-004.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-005.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-006.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-007.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-008.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-009.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-010.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.02/15.02.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-004.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-005.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-006.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-007.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-008.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-009.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-010.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-011.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-012.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-013.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-014.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-015.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-016.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-017.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-018.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-019.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-020.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-021.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.03/15.02.03-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.01/15.02.04.01-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.01/15.02.04.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.01/15.02.04.01-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.01/15.02.04.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-004.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.02/15.02.04.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.03/15.02.04.03-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.03/15.02.04.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.03/15.02.04.03-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.03/15.02.04.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.03/15.02.04.03-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.03/15.02.04.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-004.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-005.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-006.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-007.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-008.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-009.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-010.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.04/15.02.04.04-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-004.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.05/15.02.04.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-004.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-005.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-006.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.06/15.02.04.06-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.07/15.02.04.07-001.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.07/15.02.04.07-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.07/15.02.04.07-002.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.07/15.02.04.07-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.07/15.02.04.07-003.js
+++ b/tests/jerry-test-suite/15/15.02/15.02.04/15.02.04.07/15.02.04.07-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-001.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-002.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-004.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-005.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-007.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-008.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-009.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-010.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-011.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-012s.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.02/15.03.02.01/15.03.02.01-012s.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-001.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-002.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-003.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-004.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-001.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-002.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-003.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-004.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.01/15.03.03.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.02/15.03.03.02-001.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.03/15.03.03.02/15.03.03.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-001.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-002.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-003.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-004.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-005.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-006.js
+++ b/tests/jerry-test-suite/15/15.03/15.03.04/15.03.04.02/15.03.04.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-001.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-002.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-003.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-004.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-005.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-006.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-007.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-008.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.01/15.04.02.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-001.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-002.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-003.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-004.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-005.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-006.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-007.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-008.js
+++ b/tests/jerry-test-suite/15/15.04/15.04.02/15.04.02.02/15.04.02.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-003.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-004.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-005.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-006.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-007.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-008.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-009.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-010.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-011.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-012.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-013.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-014.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-015.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.01/15.05.01.01/15.05.01.01-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.02/15.05.02.01/15.05.02.01-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.02/15.05.02.01/15.05.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.02/15.05.02.01/15.05.02.01-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.02/15.05.02.01/15.05.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.01/15.05.03.01-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.01/15.05.03.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.01/15.05.03.01-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.01/15.05.03.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.02/15.05.03.02-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.02/15.05.03.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.02/15.05.03.02-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.03/15.05.03.02/15.05.03.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.01/15.05.04.01-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.01/15.05.04.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.02/15.05.04.02-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.02/15.05.04.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.02/15.05.04.02-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.02/15.05.04.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.03/15.05.04.03-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.03/15.05.04.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-003.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-004.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.04/15.05.04.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-003.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-004.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.05/15.05.04.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-003.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-004.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.06/15.05.04.06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.07/15.05.04.07-001.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.07/15.05.04.07-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.07/15.05.04.07-002.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.07/15.05.04.07-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.07/15.05.04.07-003.js
+++ b/tests/jerry-test-suite/15/15.05/15.05.04/15.05.04.07/15.05.04.07-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-001.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-002.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-003.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-004.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-005.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-006.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-007.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-008.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-009.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-010.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-011.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-012.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.01/15.06.01.01/15.06.01.01-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.02/15.06.02.01/15.06.02.01-001.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.02/15.06.02.01/15.06.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.02/15.06.02.01/15.06.02.01-002.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.02/15.06.02.01/15.06.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.03/15.06.03.01/15.06.03.01-001.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.03/15.06.03.01/15.06.03.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.01/15.06.04.01-001.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.01/15.06.04.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.02/15.06.04.02-001.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.02/15.06.04.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.02/15.06.04.02-002.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.02/15.06.04.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.02/15.06.04.02-003.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.02/15.06.04.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.03/15.06.04.03-001.js
+++ b/tests/jerry-test-suite/15/15.06/15.06.04/15.06.04.03/15.06.04.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-007.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-008.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-009.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-010.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.01/15.07.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-007.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-008.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-009.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-010.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-011.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.02/15.07.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-007.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-008.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-009.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-010.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-011.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.01/15.07.03.01-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.02/15.07.03.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.03/15.07.03.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.04/15.07.03.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-007.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.05/15.07.03.05-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-007.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.03/15.07.03.06/15.07.03.06-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.01/15.07.04.01-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.01/15.07.04.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.01/15.07.04.01-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.01/15.07.04.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-008.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-009.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-010.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-011.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-012.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-013.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.02/15.07.04.02-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-001.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-002.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-003.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-004.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-005.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-006.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-007.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-008.js
+++ b/tests/jerry-test-suite/15/15.07/15.07.04/15.07.04.05/15.07.04.05-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.01/15.08.02.01-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.02/15.08.02.02-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-009.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.03/15.08.02.03-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-009.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.04/15.08.02.04-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-009.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-010.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-011.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-012.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-013.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-014.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-015.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-016.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-017.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-018.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-019.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-020.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-021.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-022.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-023.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-024.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-025.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-026.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-027.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-028.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-029.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.05/15.08.02.05-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-009.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-010.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-011.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-012.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.06/15.08.02.06-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.07/15.08.02.07-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.08/15.08.02.08-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.09/15.08.02.09-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.10/15.08.02.10-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-009.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-010.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-011.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-012.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-013.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-014.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.11/15.08.02.11-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-009.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-010.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-011.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-012.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-013.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-014.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.12/15.08.02.12-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-008.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-008.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-009.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-009.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-010.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-010.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-011.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-011.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-012.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-012.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-013.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-013.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-014.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-014.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-015.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-015.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-016.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-016.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-017.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-017.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-018.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-018.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-019.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-019.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-020.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-020.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-021.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-021.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-022.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-022.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-023.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-023.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-024.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-024.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-025.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-025.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-026.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-026.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-027.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-027.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-028.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-028.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-029.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-029.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-030.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-030.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-031.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.13/15.08.02.13-031.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.15/15.08.02.15-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.16/15.08.02.16-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.17/15.08.02.17-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-001.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-001.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-002.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-002.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-003.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-003.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-004.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-004.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-005.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-005.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-006.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-006.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-007.js
+++ b/tests/jerry-test-suite/15/15.08/15.08.02/15.08.02.18/15.08.02.18-007.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/N.compact-profile-error.js
+++ b/tests/jerry/N.compact-profile-error.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/and-or.js
+++ b/tests/jerry/and-or.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/arguments.js
+++ b/tests/jerry/arguments.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/arithmetics-2.js
+++ b/tests/jerry/arithmetics-2.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/arithmetics-bignums.js
+++ b/tests/jerry/arithmetics-bignums.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2016 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/arithmetics.js
+++ b/tests/jerry/arithmetics.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-concat.js
+++ b/tests/jerry/array-prototype-concat.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-every.js
+++ b/tests/jerry/array-prototype-every.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-filter.js
+++ b/tests/jerry/array-prototype-filter.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-foreach.js
+++ b/tests/jerry/array-prototype-foreach.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-indexof.js
+++ b/tests/jerry/array-prototype-indexof.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-join.js
+++ b/tests/jerry/array-prototype-join.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-lastindexof.js
+++ b/tests/jerry/array-prototype-lastindexof.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-map.js
+++ b/tests/jerry/array-prototype-map.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-pop.js
+++ b/tests/jerry/array-prototype-pop.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-push.js
+++ b/tests/jerry/array-prototype-push.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-reduce-right.js
+++ b/tests/jerry/array-prototype-reduce-right.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-reduce.js
+++ b/tests/jerry/array-prototype-reduce.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-reverse.js
+++ b/tests/jerry/array-prototype-reverse.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-shift.js
+++ b/tests/jerry/array-prototype-shift.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-slice.js
+++ b/tests/jerry/array-prototype-slice.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-some.js
+++ b/tests/jerry/array-prototype-some.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-sort.js
+++ b/tests/jerry/array-prototype-sort.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-splice.js
+++ b/tests/jerry/array-prototype-splice.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-tolocalestring.js
+++ b/tests/jerry/array-prototype-tolocalestring.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-tostring.js
+++ b/tests/jerry/array-prototype-tostring.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array-prototype-unshift.js
+++ b/tests/jerry/array-prototype-unshift.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/array.js
+++ b/tests/jerry/array.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/assignments.js
+++ b/tests/jerry/assignments.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/bitwise-logic.js
+++ b/tests/jerry/bitwise-logic.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/break-continue-nested-to-try-with-blocks.js
+++ b/tests/jerry/break-continue-nested-to-try-with-blocks.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/builtin-constructor-class.js
+++ b/tests/jerry/builtin-constructor-class.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/date-annexb.js
+++ b/tests/jerry/date-annexb.js
@@ -1,5 +1,4 @@
-// Copyright 2015-2016 Samsung Electronics Co., Ltd.
-// Copyright 2015-2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/date-construct.js
+++ b/tests/jerry/date-construct.js
@@ -1,5 +1,4 @@
-// Copyright 2015-2016 Samsung Electronics Co., Ltd.
-// Copyright 2015-2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/date-getters.js
+++ b/tests/jerry/date-getters.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/date-parse.js
+++ b/tests/jerry/date-parse.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/date-setters.js
+++ b/tests/jerry/date-setters.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/date-tostring.js
+++ b/tests/jerry/date-tostring.js
@@ -1,5 +1,4 @@
-// Copyright 2015-2016 Samsung Electronics Co., Ltd.
-// Copyright 2015-2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/date-utc.js
+++ b/tests/jerry/date-utc.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/delete.js
+++ b/tests/jerry/delete.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/empty-varg.js
+++ b/tests/jerry/empty-varg.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/equality.js
+++ b/tests/jerry/equality.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/error.js
+++ b/tests/jerry/error.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/escape-sequences.js
+++ b/tests/jerry/escape-sequences.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/eval.js
+++ b/tests/jerry/eval.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/arguments-assignment-strict.js
+++ b/tests/jerry/fail/1/arguments-assignment-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/arguments-catch-strict.js
+++ b/tests/jerry/fail/1/arguments-catch-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/arguments-in-prop-set-param-list-strict.js
+++ b/tests/jerry/fail/1/arguments-in-prop-set-param-list-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/arguments-in-var-decl-strict.js
+++ b/tests/jerry/fail/1/arguments-in-var-decl-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/arguments-param-strict.js
+++ b/tests/jerry/fail/1/arguments-param-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/arguments-postfix-strict.js
+++ b/tests/jerry/fail/1/arguments-postfix-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/arguments-prefix-strict.js
+++ b/tests/jerry/fail/1/arguments-prefix-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/delete-strict.js
+++ b/tests/jerry/fail/1/delete-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/escape-sequences-invalid-hex.js
+++ b/tests/jerry/fail/1/escape-sequences-invalid-hex.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/escape-sequences-invalid-unicode.js
+++ b/tests/jerry/fail/1/escape-sequences-invalid-unicode.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/escape-sequences-invalid-variable.js
+++ b/tests/jerry/fail/1/escape-sequences-invalid-variable.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/eval-assignment-strict.js
+++ b/tests/jerry/fail/1/eval-assignment-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/eval-catch-strict.js
+++ b/tests/jerry/fail/1/eval-catch-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/eval-in-prop-set-param-list-strict.js
+++ b/tests/jerry/fail/1/eval-in-prop-set-param-list-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/eval-in-var-decl-strict.js
+++ b/tests/jerry/fail/1/eval-in-var-decl-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/eval-param-strict.js
+++ b/tests/jerry/fail/1/eval-param-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/eval-postfix-strict.js
+++ b/tests/jerry/fail/1/eval-postfix-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/eval-prefix-strict.js
+++ b/tests/jerry/fail/1/eval-prefix-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/func-expr-strict.js
+++ b/tests/jerry/fail/1/func-expr-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/labelled-statements-break-across-function.js
+++ b/tests/jerry/fail/1/labelled-statements-break-across-function.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/labelled-statements-duplicate-label.js
+++ b/tests/jerry/fail/1/labelled-statements-duplicate-label.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/labelled-statements-no-label.js
+++ b/tests/jerry/fail/1/labelled-statements-no-label.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/let-strict.js
+++ b/tests/jerry/fail/1/let-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/object-get-data.js
+++ b/tests/jerry/fail/1/object-get-data.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/object-get-get.js
+++ b/tests/jerry/fail/1/object-get-get.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/object-several-prop-names-strict.js
+++ b/tests/jerry/fail/1/object-several-prop-names-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/octal-strict.js
+++ b/tests/jerry/fail/1/octal-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/param-duplication-strict.js
+++ b/tests/jerry/fail/1/param-duplication-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/regression-test-issue-358.js
+++ b/tests/jerry/fail/1/regression-test-issue-358.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/regression-test-issue-384.js
+++ b/tests/jerry/fail/1/regression-test-issue-384.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/throw-error-object.js
+++ b/tests/jerry/fail/1/throw-error-object.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/throw-number.js
+++ b/tests/jerry/fail/1/throw-number.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/throw-string.js
+++ b/tests/jerry/fail/1/throw-string.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/fail/1/with-strict.js
+++ b/tests/jerry/fail/1/with-strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/for-in.js
+++ b/tests/jerry/for-in.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/for.js
+++ b/tests/jerry/for.js
@@ -1,5 +1,4 @@
-// Copyright 2014-2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/func-decl.js
+++ b/tests/jerry/func-decl.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function-args.js
+++ b/tests/jerry/function-args.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function-construct.js
+++ b/tests/jerry/function-construct.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function-prototype-apply.js
+++ b/tests/jerry/function-prototype-apply.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function-prototype-bind.js
+++ b/tests/jerry/function-prototype-bind.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function-prototype-tostring.js
+++ b/tests/jerry/function-prototype-tostring.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function-return.js
+++ b/tests/jerry/function-return.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function-scopes.js
+++ b/tests/jerry/function-scopes.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function.js
+++ b/tests/jerry/function.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/function.prototype.js
+++ b/tests/jerry/function.prototype.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/gc.js
+++ b/tests/jerry/gc.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/get-value.js
+++ b/tests/jerry/get-value.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/getter-setter-this-value.js
+++ b/tests/jerry/getter-setter-this-value.js
@@ -1,4 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/global-escaping.js
+++ b/tests/jerry/global-escaping.js
@@ -1,5 +1,4 @@
-// Copyright 2015 University of Szeged
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/global-parsefloat.js
+++ b/tests/jerry/global-parsefloat.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/global-parseint.js
+++ b/tests/jerry/global-parseint.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/global-uri-coding.js
+++ b/tests/jerry/global-uri-coding.js
@@ -1,5 +1,4 @@
-// Copyright 2015 University of Szeged
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/global.js
+++ b/tests/jerry/global.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/hash.js
+++ b/tests/jerry/hash.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/if-else.js
+++ b/tests/jerry/if-else.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/insert-semicolon.js
+++ b/tests/jerry/insert-semicolon.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/json-parse.js
+++ b/tests/jerry/json-parse.js
@@ -1,5 +1,4 @@
-// Copyright 2015 University of Szeged
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/json-stringify.js
+++ b/tests/jerry/json-stringify.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/labelled-statements.js
+++ b/tests/jerry/labelled-statements.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/logical.js
+++ b/tests/jerry/logical.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-abs.js
+++ b/tests/jerry/math-abs.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-exp.js
+++ b/tests/jerry/math-exp.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-log.js
+++ b/tests/jerry/math-log.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-max.js
+++ b/tests/jerry/math-max.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-min.js
+++ b/tests/jerry/math-min.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-pow.js
+++ b/tests/jerry/math-pow.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-round.js
+++ b/tests/jerry/math-round.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/math-trig.js
+++ b/tests/jerry/math-trig.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/nested-function.js
+++ b/tests/jerry/nested-function.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/new-line-in-literal.js
+++ b/tests/jerry/new-line-in-literal.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/number-prototype-to-exponential.js
+++ b/tests/jerry/number-prototype-to-exponential.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/number-prototype-to-fixed.js
+++ b/tests/jerry/number-prototype-to-fixed.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/number-prototype-to-precision.js
+++ b/tests/jerry/number-prototype-to-precision.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/number-prototype-to-string.js
+++ b/tests/jerry/number-prototype-to-string.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-create.js
+++ b/tests/jerry/object-create.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-define-properties.js
+++ b/tests/jerry/object-define-properties.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-defineproperty.js
+++ b/tests/jerry/object-defineproperty.js
@@ -1,5 +1,4 @@
-// Copyright 2015-2016 Samsung Electronics Co., Ltd.
-// Copyright 2015-2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-get-own-property-descriptor.js
+++ b/tests/jerry/object-get-own-property-descriptor.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-get-own-property-names.js
+++ b/tests/jerry/object-get-own-property-names.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-getprototypeof.js
+++ b/tests/jerry/object-getprototypeof.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-is-extensible.js
+++ b/tests/jerry/object-is-extensible.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-keys.js
+++ b/tests/jerry/object-keys.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-literal-2.js
+++ b/tests/jerry/object-literal-2.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-literal-3.js
+++ b/tests/jerry/object-literal-3.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-literal.js
+++ b/tests/jerry/object-literal.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-prototype-hasownproperty.js
+++ b/tests/jerry/object-prototype-hasownproperty.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-prototype-isprototypeof.js
+++ b/tests/jerry/object-prototype-isprototypeof.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-prototype-propertyisenumerable.js
+++ b/tests/jerry/object-prototype-propertyisenumerable.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object-prototype-tolocalestring.js
+++ b/tests/jerry/object-prototype-tolocalestring.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object_freeze.js
+++ b/tests/jerry/object_freeze.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/object_seal.js
+++ b/tests/jerry/object_seal.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/octal.js
+++ b/tests/jerry/octal.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/parser-oom.js
+++ b/tests/jerry/parser-oom.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-alternatives.js
+++ b/tests/jerry/regexp-alternatives.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-assertions.js
+++ b/tests/jerry/regexp-assertions.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-backreference.js
+++ b/tests/jerry/regexp-backreference.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-capture-groups.js
+++ b/tests/jerry/regexp-capture-groups.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-character-class.js
+++ b/tests/jerry/regexp-character-class.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-construct.js
+++ b/tests/jerry/regexp-construct.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-literal.js
+++ b/tests/jerry/regexp-literal.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-non-capture-groups.js
+++ b/tests/jerry/regexp-non-capture-groups.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-routines.js
+++ b/tests/jerry/regexp-routines.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regexp-simple-atom-and-iterations.js
+++ b/tests/jerry/regexp-simple-atom-and-iterations.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1054.js
+++ b/tests/jerry/regression-test-issue-1054.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1065.js
+++ b/tests/jerry/regression-test-issue-1065.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1071.js
+++ b/tests/jerry/regression-test-issue-1071.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1072.js
+++ b/tests/jerry/regression-test-issue-1072.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1073.js
+++ b/tests/jerry/regression-test-issue-1073.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1074.js
+++ b/tests/jerry/regression-test-issue-1074.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1075.js
+++ b/tests/jerry/regression-test-issue-1075.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1076.js
+++ b/tests/jerry/regression-test-issue-1076.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1078.js
+++ b/tests/jerry/regression-test-issue-1078.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1079.js
+++ b/tests/jerry/regression-test-issue-1079.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1080.js
+++ b/tests/jerry/regression-test-issue-1080.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1081.js
+++ b/tests/jerry/regression-test-issue-1081.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1082.js
+++ b/tests/jerry/regression-test-issue-1082.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1083.js
+++ b/tests/jerry/regression-test-issue-1083.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-112.js
+++ b/tests/jerry/regression-test-issue-112.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-113.js
+++ b/tests/jerry/regression-test-issue-113.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-114.js
+++ b/tests/jerry/regression-test-issue-114.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-115.js
+++ b/tests/jerry/regression-test-issue-115.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-116.js
+++ b/tests/jerry/regression-test-issue-116.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-117.js
+++ b/tests/jerry/regression-test-issue-117.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-121.js
+++ b/tests/jerry/regression-test-issue-121.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-122.js
+++ b/tests/jerry/regression-test-issue-122.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-123.js
+++ b/tests/jerry/regression-test-issue-123.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-128.js
+++ b/tests/jerry/regression-test-issue-128.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1282.js
+++ b/tests/jerry/regression-test-issue-1282.js
@@ -1,4 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1284.js
+++ b/tests/jerry/regression-test-issue-1284.js
@@ -1,4 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1286.js
+++ b/tests/jerry/regression-test-issue-1286.js
@@ -1,4 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-129.js
+++ b/tests/jerry/regression-test-issue-129.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1292.js
+++ b/tests/jerry/regression-test-issue-1292.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-130.js
+++ b/tests/jerry/regression-test-issue-130.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1300.js
+++ b/tests/jerry/regression-test-issue-1300.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1309.js
+++ b/tests/jerry/regression-test-issue-1309.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-132.js
+++ b/tests/jerry/regression-test-issue-132.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1386.js
+++ b/tests/jerry/regression-test-issue-1386.js
@@ -1,4 +1,4 @@
-// Copyright 2016 Hayun Lee (lhy920806@gmail.com)
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1387.js
+++ b/tests/jerry/regression-test-issue-1387.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-1389.js
+++ b/tests/jerry/regression-test-issue-1389.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-156.js
+++ b/tests/jerry/regression-test-issue-156.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-164.js
+++ b/tests/jerry/regression-test-issue-164.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-195.js
+++ b/tests/jerry/regression-test-issue-195.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-212.js
+++ b/tests/jerry/regression-test-issue-212.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-245.js
+++ b/tests/jerry/regression-test-issue-245.js
@@ -1,5 +1,4 @@
-// Copyright 2015-2016 Samsung Electronics Co., Ltd.
-// Copyright 2015-2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-255.js
+++ b/tests/jerry/regression-test-issue-255.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-257.js
+++ b/tests/jerry/regression-test-issue-257.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-260.js
+++ b/tests/jerry/regression-test-issue-260.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-261.js
+++ b/tests/jerry/regression-test-issue-261.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-262.js
+++ b/tests/jerry/regression-test-issue-262.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-263.js
+++ b/tests/jerry/regression-test-issue-263.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-264.js
+++ b/tests/jerry/regression-test-issue-264.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-265.js
+++ b/tests/jerry/regression-test-issue-265.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-266.js
+++ b/tests/jerry/regression-test-issue-266.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-267.js
+++ b/tests/jerry/regression-test-issue-267.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-274.js
+++ b/tests/jerry/regression-test-issue-274.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-276.js
+++ b/tests/jerry/regression-test-issue-276.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-279.js
+++ b/tests/jerry/regression-test-issue-279.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-280.js
+++ b/tests/jerry/regression-test-issue-280.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-281.js
+++ b/tests/jerry/regression-test-issue-281.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-285.js
+++ b/tests/jerry/regression-test-issue-285.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-312.js
+++ b/tests/jerry/regression-test-issue-312.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-316.js
+++ b/tests/jerry/regression-test-issue-316.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-339.js
+++ b/tests/jerry/regression-test-issue-339.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-340.js
+++ b/tests/jerry/regression-test-issue-340.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-341.js
+++ b/tests/jerry/regression-test-issue-341.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-354.js
+++ b/tests/jerry/regression-test-issue-354.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-359.js
+++ b/tests/jerry/regression-test-issue-359.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-380.js
+++ b/tests/jerry/regression-test-issue-380.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-381.js
+++ b/tests/jerry/regression-test-issue-381.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-429.js
+++ b/tests/jerry/regression-test-issue-429.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-440.js
+++ b/tests/jerry/regression-test-issue-440.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-447.js
+++ b/tests/jerry/regression-test-issue-447.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-453.js
+++ b/tests/jerry/regression-test-issue-453.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-541.js
+++ b/tests/jerry/regression-test-issue-541.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-563.js
+++ b/tests/jerry/regression-test-issue-563.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-566.js
+++ b/tests/jerry/regression-test-issue-566.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-612.js
+++ b/tests/jerry/regression-test-issue-612.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-613.js
+++ b/tests/jerry/regression-test-issue-613.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-614.js
+++ b/tests/jerry/regression-test-issue-614.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-639.js
+++ b/tests/jerry/regression-test-issue-639.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-640.js
+++ b/tests/jerry/regression-test-issue-640.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-641.js
+++ b/tests/jerry/regression-test-issue-641.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-642.js
+++ b/tests/jerry/regression-test-issue-642.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-644.js
+++ b/tests/jerry/regression-test-issue-644.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-646.js
+++ b/tests/jerry/regression-test-issue-646.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-652.js
+++ b/tests/jerry/regression-test-issue-652.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-653.js
+++ b/tests/jerry/regression-test-issue-653.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-654.js
+++ b/tests/jerry/regression-test-issue-654.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-655.js
+++ b/tests/jerry/regression-test-issue-655.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-667.js
+++ b/tests/jerry/regression-test-issue-667.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-669.js
+++ b/tests/jerry/regression-test-issue-669.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-680.js
+++ b/tests/jerry/regression-test-issue-680.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-686.js
+++ b/tests/jerry/regression-test-issue-686.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-689.js
+++ b/tests/jerry/regression-test-issue-689.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-703.js
+++ b/tests/jerry/regression-test-issue-703.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-725.js
+++ b/tests/jerry/regression-test-issue-725.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-736.js
+++ b/tests/jerry/regression-test-issue-736.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-737.js
+++ b/tests/jerry/regression-test-issue-737.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-738.js
+++ b/tests/jerry/regression-test-issue-738.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-739.js
+++ b/tests/jerry/regression-test-issue-739.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-741.js
+++ b/tests/jerry/regression-test-issue-741.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-743.js
+++ b/tests/jerry/regression-test-issue-743.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-745.js
+++ b/tests/jerry/regression-test-issue-745.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-747.js
+++ b/tests/jerry/regression-test-issue-747.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-781.js
+++ b/tests/jerry/regression-test-issue-781.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-782.js
+++ b/tests/jerry/regression-test-issue-782.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-783.js
+++ b/tests/jerry/regression-test-issue-783.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-785.js
+++ b/tests/jerry/regression-test-issue-785.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-786.js
+++ b/tests/jerry/regression-test-issue-786.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-787.js
+++ b/tests/jerry/regression-test-issue-787.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-798.js
+++ b/tests/jerry/regression-test-issue-798.js
@@ -1,4 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issue-962.js
+++ b/tests/jerry/regression-test-issue-962.js
@@ -1,5 +1,4 @@
-// Copyright 2016 Samsung Electronics Co., Ltd.
-// Copyright 2016 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/regression-test-issues-43-183.js
+++ b/tests/jerry/regression-test-issues-43-183.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/relational.js
+++ b/tests/jerry/relational.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/shift.js
+++ b/tests/jerry/shift.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/sqrt.js
+++ b/tests/jerry/sqrt.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/strict.js
+++ b/tests/jerry/strict.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-charat.js
+++ b/tests/jerry/string-prototype-charat.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-charcodeat.js
+++ b/tests/jerry/string-prototype-charcodeat.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-concat.js
+++ b/tests/jerry/string-prototype-concat.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-indexof.js
+++ b/tests/jerry/string-prototype-indexof.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-lastindexof.js
+++ b/tests/jerry/string-prototype-lastindexof.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-localecompare.js
+++ b/tests/jerry/string-prototype-localecompare.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-match.js
+++ b/tests/jerry/string-prototype-match.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-replace.js
+++ b/tests/jerry/string-prototype-replace.js
@@ -1,5 +1,4 @@
-// Copyright 2015 University of Szeged
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-search.js
+++ b/tests/jerry/string-prototype-search.js
@@ -1,5 +1,4 @@
-// Copyright 2015 University of Szeged
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-slice.js
+++ b/tests/jerry/string-prototype-slice.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-split.js
+++ b/tests/jerry/string-prototype-split.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-substr.js
+++ b/tests/jerry/string-prototype-substr.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-substring.js
+++ b/tests/jerry/string-prototype-substring.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype-trim.js
+++ b/tests/jerry/string-prototype-trim.js
@@ -1,5 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
-// Copyright 2015 University of Szeged.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-prototype.js
+++ b/tests/jerry/string-prototype.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-surrogates-concat.js
+++ b/tests/jerry/string-surrogates-concat.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string-upper-lower-case-conversion.js
+++ b/tests/jerry/string-upper-lower-case-conversion.js
@@ -1,5 +1,4 @@
-// Copyright 2015 University of Szeged
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/string.js
+++ b/tests/jerry/string.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/switch-case.js
+++ b/tests/jerry/switch-case.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/test-new-string.js
+++ b/tests/jerry/test-new-string.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/this-arg.js
+++ b/tests/jerry/this-arg.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/try-catch-finally.js
+++ b/tests/jerry/try-catch-finally.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/typeof.js
+++ b/tests/jerry/typeof.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/unary-plus-minus.js
+++ b/tests/jerry/unary-plus-minus.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/var-decl.js
+++ b/tests/jerry/var-decl.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/variables.js
+++ b/tests/jerry/variables.js
@@ -1,4 +1,4 @@
-// Copyright 2014 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/jerry/zero-character.js
+++ b/tests/jerry/zero-character.js
@@ -1,4 +1,4 @@
-// Copyright 2015 Samsung Electronics Co., Ltd.
+// Copyright JS Foundation and other contributors, http://js.foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-common.h
+++ b/tests/unit/test-common.h
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-date-helpers.c
+++ b/tests/unit/test-date-helpers.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2015-2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-heap.c
+++ b/tests/unit/test-heap.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-libm.c
+++ b/tests/unit/test-libm.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-libm.inc.h
+++ b/tests/unit/test-libm.inc.h
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-lit-char-helpers.c
+++ b/tests/unit/test-lit-char-helpers.c
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-literal-storage.c
+++ b/tests/unit/test-literal-storage.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-longjmp.c
+++ b/tests/unit/test-longjmp.c
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-number-to-integer.c
+++ b/tests/unit/test-number-to-integer.c
@@ -1,4 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-number-to-string.c
+++ b/tests/unit/test-number-to-string.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-poolman.c
+++ b/tests/unit/test-poolman.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-string-to-number.c
+++ b/tests/unit/test-string-to-number.c
@@ -1,5 +1,4 @@
-/* Copyright 2014-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/test-strings.c
+++ b/tests/unit/test-strings.c
@@ -1,5 +1,4 @@
-/* Copyright 2015-2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/apt-get-install-qemu-arm.sh
+++ b/tools/apt-get-install-qemu-arm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/brew-install-deps.sh
+++ b/tools/brew-install-deps.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/check-cppcheck.sh
+++ b/tools/check-cppcheck.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/check-license.py
+++ b/tools/check-license.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/check-signed-off.sh
+++ b/tools/check-signed-off.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/check-vera.sh
+++ b/tools/check-vera.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/gen-test-libm.sh
+++ b/tools/gen-test-libm.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/generator.sh
+++ b/tools/generator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014-2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/make-log-perf-compare.sh
+++ b/tools/make-log-perf-compare.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/mem-stats-measure.sh
+++ b/tools/mem-stats-measure.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/perf.sh
+++ b/tools/perf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014-2016 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/print-unicode-ranges.sh
+++ b/tools/print-unicode-ranges.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/rss-measure.sh
+++ b/tools/rss-measure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014-2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/run-mem-stats-test.sh
+++ b/tools/run-mem-stats-test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/run-perf-test.sh
+++ b/tools/run-perf-test.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/runners/run-benchmarks.sh
+++ b/tools/runners/run-benchmarks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014-2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/runners/run-stability-test.sh
+++ b/tools/runners/run-stability-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014-2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/runners/run-test-suite-test262.sh
+++ b/tools/runners/run-test-suite-test262.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/runners/run-test-suite.sh
+++ b/tools/runners/run-test-suite.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/runners/run-tests-remote.sh
+++ b/tools/runners/run-tests-remote.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/runners/run-unittests-remote.sh
+++ b/tools/runners/run-unittests-remote.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/runners/run-unittests.sh
+++ b/tools/runners/run-unittests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/sort-fails.sh
+++ b/tools/sort-fails.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/unit-tests/Makefile
+++ b/tools/unit-tests/Makefile
@@ -1,5 +1,4 @@
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/unit-tests/gen-test-libm.c
+++ b/tools/unit-tests/gen-test-libm.c
@@ -1,5 +1,4 @@
-/* Copyright 2016 Samsung Electronics Co., Ltd.
- * Copyright 2016 University of Szeged.
+/* Copyright JS Foundation and other contributors, http://js.foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +32,7 @@
 int
 main (int argc, char **args)
 {
-  printf ("/* Copyright 2016 Samsung Electronics Co., Ltd.\n"
-          " * Copyright 2016 University of Szeged.\n"
+  printf ("/* Copyright JS Foundation and other contributors, http://js.foundation
           " *\n"
           " * Licensed under the Apache License, Version 2.0 (the \"License\");\n"
           " * you may not use this file except in compliance with the License.\n"

--- a/tools/update-webpage.sh
+++ b/tools/update-webpage.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_always_curly.tcl
+++ b/tools/vera++/scripts/rules/jerry_always_curly.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_braces_on_separate_line.tcl
+++ b/tools/vera++/scripts/rules/jerry_braces_on_separate_line.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_braces_same_line_or_column.tcl
+++ b/tools/vera++/scripts/rules/jerry_braces_same_line_or_column.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_comment_function_end.tcl
+++ b/tools/vera++/scripts/rules/jerry_comment_function_end.tcl
@@ -1,7 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_funcname_space_parentheses.tcl
+++ b/tools/vera++/scripts/rules/jerry_funcname_space_parentheses.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_identifier_no_space_bracket.tcl
+++ b/tools/vera++/scripts/rules/jerry_identifier_no_space_bracket.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_indentation.tcl
+++ b/tools/vera++/scripts/rules/jerry_indentation.tcl
@@ -1,7 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2014-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_max_line_length.tcl
+++ b/tools/vera++/scripts/rules/jerry_max_line_length.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_no_space_after_opening_parentheses.tcl
+++ b/tools/vera++/scripts/rules/jerry_no_space_after_opening_parentheses.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_no_space_before_closing_parentheses.tcl
+++ b/tools/vera++/scripts/rules/jerry_no_space_before_closing_parentheses.tcl
@@ -1,7 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015-2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_no_tabs.tcl
+++ b/tools/vera++/scripts/rules/jerry_no_tabs.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_no_trailing_spaces.tcl
+++ b/tools/vera++/scripts/rules/jerry_no_trailing_spaces.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_pointer_declarator_space.tcl
+++ b/tools/vera++/scripts/rules/jerry_pointer_declarator_space.tcl
@@ -1,7 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_switch_case.tcl
+++ b/tools/vera++/scripts/rules/jerry_switch_case.tcl
@@ -1,6 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2014-2015 Samsung Electronics Co., Ltd.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/vera++/scripts/rules/jerry_typecast_space_parentheses.tcl
+++ b/tools/vera++/scripts/rules/jerry_typecast_space_parentheses.tcl
@@ -1,7 +1,6 @@
 #!/usr/bin/tclsh
 
-# Copyright 2016 Samsung Electronics Co., Ltd.
-# Copyright 2016 University of Szeged.
+# Copyright JS Foundation and other contributors, http://js.foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Since the project is now hosted at the JS Foundation we can move to unified copyright notices for the project.

Starting with this commit all future contributions to the project should only carry the following copyright notice (except for third-party code which requires copyright information to be preserved):

"Copyright JS Foundation and other contributors, http://js.foundation" (without the quotes)

This avoids cluttering the codebase with contributor-specific copyright notices which have a higher maintenance overhead and tend to get outdated quickly. Also dropping the year from the copyright notices helps to avoid yearly code changes just to update the copyright notices.

Note that each contributor still retains full copyright ownership of his/her contributions and the respective authorship is tracked very accurately via Git.

JerryScript-DCO-1.0-Signed-off-by: Tilmann Scheller t.scheller@samsung.com