### PR TITLE
Add feature to remove parser.

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -21,6 +21,7 @@ set(FEATURE_CPOINTER_32_BIT OFF    CACHE BOOL   "Enable 32 bit compressed pointe
 set(FEATURE_ERROR_MESSAGES  OFF    CACHE BOOL   "Enable error messages?")
 set(FEATURE_MEM_STATS       OFF    CACHE BOOL   "Enable memory statistics?")
 set(FEATURE_MEM_STRESS_TEST OFF    CACHE BOOL   "Enable mem-stress test?")
+set(FEATURE_PARSER_DISABLE  OFF    CACHE BOOL   "Disable the parser and 'eval' and use only snapshots?")
 set(FEATURE_PARSER_DUMP     OFF    CACHE BOOL   "Enable parser byte-code dumps?")
 set(FEATURE_PROFILE         "es5.1" CACHE STRING "Profile types: es5.1, minimal, es2015-subset")
 set(FEATURE_REGEXP_DUMP     OFF    CACHE BOOL   "Enable regexp byte-code dumps?")
@@ -35,6 +36,7 @@ message(STATUS "FEATURE_CPOINTER_32_BIT   " ${FEATURE_CPOINTER_32_BIT})
 message(STATUS "FEATURE_ERROR_MESSAGES    " ${FEATURE_ERROR_MESSAGES})
 message(STATUS "FEATURE_MEM_STATS         " ${FEATURE_MEM_STATS})
 message(STATUS "FEATURE_MEM_STRESS_TEST   " ${FEATURE_MEM_STRESS_TEST})
+message(STATUS "FEATURE_PARSER_DISABLE    " ${FEATURE_PARSER_DISABLE})
 message(STATUS "FEATURE_PARSER_DUMP       " ${FEATURE_PARSER_DUMP})
 message(STATUS "FEATURE_PROFILE           " ${FEATURE_PROFILE})
 message(STATUS "FEATURE_REGEXP_DUMP       " ${FEATURE_REGEXP_DUMP})
@@ -140,6 +142,15 @@ endif()
 # Memory management stress-test mode
 if(FEATURE_MEM_STRESS_TEST)
   set(DEFINES_JERRY ${DEFINES_JERRY} JMEM_GC_BEFORE_EACH_ALLOC)
+endif()
+
+# Disable parser and enable snapshots
+if(FEATURE_PARSER_DISABLE)
+  set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_DISABLE_PARSER)
+  if(NOT FEATURE_SNAPSHOT_EXEC MATCHES ON)
+    set(FEATURE_SNAPSHOT_EXEC ON)
+	message(STATUS "Parser has been disabled, snapshot is now on")
+  endif()
 endif()
 
 # Parser byte-code dumps

--- a/jerry-core/parser/js/byte-code.c
+++ b/jerry-core/parser/js/byte-code.c
@@ -15,6 +15,8 @@
 
 #include "js-parser-internal.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -75,3 +77,5 @@ const char * const cbc_ext_names[] =
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/common.c
+++ b/jerry-core/parser/js/common.c
@@ -16,6 +16,8 @@
 #include "common.h"
 #include "ecma-helpers.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -133,3 +135,5 @@ util_print_literal (lexer_literal_t *literal_p) /**< literal */
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -20,6 +20,8 @@
 #include "js-parser-internal.h"
 #include "lit-char-helpers.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -2137,3 +2139,5 @@ lexer_compare_identifier_to_current (parser_context_t *context_p,        /**< co
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -15,6 +15,8 @@
 
 #include "js-parser-internal.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -1528,3 +1530,5 @@ parser_parse_expression (parser_context_t *context_p, /**< context */
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/js-parser-mem.c
+++ b/jerry-core/parser/js/js-parser-mem.c
@@ -15,6 +15,8 @@
 
 #include "js-parser-internal.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup mem Memory allocation
  * @{
  *
@@ -675,3 +677,5 @@ parser_stack_iterator_write (parser_stack_iterator_t *iterator, /**< iterator */
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/js-parser-scanner.c
+++ b/jerry-core/parser/js/js-parser-scanner.c
@@ -15,6 +15,8 @@
 
 #include "js-parser-internal.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -675,3 +677,5 @@ parser_scan_until (parser_context_t *context_p, /**< context */
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -15,6 +15,8 @@
 
 #include "js-parser-internal.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -2143,3 +2145,5 @@ parser_free_jumps (parser_stack_iterator_t iterator) /**< iterator position */
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -15,6 +15,8 @@
 
 #include "js-parser-internal.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -937,3 +939,5 @@ parser_error_to_string (parser_error_t error) /**< error code */
  * @}
  * @}
  */
+
+#endif /* !JERRY_DISABLE_PARSER */

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -19,6 +19,8 @@
 #include "jcontext.h"
 #include "js-parser-internal.h"
 
+#ifndef JERRY_DISABLE_PARSER
+
 /** \addtogroup parser Parser
  * @{
  *
@@ -2228,6 +2230,8 @@ parser_raise_error (parser_context_t *context_p, /**< context */
 #define PARSE_ERR_POS_END         "]"
 #define PARSE_ERR_POS_END_SIZE    ((uint32_t) sizeof (PARSE_ERR_POS_END))
 
+#endif /* !JERRY_DISABLE_PARSER */
+
 /**
  * Parse EcamScript source code
  *
@@ -2243,6 +2247,7 @@ parser_parse_script (const uint8_t *source_p, /**< source code */
                      bool is_strict, /**< strict mode */
                      ecma_compiled_code_t **bytecode_data_p) /**< [out] JS bytecode */
 {
+#ifndef JERRY_DISABLE_PARSER
   parser_error_location_t parser_error;
   *bytecode_data_p = parser_parse_source (source_p, size, is_strict, &parser_error);
 
@@ -2305,8 +2310,15 @@ parser_parse_script (const uint8_t *source_p, /**< source code */
     return ecma_raise_syntax_error ("");
 #endif /* JERRY_ENABLE_ERROR_MESSAGES */
   }
-
   return ecma_make_simple_value (ECMA_SIMPLE_VALUE_TRUE);
+#else /* !JERRY_DISABLE_PARSER */
+  JERRY_UNUSED (source_p);
+  JERRY_UNUSED (size);
+  JERRY_UNUSED (is_strict);
+  JERRY_UNUSED (bytecode_data_p);
+
+  return ecma_raise_syntax_error (ECMA_ERR_MSG ("The parser has been disabled."));
+#endif /* JERRY_DISABLE_PARSER */
 } /* parser_parse_script */
 
 /**


### PR DESCRIPTION
Remove the parser so we can save space if we are only interested in running snapshots.
Removing the parser enables the snapshot execution.

JerryScript-DCO-1.0-Signed-off-by: Sergio Martinez sergio.martinez.rodriguez@intel.com