### PR TITLE
Add #if control around GCC builtin functions so that the code can be compiled using non-GCC compilers.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -343,7 +343,7 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg, /**< this argument 
         while (string_curr_p > start_p)
         {
           ecma_char_t current_char = *(--string_curr_p);
-          ecma_number_t current_number;
+          ecma_number_t current_number = ECMA_NUMBER_MINUS_ONE;
 
           if ((current_char >= LIT_CHAR_LOWERCASE_A && current_char <= LIT_CHAR_LOWERCASE_Z))
           {

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -43,8 +43,13 @@
 /*
  * Conditions' likeliness, unlikeliness.
  */
-#define likely(x) __builtin_expect (!!(x), 1)
-#define unlikely(x) __builtin_expect (!!(x) , 0)
+#ifdef __GNUC__
+#define likely(x)       __builtin_expect(!!(x), 1)
+#define unlikely(x)     __builtin_expect(!!(x), 0)
+#else /* !__GNUC__ */
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+#endif /* __GNUC__ */
 
 /*
  * Normally compilers store const(ant)s in ROM. Thus saving RAM.
@@ -108,7 +113,11 @@ void __noreturn jerry_unreachable (const char *file, const char *function, const
     } \
   } while (0)
 
+#ifdef __GNUC__
 #define JERRY_UNREACHABLE() __builtin_unreachable ()
+#else /* !__GNUC__ */
+#define JERRY_UNREACHABLE()
+#endif /* __GNUC__ */
 #endif /* !JERRY_NDEBUG */
 
 /**

--- a/jerry-libc/include/assert.h
+++ b/jerry-libc/include/assert.h
@@ -28,7 +28,7 @@ extern "C"
 #define assert(x) \
   do \
   { \
-    if (__builtin_expect (!(x), 0)) \
+    if (!(x)) \
     { \
       fprintf (stderr, "%s:%d: %s: Assertion `%s' failed.", __FILE__, __LINE__, __func__, #x); \
       abort (); \


### PR DESCRIPTION
The header says it all -- only some of the GCC builtin functions are protected by "#ifdef (__GNUC__)", and this change would protect the builtin functions in jrt.h and assert.h.