### PR TITLE
target: mbedos5: Define JERRY_JS_PARSER macro

### DIFF
--- a/targets/mbedos5/mbed_app.json
+++ b/targets/mbedos5/mbed_app.json
@@ -3,5 +3,6 @@
         "NRF52_DK": {
             "target.uart_hwfc": 0
         }
-    }
+    },
+    "macros": ["JERRY_JS_PARSER"]
 }


### PR DESCRIPTION
Define JERRY_JS_PARSER macro, which is now required to be defined. Fixes build issues against mbedos5 target.

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com