### PR TITLE
Remove the inline flag of ArrayBuffer helper functions

### DIFF
--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -103,7 +103,7 @@ ecma_arraybuffer_new_object (ecma_length_t length) /**< length of the arraybuffe
  *
  * @return ecma_length_t, the length of the arraybuffer
  */
-inline ecma_length_t __attr_pure___ __attr_always_inline___
+ecma_length_t __attr_pure___
 ecma_arraybuffer_get_length (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));
@@ -117,7 +117,7 @@ ecma_arraybuffer_get_length (ecma_object_t *object_p) /**< pointer to the ArrayB
  *
  * @return pointer to the data buffer
  */
-inline lit_utf8_byte_t * __attr_pure___ __attr_always_inline___
+lit_utf8_byte_t * __attr_pure___
 ecma_arraybuffer_get_buffer (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -34,9 +34,9 @@ ecma_op_create_arraybuffer_object (const ecma_value_t *, ecma_length_t);
 extern ecma_object_t *
 ecma_arraybuffer_new_object (ecma_length_t);
 extern lit_utf8_byte_t *
-ecma_arraybuffer_get_buffer (ecma_object_t *) __attr_pure___ __attr_always_inline___;
+ecma_arraybuffer_get_buffer (ecma_object_t *) __attr_pure___;
 extern ecma_length_t
-ecma_arraybuffer_get_length (ecma_object_t *) __attr_pure___ __attr_always_inline___;
+ecma_arraybuffer_get_length (ecma_object_t *) __attr_pure___;
 
 /**
  * @}


### PR DESCRIPTION
related issue #1468

Latest GCC compiler will report an error when the inline function definition is in a different source file
so we remove the inline flag

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com