### PR TITLE
Remove redundant extern keywords from function declarations/definitions.

### DIFF
--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -30,108 +30,108 @@
  *
  * @return pointer to allocated memory
  */
-extern ecma_object_t *ecma_alloc_object (void);
+ecma_object_t *ecma_alloc_object (void);
 
 /**
  * Dealloc memory from an ecma-object
  */
-extern void ecma_dealloc_object (ecma_object_t *);
+void ecma_dealloc_object (ecma_object_t *);
 
 /**
  * Allocate memory for ecma-number
  *
  * @return pointer to allocated memory
  */
-extern ecma_number_t *ecma_alloc_number (void);
+ecma_number_t *ecma_alloc_number (void);
 
 /**
  * Dealloc memory from an ecma-number
  */
-extern void ecma_dealloc_number (ecma_number_t *);
+void ecma_dealloc_number (ecma_number_t *);
 
 /**
  * Allocate memory for header of a collection
  *
  * @return pointer to allocated memory
  */
-extern ecma_collection_header_t *ecma_alloc_collection_header (void);
+ecma_collection_header_t *ecma_alloc_collection_header (void);
 
 /**
  * Dealloc memory from the collection's header
  */
-extern void ecma_dealloc_collection_header (ecma_collection_header_t *);
+void ecma_dealloc_collection_header (ecma_collection_header_t *);
 
 /**
  * Allocate memory for non-first chunk of a collection
  *
  * @return pointer to allocated memory
  */
-extern ecma_collection_chunk_t *ecma_alloc_collection_chunk (void);
+ecma_collection_chunk_t *ecma_alloc_collection_chunk (void);
 
 /**
  * Dealloc memory from non-first chunk of a collection
  */
-extern void ecma_dealloc_collection_chunk (ecma_collection_chunk_t *);
+void ecma_dealloc_collection_chunk (ecma_collection_chunk_t *);
 
 /**
  * Allocate memory for ecma-string descriptor
  *
  * @return pointer to allocated memory
  */
-extern ecma_string_t *ecma_alloc_string (void);
+ecma_string_t *ecma_alloc_string (void);
 
 /**
  * Dealloc memory from ecma-string descriptor
  */
-extern void ecma_dealloc_string (ecma_string_t *);
+void ecma_dealloc_string (ecma_string_t *);
 
 /**
  * Allocate memory for getter-setter pointer pair
  *
  * @return pointer to allocated memory
  */
-extern ecma_getter_setter_pointers_t *ecma_alloc_getter_setter_pointers (void);
+ecma_getter_setter_pointers_t *ecma_alloc_getter_setter_pointers (void);
 
 /**
  * Dealloc memory from getter-setter pointer pair
  */
-extern void ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *);
+void ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *);
 
 /**
 * Allocate memory for external pointer
 *
 * @return pointer to allocated memory
 */
-extern ecma_external_pointer_t *ecma_alloc_external_pointer (void);
+ecma_external_pointer_t *ecma_alloc_external_pointer (void);
 
 /**
 * Dealloc memory from external pointer
 */
-extern void ecma_dealloc_external_pointer (ecma_external_pointer_t *);
+void ecma_dealloc_external_pointer (ecma_external_pointer_t *);
 
 /*
  * Allocate memory for extended object
  *
  * @return pointer to allocated memory
  */
-extern ecma_extended_object_t *ecma_alloc_extended_object (size_t);
+ecma_extended_object_t *ecma_alloc_extended_object (size_t);
 
 /**
  * Dealloc memory of an extended object
  */
-extern void ecma_dealloc_extended_object (ecma_extended_object_t *, size_t);
+void ecma_dealloc_extended_object (ecma_extended_object_t *, size_t);
 
 /**
  * Allocate memory for ecma-property pair
  *
  * @return pointer to allocated memory
  */
-extern ecma_property_pair_t *ecma_alloc_property_pair (void);
+ecma_property_pair_t *ecma_alloc_property_pair (void);
 
 /**
  * Dealloc memory from an ecma-property pair
  */
-extern void ecma_dealloc_property_pair (ecma_property_pair_t *);
+void ecma_dealloc_property_pair (ecma_property_pair_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-gc.h
+++ b/jerry-core/ecma/base/ecma-gc.h
@@ -26,11 +26,11 @@
  * @{
  */
 
-extern void ecma_init_gc_info (ecma_object_t *);
-extern void ecma_ref_object (ecma_object_t *);
-extern void ecma_deref_object (ecma_object_t *);
-extern void ecma_gc_run (jmem_free_unused_memory_severity_t);
-extern void ecma_free_unused_memory (jmem_free_unused_memory_severity_t);
+void ecma_init_gc_info (ecma_object_t *);
+void ecma_ref_object (ecma_object_t *);
+void ecma_deref_object (ecma_object_t *);
+void ecma_gc_run (jmem_free_unused_memory_severity_t);
+void ecma_free_unused_memory (jmem_free_unused_memory_severity_t);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -111,132 +111,132 @@
   }
 
 /* ecma-helpers-value.c */
-extern bool ecma_is_value_direct (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_simple (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_empty (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_undefined (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_null (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_boolean (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_true (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_false (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_found (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_array_hole (ecma_value_t) __attr_pure___;
+bool ecma_is_value_direct (ecma_value_t) __attr_pure___;
+bool ecma_is_value_simple (ecma_value_t) __attr_pure___;
+bool ecma_is_value_empty (ecma_value_t) __attr_pure___;
+bool ecma_is_value_undefined (ecma_value_t) __attr_pure___;
+bool ecma_is_value_null (ecma_value_t) __attr_pure___;
+bool ecma_is_value_boolean (ecma_value_t) __attr_pure___;
+bool ecma_is_value_true (ecma_value_t) __attr_pure___;
+bool ecma_is_value_false (ecma_value_t) __attr_pure___;
+bool ecma_is_value_found (ecma_value_t) __attr_pure___;
+bool ecma_is_value_array_hole (ecma_value_t) __attr_pure___;
 
-extern bool ecma_is_value_integer_number (ecma_value_t) __attr_pure___;
-extern bool ecma_are_values_integer_numbers (ecma_value_t, ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_float_number (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_number (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_string (ecma_value_t) __attr_pure___;
-extern bool ecma_is_value_object (ecma_value_t) __attr_pure___;
+bool ecma_is_value_integer_number (ecma_value_t) __attr_pure___;
+bool ecma_are_values_integer_numbers (ecma_value_t, ecma_value_t) __attr_pure___;
+bool ecma_is_value_float_number (ecma_value_t) __attr_pure___;
+bool ecma_is_value_number (ecma_value_t) __attr_pure___;
+bool ecma_is_value_string (ecma_value_t) __attr_pure___;
+bool ecma_is_value_object (ecma_value_t) __attr_pure___;
 
-extern void ecma_check_value_type_is_spec_defined (ecma_value_t);
+void ecma_check_value_type_is_spec_defined (ecma_value_t);
 
-extern ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value) __attr_const___;
-extern ecma_value_t ecma_make_boolean_value (bool) __attr_const___;
-extern ecma_value_t ecma_make_integer_value (ecma_integer_value_t) __attr_const___;
-extern ecma_value_t ecma_make_nan_value (void);
-extern ecma_value_t ecma_make_number_value (ecma_number_t);
-extern ecma_value_t ecma_make_int32_value (int32_t);
-extern ecma_value_t ecma_make_uint32_value (uint32_t);
-extern ecma_value_t ecma_make_string_value (const ecma_string_t *);
-extern ecma_value_t ecma_make_object_value (const ecma_object_t *);
-extern ecma_value_t ecma_make_error_value (ecma_value_t);
-extern ecma_value_t ecma_make_error_obj_value (const ecma_object_t *);
-extern ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t) __attr_pure___;
-extern ecma_number_t ecma_get_float_from_value (ecma_value_t) __attr_pure___;
-extern ecma_number_t ecma_get_number_from_value (ecma_value_t) __attr_pure___;
-extern uint32_t ecma_get_uint32_from_value (ecma_value_t) __attr_pure___;
-extern ecma_string_t *ecma_get_string_from_value (ecma_value_t) __attr_pure___;
-extern ecma_object_t *ecma_get_object_from_value (ecma_value_t) __attr_pure___;
-extern ecma_value_t ecma_get_value_from_error_value (ecma_value_t) __attr_pure___;
-extern ecma_value_t ecma_invert_boolean_value (ecma_value_t) __attr_pure___;
-extern ecma_value_t ecma_copy_value (ecma_value_t);
-extern ecma_value_t ecma_fast_copy_value (ecma_value_t);
-extern ecma_value_t ecma_copy_value_if_not_object (ecma_value_t);
-extern ecma_value_t ecma_update_float_number (ecma_value_t, ecma_number_t);
-extern void ecma_value_assign_value (ecma_value_t *, ecma_value_t);
-extern void ecma_value_assign_number (ecma_value_t *, ecma_number_t);
-extern void ecma_value_assign_uint32 (ecma_value_t *, uint32_t);
-extern void ecma_free_value (ecma_value_t);
-extern void ecma_fast_free_value (ecma_value_t);
-extern void ecma_free_value_if_not_object (ecma_value_t);
+ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value) __attr_const___;
+ecma_value_t ecma_make_boolean_value (bool) __attr_const___;
+ecma_value_t ecma_make_integer_value (ecma_integer_value_t) __attr_const___;
+ecma_value_t ecma_make_nan_value (void);
+ecma_value_t ecma_make_number_value (ecma_number_t);
+ecma_value_t ecma_make_int32_value (int32_t);
+ecma_value_t ecma_make_uint32_value (uint32_t);
+ecma_value_t ecma_make_string_value (const ecma_string_t *);
+ecma_value_t ecma_make_object_value (const ecma_object_t *);
+ecma_value_t ecma_make_error_value (ecma_value_t);
+ecma_value_t ecma_make_error_obj_value (const ecma_object_t *);
+ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t) __attr_pure___;
+ecma_number_t ecma_get_float_from_value (ecma_value_t) __attr_pure___;
+ecma_number_t ecma_get_number_from_value (ecma_value_t) __attr_pure___;
+uint32_t ecma_get_uint32_from_value (ecma_value_t) __attr_pure___;
+ecma_string_t *ecma_get_string_from_value (ecma_value_t) __attr_pure___;
+ecma_object_t *ecma_get_object_from_value (ecma_value_t) __attr_pure___;
+ecma_value_t ecma_get_value_from_error_value (ecma_value_t) __attr_pure___;
+ecma_value_t ecma_invert_boolean_value (ecma_value_t) __attr_pure___;
+ecma_value_t ecma_copy_value (ecma_value_t);
+ecma_value_t ecma_fast_copy_value (ecma_value_t);
+ecma_value_t ecma_copy_value_if_not_object (ecma_value_t);
+ecma_value_t ecma_update_float_number (ecma_value_t, ecma_number_t);
+void ecma_value_assign_value (ecma_value_t *, ecma_value_t);
+void ecma_value_assign_number (ecma_value_t *, ecma_number_t);
+void ecma_value_assign_uint32 (ecma_value_t *, uint32_t);
+void ecma_free_value (ecma_value_t);
+void ecma_fast_free_value (ecma_value_t);
+void ecma_free_value_if_not_object (ecma_value_t);
 
 /* ecma-helpers-string.c */
-extern ecma_string_t *ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *, lit_utf8_size_t);
-extern ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *, lit_utf8_size_t);
-extern ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t);
-extern ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t);
-extern ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t);
-extern ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t);
-extern ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t);
-extern ecma_string_t *ecma_new_ecma_length_string ();
-extern ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *, ecma_string_t *);
-extern void ecma_ref_ecma_string (ecma_string_t *);
-extern void ecma_deref_ecma_string (ecma_string_t *);
-extern ecma_number_t ecma_string_to_number (const ecma_string_t *);
-extern uint32_t ecma_string_get_array_index (const ecma_string_t *);
+ecma_string_t *ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *, lit_utf8_size_t);
+ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *, lit_utf8_size_t);
+ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t);
+ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t);
+ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t);
+ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t);
+ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t);
+ecma_string_t *ecma_new_ecma_length_string ();
+ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *, ecma_string_t *);
+void ecma_ref_ecma_string (ecma_string_t *);
+void ecma_deref_ecma_string (ecma_string_t *);
+ecma_number_t ecma_string_to_number (const ecma_string_t *);
+uint32_t ecma_string_get_array_index (const ecma_string_t *);
 
-extern lit_utf8_size_t __attr_return_value_should_be_checked___
+lit_utf8_size_t __attr_return_value_should_be_checked___
 ecma_string_copy_to_utf8_buffer (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
-extern void ecma_string_to_utf8_bytes (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
-extern const lit_utf8_byte_t *ecma_string_raw_chars (const ecma_string_t *, lit_utf8_size_t *, bool *);
-extern void ecma_init_ecma_string_from_uint32 (ecma_string_t *, uint32_t);
-extern void ecma_init_ecma_length_string (ecma_string_t *);
-extern bool ecma_string_is_empty (const ecma_string_t *);
-extern bool ecma_string_is_length (const ecma_string_t *);
+void ecma_string_to_utf8_bytes (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
+const lit_utf8_byte_t *ecma_string_raw_chars (const ecma_string_t *, lit_utf8_size_t *, bool *);
+void ecma_init_ecma_string_from_uint32 (ecma_string_t *, uint32_t);
+void ecma_init_ecma_length_string (ecma_string_t *);
+bool ecma_string_is_empty (const ecma_string_t *);
+bool ecma_string_is_length (const ecma_string_t *);
 
-extern jmem_cpointer_t ecma_string_to_property_name (ecma_string_t *, ecma_property_t *);
-extern ecma_string_t *ecma_string_from_property_name (ecma_property_t, jmem_cpointer_t);
-extern lit_string_hash_t ecma_string_get_property_name_hash (ecma_property_t, jmem_cpointer_t);
-extern uint32_t ecma_string_get_property_index (ecma_property_t, jmem_cpointer_t);
-extern bool ecma_string_compare_to_property_name (ecma_property_t, jmem_cpointer_t, const ecma_string_t *);
+jmem_cpointer_t ecma_string_to_property_name (ecma_string_t *, ecma_property_t *);
+ecma_string_t *ecma_string_from_property_name (ecma_property_t, jmem_cpointer_t);
+lit_string_hash_t ecma_string_get_property_name_hash (ecma_property_t, jmem_cpointer_t);
+uint32_t ecma_string_get_property_index (ecma_property_t, jmem_cpointer_t);
+bool ecma_string_compare_to_property_name (ecma_property_t, jmem_cpointer_t, const ecma_string_t *);
 
-extern bool ecma_compare_ecma_strings (const ecma_string_t *, const ecma_string_t *);
-extern bool ecma_compare_ecma_strings_relational (const ecma_string_t *, const ecma_string_t *);
-extern ecma_length_t ecma_string_get_length (const ecma_string_t *);
-extern ecma_length_t ecma_string_get_utf8_length (const ecma_string_t *);
-extern lit_utf8_size_t ecma_string_get_size (const ecma_string_t *);
-extern lit_utf8_size_t ecma_string_get_utf8_size (const ecma_string_t *);
-extern ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *, ecma_length_t);
+bool ecma_compare_ecma_strings (const ecma_string_t *, const ecma_string_t *);
+bool ecma_compare_ecma_strings_relational (const ecma_string_t *, const ecma_string_t *);
+ecma_length_t ecma_string_get_length (const ecma_string_t *);
+ecma_length_t ecma_string_get_utf8_length (const ecma_string_t *);
+lit_utf8_size_t ecma_string_get_size (const ecma_string_t *);
+lit_utf8_size_t ecma_string_get_utf8_size (const ecma_string_t *);
+ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *, ecma_length_t);
 
-extern ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t);
-extern ecma_string_t *ecma_get_magic_string_ex (lit_magic_string_ex_id_t);
-extern lit_magic_string_id_t ecma_get_string_magic (const ecma_string_t *);
+ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t);
+ecma_string_t *ecma_get_magic_string_ex (lit_magic_string_ex_id_t);
+lit_magic_string_id_t ecma_get_string_magic (const ecma_string_t *);
 
-extern lit_string_hash_t ecma_string_hash (const ecma_string_t *);
-extern ecma_string_t *ecma_string_substr (const ecma_string_t *, ecma_length_t, ecma_length_t);
-extern ecma_string_t *ecma_string_trim (const ecma_string_t *);
+lit_string_hash_t ecma_string_hash (const ecma_string_t *);
+ecma_string_t *ecma_string_substr (const ecma_string_t *, ecma_length_t, ecma_length_t);
+ecma_string_t *ecma_string_trim (const ecma_string_t *);
 
 /* ecma-helpers-number.c */
-extern ecma_number_t ecma_number_make_nan (void);
-extern ecma_number_t ecma_number_make_infinity (bool);
-extern bool ecma_number_is_nan (ecma_number_t);
-extern bool ecma_number_is_negative (ecma_number_t);
-extern bool ecma_number_is_zero (ecma_number_t);
-extern bool ecma_number_is_infinity (ecma_number_t);
-extern int32_t
+ecma_number_t ecma_number_make_nan (void);
+ecma_number_t ecma_number_make_infinity (bool);
+bool ecma_number_is_nan (ecma_number_t);
+bool ecma_number_is_negative (ecma_number_t);
+bool ecma_number_is_zero (ecma_number_t);
+bool ecma_number_is_infinity (ecma_number_t);
+int32_t
 ecma_number_get_fraction_and_exponent (ecma_number_t, uint64_t *, int32_t *);
-extern ecma_number_t
+ecma_number_t
 ecma_number_make_normal_positive_from_fraction_and_exponent (uint64_t, int32_t);
-extern ecma_number_t
+ecma_number_t
 ecma_number_make_from_sign_mantissa_and_exponent (bool, uint64_t, int32_t);
-extern ecma_number_t ecma_number_get_prev (ecma_number_t);
-extern ecma_number_t ecma_number_get_next (ecma_number_t);
-extern ecma_number_t ecma_number_negate (ecma_number_t);
-extern ecma_number_t ecma_number_trunc (ecma_number_t);
-extern ecma_number_t ecma_number_calc_remainder (ecma_number_t, ecma_number_t);
-extern ecma_number_t ecma_number_add (ecma_number_t, ecma_number_t);
-extern ecma_number_t ecma_number_substract (ecma_number_t, ecma_number_t);
-extern ecma_number_t ecma_number_multiply (ecma_number_t, ecma_number_t);
-extern ecma_number_t ecma_number_divide (ecma_number_t, ecma_number_t);
-extern lit_utf8_size_t ecma_number_to_decimal (ecma_number_t, lit_utf8_byte_t *, int32_t *);
+ecma_number_t ecma_number_get_prev (ecma_number_t);
+ecma_number_t ecma_number_get_next (ecma_number_t);
+ecma_number_t ecma_number_negate (ecma_number_t);
+ecma_number_t ecma_number_trunc (ecma_number_t);
+ecma_number_t ecma_number_calc_remainder (ecma_number_t, ecma_number_t);
+ecma_number_t ecma_number_add (ecma_number_t, ecma_number_t);
+ecma_number_t ecma_number_substract (ecma_number_t, ecma_number_t);
+ecma_number_t ecma_number_multiply (ecma_number_t, ecma_number_t);
+ecma_number_t ecma_number_divide (ecma_number_t, ecma_number_t);
+lit_utf8_size_t ecma_number_to_decimal (ecma_number_t, lit_utf8_byte_t *, int32_t *);
 
 /* ecma-helpers-values-collection.c */
-extern ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t[], ecma_length_t, bool);
-extern void ecma_free_values_collection (ecma_collection_header_t *, bool);
-extern void ecma_append_to_values_collection (ecma_collection_header_t *, ecma_value_t, bool);
-extern void ecma_remove_last_value_from_values_collection (ecma_collection_header_t *);
-extern ecma_collection_header_t *ecma_new_strings_collection (ecma_string_t *[], ecma_length_t);
+ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t[], ecma_length_t, bool);
+void ecma_free_values_collection (ecma_collection_header_t *, bool);
+void ecma_append_to_values_collection (ecma_collection_header_t *, ecma_value_t, bool);
+void ecma_remove_last_value_from_values_collection (ecma_collection_header_t *);
+ecma_collection_header_t *ecma_new_strings_collection (ecma_string_t *[], ecma_length_t);
 
 /**
  * Context of ecma values' collection iterator
@@ -251,89 +251,89 @@ typedef struct
   const ecma_value_t *current_chunk_end_p; /**< pointer to place right after the end of current chunk's data */
 } ecma_collection_iterator_t;
 
-extern void
+void
 ecma_collection_iterator_init (ecma_collection_iterator_t *, ecma_collection_header_t *);
-extern bool
+bool
 ecma_collection_iterator_next (ecma_collection_iterator_t *);
 
 /* ecma-helpers.c */
-extern ecma_object_t *ecma_create_object (ecma_object_t *, size_t, ecma_object_type_t);
-extern ecma_object_t *ecma_create_decl_lex_env (ecma_object_t *);
-extern ecma_object_t *ecma_create_object_lex_env (ecma_object_t *, ecma_object_t *, bool);
-extern bool ecma_is_lexical_environment (const ecma_object_t *) __attr_pure___;
-extern bool ecma_get_object_extensible (const ecma_object_t *) __attr_pure___;
-extern void ecma_set_object_extensible (ecma_object_t *, bool);
-extern ecma_object_type_t ecma_get_object_type (const ecma_object_t *) __attr_pure___;
-extern void ecma_set_object_type (ecma_object_t *, ecma_object_type_t);
-extern ecma_object_t *ecma_get_object_prototype (const ecma_object_t *) __attr_pure___;
-extern bool ecma_get_object_is_builtin (const ecma_object_t *) __attr_pure___;
-extern void ecma_set_object_is_builtin (ecma_object_t *);
-extern ecma_lexical_environment_type_t ecma_get_lex_env_type (const ecma_object_t *) __attr_pure___;
-extern ecma_object_t *ecma_get_lex_env_outer_reference (const ecma_object_t *) __attr_pure___;
-extern ecma_property_header_t *ecma_get_property_list (const ecma_object_t *) __attr_pure___;
-extern ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *) __attr_pure___;
-extern bool ecma_get_lex_env_provide_this (const ecma_object_t *) __attr_pure___;
+ecma_object_t *ecma_create_object (ecma_object_t *, size_t, ecma_object_type_t);
+ecma_object_t *ecma_create_decl_lex_env (ecma_object_t *);
+ecma_object_t *ecma_create_object_lex_env (ecma_object_t *, ecma_object_t *, bool);
+bool ecma_is_lexical_environment (const ecma_object_t *) __attr_pure___;
+bool ecma_get_object_extensible (const ecma_object_t *) __attr_pure___;
+void ecma_set_object_extensible (ecma_object_t *, bool);
+ecma_object_type_t ecma_get_object_type (const ecma_object_t *) __attr_pure___;
+void ecma_set_object_type (ecma_object_t *, ecma_object_type_t);
+ecma_object_t *ecma_get_object_prototype (const ecma_object_t *) __attr_pure___;
+bool ecma_get_object_is_builtin (const ecma_object_t *) __attr_pure___;
+void ecma_set_object_is_builtin (ecma_object_t *);
+ecma_lexical_environment_type_t ecma_get_lex_env_type (const ecma_object_t *) __attr_pure___;
+ecma_object_t *ecma_get_lex_env_outer_reference (const ecma_object_t *) __attr_pure___;
+ecma_property_header_t *ecma_get_property_list (const ecma_object_t *) __attr_pure___;
+ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *) __attr_pure___;
+bool ecma_get_lex_env_provide_this (const ecma_object_t *) __attr_pure___;
 
-extern ecma_value_t *ecma_create_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-extern ecma_value_t *ecma_find_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-extern ecma_value_t *ecma_get_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+ecma_value_t *ecma_create_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+ecma_value_t *ecma_find_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+ecma_value_t *ecma_get_internal_property (ecma_object_t *, ecma_internal_property_id_t);
 
-extern ecma_property_value_t *
+ecma_property_value_t *
 ecma_create_named_data_property (ecma_object_t *, ecma_string_t *, uint8_t, ecma_property_t **);
-extern ecma_property_value_t *
+ecma_property_value_t *
 ecma_create_named_accessor_property (ecma_object_t *, ecma_string_t *, ecma_object_t *,
                                      ecma_object_t *, uint8_t, ecma_property_t **);
-extern ecma_property_t *
+ecma_property_t *
 ecma_find_named_property (ecma_object_t *, ecma_string_t *);
-extern ecma_property_value_t *
+ecma_property_value_t *
 ecma_get_named_data_property (ecma_object_t *, ecma_string_t *);
 
-extern void ecma_free_property (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
+void ecma_free_property (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
 
-extern void ecma_delete_property (ecma_object_t *, ecma_property_value_t *);
-extern uint32_t ecma_delete_array_properties (ecma_object_t *, uint32_t, uint32_t);
+void ecma_delete_property (ecma_object_t *, ecma_property_value_t *);
+uint32_t ecma_delete_array_properties (ecma_object_t *, uint32_t, uint32_t);
 
-extern void ecma_named_data_property_assign_value (ecma_object_t *, ecma_property_value_t *, ecma_value_t);
+void ecma_named_data_property_assign_value (ecma_object_t *, ecma_property_value_t *, ecma_value_t);
 
-extern ecma_object_t *ecma_get_named_accessor_property_getter (const ecma_property_value_t *);
-extern ecma_object_t *ecma_get_named_accessor_property_setter (const ecma_property_value_t *);
-extern void ecma_set_named_accessor_property_getter (ecma_object_t *, ecma_property_value_t *, ecma_object_t *);
-extern void ecma_set_named_accessor_property_setter (ecma_object_t *, ecma_property_value_t *, ecma_object_t *);
-extern bool ecma_is_property_writable (ecma_property_t);
-extern void ecma_set_property_writable_attr (ecma_property_t *, bool);
-extern bool ecma_is_property_enumerable (ecma_property_t);
-extern void ecma_set_property_enumerable_attr (ecma_property_t *, bool);
-extern bool ecma_is_property_configurable (ecma_property_t);
-extern void ecma_set_property_configurable_attr (ecma_property_t *, bool);
+ecma_object_t *ecma_get_named_accessor_property_getter (const ecma_property_value_t *);
+ecma_object_t *ecma_get_named_accessor_property_setter (const ecma_property_value_t *);
+void ecma_set_named_accessor_property_getter (ecma_object_t *, ecma_property_value_t *, ecma_object_t *);
+void ecma_set_named_accessor_property_setter (ecma_object_t *, ecma_property_value_t *, ecma_object_t *);
+bool ecma_is_property_writable (ecma_property_t);
+void ecma_set_property_writable_attr (ecma_property_t *, bool);
+bool ecma_is_property_enumerable (ecma_property_t);
+void ecma_set_property_enumerable_attr (ecma_property_t *, bool);
+bool ecma_is_property_configurable (ecma_property_t);
+void ecma_set_property_configurable_attr (ecma_property_t *, bool);
 
-extern bool ecma_is_property_lcached (ecma_property_t *);
-extern void ecma_set_property_lcached (ecma_property_t *, bool);
+bool ecma_is_property_lcached (ecma_property_t *);
+void ecma_set_property_lcached (ecma_property_t *, bool);
 
-extern ecma_property_descriptor_t ecma_make_empty_property_descriptor (void);
-extern void ecma_free_property_descriptor (ecma_property_descriptor_t *);
+ecma_property_descriptor_t ecma_make_empty_property_descriptor (void);
+void ecma_free_property_descriptor (ecma_property_descriptor_t *);
 
-extern ecma_property_t *ecma_get_next_property_pair (ecma_property_pair_t *);
+ecma_property_t *ecma_get_next_property_pair (ecma_property_pair_t *);
 
-extern void ecma_bytecode_ref (ecma_compiled_code_t *);
-extern void ecma_bytecode_deref (ecma_compiled_code_t *);
+void ecma_bytecode_ref (ecma_compiled_code_t *);
+void ecma_bytecode_deref (ecma_compiled_code_t *);
 
 /* ecma-helpers-external-pointers.c */
-extern bool
+bool
 ecma_create_external_pointer_property (ecma_object_t *, ecma_internal_property_id_t, ecma_external_pointer_t);
-extern bool
+bool
 ecma_get_external_pointer_value (ecma_object_t *, ecma_internal_property_id_t, ecma_external_pointer_t *);
-extern void
+void
 ecma_free_external_pointer_in_property (ecma_property_t *);
 
 /* ecma-helpers-conversion.c */
-extern ecma_number_t ecma_utf8_string_to_number (const lit_utf8_byte_t *, lit_utf8_size_t);
-extern lit_utf8_size_t ecma_uint32_to_utf8_string (uint32_t, lit_utf8_byte_t *, lit_utf8_size_t);
-extern uint32_t ecma_number_to_uint32 (ecma_number_t);
-extern int32_t ecma_number_to_int32 (ecma_number_t);
-extern lit_utf8_size_t ecma_number_to_utf8_string (ecma_number_t, lit_utf8_byte_t *, lit_utf8_size_t);
+ecma_number_t ecma_utf8_string_to_number (const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_utf8_size_t ecma_uint32_to_utf8_string (uint32_t, lit_utf8_byte_t *, lit_utf8_size_t);
+uint32_t ecma_number_to_uint32 (ecma_number_t);
+int32_t ecma_number_to_int32 (ecma_number_t);
+lit_utf8_size_t ecma_number_to_utf8_string (ecma_number_t, lit_utf8_byte_t *, lit_utf8_size_t);
 
 /* ecma-helpers-errol.c */
-extern lit_utf8_size_t ecma_errol0_dtoa (double, lit_utf8_byte_t *, int32_t *);
+lit_utf8_size_t ecma_errol0_dtoa (double, lit_utf8_byte_t *, int32_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-init-finalize.h
+++ b/jerry-core/ecma/base/ecma-init-finalize.h
@@ -23,8 +23,8 @@
  * @{
  */
 
-extern void ecma_init (void);
-extern void ecma_finalize (void);
+void ecma_init (void);
+void ecma_finalize (void);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-lcache.h
+++ b/jerry-core/ecma/base/ecma-lcache.h
@@ -23,10 +23,10 @@
  * @{
  */
 
-extern void ecma_lcache_init (void);
-extern void ecma_lcache_insert (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
-extern ecma_property_t *ecma_lcache_lookup (ecma_object_t *, const ecma_string_t *);
-extern void ecma_lcache_invalidate (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
+void ecma_lcache_init (void);
+void ecma_lcache_insert (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
+ecma_property_t *ecma_lcache_lookup (ecma_object_t *, const ecma_string_t *);
+void ecma_lcache_invalidate (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-literal-storage.h
+++ b/jerry-core/ecma/base/ecma-literal-storage.h
@@ -36,19 +36,19 @@ typedef struct
   jmem_cpointer_t literal_offset; /**< literal offset */
 } lit_mem_to_snapshot_id_map_entry_t;
 
-extern void ecma_finalize_lit_storage (void);
+void ecma_finalize_lit_storage (void);
 
-extern jmem_cpointer_t ecma_find_or_create_literal_string (const lit_utf8_byte_t *, lit_utf8_size_t);
-extern jmem_cpointer_t ecma_find_or_create_literal_number (ecma_number_t);
+jmem_cpointer_t ecma_find_or_create_literal_string (const lit_utf8_byte_t *, lit_utf8_size_t);
+jmem_cpointer_t ecma_find_or_create_literal_number (ecma_number_t);
 
 #ifdef JERRY_ENABLE_SNAPSHOT_SAVE
-extern bool
+bool
 ecma_save_literals_for_snapshot (uint8_t *, size_t, size_t *,
                                  lit_mem_to_snapshot_id_map_entry_t **, uint32_t *, uint32_t *);
 #endif /* JERRY_ENABLE_SNAPSHOT_SAVE */
 
 #ifdef JERRY_ENABLE_SNAPSHOT_EXEC
-extern bool
+bool
 ecma_load_literals_from_snapshot (const uint8_t *, uint32_t,
                                   lit_mem_to_snapshot_id_map_entry_t **, uint32_t *);
 #endif /* JERRY_ENABLE_SNAPSHOT_EXEC */

--- a/jerry-core/ecma/base/ecma-property-hashmap.h
+++ b/jerry-core/ecma/base/ecma-property-hashmap.h
@@ -52,13 +52,13 @@ typedef struct
    */
 } ecma_property_hashmap_t;
 
-extern void ecma_property_hashmap_create (ecma_object_t *);
-extern void ecma_property_hashmap_free (ecma_object_t *);
-extern void ecma_property_hashmap_insert (ecma_object_t *, ecma_string_t *, ecma_property_pair_t *, int);
-extern void ecma_property_hashmap_delete (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
+void ecma_property_hashmap_create (ecma_object_t *);
+void ecma_property_hashmap_free (ecma_object_t *);
+void ecma_property_hashmap_insert (ecma_object_t *, ecma_string_t *, ecma_property_pair_t *, int);
+void ecma_property_hashmap_delete (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
-extern ecma_property_t *ecma_property_hashmap_find (ecma_property_hashmap_t *, ecma_string_t *, jmem_cpointer_t *);
+ecma_property_t *ecma_property_hashmap_find (ecma_property_hashmap_t *, ecma_string_t *, jmem_cpointer_t *);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -26,24 +26,24 @@
  * @{
  */
 
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_object_to_string (const ecma_value_t);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *, uint32_t);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_object_get_properties (ecma_object_t *, bool);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_array_concat_value (ecma_object_t *, uint32_t *, ecma_value_t);
-extern uint32_t
+uint32_t
 ecma_builtin_helper_array_index_normalize (ecma_number_t, uint32_t);
-extern uint32_t
+uint32_t
 ecma_builtin_helper_string_index_normalize (ecma_number_t, uint32_t, bool);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t, ecma_value_t,
                                                       ecma_value_t, bool);
-extern bool
+bool
 ecma_builtin_helper_string_find_index (ecma_string_t *, ecma_string_t *, bool, ecma_length_t, ecma_length_t *);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_def_prop (ecma_object_t *, ecma_string_t *, ecma_value_t,
                               bool, bool, bool, bool);
 
@@ -93,36 +93,36 @@ typedef enum
 } ecma_date_timezone_t;
 
 /* ecma-builtin-helpers-date.c */
-extern ecma_number_t ecma_date_day (ecma_number_t);
-extern ecma_number_t ecma_date_time_within_day (ecma_number_t);
-extern ecma_number_t ecma_date_days_in_year (ecma_number_t);
-extern ecma_number_t ecma_date_day_from_year (ecma_number_t);
-extern ecma_number_t ecma_date_time_from_year (ecma_number_t);
-extern ecma_number_t ecma_date_year_from_time (ecma_number_t);
-extern ecma_number_t ecma_date_in_leap_year (ecma_number_t);
-extern ecma_number_t ecma_date_day_within_year (ecma_number_t);
-extern ecma_number_t ecma_date_month_from_time (ecma_number_t);
-extern ecma_number_t ecma_date_date_from_time (ecma_number_t);
-extern ecma_number_t ecma_date_week_day (ecma_number_t);
-extern ecma_number_t ecma_date_local_tza ();
-extern ecma_number_t ecma_date_daylight_saving_ta (ecma_number_t);
-extern ecma_number_t ecma_date_local_time (ecma_number_t);
-extern ecma_number_t ecma_date_utc (ecma_number_t);
-extern ecma_number_t ecma_date_hour_from_time (ecma_number_t);
-extern ecma_number_t ecma_date_min_from_time (ecma_number_t);
-extern ecma_number_t ecma_date_sec_from_time (ecma_number_t);
-extern ecma_number_t ecma_date_ms_from_time (ecma_number_t);
-extern ecma_number_t ecma_date_make_time (ecma_number_t, ecma_number_t, ecma_number_t, ecma_number_t);
-extern ecma_number_t ecma_date_make_day (ecma_number_t, ecma_number_t, ecma_number_t);
-extern ecma_number_t ecma_date_make_date (ecma_number_t, ecma_number_t);
-extern ecma_number_t ecma_date_time_clip (ecma_number_t);
-extern ecma_number_t ecma_date_timezone_offset (ecma_number_t);
+ecma_number_t ecma_date_day (ecma_number_t);
+ecma_number_t ecma_date_time_within_day (ecma_number_t);
+ecma_number_t ecma_date_days_in_year (ecma_number_t);
+ecma_number_t ecma_date_day_from_year (ecma_number_t);
+ecma_number_t ecma_date_time_from_year (ecma_number_t);
+ecma_number_t ecma_date_year_from_time (ecma_number_t);
+ecma_number_t ecma_date_in_leap_year (ecma_number_t);
+ecma_number_t ecma_date_day_within_year (ecma_number_t);
+ecma_number_t ecma_date_month_from_time (ecma_number_t);
+ecma_number_t ecma_date_date_from_time (ecma_number_t);
+ecma_number_t ecma_date_week_day (ecma_number_t);
+ecma_number_t ecma_date_local_tza ();
+ecma_number_t ecma_date_daylight_saving_ta (ecma_number_t);
+ecma_number_t ecma_date_local_time (ecma_number_t);
+ecma_number_t ecma_date_utc (ecma_number_t);
+ecma_number_t ecma_date_hour_from_time (ecma_number_t);
+ecma_number_t ecma_date_min_from_time (ecma_number_t);
+ecma_number_t ecma_date_sec_from_time (ecma_number_t);
+ecma_number_t ecma_date_ms_from_time (ecma_number_t);
+ecma_number_t ecma_date_make_time (ecma_number_t, ecma_number_t, ecma_number_t, ecma_number_t);
+ecma_number_t ecma_date_make_day (ecma_number_t, ecma_number_t, ecma_number_t);
+ecma_number_t ecma_date_make_date (ecma_number_t, ecma_number_t);
+ecma_number_t ecma_date_time_clip (ecma_number_t);
+ecma_number_t ecma_date_timezone_offset (ecma_number_t);
 
-extern ecma_value_t ecma_date_value_to_string (ecma_number_t);
-extern ecma_value_t ecma_date_value_to_utc_string (ecma_number_t);
-extern ecma_value_t ecma_date_value_to_iso_string (ecma_number_t);
-extern ecma_value_t ecma_date_value_to_date_string (ecma_number_t);
-extern ecma_value_t ecma_date_value_to_time_string (ecma_number_t);
+ecma_value_t ecma_date_value_to_string (ecma_number_t);
+ecma_value_t ecma_date_value_to_utc_string (ecma_number_t);
+ecma_value_t ecma_date_value_to_iso_string (ecma_number_t);
+ecma_value_t ecma_date_value_to_date_string (ecma_number_t);
+ecma_value_t ecma_date_value_to_time_string (ecma_number_t);
 
 #endif /* !CONFIG_DISABLE_DATE_BUILTIN */
 
@@ -149,22 +149,22 @@ typedef struct
   ecma_object_t *replacer_function_p;
 } ecma_json_stringify_context_t;
 
-extern bool ecma_has_object_value_in_collection (ecma_collection_header_t *, ecma_value_t);
-extern bool ecma_has_string_value_in_collection (ecma_collection_header_t *, ecma_value_t);
+bool ecma_has_object_value_in_collection (ecma_collection_header_t *, ecma_value_t);
+bool ecma_has_string_value_in_collection (ecma_collection_header_t *, ecma_value_t);
 
-extern ecma_string_t *
+ecma_string_t *
 ecma_builtin_helper_json_create_hex_digit_ecma_string (uint8_t);
-extern ecma_string_t *
+ecma_string_t *
 ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *, ecma_string_t *);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_json_create_formatted_json (ecma_string_t *, ecma_string_t *, ecma_string_t *,
                                                 ecma_collection_header_t *, ecma_json_stringify_context_t *);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_json_create_non_formatted_json (ecma_string_t *, ecma_string_t *, ecma_collection_header_t *);
 
 /* ecma-builtin-helper-error.c */
 
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_helper_error_dispatch_call (ecma_standard_error_t, const ecma_value_t *, ecma_length_t);
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -77,13 +77,13 @@ typedef struct
                 lowercase_name) \
 extern const ecma_builtin_property_descriptor_t \
 ecma_builtin_ ## lowercase_name ## _property_descriptor_list[]; \
-extern ecma_value_t \
+ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_call (const ecma_value_t *, \
                                                    ecma_length_t); \
-extern ecma_value_t \
+ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_construct (const ecma_value_t *, \
                                                         ecma_length_t); \
-extern ecma_value_t \
+ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_routine (uint16_t builtin_routine_id, \
                                                       ecma_value_t this_arg_value, \
                                                       const ecma_value_t [], \

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -65,26 +65,26 @@ typedef enum
 #define ECMA_ACCESSOR_READ_WRITE_GET_GETTER_ID(value) ((uint16_t) ((value) >> 8))
 
 /* ecma-builtins.c */
-extern void ecma_finalize_builtins (void);
+void ecma_finalize_builtins (void);
 
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_dispatch_call (ecma_object_t *, ecma_value_t,
                             const ecma_value_t *, ecma_length_t);
-extern ecma_value_t
+ecma_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *,
                                  const ecma_value_t *, ecma_length_t);
-extern ecma_property_t *
+ecma_property_t *
 ecma_builtin_try_to_instantiate_property (ecma_object_t *, ecma_string_t *);
-extern void
+void
 ecma_builtin_list_lazy_property_names (ecma_object_t *,
                                        bool,
                                        ecma_collection_header_t *,
                                        ecma_collection_header_t *);
-extern bool
+bool
 ecma_builtin_is (ecma_object_t *, ecma_builtin_id_t);
-extern ecma_object_t *
+ecma_object_t *
 ecma_builtin_get (ecma_builtin_id_t);
-extern bool
+bool
 ecma_builtin_function_is_routine (ecma_object_t *);
 
 #endif /* !ECMA_BUILTINS_H */

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -137,7 +137,7 @@ ecma_op_create_array_object (const ecma_value_t *arguments_list_p, /**< list of 
  * @return ecma value
  *         Returned value must be freed with ecma_free_value
  */
-extern ecma_value_t
+ecma_value_t
 ecma_op_array_object_set_length (ecma_object_t *object_p, /**< the array object */
                                  ecma_value_t new_value, /**< new length value */
                                  uint32_t flags) /**< configuration options */

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -39,16 +39,16 @@ typedef enum
                                                          *   in the property descriptor */
 } ecma_array_object_set_length_flags_t;
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_create_array_object (const ecma_value_t *, ecma_length_t, bool);
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_array_object_set_length (ecma_object_t *, ecma_value_t, uint32_t);
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_array_object_define_own_property (ecma_object_t *, ecma_string_t *, const ecma_property_descriptor_t *, bool);
 
-extern void
+void
 ecma_op_array_list_lazy_property_names (ecma_object_t *, bool,
                                         ecma_collection_header_t *, ecma_collection_header_t *);
 

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -25,17 +25,17 @@
  * @{
  */
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_create_arraybuffer_object (const ecma_value_t *, ecma_length_t);
 
 /**
  * Helper functions for arraybuffer.
  */
-extern ecma_object_t *
+ecma_object_t *
 ecma_arraybuffer_new_object (ecma_length_t);
-extern lit_utf8_byte_t *
+lit_utf8_byte_t *
 ecma_arraybuffer_get_buffer (ecma_object_t *) __attr_pure___;
-extern ecma_length_t
+ecma_length_t
 ecma_arraybuffer_get_length (ecma_object_t *) __attr_pure___;
 
 /**

--- a/jerry-core/ecma/operations/ecma-boolean-object.h
+++ b/jerry-core/ecma/operations/ecma-boolean-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-extern ecma_value_t ecma_op_create_boolean_object (ecma_value_t);
+ecma_value_t ecma_op_create_boolean_object (ecma_value_t);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-comparison.h
+++ b/jerry-core/ecma/operations/ecma-comparison.h
@@ -26,9 +26,9 @@
  * @{
  */
 
-extern ecma_value_t ecma_op_abstract_equality_compare (ecma_value_t, ecma_value_t);
-extern bool ecma_op_strict_equality_compare (ecma_value_t, ecma_value_t);
-extern ecma_value_t ecma_op_abstract_relational_compare (ecma_value_t, ecma_value_t, bool);
+ecma_value_t ecma_op_abstract_equality_compare (ecma_value_t, ecma_value_t);
+bool ecma_op_strict_equality_compare (ecma_value_t, ecma_value_t);
+ecma_value_t ecma_op_abstract_relational_compare (ecma_value_t, ecma_value_t, bool);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -37,16 +37,16 @@ typedef enum
   ECMA_PREFERRED_TYPE_STRING /**< String */
 } ecma_preferred_type_hint_t;
 
-extern ecma_value_t ecma_op_check_object_coercible (ecma_value_t);
-extern bool ecma_op_same_value (ecma_value_t, ecma_value_t);
-extern ecma_value_t ecma_op_to_primitive (ecma_value_t, ecma_preferred_type_hint_t);
-extern bool ecma_op_to_boolean (ecma_value_t);
-extern ecma_value_t ecma_op_to_number (ecma_value_t);
-extern ecma_value_t ecma_op_to_string (ecma_value_t);
-extern ecma_value_t ecma_op_to_object (ecma_value_t);
+ecma_value_t ecma_op_check_object_coercible (ecma_value_t);
+bool ecma_op_same_value (ecma_value_t, ecma_value_t);
+ecma_value_t ecma_op_to_primitive (ecma_value_t, ecma_preferred_type_hint_t);
+bool ecma_op_to_boolean (ecma_value_t);
+ecma_value_t ecma_op_to_number (ecma_value_t);
+ecma_value_t ecma_op_to_string (ecma_value_t);
+ecma_value_t ecma_op_to_object (ecma_value_t);
 
-extern ecma_object_t *ecma_op_from_property_descriptor (const ecma_property_descriptor_t *);
-extern ecma_value_t ecma_op_to_property_descriptor (ecma_value_t, ecma_property_descriptor_t *);
+ecma_object_t *ecma_op_from_property_descriptor (const ecma_property_descriptor_t *);
+ecma_value_t ecma_op_to_property_descriptor (ecma_value_t, ecma_property_descriptor_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-eval.h
+++ b/jerry-core/ecma/operations/ecma-eval.h
@@ -25,10 +25,10 @@
  * @{
  */
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_eval (ecma_string_t *, bool, bool);
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_eval_chars_buffer (const lit_utf8_byte_t *, size_t, bool, bool);
 
 /**

--- a/jerry-core/ecma/operations/ecma-exceptions.h
+++ b/jerry-core/ecma/operations/ecma-exceptions.h
@@ -48,16 +48,16 @@ typedef enum
   ECMA_ERROR_URI        /**< URIError */
 } ecma_standard_error_t;
 
-extern ecma_object_t *ecma_new_standard_error (ecma_standard_error_t);
-extern ecma_object_t *ecma_new_standard_error_with_message (ecma_standard_error_t, ecma_string_t *);
-extern ecma_value_t ecma_raise_standard_error (ecma_standard_error_t, const lit_utf8_byte_t *);
-extern ecma_value_t ecma_raise_common_error (const char *);
-extern ecma_value_t ecma_raise_eval_error (const char *);
-extern ecma_value_t ecma_raise_range_error (const char *);
-extern ecma_value_t ecma_raise_reference_error (const char *);
-extern ecma_value_t ecma_raise_syntax_error (const char *);
-extern ecma_value_t ecma_raise_type_error (const char *);
-extern ecma_value_t ecma_raise_uri_error (const char *);
+ecma_object_t *ecma_new_standard_error (ecma_standard_error_t);
+ecma_object_t *ecma_new_standard_error_with_message (ecma_standard_error_t, ecma_string_t *);
+ecma_value_t ecma_raise_standard_error (ecma_standard_error_t, const lit_utf8_byte_t *);
+ecma_value_t ecma_raise_common_error (const char *);
+ecma_value_t ecma_raise_eval_error (const char *);
+ecma_value_t ecma_raise_range_error (const char *);
+ecma_value_t ecma_raise_reference_error (const char *);
+ecma_value_t ecma_raise_syntax_error (const char *);
+ecma_value_t ecma_raise_type_error (const char *);
+ecma_value_t ecma_raise_uri_error (const char *);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -26,31 +26,31 @@
  * @{
  */
 
-extern bool ecma_op_is_callable (ecma_value_t);
-extern bool ecma_is_constructor (ecma_value_t);
+bool ecma_op_is_callable (ecma_value_t);
+bool ecma_is_constructor (ecma_value_t);
 
-extern ecma_object_t *
+ecma_object_t *
 ecma_op_create_function_object (ecma_object_t *, bool, const ecma_compiled_code_t *);
 
-extern void
+void
 ecma_op_function_list_lazy_property_names (bool,
                                            ecma_collection_header_t *,
                                            ecma_collection_header_t *);
 
-extern ecma_property_t *
+ecma_property_t *
 ecma_op_function_try_lazy_instantiate_property (ecma_object_t *, ecma_string_t *);
 
-extern ecma_object_t *
+ecma_object_t *
 ecma_op_create_external_function_object (ecma_external_pointer_t);
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_function_call (ecma_object_t *, ecma_value_t,
                        const ecma_value_t *, ecma_length_t);
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_function_construct (ecma_object_t *, const ecma_value_t *, ecma_length_t);
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_function_has_instance (ecma_object_t *, ecma_value_t);
 
 /**

--- a/jerry-core/ecma/operations/ecma-lex-env.h
+++ b/jerry-core/ecma/operations/ecma-lex-env.h
@@ -30,31 +30,31 @@
  * @{
  */
 
-extern void ecma_init_global_lex_env (void);
-extern void ecma_finalize_global_lex_env (void);
-extern ecma_object_t *ecma_get_global_environment (void);
+void ecma_init_global_lex_env (void);
+void ecma_finalize_global_lex_env (void);
+ecma_object_t *ecma_get_global_environment (void);
 
 /**
  * @}
  */
 
 /* ECMA-262 v5, 8.7.1 and 8.7.2 */
-extern ecma_value_t ecma_op_get_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_value_t ecma_op_get_value_object_base (ecma_value_t, ecma_string_t *);
-extern ecma_value_t ecma_op_put_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool, ecma_value_t);
+ecma_value_t ecma_op_get_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool);
+ecma_value_t ecma_op_get_value_object_base (ecma_value_t, ecma_string_t *);
+ecma_value_t ecma_op_put_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool, ecma_value_t);
 
 /* ECMA-262 v5, Table 17. Abstract methods of Environment Records */
-extern bool ecma_op_has_binding (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_create_mutable_binding (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_value_t ecma_op_set_mutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
-extern ecma_value_t ecma_op_get_binding_value (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_value_t ecma_op_delete_binding (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_implicit_this_value (ecma_object_t *);
+bool ecma_op_has_binding (ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_create_mutable_binding (ecma_object_t *, ecma_string_t *, bool);
+ecma_value_t ecma_op_set_mutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
+ecma_value_t ecma_op_get_binding_value (ecma_object_t *, ecma_string_t *, bool);
+ecma_value_t ecma_op_delete_binding (ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_implicit_this_value (ecma_object_t *);
 
 /* ECMA-262 v5, Table 18. Additional methods of Declarative Environment Records */
-extern void ecma_op_create_immutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t);
+void ecma_op_create_immutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t);
 
-extern ecma_object_t *ecma_op_create_global_environment (ecma_object_t *);
+ecma_object_t *ecma_op_create_global_environment (ecma_object_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-number-arithmetic.h
+++ b/jerry-core/ecma/operations/ecma-number-arithmetic.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-extern ecma_number_t ecma_op_number_remainder (ecma_number_t, ecma_number_t);
+ecma_number_t ecma_op_number_remainder (ecma_number_t, ecma_number_t);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-number-object.h
+++ b/jerry-core/ecma/operations/ecma-number-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-extern ecma_value_t ecma_op_create_number_object (ecma_value_t);
+ecma_value_t ecma_op_create_number_object (ecma_value_t);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -19,13 +19,13 @@
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
 
-extern void
+void
 ecma_op_create_arguments_object (ecma_object_t *, ecma_object_t *, const ecma_value_t *,
                                  ecma_length_t, const ecma_compiled_code_t *);
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_value_t
+ecma_value_t
 ecma_op_arguments_object_define_own_property (ecma_object_t *, ecma_string_t *,
                                               const ecma_property_descriptor_t *, bool);
 

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -26,15 +26,15 @@
  * @{
  */
 
-extern ecma_value_t ecma_reject (bool);
-extern ecma_object_t *ecma_op_create_object_object_noarg (void);
-extern ecma_value_t ecma_op_create_object_object_arg (ecma_value_t);
-extern ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *);
+ecma_value_t ecma_reject (bool);
+ecma_object_t *ecma_op_create_object_object_noarg (void);
+ecma_value_t ecma_op_create_object_object_arg (ecma_value_t);
+ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *);
 
-extern ecma_value_t ecma_op_general_object_delete (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_value_t ecma_op_general_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
-extern ecma_value_t ecma_op_general_object_define_own_property (ecma_object_t *, ecma_string_t *,
-                                                                const ecma_property_descriptor_t *, bool);
+ecma_value_t ecma_op_general_object_delete (ecma_object_t *, ecma_string_t *, bool);
+ecma_value_t ecma_op_general_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
+ecma_value_t ecma_op_general_object_define_own_property (ecma_object_t *, ecma_string_t *,
+                                                         const ecma_property_descriptor_t *, bool);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -26,29 +26,29 @@
  * @{
  */
 
-extern ecma_property_t ecma_op_object_get_own_property (ecma_object_t *, ecma_string_t *,
-                                                        ecma_property_ref_t *, uint32_t);
-extern ecma_property_t ecma_op_object_get_property (ecma_object_t *, ecma_string_t *,
-                                                    ecma_property_ref_t *, uint32_t);
-extern bool ecma_op_object_has_own_property (ecma_object_t *, ecma_string_t *);
-extern bool ecma_op_object_has_property (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_object_find_own (ecma_value_t, ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_object_find (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_object_get_own_data_prop (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
-extern ecma_value_t ecma_op_object_delete (ecma_object_t *, ecma_string_t *, bool);
-extern ecma_value_t ecma_op_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
-extern ecma_value_t ecma_op_object_define_own_property (ecma_object_t *, ecma_string_t *,
-                                                        const ecma_property_descriptor_t *, bool);
-extern bool ecma_op_object_get_own_property_descriptor (ecma_object_t *, ecma_string_t *,
-                                                        ecma_property_descriptor_t *);
-extern ecma_value_t ecma_op_object_has_instance (ecma_object_t *, ecma_value_t);
-extern bool ecma_op_object_is_prototype_of (ecma_object_t *, ecma_object_t *);
-extern ecma_collection_header_t * ecma_op_object_get_property_names (ecma_object_t *, bool, bool, bool);
+ecma_property_t ecma_op_object_get_own_property (ecma_object_t *, ecma_string_t *,
+                                                 ecma_property_ref_t *, uint32_t);
+ecma_property_t ecma_op_object_get_property (ecma_object_t *, ecma_string_t *,
+                                             ecma_property_ref_t *, uint32_t);
+bool ecma_op_object_has_own_property (ecma_object_t *, ecma_string_t *);
+bool ecma_op_object_has_property (ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_object_find_own (ecma_value_t, ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_object_find (ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_object_get_own_data_prop (ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
+ecma_value_t ecma_op_object_delete (ecma_object_t *, ecma_string_t *, bool);
+ecma_value_t ecma_op_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
+ecma_value_t ecma_op_object_define_own_property (ecma_object_t *, ecma_string_t *,
+                                                 const ecma_property_descriptor_t *, bool);
+bool ecma_op_object_get_own_property_descriptor (ecma_object_t *, ecma_string_t *,
+                                                 ecma_property_descriptor_t *);
+ecma_value_t ecma_op_object_has_instance (ecma_object_t *, ecma_value_t);
+bool ecma_op_object_is_prototype_of (ecma_object_t *, ecma_object_t *);
+ecma_collection_header_t * ecma_op_object_get_property_names (ecma_object_t *, bool, bool, bool);
 
-extern lit_magic_string_id_t ecma_object_get_class_name (ecma_object_t *);
-extern bool ecma_object_class_is (ecma_object_t *, uint32_t);
+lit_magic_string_id_t ecma_object_get_class_name (ecma_object_t *);
+bool ecma_object_class_is (ecma_object_t *, uint32_t);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-reference.h
+++ b/jerry-core/ecma/operations/ecma-reference.h
@@ -26,8 +26,8 @@
  * @{
  */
 
-extern ecma_object_t *ecma_op_resolve_reference_base (ecma_object_t *, ecma_string_t *);
-extern ecma_value_t ecma_op_resolve_reference_value (ecma_object_t *, ecma_string_t *);
+ecma_object_t *ecma_op_resolve_reference_base (ecma_object_t *, ecma_string_t *);
+ecma_value_t ecma_op_resolve_reference_value (ecma_object_t *, ecma_string_t *);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -25,10 +25,10 @@
  * @{
  */
 
-extern ecma_value_t
+ecma_value_t
 ecma_op_create_string_object (const ecma_value_t *, ecma_length_t);
 
-extern void
+void
 ecma_op_string_list_lazy_property_names (ecma_object_t *,
                                          bool,
                                          ecma_collection_header_t *,

--- a/jerry-core/jerry-internal.h
+++ b/jerry-core/jerry-internal.h
@@ -23,14 +23,14 @@
 #include "ecma-globals.h"
 #include "jerry-api.h"
 
-extern ecma_value_t
+ecma_value_t
 jerry_dispatch_external_function (ecma_object_t *,
                                   ecma_external_pointer_t,
                                   ecma_value_t,
                                   const ecma_value_t *,
                                   ecma_length_t);
 
-extern void
+void
 jerry_dispatch_object_free_callback (ecma_external_pointer_t, ecma_external_pointer_t);
 
 #endif /* !JERRY_INTERNAL_H */

--- a/jerry-core/jmem/jmem-allocator-internal.h
+++ b/jerry-core/jmem/jmem-allocator-internal.h
@@ -24,7 +24,7 @@
  * @{
  */
 
-extern void jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t);
+void jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t);
 
 /**
  * @}

--- a/jerry-core/jmem/jmem-allocator.h
+++ b/jerry-core/jmem/jmem-allocator.h
@@ -151,18 +151,18 @@ typedef void (*jmem_free_unused_memory_callback_t) (jmem_free_unused_memory_seve
     } \
   } while (false);
 
-extern void jmem_init (void);
-extern void jmem_finalize (void);
+void jmem_init (void);
+void jmem_finalize (void);
 
-extern jmem_cpointer_t jmem_compress_pointer (const void *);
-extern void *jmem_decompress_pointer (uintptr_t);
+jmem_cpointer_t jmem_compress_pointer (const void *);
+void *jmem_decompress_pointer (uintptr_t);
 
-extern void jmem_register_free_unused_memory_callback (jmem_free_unused_memory_callback_t);
-extern void jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t);
+void jmem_register_free_unused_memory_callback (jmem_free_unused_memory_callback_t);
+void jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t);
 
 #ifdef JMEM_STATS
-extern void jmem_stats_reset_peak (void);
-extern void jmem_stats_print (void);
+void jmem_stats_reset_peak (void);
+void jmem_stats_print (void);
 #endif /* JMEM_STATS */
 
 /**

--- a/jerry-core/jmem/jmem-heap.h
+++ b/jerry-core/jmem/jmem-heap.h
@@ -28,12 +28,12 @@
  * @{
  */
 
-extern void jmem_heap_init (void);
-extern void jmem_heap_finalize (void);
-extern void *jmem_heap_alloc_block (const size_t);
-extern void *jmem_heap_alloc_block_null_on_error (const size_t);
-extern void jmem_heap_free_block (void *, const size_t);
-extern bool jmem_is_heap_pointer (const void *);
+void jmem_heap_init (void);
+void jmem_heap_finalize (void);
+void *jmem_heap_alloc_block (const size_t);
+void *jmem_heap_alloc_block_null_on_error (const size_t);
+void jmem_heap_free_block (void *, const size_t);
+bool jmem_is_heap_pointer (const void *);
 
 #ifdef JMEM_STATS
 /**
@@ -62,9 +62,9 @@ typedef struct
   size_t free_iter_count;
 } jmem_heap_stats_t;
 
-extern void jmem_heap_get_stats (jmem_heap_stats_t *);
-extern void jmem_heap_stats_reset_peak (void);
-extern void jmem_heap_stats_print (void);
+void jmem_heap_get_stats (jmem_heap_stats_t *);
+void jmem_heap_stats_reset_peak (void);
+void jmem_heap_stats_print (void);
 #endif /* JMEM_STATS */
 
 #ifdef JERRY_VALGRIND_FREYA
@@ -73,7 +73,7 @@ extern void jmem_heap_stats_print (void);
 #error Valgrind and valgrind-freya modes are not compatible.
 #endif /* JERRY_VALGRIND */
 
-extern void jmem_heap_valgrind_freya_mempool_request (void);
+void jmem_heap_valgrind_freya_mempool_request (void);
 
 #define JMEM_HEAP_VALGRIND_FREYA_MEMPOOL_REQUEST() jmem_heap_valgrind_freya_mempool_request ()
 

--- a/jerry-core/jmem/jmem-poolman.h
+++ b/jerry-core/jmem/jmem-poolman.h
@@ -28,10 +28,10 @@
  * @{
  */
 
-extern void jmem_pools_finalize (void);
-extern void *jmem_pools_alloc (size_t);
-extern void jmem_pools_free (void *, size_t);
-extern void jmem_pools_collect_empty (void);
+void jmem_pools_finalize (void);
+void *jmem_pools_alloc (size_t);
+void jmem_pools_free (void *, size_t);
+void jmem_pools_collect_empty (void);
 
 #ifdef JMEM_STATS
 /**
@@ -58,9 +58,9 @@ typedef struct
   size_t reused_count;
 } jmem_pools_stats_t;
 
-extern void jmem_pools_get_stats (jmem_pools_stats_t *);
-extern void jmem_pools_stats_reset_peak (void);
-extern void jmem_pools_stats_print (void);
+void jmem_pools_get_stats (jmem_pools_stats_t *);
+void jmem_pools_stats_reset_peak (void);
+void jmem_pools_stats_print (void);
 #endif /* JMEM_STATS */
 
 /**

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -81,8 +81,8 @@
   enum { JERRY_STATIC_ASSERT_GLUE (static_assertion_failed_, __LINE__, msg) = 1 / (!!(x)) }
 
 #ifndef JERRY_NDEBUG
-extern void __noreturn jerry_assert_fail (const char *, const char *, const char *, const uint32_t);
-extern void __noreturn jerry_unreachable (const char *, const char *, const uint32_t);
+void __noreturn jerry_assert_fail (const char *, const char *, const char *, const uint32_t);
+void __noreturn jerry_unreachable (const char *, const char *, const uint32_t);
 
 #define JERRY_ASSERT(x) \
   do \
@@ -114,7 +114,7 @@ extern void __noreturn jerry_unreachable (const char *, const char *, const uint
 /**
  * Exit on fatal error
  */
-extern void __noreturn jerry_fatal (jerry_fatal_code_t);
+void __noreturn jerry_fatal (jerry_fatal_code_t);
 
 /*
  * Logging

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -27,7 +27,7 @@
 #define LIT_CHAR_ZWJ  ((ecma_char_t) 0x200D) /* zero width joiner */
 #define LIT_CHAR_BOM  ((ecma_char_t) 0xFEFF) /* byte order mark */
 
-extern bool lit_char_is_format_control (ecma_char_t);
+bool lit_char_is_format_control (ecma_char_t);
 
 /*
  * Whitespace characters (ECMA-262 v5, Table 2)
@@ -39,7 +39,7 @@ extern bool lit_char_is_format_control (ecma_char_t);
 #define LIT_CHAR_NBSP ((ecma_char_t) 0x00A0) /* no-break space */
 /* LIT_CHAR_BOM is defined above */
 
-extern bool lit_char_is_white_space (ecma_char_t);
+bool lit_char_is_white_space (ecma_char_t);
 
 /*
  * Line terminator characters (ECMA-262 v5, Table 3)
@@ -49,7 +49,7 @@ extern bool lit_char_is_white_space (ecma_char_t);
 #define LIT_CHAR_LS ((ecma_char_t) 0x2028) /* line separator */
 #define LIT_CHAR_PS ((ecma_char_t) 0x2029) /* paragraph separator */
 
-extern bool lit_char_is_line_terminator (ecma_char_t);
+bool lit_char_is_line_terminator (ecma_char_t);
 
 /*
  * String Single Character Escape Sequences (ECMA-262 v5, Table 4)
@@ -77,10 +77,10 @@ extern bool lit_char_is_line_terminator (ecma_char_t);
 #define LIT_CHAR_UNDERSCORE  ((ecma_char_t) '_')  /* low line (underscore) */
 /* LIT_CHAR_BACKSLASH defined above */
 
-extern bool lit_char_is_identifier_start (const uint8_t *);
-extern bool lit_char_is_identifier_part (const uint8_t *);
-extern bool lit_char_is_identifier_start_character (ecma_char_t);
-extern bool lit_char_is_identifier_part_character (ecma_char_t);
+bool lit_char_is_identifier_start (const uint8_t *);
+bool lit_char_is_identifier_part (const uint8_t *);
+bool lit_char_is_identifier_start_character (ecma_char_t);
+bool lit_char_is_identifier_part_character (ecma_char_t);
 
 /*
  * Punctuator characters (ECMA-262 v5, 7.7)
@@ -213,12 +213,12 @@ extern bool lit_char_is_identifier_part_character (ecma_char_t);
 
 #define LEXER_TO_ASCII_LOWERCASE(character) ((character) | LIT_CHAR_SP)
 
-extern bool lit_char_is_octal_digit (ecma_char_t);
-extern bool lit_char_is_decimal_digit (ecma_char_t);
-extern bool lit_char_is_hex_digit (ecma_char_t);
-extern uint32_t lit_char_hex_to_int (ecma_char_t);
-extern size_t lit_char_to_utf8_bytes (uint8_t *, ecma_char_t);
-extern size_t lit_char_get_utf8_length (ecma_char_t);
+bool lit_char_is_octal_digit (ecma_char_t);
+bool lit_char_is_decimal_digit (ecma_char_t);
+bool lit_char_is_hex_digit (ecma_char_t);
+uint32_t lit_char_hex_to_int (ecma_char_t);
+size_t lit_char_to_utf8_bytes (uint8_t *, ecma_char_t);
+size_t lit_char_get_utf8_length (ecma_char_t);
 
 /* read a hex encoded code point from a zero terminated buffer */
 bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *, lit_utf8_size_t, ecma_char_ptr_t);
@@ -231,7 +231,7 @@ bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *, lit_utf8_size_t, ecma
 /*
  * Part of IsWordChar abstract operation (ECMA-262 v5, 15.10.2.6, step 3)
  */
-extern bool lit_char_is_word_char (ecma_char_t);
+bool lit_char_is_word_char (ecma_char_t);
 
 /*
  * Utility functions for uppercasing / lowercasing

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -324,7 +324,7 @@ lit_is_ex_utf8_string_pair_magic (const lit_utf8_byte_t *string1_p, /**< first u
  *
  * @return pointer to the byte next to the last copied in the buffer
  */
-extern lit_utf8_byte_t *
+lit_utf8_byte_t *
 lit_copy_magic_string_to_buffer (lit_magic_string_id_t id, /**< magic string id */
                                  lit_utf8_byte_t *buffer_p, /**< destination buffer */
                                  lit_utf8_size_t buffer_size) /**< size of buffer */

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -42,25 +42,25 @@ typedef enum
  */
 typedef uint32_t lit_magic_string_ex_id_t;
 
-extern uint32_t lit_get_magic_string_ex_count (void);
+uint32_t lit_get_magic_string_ex_count (void);
 
-extern const lit_utf8_byte_t *lit_get_magic_string_utf8 (lit_magic_string_id_t);
-extern lit_utf8_size_t lit_get_magic_string_size (lit_magic_string_id_t);
-extern lit_magic_string_id_t lit_get_magic_string_size_block_start (lit_utf8_size_t);
+const lit_utf8_byte_t *lit_get_magic_string_utf8 (lit_magic_string_id_t);
+lit_utf8_size_t lit_get_magic_string_size (lit_magic_string_id_t);
+lit_magic_string_id_t lit_get_magic_string_size_block_start (lit_utf8_size_t);
 
-extern const lit_utf8_byte_t *lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t);
-extern lit_utf8_size_t lit_get_magic_string_ex_size (lit_magic_string_ex_id_t);
+const lit_utf8_byte_t *lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t);
+lit_utf8_size_t lit_get_magic_string_ex_size (lit_magic_string_ex_id_t);
 
-extern void lit_magic_strings_ex_set (const lit_utf8_byte_t **, uint32_t, const lit_utf8_size_t *);
+void lit_magic_strings_ex_set (const lit_utf8_byte_t **, uint32_t, const lit_utf8_size_t *);
 
-extern lit_magic_string_id_t lit_is_utf8_string_magic (const lit_utf8_byte_t *, lit_utf8_size_t);
-extern lit_magic_string_id_t lit_is_utf8_string_pair_magic (const lit_utf8_byte_t *, lit_utf8_size_t,
-                                                            const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_magic_string_id_t lit_is_utf8_string_magic (const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_magic_string_id_t lit_is_utf8_string_pair_magic (const lit_utf8_byte_t *, lit_utf8_size_t,
+                                                     const lit_utf8_byte_t *, lit_utf8_size_t);
 
-extern lit_magic_string_ex_id_t lit_is_ex_utf8_string_magic (const lit_utf8_byte_t *, lit_utf8_size_t);
-extern lit_magic_string_ex_id_t lit_is_ex_utf8_string_pair_magic (const lit_utf8_byte_t *, lit_utf8_size_t,
-                                                                  const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_magic_string_ex_id_t lit_is_ex_utf8_string_magic (const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_magic_string_ex_id_t lit_is_ex_utf8_string_pair_magic (const lit_utf8_byte_t *, lit_utf8_size_t,
+                                                           const lit_utf8_byte_t *, lit_utf8_size_t);
 
-extern lit_utf8_byte_t *lit_copy_magic_string_to_buffer (lit_magic_string_id_t, lit_utf8_byte_t *, lit_utf8_size_t);
+lit_utf8_byte_t *lit_copy_magic_string_to_buffer (lit_magic_string_id_t, lit_utf8_byte_t *, lit_utf8_size_t);
 
 #endif /* !LIT_MAGIC_STRINGS_H */

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -128,7 +128,7 @@ typedef struct
 } parser_error_location_t;
 
 /* Note: source must be a valid UTF-8 string */
-extern ecma_value_t parser_parse_script (const uint8_t *, size_t, bool, ecma_compiled_code_t **);
+ecma_value_t parser_parse_script (const uint8_t *, size_t, bool, ecma_compiled_code_t **);
 
 const char *parser_error_to_string (parser_error_t);
 

--- a/jerry-core/vm/vm-stack.h
+++ b/jerry-core/vm/vm-stack.h
@@ -66,9 +66,9 @@ typedef enum
   VM_CONTEXT_FOR_IN,                          /**< for-in context */
 } vm_stack_context_type_t;
 
-extern ecma_value_t *vm_stack_context_abort (vm_frame_ctx_t *, ecma_value_t *);
-extern bool vm_stack_find_finally (vm_frame_ctx_t *, ecma_value_t **,
-                                   vm_stack_context_type_t, uint32_t);
+ecma_value_t *vm_stack_context_abort (vm_frame_ctx_t *, ecma_value_t *);
+bool vm_stack_find_finally (vm_frame_ctx_t *, ecma_value_t **,
+                            vm_stack_context_type_t, uint32_t);
 
 /**
  * @}

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -274,15 +274,15 @@ typedef enum
   VM_EXEC_CONSTRUCT,             /**< construct a new object */
 } vm_call_operation;
 
-extern ecma_value_t vm_run_global (const ecma_compiled_code_t *);
-extern ecma_value_t vm_run_eval (ecma_compiled_code_t *, bool);
+ecma_value_t vm_run_global (const ecma_compiled_code_t *);
+ecma_value_t vm_run_eval (ecma_compiled_code_t *, bool);
 
-extern ecma_value_t vm_run (const ecma_compiled_code_t *, ecma_value_t,
-                            ecma_object_t *, bool, const ecma_value_t *,
-                            ecma_length_t);
+ecma_value_t vm_run (const ecma_compiled_code_t *, ecma_value_t,
+                     ecma_object_t *, bool, const ecma_value_t *,
+                     ecma_length_t);
 
-extern bool vm_is_strict_mode (void);
-extern bool vm_is_direct_eval_form_call (void);
+bool vm_is_strict_mode (void);
+bool vm_is_direct_eval_form_call (void);
 
 /**
  * @}

--- a/jerry-libc/target/posix/jerry-libc-target.c
+++ b/jerry-libc/target/posix/jerry-libc-target.c
@@ -40,10 +40,10 @@
 
 #include "jerry-libc-defs.h"
 
-extern long int syscall_0 (long int syscall_no);
-extern long int syscall_1 (long int syscall_no, long int arg1);
-extern long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
-extern long int syscall_3 (long int syscall_no, long int arg1, long int arg2, long int arg3);
+long int syscall_0 (long int syscall_no);
+long int syscall_1 (long int syscall_no, long int arg1);
+long int syscall_2 (long int syscall_no, long int arg1, long int arg2);
+long int syscall_3 (long int syscall_no, long int arg1, long int arg2, long int arg3);
 
 /**
  * Exit - cause normal process termination with specified status code

--- a/jerry-libm/jerry-libm-internal.h
+++ b/jerry-libm/jerry-libm-internal.h
@@ -49,34 +49,34 @@
 /*
  * ANSI/POSIX
  */
-extern double acos (double);
-extern double asin (double);
-extern double atan (double);
-extern double atan2 (double, double);
-extern double cos (double);
-extern double sin (double);
-extern double tan (double);
+double acos (double);
+double asin (double);
+double atan (double);
+double atan2 (double, double);
+double cos (double);
+double sin (double);
+double tan (double);
 
-extern double exp (double);
-extern double log (double);
+double exp (double);
+double log (double);
 
-extern double pow (double, double);
-extern double sqrt (double);
+double pow (double, double);
+double sqrt (double);
 
-extern double ceil (double);
-extern double fabs (double);
-extern double floor (double);
-extern double fmod (double, double);
+double ceil (double);
+double fabs (double);
+double floor (double);
+double fmod (double, double);
 
-extern int isnan (double);
-extern int finite (double);
+int isnan (double);
+int finite (double);
 
 double nextafter (double, double);
 
 /*
  * Functions callable from C, intended to support IEEE arithmetic.
  */
-extern double copysign (double, double);
-extern double scalbn (double, int);
+double copysign (double, double);
+double scalbn (double, int);
 
 #endif /* !JERRY_LIBM_INTERNAL_H */

--- a/targets/curie_bsp/include/setjmp.h
+++ b/targets/curie_bsp/include/setjmp.h
@@ -19,7 +19,7 @@
 
 typedef uint64_t jmp_buf[14];
 
-extern  int setjmp (jmp_buf env);
-extern  void longjmp (jmp_buf env, int val);
+int setjmp (jmp_buf env);
+void longjmp (jmp_buf env, int val);
 
 #endif /* !SETJMP_H */

--- a/targets/esp8266/user/jerry_port.c
+++ b/targets/esp8266/user/jerry_port.c
@@ -18,7 +18,7 @@
 #include <stdarg.h>
 
 #include "jerry-core/jerry-port.h"
-extern int ets_putc (int);
+int ets_putc (int);
 
 /**
  * Provide console message implementation for the engine.


### PR DESCRIPTION
Extern keywords on function declarations/definitions provide no additional value since function declarations/definitions default to external linkage in C99, e.g. removing them won't change the semantics of the program.

The extern keywords were essentially a legacy from the early days of the project. This commit cleans this up across the whole codebase in one go to minimize history disruption.

The bulk of the changes in this commit were produced by a custom clang-tidy checker.

Note that variables declarations carrying the extern keyword are untouched by this commit since there the presence of the keyword actually has an impact on the semantics of the program.

JerryScript-DCO-1.0-Signed-off-by: Tilmann Scheller t.scheller@samsung.com