### PR TITLE
Add parameter names to function declarations.

### DIFF
--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -35,7 +35,7 @@ ecma_object_t *ecma_alloc_object (void);
 /**
  * Dealloc memory from an ecma-object
  */
-void ecma_dealloc_object (ecma_object_t *);
+void ecma_dealloc_object (ecma_object_t *object_p);
 
 /**
  * Allocate memory for ecma-number
@@ -47,7 +47,7 @@ ecma_number_t *ecma_alloc_number (void);
 /**
  * Dealloc memory from an ecma-number
  */
-void ecma_dealloc_number (ecma_number_t *);
+void ecma_dealloc_number (ecma_number_t *number_p);
 
 /**
  * Allocate memory for header of a collection
@@ -59,7 +59,7 @@ ecma_collection_header_t *ecma_alloc_collection_header (void);
 /**
  * Dealloc memory from the collection's header
  */
-void ecma_dealloc_collection_header (ecma_collection_header_t *);
+void ecma_dealloc_collection_header (ecma_collection_header_t *collection_header_p);
 
 /**
  * Allocate memory for non-first chunk of a collection
@@ -71,7 +71,7 @@ ecma_collection_chunk_t *ecma_alloc_collection_chunk (void);
 /**
  * Dealloc memory from non-first chunk of a collection
  */
-void ecma_dealloc_collection_chunk (ecma_collection_chunk_t *);
+void ecma_dealloc_collection_chunk (ecma_collection_chunk_t *collection_chunk_p);
 
 /**
  * Allocate memory for ecma-string descriptor
@@ -83,7 +83,7 @@ ecma_string_t *ecma_alloc_string (void);
 /**
  * Dealloc memory from ecma-string descriptor
  */
-void ecma_dealloc_string (ecma_string_t *);
+void ecma_dealloc_string (ecma_string_t *string_p);
 
 /**
  * Allocate memory for getter-setter pointer pair
@@ -95,7 +95,7 @@ ecma_getter_setter_pointers_t *ecma_alloc_getter_setter_pointers (void);
 /**
  * Dealloc memory from getter-setter pointer pair
  */
-void ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *);
+void ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *getter_setter_pointers_p);
 
 /**
 * Allocate memory for external pointer
@@ -107,19 +107,19 @@ ecma_external_pointer_t *ecma_alloc_external_pointer (void);
 /**
 * Dealloc memory from external pointer
 */
-void ecma_dealloc_external_pointer (ecma_external_pointer_t *);
+void ecma_dealloc_external_pointer (ecma_external_pointer_t *external_pointer_p);
 
 /*
  * Allocate memory for extended object
  *
  * @return pointer to allocated memory
  */
-ecma_extended_object_t *ecma_alloc_extended_object (size_t);
+ecma_extended_object_t *ecma_alloc_extended_object (size_t size);
 
 /**
  * Dealloc memory of an extended object
  */
-void ecma_dealloc_extended_object (ecma_extended_object_t *, size_t);
+void ecma_dealloc_extended_object (ecma_extended_object_t *ext_object_p, size_t size);
 
 /**
  * Allocate memory for ecma-property pair
@@ -131,7 +131,7 @@ ecma_property_pair_t *ecma_alloc_property_pair (void);
 /**
  * Dealloc memory from an ecma-property pair
  */
-void ecma_dealloc_property_pair (ecma_property_pair_t *);
+void ecma_dealloc_property_pair (ecma_property_pair_t *property_pair_p);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-gc.h
+++ b/jerry-core/ecma/base/ecma-gc.h
@@ -26,11 +26,11 @@
  * @{
  */
 
-void ecma_init_gc_info (ecma_object_t *);
-void ecma_ref_object (ecma_object_t *);
-void ecma_deref_object (ecma_object_t *);
-void ecma_gc_run (jmem_free_unused_memory_severity_t);
-void ecma_free_unused_memory (jmem_free_unused_memory_severity_t);
+void ecma_init_gc_info (ecma_object_t *object_p);
+void ecma_ref_object (ecma_object_t *object_p);
+void ecma_deref_object (ecma_object_t *object_p);
+void ecma_gc_run (jmem_free_unused_memory_severity_t severity);
+void ecma_free_unused_memory (jmem_free_unused_memory_severity_t severity);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -111,132 +111,138 @@
   }
 
 /* ecma-helpers-value.c */
-bool ecma_is_value_direct (ecma_value_t) __attr_pure___;
-bool ecma_is_value_simple (ecma_value_t) __attr_pure___;
-bool ecma_is_value_empty (ecma_value_t) __attr_pure___;
-bool ecma_is_value_undefined (ecma_value_t) __attr_pure___;
-bool ecma_is_value_null (ecma_value_t) __attr_pure___;
-bool ecma_is_value_boolean (ecma_value_t) __attr_pure___;
-bool ecma_is_value_true (ecma_value_t) __attr_pure___;
-bool ecma_is_value_false (ecma_value_t) __attr_pure___;
-bool ecma_is_value_found (ecma_value_t) __attr_pure___;
-bool ecma_is_value_array_hole (ecma_value_t) __attr_pure___;
+bool ecma_is_value_direct (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_simple (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_empty (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_undefined (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_null (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_boolean (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_true (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_false (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_found (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_array_hole (ecma_value_t value) __attr_pure___;
 
-bool ecma_is_value_integer_number (ecma_value_t) __attr_pure___;
-bool ecma_are_values_integer_numbers (ecma_value_t, ecma_value_t) __attr_pure___;
-bool ecma_is_value_float_number (ecma_value_t) __attr_pure___;
-bool ecma_is_value_number (ecma_value_t) __attr_pure___;
-bool ecma_is_value_string (ecma_value_t) __attr_pure___;
-bool ecma_is_value_object (ecma_value_t) __attr_pure___;
+bool ecma_is_value_integer_number (ecma_value_t value) __attr_pure___;
+bool ecma_are_values_integer_numbers (ecma_value_t first_value, ecma_value_t second_value) __attr_pure___;
+bool ecma_is_value_float_number (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_number (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_string (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_object (ecma_value_t value) __attr_pure___;
 
-void ecma_check_value_type_is_spec_defined (ecma_value_t);
+void ecma_check_value_type_is_spec_defined (ecma_value_t value);
 
 ecma_value_t ecma_make_simple_value (const ecma_simple_value_t value) __attr_const___;
-ecma_value_t ecma_make_boolean_value (bool) __attr_const___;
-ecma_value_t ecma_make_integer_value (ecma_integer_value_t) __attr_const___;
+ecma_value_t ecma_make_boolean_value (bool boolean_value) __attr_const___;
+ecma_value_t ecma_make_integer_value (ecma_integer_value_t integer_value) __attr_const___;
 ecma_value_t ecma_make_nan_value (void);
-ecma_value_t ecma_make_number_value (ecma_number_t);
-ecma_value_t ecma_make_int32_value (int32_t);
-ecma_value_t ecma_make_uint32_value (uint32_t);
-ecma_value_t ecma_make_string_value (const ecma_string_t *);
-ecma_value_t ecma_make_object_value (const ecma_object_t *);
-ecma_value_t ecma_make_error_value (ecma_value_t);
-ecma_value_t ecma_make_error_obj_value (const ecma_object_t *);
-ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t) __attr_pure___;
-ecma_number_t ecma_get_float_from_value (ecma_value_t) __attr_pure___;
-ecma_number_t ecma_get_number_from_value (ecma_value_t) __attr_pure___;
-uint32_t ecma_get_uint32_from_value (ecma_value_t) __attr_pure___;
-ecma_string_t *ecma_get_string_from_value (ecma_value_t) __attr_pure___;
-ecma_object_t *ecma_get_object_from_value (ecma_value_t) __attr_pure___;
-ecma_value_t ecma_get_value_from_error_value (ecma_value_t) __attr_pure___;
-ecma_value_t ecma_invert_boolean_value (ecma_value_t) __attr_pure___;
-ecma_value_t ecma_copy_value (ecma_value_t);
-ecma_value_t ecma_fast_copy_value (ecma_value_t);
-ecma_value_t ecma_copy_value_if_not_object (ecma_value_t);
-ecma_value_t ecma_update_float_number (ecma_value_t, ecma_number_t);
-void ecma_value_assign_value (ecma_value_t *, ecma_value_t);
-void ecma_value_assign_number (ecma_value_t *, ecma_number_t);
-void ecma_value_assign_uint32 (ecma_value_t *, uint32_t);
-void ecma_free_value (ecma_value_t);
-void ecma_fast_free_value (ecma_value_t);
-void ecma_free_value_if_not_object (ecma_value_t);
+ecma_value_t ecma_make_number_value (ecma_number_t ecma_number);
+ecma_value_t ecma_make_int32_value (int32_t int32_number);
+ecma_value_t ecma_make_uint32_value (uint32_t uint32_number);
+ecma_value_t ecma_make_string_value (const ecma_string_t *ecma_string_p);
+ecma_value_t ecma_make_object_value (const ecma_object_t *object_p);
+ecma_value_t ecma_make_error_value (ecma_value_t value);
+ecma_value_t ecma_make_error_obj_value (const ecma_object_t *object_p);
+ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t value) __attr_pure___;
+ecma_number_t ecma_get_float_from_value (ecma_value_t value) __attr_pure___;
+ecma_number_t ecma_get_number_from_value (ecma_value_t value) __attr_pure___;
+uint32_t ecma_get_uint32_from_value (ecma_value_t value) __attr_pure___;
+ecma_string_t *ecma_get_string_from_value (ecma_value_t value) __attr_pure___;
+ecma_object_t *ecma_get_object_from_value (ecma_value_t value) __attr_pure___;
+ecma_value_t ecma_get_value_from_error_value (ecma_value_t value) __attr_pure___;
+ecma_value_t ecma_invert_boolean_value (ecma_value_t value) __attr_pure___;
+ecma_value_t ecma_copy_value (ecma_value_t value);
+ecma_value_t ecma_fast_copy_value (ecma_value_t value);
+ecma_value_t ecma_copy_value_if_not_object (ecma_value_t value);
+ecma_value_t ecma_update_float_number (ecma_value_t float_value, ecma_number_t new_number);
+void ecma_value_assign_value (ecma_value_t *value_p, ecma_value_t ecma_value);
+void ecma_value_assign_number (ecma_value_t *value_p, ecma_number_t ecma_number);
+void ecma_value_assign_uint32 (ecma_value_t *value_p, uint32_t uint32_number);
+void ecma_free_value (ecma_value_t value);
+void ecma_fast_free_value (ecma_value_t value);
+void ecma_free_value_if_not_object (ecma_value_t value);
 
 /* ecma-helpers-string.c */
-ecma_string_t *ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *, lit_utf8_size_t);
-ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *, lit_utf8_size_t);
-ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t);
-ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t);
-ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t);
-ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t);
-ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t);
+ecma_string_t *ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *string_p, lit_utf8_size_t string_size);
+ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *string_p,
+                                                                  lit_utf8_size_t string_size);
+ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t code_unit);
+ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t uint32_number);
+ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t num);
+ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t id);
+ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id);
 ecma_string_t *ecma_new_ecma_length_string ();
-ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *, ecma_string_t *);
-void ecma_ref_ecma_string (ecma_string_t *);
-void ecma_deref_ecma_string (ecma_string_t *);
-ecma_number_t ecma_string_to_number (const ecma_string_t *);
-uint32_t ecma_string_get_array_index (const ecma_string_t *);
+ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *string1_p, ecma_string_t *string2_p);
+void ecma_ref_ecma_string (ecma_string_t *string_p);
+void ecma_deref_ecma_string (ecma_string_t *string_p);
+ecma_number_t ecma_string_to_number (const ecma_string_t *str_p);
+uint32_t ecma_string_get_array_index (const ecma_string_t *str_p);
 
 lit_utf8_size_t __attr_return_value_should_be_checked___
-ecma_string_copy_to_utf8_buffer (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
-void ecma_string_to_utf8_bytes (const ecma_string_t *, lit_utf8_byte_t *, lit_utf8_size_t);
-const lit_utf8_byte_t *ecma_string_raw_chars (const ecma_string_t *, lit_utf8_size_t *, bool *);
-void ecma_init_ecma_string_from_uint32 (ecma_string_t *, uint32_t);
-void ecma_init_ecma_length_string (ecma_string_t *);
-bool ecma_string_is_empty (const ecma_string_t *);
-bool ecma_string_is_length (const ecma_string_t *);
+ecma_string_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, lit_utf8_byte_t *buffer_p,
+                                 lit_utf8_size_t buffer_size);
+void ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, lit_utf8_byte_t *buffer_p,
+                                lit_utf8_size_t buffer_size);
+const lit_utf8_byte_t *ecma_string_raw_chars (const ecma_string_t *string_p, lit_utf8_size_t *size_p, bool *is_ascii_p);
+void ecma_init_ecma_string_from_uint32 (ecma_string_t *string_desc_p, uint32_t uint32_number);
+void ecma_init_ecma_length_string (ecma_string_t *string_desc_p);
+bool ecma_string_is_empty (const ecma_string_t *str_p);
+bool ecma_string_is_length (const ecma_string_t *string_p);
 
-jmem_cpointer_t ecma_string_to_property_name (ecma_string_t *, ecma_property_t *);
-ecma_string_t *ecma_string_from_property_name (ecma_property_t, jmem_cpointer_t);
-lit_string_hash_t ecma_string_get_property_name_hash (ecma_property_t, jmem_cpointer_t);
-uint32_t ecma_string_get_property_index (ecma_property_t, jmem_cpointer_t);
-bool ecma_string_compare_to_property_name (ecma_property_t, jmem_cpointer_t, const ecma_string_t *);
+jmem_cpointer_t ecma_string_to_property_name (ecma_string_t *prop_name_p, ecma_property_t *name_type_p);
+ecma_string_t *ecma_string_from_property_name (ecma_property_t property, jmem_cpointer_t prop_name_cp);
+lit_string_hash_t ecma_string_get_property_name_hash (ecma_property_t property, jmem_cpointer_t prop_name_cp);
+uint32_t ecma_string_get_property_index (ecma_property_t property, jmem_cpointer_t prop_name_cp);
+bool ecma_string_compare_to_property_name (ecma_property_t property, jmem_cpointer_t prop_name_cp,
+                                           const ecma_string_t *string_p);
 
-bool ecma_compare_ecma_strings (const ecma_string_t *, const ecma_string_t *);
-bool ecma_compare_ecma_strings_relational (const ecma_string_t *, const ecma_string_t *);
-ecma_length_t ecma_string_get_length (const ecma_string_t *);
-ecma_length_t ecma_string_get_utf8_length (const ecma_string_t *);
-lit_utf8_size_t ecma_string_get_size (const ecma_string_t *);
-lit_utf8_size_t ecma_string_get_utf8_size (const ecma_string_t *);
-ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *, ecma_length_t);
+bool ecma_compare_ecma_strings (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
+bool ecma_compare_ecma_strings_relational (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
+ecma_length_t ecma_string_get_length (const ecma_string_t *string_p);
+ecma_length_t ecma_string_get_utf8_length (const ecma_string_t *string_p);
+lit_utf8_size_t ecma_string_get_size (const ecma_string_t *string_p);
+lit_utf8_size_t ecma_string_get_utf8_size (const ecma_string_t *string_p);
+ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *string_p, ecma_length_t index);
 
-ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t);
-ecma_string_t *ecma_get_magic_string_ex (lit_magic_string_ex_id_t);
-lit_magic_string_id_t ecma_get_string_magic (const ecma_string_t *);
+ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t id);
+ecma_string_t *ecma_get_magic_string_ex (lit_magic_string_ex_id_t id);
+lit_magic_string_id_t ecma_get_string_magic (const ecma_string_t *string_p);
 
-lit_string_hash_t ecma_string_hash (const ecma_string_t *);
-ecma_string_t *ecma_string_substr (const ecma_string_t *, ecma_length_t, ecma_length_t);
-ecma_string_t *ecma_string_trim (const ecma_string_t *);
+lit_string_hash_t ecma_string_hash (const ecma_string_t *string_p);
+ecma_string_t *ecma_string_substr (const ecma_string_t *string_p, ecma_length_t start_pos, ecma_length_t end_pos);
+ecma_string_t *ecma_string_trim (const ecma_string_t *string_p);
 
 /* ecma-helpers-number.c */
 ecma_number_t ecma_number_make_nan (void);
-ecma_number_t ecma_number_make_infinity (bool);
-bool ecma_number_is_nan (ecma_number_t);
-bool ecma_number_is_negative (ecma_number_t);
-bool ecma_number_is_zero (ecma_number_t);
-bool ecma_number_is_infinity (ecma_number_t);
+ecma_number_t ecma_number_make_infinity (bool sign);
+bool ecma_number_is_nan (ecma_number_t num);
+bool ecma_number_is_negative (ecma_number_t num);
+bool ecma_number_is_zero (ecma_number_t num);
+bool ecma_number_is_infinity (ecma_number_t num);
 int32_t
-ecma_number_get_fraction_and_exponent (ecma_number_t, uint64_t *, int32_t *);
+ecma_number_get_fraction_and_exponent (ecma_number_t num, uint64_t *out_fraction_p, int32_t *out_exponent_p);
 ecma_number_t
-ecma_number_make_normal_positive_from_fraction_and_exponent (uint64_t, int32_t);
+ecma_number_make_normal_positive_from_fraction_and_exponent (uint64_t fraction, int32_t exponent);
 ecma_number_t
-ecma_number_make_from_sign_mantissa_and_exponent (bool, uint64_t, int32_t);
-ecma_number_t ecma_number_get_prev (ecma_number_t);
-ecma_number_t ecma_number_get_next (ecma_number_t);
-ecma_number_t ecma_number_negate (ecma_number_t);
-ecma_number_t ecma_number_trunc (ecma_number_t);
-ecma_number_t ecma_number_calc_remainder (ecma_number_t, ecma_number_t);
-ecma_number_t ecma_number_add (ecma_number_t, ecma_number_t);
-ecma_number_t ecma_number_substract (ecma_number_t, ecma_number_t);
-ecma_number_t ecma_number_multiply (ecma_number_t, ecma_number_t);
-ecma_number_t ecma_number_divide (ecma_number_t, ecma_number_t);
-lit_utf8_size_t ecma_number_to_decimal (ecma_number_t, lit_utf8_byte_t *, int32_t *);
+ecma_number_make_from_sign_mantissa_and_exponent (bool sign, uint64_t mantissa, int32_t exponent);
+ecma_number_t ecma_number_get_prev (ecma_number_t num);
+ecma_number_t ecma_number_get_next (ecma_number_t num);
+ecma_number_t ecma_number_negate (ecma_number_t num);
+ecma_number_t ecma_number_trunc (ecma_number_t num);
+ecma_number_t ecma_number_calc_remainder (ecma_number_t left_num, ecma_number_t right_num);
+ecma_number_t ecma_number_add (ecma_number_t left_num, ecma_number_t right_num);
+ecma_number_t ecma_number_substract (ecma_number_t left_num, ecma_number_t right_num);
+ecma_number_t ecma_number_multiply (ecma_number_t left_num, ecma_number_t right_num);
+ecma_number_t ecma_number_divide (ecma_number_t left_num, ecma_number_t right_num);
+lit_utf8_size_t ecma_number_to_decimal (ecma_number_t num, lit_utf8_byte_t *out_digits_p, int32_t *out_decimal_exp_p);
 
 /* ecma-helpers-values-collection.c */
-ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t[], ecma_length_t, bool);
-void ecma_free_values_collection (ecma_collection_header_t *, bool);
-void ecma_append_to_values_collection (ecma_collection_header_t *, ecma_value_t, bool);
-void ecma_remove_last_value_from_values_collection (ecma_collection_header_t *);
-ecma_collection_header_t *ecma_new_strings_collection (ecma_string_t *[], ecma_length_t);
+ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t values_buffer[], ecma_length_t values_number,
+                                                      bool do_ref_if_object);
+void ecma_free_values_collection (ecma_collection_header_t *header_p, bool do_deref_if_object);
+void ecma_append_to_values_collection (ecma_collection_header_t *header_p, ecma_value_t v, bool do_ref_if_object);
+void ecma_remove_last_value_from_values_collection (ecma_collection_header_t *header_p);
+ecma_collection_header_t *ecma_new_strings_collection (ecma_string_t *string_ptrs_buffer[],
+                                                       ecma_length_t strings_number);
 
 /**
  * Context of ecma values' collection iterator
@@ -252,88 +258,95 @@ typedef struct
 } ecma_collection_iterator_t;
 
 void
-ecma_collection_iterator_init (ecma_collection_iterator_t *, ecma_collection_header_t *);
+ecma_collection_iterator_init (ecma_collection_iterator_t *iterator_p, ecma_collection_header_t *collection_p);
 bool
-ecma_collection_iterator_next (ecma_collection_iterator_t *);
+ecma_collection_iterator_next (ecma_collection_iterator_t *iterator_p);
 
 /* ecma-helpers.c */
-ecma_object_t *ecma_create_object (ecma_object_t *, size_t, ecma_object_type_t);
-ecma_object_t *ecma_create_decl_lex_env (ecma_object_t *);
-ecma_object_t *ecma_create_object_lex_env (ecma_object_t *, ecma_object_t *, bool);
-bool ecma_is_lexical_environment (const ecma_object_t *) __attr_pure___;
-bool ecma_get_object_extensible (const ecma_object_t *) __attr_pure___;
-void ecma_set_object_extensible (ecma_object_t *, bool);
-ecma_object_type_t ecma_get_object_type (const ecma_object_t *) __attr_pure___;
-void ecma_set_object_type (ecma_object_t *, ecma_object_type_t);
-ecma_object_t *ecma_get_object_prototype (const ecma_object_t *) __attr_pure___;
-bool ecma_get_object_is_builtin (const ecma_object_t *) __attr_pure___;
-void ecma_set_object_is_builtin (ecma_object_t *);
-ecma_lexical_environment_type_t ecma_get_lex_env_type (const ecma_object_t *) __attr_pure___;
-ecma_object_t *ecma_get_lex_env_outer_reference (const ecma_object_t *) __attr_pure___;
-ecma_property_header_t *ecma_get_property_list (const ecma_object_t *) __attr_pure___;
-ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *) __attr_pure___;
-bool ecma_get_lex_env_provide_this (const ecma_object_t *) __attr_pure___;
+ecma_object_t *ecma_create_object (ecma_object_t *prototype_object_p, size_t ext_object_size, ecma_object_type_t type);
+ecma_object_t *ecma_create_decl_lex_env (ecma_object_t *outer_lexical_environment_p);
+ecma_object_t *ecma_create_object_lex_env (ecma_object_t *outer_lexical_environment_p, ecma_object_t *binding_obj_p,
+                                           bool provide_this);
+bool ecma_is_lexical_environment (const ecma_object_t *object_p) __attr_pure___;
+bool ecma_get_object_extensible (const ecma_object_t *object_p) __attr_pure___;
+void ecma_set_object_extensible (ecma_object_t *object_p, bool is_extensible);
+ecma_object_type_t ecma_get_object_type (const ecma_object_t *object_p) __attr_pure___;
+void ecma_set_object_type (ecma_object_t *object_p, ecma_object_type_t type);
+ecma_object_t *ecma_get_object_prototype (const ecma_object_t *object_p) __attr_pure___;
+bool ecma_get_object_is_builtin (const ecma_object_t *object_p) __attr_pure___;
+void ecma_set_object_is_builtin (ecma_object_t *object_p);
+ecma_lexical_environment_type_t ecma_get_lex_env_type (const ecma_object_t *object_p) __attr_pure___;
+ecma_object_t *ecma_get_lex_env_outer_reference (const ecma_object_t *object_p) __attr_pure___;
+ecma_property_header_t *ecma_get_property_list (const ecma_object_t *object_p) __attr_pure___;
+ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *object_p) __attr_pure___;
+bool ecma_get_lex_env_provide_this (const ecma_object_t *object_p) __attr_pure___;
 
-ecma_value_t *ecma_create_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-ecma_value_t *ecma_find_internal_property (ecma_object_t *, ecma_internal_property_id_t);
-ecma_value_t *ecma_get_internal_property (ecma_object_t *, ecma_internal_property_id_t);
+ecma_value_t *ecma_create_internal_property (ecma_object_t *object_p, ecma_internal_property_id_t property_id);
+ecma_value_t *ecma_find_internal_property (ecma_object_t *object_p, ecma_internal_property_id_t property_id);
+ecma_value_t *ecma_get_internal_property (ecma_object_t *object_p, ecma_internal_property_id_t property_id);
 
 ecma_property_value_t *
-ecma_create_named_data_property (ecma_object_t *, ecma_string_t *, uint8_t, ecma_property_t **);
+ecma_create_named_data_property (ecma_object_t *object_p, ecma_string_t *name_p, uint8_t prop_attributes,
+                                 ecma_property_t **out_prop_p);
 ecma_property_value_t *
-ecma_create_named_accessor_property (ecma_object_t *, ecma_string_t *, ecma_object_t *,
-                                     ecma_object_t *, uint8_t, ecma_property_t **);
+ecma_create_named_accessor_property (ecma_object_t *object_p, ecma_string_t *name_p, ecma_object_t *get_p,
+                                     ecma_object_t *set_p, uint8_t prop_attributes, ecma_property_t **out_prop_p);
 ecma_property_t *
-ecma_find_named_property (ecma_object_t *, ecma_string_t *);
+ecma_find_named_property (ecma_object_t *obj_p, ecma_string_t *name_p);
 ecma_property_value_t *
-ecma_get_named_data_property (ecma_object_t *, ecma_string_t *);
+ecma_get_named_data_property (ecma_object_t *obj_p, ecma_string_t *name_p);
 
-void ecma_free_property (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
+void ecma_free_property (ecma_object_t *object_p, jmem_cpointer_t name_cp, ecma_property_t *property_p);
 
-void ecma_delete_property (ecma_object_t *, ecma_property_value_t *);
-uint32_t ecma_delete_array_properties (ecma_object_t *, uint32_t, uint32_t);
+void ecma_delete_property (ecma_object_t *object_p, ecma_property_value_t *prop_value_p);
+uint32_t ecma_delete_array_properties (ecma_object_t *object_p, uint32_t new_length, uint32_t old_length);
 
-void ecma_named_data_property_assign_value (ecma_object_t *, ecma_property_value_t *, ecma_value_t);
+void ecma_named_data_property_assign_value (ecma_object_t *obj_p, ecma_property_value_t *prop_value_p,
+                                            ecma_value_t value);
 
-ecma_object_t *ecma_get_named_accessor_property_getter (const ecma_property_value_t *);
-ecma_object_t *ecma_get_named_accessor_property_setter (const ecma_property_value_t *);
-void ecma_set_named_accessor_property_getter (ecma_object_t *, ecma_property_value_t *, ecma_object_t *);
-void ecma_set_named_accessor_property_setter (ecma_object_t *, ecma_property_value_t *, ecma_object_t *);
-bool ecma_is_property_writable (ecma_property_t);
-void ecma_set_property_writable_attr (ecma_property_t *, bool);
-bool ecma_is_property_enumerable (ecma_property_t);
-void ecma_set_property_enumerable_attr (ecma_property_t *, bool);
-bool ecma_is_property_configurable (ecma_property_t);
-void ecma_set_property_configurable_attr (ecma_property_t *, bool);
+ecma_object_t *ecma_get_named_accessor_property_getter (const ecma_property_value_t *prop_value_p);
+ecma_object_t *ecma_get_named_accessor_property_setter (const ecma_property_value_t *prop_value_p);
+void ecma_set_named_accessor_property_getter (ecma_object_t *object_p, ecma_property_value_t *prop_value_p,
+                                              ecma_object_t *getter_p);
+void ecma_set_named_accessor_property_setter (ecma_object_t *object_p, ecma_property_value_t *prop_value_p,
+                                              ecma_object_t *setter_p);
+bool ecma_is_property_writable (ecma_property_t property);
+void ecma_set_property_writable_attr (ecma_property_t *property_p, bool is_writable);
+bool ecma_is_property_enumerable (ecma_property_t property);
+void ecma_set_property_enumerable_attr (ecma_property_t *property_p, bool is_enumerable);
+bool ecma_is_property_configurable (ecma_property_t property);
+void ecma_set_property_configurable_attr (ecma_property_t *property_p, bool is_configurable);
 
-bool ecma_is_property_lcached (ecma_property_t *);
-void ecma_set_property_lcached (ecma_property_t *, bool);
+bool ecma_is_property_lcached (ecma_property_t *property_p);
+void ecma_set_property_lcached (ecma_property_t *property_p, bool is_lcached);
 
 ecma_property_descriptor_t ecma_make_empty_property_descriptor (void);
-void ecma_free_property_descriptor (ecma_property_descriptor_t *);
+void ecma_free_property_descriptor (ecma_property_descriptor_t *prop_desc_p);
 
 ecma_property_t *ecma_get_next_property_pair (ecma_property_pair_t *);
 
-void ecma_bytecode_ref (ecma_compiled_code_t *);
-void ecma_bytecode_deref (ecma_compiled_code_t *);
+void ecma_bytecode_ref (ecma_compiled_code_t *bytecode_p);
+void ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p);
 
 /* ecma-helpers-external-pointers.c */
 bool
-ecma_create_external_pointer_property (ecma_object_t *, ecma_internal_property_id_t, ecma_external_pointer_t);
+ecma_create_external_pointer_property (ecma_object_t *obj_p, ecma_internal_property_id_t id,
+                                       ecma_external_pointer_t ptr_value);
 bool
-ecma_get_external_pointer_value (ecma_object_t *, ecma_internal_property_id_t, ecma_external_pointer_t *);
+ecma_get_external_pointer_value (ecma_object_t *obj_p, ecma_internal_property_id_t id,
+                                 ecma_external_pointer_t *out_pointer_p);
 void
-ecma_free_external_pointer_in_property (ecma_property_t *);
+ecma_free_external_pointer_in_property (ecma_property_t *prop_p);
 
 /* ecma-helpers-conversion.c */
-ecma_number_t ecma_utf8_string_to_number (const lit_utf8_byte_t *, lit_utf8_size_t);
-lit_utf8_size_t ecma_uint32_to_utf8_string (uint32_t, lit_utf8_byte_t *, lit_utf8_size_t);
-uint32_t ecma_number_to_uint32 (ecma_number_t);
-int32_t ecma_number_to_int32 (ecma_number_t);
-lit_utf8_size_t ecma_number_to_utf8_string (ecma_number_t, lit_utf8_byte_t *, lit_utf8_size_t);
+ecma_number_t ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, lit_utf8_size_t str_size);
+lit_utf8_size_t ecma_uint32_to_utf8_string (uint32_t value, lit_utf8_byte_t *out_buffer_p, lit_utf8_size_t buffer_size);
+uint32_t ecma_number_to_uint32 (ecma_number_t num);
+int32_t ecma_number_to_int32 (ecma_number_t num);
+lit_utf8_size_t ecma_number_to_utf8_string (ecma_number_t num, lit_utf8_byte_t *buffer_p, lit_utf8_size_t buffer_size);
 
 /* ecma-helpers-errol.c */
-lit_utf8_size_t ecma_errol0_dtoa (double, lit_utf8_byte_t *, int32_t *);
+lit_utf8_size_t ecma_errol0_dtoa (double val, lit_utf8_byte_t *buffer_p, int32_t *exp_p);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-lcache.h
+++ b/jerry-core/ecma/base/ecma-lcache.h
@@ -24,9 +24,9 @@
  */
 
 void ecma_lcache_init (void);
-void ecma_lcache_insert (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
-ecma_property_t *ecma_lcache_lookup (ecma_object_t *, const ecma_string_t *);
-void ecma_lcache_invalidate (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
+void ecma_lcache_insert (ecma_object_t *object_p, jmem_cpointer_t name_cp, ecma_property_t *prop_p);
+ecma_property_t *ecma_lcache_lookup (ecma_object_t *object_p, const ecma_string_t *prop_name_p);
+void ecma_lcache_invalidate (ecma_object_t *object_p, jmem_cpointer_t name_cp, ecma_property_t *prop_p);
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-literal-storage.h
+++ b/jerry-core/ecma/base/ecma-literal-storage.h
@@ -38,8 +38,8 @@ typedef struct
 
 void ecma_finalize_lit_storage (void);
 
-jmem_cpointer_t ecma_find_or_create_literal_string (const lit_utf8_byte_t *, lit_utf8_size_t);
-jmem_cpointer_t ecma_find_or_create_literal_number (ecma_number_t);
+jmem_cpointer_t ecma_find_or_create_literal_string (const lit_utf8_byte_t *chars_p, lit_utf8_size_t size);
+jmem_cpointer_t ecma_find_or_create_literal_number (ecma_number_t number_arg);
 
 #ifdef JERRY_ENABLE_SNAPSHOT_SAVE
 bool

--- a/jerry-core/ecma/base/ecma-property-hashmap.h
+++ b/jerry-core/ecma/base/ecma-property-hashmap.h
@@ -52,13 +52,15 @@ typedef struct
    */
 } ecma_property_hashmap_t;
 
-void ecma_property_hashmap_create (ecma_object_t *);
-void ecma_property_hashmap_free (ecma_object_t *);
-void ecma_property_hashmap_insert (ecma_object_t *, ecma_string_t *, ecma_property_pair_t *, int);
-void ecma_property_hashmap_delete (ecma_object_t *, jmem_cpointer_t, ecma_property_t *);
+void ecma_property_hashmap_create (ecma_object_t *object_p);
+void ecma_property_hashmap_free (ecma_object_t *object_p);
+void ecma_property_hashmap_insert (ecma_object_t *object_p, ecma_string_t *name_p,
+                                   ecma_property_pair_t *property_pair_p, int property_index);
+void ecma_property_hashmap_delete (ecma_object_t *object_p, jmem_cpointer_t name_cp, ecma_property_t *property_p);
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
-ecma_property_t *ecma_property_hashmap_find (ecma_property_hashmap_t *, ecma_string_t *, jmem_cpointer_t *);
+ecma_property_t *ecma_property_hashmap_find (ecma_property_hashmap_t *hashmap_p, ecma_string_t *name_p,
+                                             jmem_cpointer_t *property_real_name_cp);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -27,25 +27,26 @@
  */
 
 ecma_value_t
-ecma_builtin_helper_object_to_string (const ecma_value_t);
+ecma_builtin_helper_object_to_string (const ecma_value_t this_arg);
 ecma_value_t
-ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *, uint32_t);
+ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, uint32_t index);
 ecma_value_t
-ecma_builtin_helper_object_get_properties (ecma_object_t *, bool);
+ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, bool only_enumerable_properties);
 ecma_value_t
-ecma_builtin_helper_array_concat_value (ecma_object_t *, uint32_t *, ecma_value_t);
+ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, uint32_t *length_p, ecma_value_t value);
 uint32_t
-ecma_builtin_helper_array_index_normalize (ecma_number_t, uint32_t);
+ecma_builtin_helper_array_index_normalize (ecma_number_t index, uint32_t length);
 uint32_t
-ecma_builtin_helper_string_index_normalize (ecma_number_t, uint32_t, bool);
+ecma_builtin_helper_string_index_normalize (ecma_number_t index, uint32_t length, bool nan_to_zero);
 ecma_value_t
-ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t, ecma_value_t,
-                                                      ecma_value_t, bool);
+ecma_builtin_helper_string_prototype_object_index_of (ecma_value_t this_arg, ecma_value_t arg1,
+                                                      ecma_value_t arg2, bool first_index);
 bool
-ecma_builtin_helper_string_find_index (ecma_string_t *, ecma_string_t *, bool, ecma_length_t, ecma_length_t *);
+ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, ecma_string_t *search_str_p, bool first_index,
+                                       ecma_length_t start_pos, ecma_length_t *ret_index_p);
 ecma_value_t
-ecma_builtin_helper_def_prop (ecma_object_t *, ecma_string_t *, ecma_value_t,
-                              bool, bool, bool, bool);
+ecma_builtin_helper_def_prop (ecma_object_t *obj_p, ecma_string_t *index_p, ecma_value_t value,
+                              bool writable, bool enumerable, bool configurable, bool is_throw);
 
 #ifndef CONFIG_DISABLE_DATE_BUILTIN
 
@@ -93,36 +94,36 @@ typedef enum
 } ecma_date_timezone_t;
 
 /* ecma-builtin-helpers-date.c */
-ecma_number_t ecma_date_day (ecma_number_t);
-ecma_number_t ecma_date_time_within_day (ecma_number_t);
-ecma_number_t ecma_date_days_in_year (ecma_number_t);
-ecma_number_t ecma_date_day_from_year (ecma_number_t);
-ecma_number_t ecma_date_time_from_year (ecma_number_t);
-ecma_number_t ecma_date_year_from_time (ecma_number_t);
-ecma_number_t ecma_date_in_leap_year (ecma_number_t);
-ecma_number_t ecma_date_day_within_year (ecma_number_t);
-ecma_number_t ecma_date_month_from_time (ecma_number_t);
-ecma_number_t ecma_date_date_from_time (ecma_number_t);
-ecma_number_t ecma_date_week_day (ecma_number_t);
+ecma_number_t ecma_date_day (ecma_number_t time);
+ecma_number_t ecma_date_time_within_day (ecma_number_t time);
+ecma_number_t ecma_date_days_in_year (ecma_number_t year);
+ecma_number_t ecma_date_day_from_year (ecma_number_t year);
+ecma_number_t ecma_date_time_from_year (ecma_number_t year);
+ecma_number_t ecma_date_year_from_time (ecma_number_t time);
+ecma_number_t ecma_date_in_leap_year (ecma_number_t time);
+ecma_number_t ecma_date_day_within_year (ecma_number_t time);
+ecma_number_t ecma_date_month_from_time (ecma_number_t time);
+ecma_number_t ecma_date_date_from_time (ecma_number_t time);
+ecma_number_t ecma_date_week_day (ecma_number_t time);
 ecma_number_t ecma_date_local_tza ();
-ecma_number_t ecma_date_daylight_saving_ta (ecma_number_t);
-ecma_number_t ecma_date_local_time (ecma_number_t);
-ecma_number_t ecma_date_utc (ecma_number_t);
-ecma_number_t ecma_date_hour_from_time (ecma_number_t);
-ecma_number_t ecma_date_min_from_time (ecma_number_t);
-ecma_number_t ecma_date_sec_from_time (ecma_number_t);
-ecma_number_t ecma_date_ms_from_time (ecma_number_t);
-ecma_number_t ecma_date_make_time (ecma_number_t, ecma_number_t, ecma_number_t, ecma_number_t);
-ecma_number_t ecma_date_make_day (ecma_number_t, ecma_number_t, ecma_number_t);
-ecma_number_t ecma_date_make_date (ecma_number_t, ecma_number_t);
-ecma_number_t ecma_date_time_clip (ecma_number_t);
-ecma_number_t ecma_date_timezone_offset (ecma_number_t);
+ecma_number_t ecma_date_daylight_saving_ta (ecma_number_t time);
+ecma_number_t ecma_date_local_time (ecma_number_t time);
+ecma_number_t ecma_date_utc (ecma_number_t time);
+ecma_number_t ecma_date_hour_from_time (ecma_number_t time);
+ecma_number_t ecma_date_min_from_time (ecma_number_t time);
+ecma_number_t ecma_date_sec_from_time (ecma_number_t time);
+ecma_number_t ecma_date_ms_from_time (ecma_number_t time);
+ecma_number_t ecma_date_make_time (ecma_number_t hour, ecma_number_t min, ecma_number_t sec, ecma_number_t ms);
+ecma_number_t ecma_date_make_day (ecma_number_t year, ecma_number_t month, ecma_number_t date);
+ecma_number_t ecma_date_make_date (ecma_number_t day, ecma_number_t time);
+ecma_number_t ecma_date_time_clip (ecma_number_t time);
+ecma_number_t ecma_date_timezone_offset (ecma_number_t time);
 
-ecma_value_t ecma_date_value_to_string (ecma_number_t);
-ecma_value_t ecma_date_value_to_utc_string (ecma_number_t);
-ecma_value_t ecma_date_value_to_iso_string (ecma_number_t);
-ecma_value_t ecma_date_value_to_date_string (ecma_number_t);
-ecma_value_t ecma_date_value_to_time_string (ecma_number_t);
+ecma_value_t ecma_date_value_to_string (ecma_number_t datetime_number);
+ecma_value_t ecma_date_value_to_utc_string (ecma_number_t datetime_number);
+ecma_value_t ecma_date_value_to_iso_string (ecma_number_t datetime_number);
+ecma_value_t ecma_date_value_to_date_string (ecma_number_t datetime_number);
+ecma_value_t ecma_date_value_to_time_string (ecma_number_t datetime_number);
 
 #endif /* !CONFIG_DISABLE_DATE_BUILTIN */
 
@@ -149,23 +150,26 @@ typedef struct
   ecma_object_t *replacer_function_p;
 } ecma_json_stringify_context_t;
 
-bool ecma_has_object_value_in_collection (ecma_collection_header_t *, ecma_value_t);
-bool ecma_has_string_value_in_collection (ecma_collection_header_t *, ecma_value_t);
+bool ecma_has_object_value_in_collection (ecma_collection_header_t *collection_p, ecma_value_t object_value);
+bool ecma_has_string_value_in_collection (ecma_collection_header_t *collection_p, ecma_value_t string_value);
 
 ecma_string_t *
-ecma_builtin_helper_json_create_hex_digit_ecma_string (uint8_t);
+ecma_builtin_helper_json_create_hex_digit_ecma_string (uint8_t value);
 ecma_string_t *
-ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *, ecma_string_t *);
+ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *partial_p, ecma_string_t *separator_p);
 ecma_value_t
-ecma_builtin_helper_json_create_formatted_json (ecma_string_t *, ecma_string_t *, ecma_string_t *,
-                                                ecma_collection_header_t *, ecma_json_stringify_context_t *);
+ecma_builtin_helper_json_create_formatted_json (ecma_string_t *left_bracket_p, ecma_string_t *right_bracket_p,
+                                                ecma_string_t *stepback_p, ecma_collection_header_t *partial_p,
+                                                ecma_json_stringify_context_t *context_p);
 ecma_value_t
-ecma_builtin_helper_json_create_non_formatted_json (ecma_string_t *, ecma_string_t *, ecma_collection_header_t *);
+ecma_builtin_helper_json_create_non_formatted_json (ecma_string_t *left_bracket_p, ecma_string_t *right_bracket_p,
+                                                    ecma_collection_header_t *partial_p);
 
 /* ecma-builtin-helper-error.c */
 
 ecma_value_t
-ecma_builtin_helper_error_dispatch_call (ecma_standard_error_t, const ecma_value_t *, ecma_length_t);
+ecma_builtin_helper_error_dispatch_call (ecma_standard_error_t error_type, const ecma_value_t *arguments_list_p,
+                                         ecma_length_t arguments_list_len);
 
 /**
  * @}

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -68,23 +68,23 @@ typedef enum
 void ecma_finalize_builtins (void);
 
 ecma_value_t
-ecma_builtin_dispatch_call (ecma_object_t *, ecma_value_t,
-                            const ecma_value_t *, ecma_length_t);
+ecma_builtin_dispatch_call (ecma_object_t *obj_p, ecma_value_t this_arg_value,
+                            const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 ecma_value_t
-ecma_builtin_dispatch_construct (ecma_object_t *,
-                                 const ecma_value_t *, ecma_length_t);
+ecma_builtin_dispatch_construct (ecma_object_t *obj_p,
+                                 const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 ecma_property_t *
-ecma_builtin_try_to_instantiate_property (ecma_object_t *, ecma_string_t *);
+ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, ecma_string_t *string_p);
 void
-ecma_builtin_list_lazy_property_names (ecma_object_t *,
-                                       bool,
-                                       ecma_collection_header_t *,
-                                       ecma_collection_header_t *);
+ecma_builtin_list_lazy_property_names (ecma_object_t *object_p,
+                                       bool separate_enumerable,
+                                       ecma_collection_header_t *main_collection_p,
+                                       ecma_collection_header_t *non_enum_collection_p);
 bool
-ecma_builtin_is (ecma_object_t *, ecma_builtin_id_t);
+ecma_builtin_is (ecma_object_t *obj_p, ecma_builtin_id_t builtin_id);
 ecma_object_t *
-ecma_builtin_get (ecma_builtin_id_t);
+ecma_builtin_get (ecma_builtin_id_t builtin_id);
 bool
-ecma_builtin_function_is_routine (ecma_object_t *);
+ecma_builtin_function_is_routine (ecma_object_t *func_obj_p);
 
 #endif /* !ECMA_BUILTINS_H */

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -40,17 +40,20 @@ typedef enum
 } ecma_array_object_set_length_flags_t;
 
 ecma_value_t
-ecma_op_create_array_object (const ecma_value_t *, ecma_length_t, bool);
+ecma_op_create_array_object (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len,
+                             bool is_treat_single_arg_as_length);
 
 ecma_value_t
-ecma_op_array_object_set_length (ecma_object_t *, ecma_value_t, uint32_t);
+ecma_op_array_object_set_length (ecma_object_t *object_p, ecma_value_t new_value, uint32_t flags);
 
 ecma_value_t
-ecma_op_array_object_define_own_property (ecma_object_t *, ecma_string_t *, const ecma_property_descriptor_t *, bool);
+ecma_op_array_object_define_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
+                                          const ecma_property_descriptor_t *property_desc_p, bool is_throw);
 
 void
-ecma_op_array_list_lazy_property_names (ecma_object_t *, bool,
-                                        ecma_collection_header_t *, ecma_collection_header_t *);
+ecma_op_array_list_lazy_property_names (ecma_object_t *obj_p, bool separate_enumerable,
+                                        ecma_collection_header_t *main_collection_p,
+                                        ecma_collection_header_t *non_enum_collection_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-boolean-object.h
+++ b/jerry-core/ecma/operations/ecma-boolean-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-ecma_value_t ecma_op_create_boolean_object (ecma_value_t);
+ecma_value_t ecma_op_create_boolean_object (ecma_value_t arg);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-comparison.h
+++ b/jerry-core/ecma/operations/ecma-comparison.h
@@ -26,9 +26,9 @@
  * @{
  */
 
-ecma_value_t ecma_op_abstract_equality_compare (ecma_value_t, ecma_value_t);
-bool ecma_op_strict_equality_compare (ecma_value_t, ecma_value_t);
-ecma_value_t ecma_op_abstract_relational_compare (ecma_value_t, ecma_value_t, bool);
+ecma_value_t ecma_op_abstract_equality_compare (ecma_value_t x, ecma_value_t y);
+bool ecma_op_strict_equality_compare (ecma_value_t x, ecma_value_t y);
+ecma_value_t ecma_op_abstract_relational_compare (ecma_value_t x, ecma_value_t y, bool left_first);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -37,16 +37,16 @@ typedef enum
   ECMA_PREFERRED_TYPE_STRING /**< String */
 } ecma_preferred_type_hint_t;
 
-ecma_value_t ecma_op_check_object_coercible (ecma_value_t);
-bool ecma_op_same_value (ecma_value_t, ecma_value_t);
-ecma_value_t ecma_op_to_primitive (ecma_value_t, ecma_preferred_type_hint_t);
-bool ecma_op_to_boolean (ecma_value_t);
-ecma_value_t ecma_op_to_number (ecma_value_t);
-ecma_value_t ecma_op_to_string (ecma_value_t);
-ecma_value_t ecma_op_to_object (ecma_value_t);
+ecma_value_t ecma_op_check_object_coercible (ecma_value_t value);
+bool ecma_op_same_value (ecma_value_t x, ecma_value_t y);
+ecma_value_t ecma_op_to_primitive (ecma_value_t value, ecma_preferred_type_hint_t preferred_type);
+bool ecma_op_to_boolean (ecma_value_t value);
+ecma_value_t ecma_op_to_number (ecma_value_t value);
+ecma_value_t ecma_op_to_string (ecma_value_t value);
+ecma_value_t ecma_op_to_object (ecma_value_t value);
 
-ecma_object_t *ecma_op_from_property_descriptor (const ecma_property_descriptor_t *);
-ecma_value_t ecma_op_to_property_descriptor (ecma_value_t, ecma_property_descriptor_t *);
+ecma_object_t *ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_desc_p);
+ecma_value_t ecma_op_to_property_descriptor (ecma_value_t obj_value, ecma_property_descriptor_t *out_prop_desc_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-eval.h
+++ b/jerry-core/ecma/operations/ecma-eval.h
@@ -26,10 +26,11 @@
  */
 
 ecma_value_t
-ecma_op_eval (ecma_string_t *, bool, bool);
+ecma_op_eval (ecma_string_t *code_p, bool is_direct, bool is_called_from_strict_mode_code);
 
 ecma_value_t
-ecma_op_eval_chars_buffer (const lit_utf8_byte_t *, size_t, bool, bool);
+ecma_op_eval_chars_buffer (const lit_utf8_byte_t *code_p, size_t code_buffer_size, bool is_direct,
+                           bool is_called_from_strict_mode_code);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-exceptions.h
+++ b/jerry-core/ecma/operations/ecma-exceptions.h
@@ -48,16 +48,16 @@ typedef enum
   ECMA_ERROR_URI        /**< URIError */
 } ecma_standard_error_t;
 
-ecma_object_t *ecma_new_standard_error (ecma_standard_error_t);
-ecma_object_t *ecma_new_standard_error_with_message (ecma_standard_error_t, ecma_string_t *);
-ecma_value_t ecma_raise_standard_error (ecma_standard_error_t, const lit_utf8_byte_t *);
-ecma_value_t ecma_raise_common_error (const char *);
-ecma_value_t ecma_raise_eval_error (const char *);
-ecma_value_t ecma_raise_range_error (const char *);
-ecma_value_t ecma_raise_reference_error (const char *);
-ecma_value_t ecma_raise_syntax_error (const char *);
-ecma_value_t ecma_raise_type_error (const char *);
-ecma_value_t ecma_raise_uri_error (const char *);
+ecma_object_t *ecma_new_standard_error (ecma_standard_error_t error_type);
+ecma_object_t *ecma_new_standard_error_with_message (ecma_standard_error_t error_type, ecma_string_t *message_string_p);
+ecma_value_t ecma_raise_standard_error (ecma_standard_error_t error_type, const lit_utf8_byte_t *msg_p);
+ecma_value_t ecma_raise_common_error (const char *msg_p);
+ecma_value_t ecma_raise_eval_error (const char *msg_p);
+ecma_value_t ecma_raise_range_error (const char *msg_p);
+ecma_value_t ecma_raise_reference_error (const char *msg_p);
+ecma_value_t ecma_raise_syntax_error (const char *msg_p);
+ecma_value_t ecma_raise_type_error (const char *msg_p);
+ecma_value_t ecma_raise_uri_error (const char *msg_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -26,32 +26,34 @@
  * @{
  */
 
-bool ecma_op_is_callable (ecma_value_t);
-bool ecma_is_constructor (ecma_value_t);
+bool ecma_op_is_callable (ecma_value_t value);
+bool ecma_is_constructor (ecma_value_t value);
 
 ecma_object_t *
-ecma_op_create_function_object (ecma_object_t *, bool, const ecma_compiled_code_t *);
+ecma_op_create_function_object (ecma_object_t *scope_p, bool is_decl_in_strict_mode,
+                                const ecma_compiled_code_t *bytecode_data_p);
 
 void
-ecma_op_function_list_lazy_property_names (bool,
-                                           ecma_collection_header_t *,
-                                           ecma_collection_header_t *);
+ecma_op_function_list_lazy_property_names (bool separate_enumerable,
+                                           ecma_collection_header_t *main_collection_p,
+                                           ecma_collection_header_t *non_enum_collection_p);
 
 ecma_property_t *
-ecma_op_function_try_lazy_instantiate_property (ecma_object_t *, ecma_string_t *);
+ecma_op_function_try_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
 
 ecma_object_t *
-ecma_op_create_external_function_object (ecma_external_pointer_t);
+ecma_op_create_external_function_object (ecma_external_pointer_t code_p);
 
 ecma_value_t
-ecma_op_function_call (ecma_object_t *, ecma_value_t,
-                       const ecma_value_t *, ecma_length_t);
+ecma_op_function_call (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
+                       const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 
 ecma_value_t
-ecma_op_function_construct (ecma_object_t *, const ecma_value_t *, ecma_length_t);
+ecma_op_function_construct (ecma_object_t *func_obj_p, const ecma_value_t *arguments_list_p,
+                            ecma_length_t arguments_list_len);
 
 ecma_value_t
-ecma_op_function_has_instance (ecma_object_t *, ecma_value_t);
+ecma_op_function_has_instance (ecma_object_t *func_obj_p, ecma_value_t value);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-lex-env.h
+++ b/jerry-core/ecma/operations/ecma-lex-env.h
@@ -39,20 +39,23 @@ ecma_object_t *ecma_get_global_environment (void);
  */
 
 /* ECMA-262 v5, 8.7.1 and 8.7.2 */
-ecma_value_t ecma_op_get_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool);
-ecma_value_t ecma_op_get_value_object_base (ecma_value_t, ecma_string_t *);
-ecma_value_t ecma_op_put_value_lex_env_base (ecma_object_t *, ecma_string_t *, bool, ecma_value_t);
+ecma_value_t ecma_op_get_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, ecma_string_t *var_name_string_p,
+                                             bool is_strict);
+ecma_value_t ecma_op_get_value_object_base (ecma_value_t base_value, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_put_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, ecma_string_t *var_name_string_p,
+                                             bool is_strict, ecma_value_t value);
 
 /* ECMA-262 v5, Table 17. Abstract methods of Environment Records */
-bool ecma_op_has_binding (ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_create_mutable_binding (ecma_object_t *, ecma_string_t *, bool);
-ecma_value_t ecma_op_set_mutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
-ecma_value_t ecma_op_get_binding_value (ecma_object_t *, ecma_string_t *, bool);
-ecma_value_t ecma_op_delete_binding (ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_implicit_this_value (ecma_object_t *);
+bool ecma_op_has_binding (ecma_object_t *lex_env_p, ecma_string_t *name_p);
+ecma_value_t ecma_op_create_mutable_binding (ecma_object_t *lex_env_p, ecma_string_t *name_p, bool is_deletable);
+ecma_value_t ecma_op_set_mutable_binding (ecma_object_t *lex_env_p, ecma_string_t *name_p, ecma_value_t value,
+                                          bool is_strict);
+ecma_value_t ecma_op_get_binding_value (ecma_object_t *lex_env_p, ecma_string_t *name_p, bool is_strict);
+ecma_value_t ecma_op_delete_binding (ecma_object_t *lex_env_p, ecma_string_t *name_p);
+ecma_value_t ecma_op_implicit_this_value (ecma_object_t *lex_env_p);
 
 /* ECMA-262 v5, Table 18. Additional methods of Declarative Environment Records */
-void ecma_op_create_immutable_binding (ecma_object_t *, ecma_string_t *, ecma_value_t);
+void ecma_op_create_immutable_binding (ecma_object_t *lex_env_p, ecma_string_t *name_p, ecma_value_t value);
 
 ecma_object_t *ecma_op_create_global_environment (ecma_object_t *);
 

--- a/jerry-core/ecma/operations/ecma-number-arithmetic.h
+++ b/jerry-core/ecma/operations/ecma-number-arithmetic.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-ecma_number_t ecma_op_number_remainder (ecma_number_t, ecma_number_t);
+ecma_number_t ecma_op_number_remainder (ecma_number_t left_num, ecma_number_t right_num);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-number-object.h
+++ b/jerry-core/ecma/operations/ecma-number-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-ecma_value_t ecma_op_create_number_object (ecma_value_t);
+ecma_value_t ecma_op_create_number_object (ecma_value_t arg);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -20,13 +20,14 @@
 #include "ecma-helpers.h"
 
 void
-ecma_op_create_arguments_object (ecma_object_t *, ecma_object_t *, const ecma_value_t *,
-                                 ecma_length_t, const ecma_compiled_code_t *);
+ecma_op_create_arguments_object (ecma_object_t *func_obj_p, ecma_object_t *lex_env_p,
+                                 const ecma_value_t *arguments_list_p, ecma_length_t arguments_number,
+                                 const ecma_compiled_code_t *bytecode_data_p);
 
 ecma_value_t
-ecma_op_arguments_object_delete (ecma_object_t *, ecma_string_t *, bool);
+ecma_op_arguments_object_delete (ecma_object_t *object_p, ecma_string_t *property_name_p, bool is_throw);
 ecma_value_t
-ecma_op_arguments_object_define_own_property (ecma_object_t *, ecma_string_t *,
-                                              const ecma_property_descriptor_t *, bool);
+ecma_op_arguments_object_define_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
+                                              const ecma_property_descriptor_t *property_desc_p, bool is_throw);
 
 #endif /* !ECMA_OBJECTS_ARGUMENTS_H */

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -26,15 +26,16 @@
  * @{
  */
 
-ecma_value_t ecma_reject (bool);
+ecma_value_t ecma_reject (bool is_throw);
 ecma_object_t *ecma_op_create_object_object_noarg (void);
-ecma_value_t ecma_op_create_object_object_arg (ecma_value_t);
-ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *);
+ecma_value_t ecma_op_create_object_object_arg (ecma_value_t value);
+ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *object_prototype_p);
 
-ecma_value_t ecma_op_general_object_delete (ecma_object_t *, ecma_string_t *, bool);
-ecma_value_t ecma_op_general_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
-ecma_value_t ecma_op_general_object_define_own_property (ecma_object_t *, ecma_string_t *,
-                                                         const ecma_property_descriptor_t *, bool);
+ecma_value_t ecma_op_general_object_delete (ecma_object_t *obj_p, ecma_string_t *property_name_p, bool is_throw);
+ecma_value_t ecma_op_general_object_default_value (ecma_object_t *obj_p, ecma_preferred_type_hint_t hint);
+ecma_value_t ecma_op_general_object_define_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
+                                                         const ecma_property_descriptor_t *property_desc_p,
+                                                         bool is_throw);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -26,29 +26,31 @@
  * @{
  */
 
-ecma_property_t ecma_op_object_get_own_property (ecma_object_t *, ecma_string_t *,
-                                                 ecma_property_ref_t *, uint32_t);
-ecma_property_t ecma_op_object_get_property (ecma_object_t *, ecma_string_t *,
-                                             ecma_property_ref_t *, uint32_t);
-bool ecma_op_object_has_own_property (ecma_object_t *, ecma_string_t *);
-bool ecma_op_object_has_property (ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_object_find_own (ecma_value_t, ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_object_find (ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_object_get_own_data_prop (ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_object_get (ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_object_put (ecma_object_t *, ecma_string_t *, ecma_value_t, bool);
-ecma_value_t ecma_op_object_delete (ecma_object_t *, ecma_string_t *, bool);
-ecma_value_t ecma_op_object_default_value (ecma_object_t *, ecma_preferred_type_hint_t);
-ecma_value_t ecma_op_object_define_own_property (ecma_object_t *, ecma_string_t *,
-                                                 const ecma_property_descriptor_t *, bool);
-bool ecma_op_object_get_own_property_descriptor (ecma_object_t *, ecma_string_t *,
-                                                 ecma_property_descriptor_t *);
-ecma_value_t ecma_op_object_has_instance (ecma_object_t *, ecma_value_t);
-bool ecma_op_object_is_prototype_of (ecma_object_t *, ecma_object_t *);
-ecma_collection_header_t * ecma_op_object_get_property_names (ecma_object_t *, bool, bool, bool);
+ecma_property_t ecma_op_object_get_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
+                                                 ecma_property_ref_t *property_ref_p, uint32_t options);
+ecma_property_t ecma_op_object_get_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
+                                             ecma_property_ref_t *property_ref_p, uint32_t options);
+bool ecma_op_object_has_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
+bool ecma_op_object_has_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_object_find_own (ecma_value_t base_value, ecma_object_t *object_p, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_object_find (ecma_object_t *object_p, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_object_get_own_data_prop (ecma_object_t *object_p, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_object_get (ecma_object_t *object_p, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_object_put (ecma_object_t *object_p, ecma_string_t *property_name_p, ecma_value_t value,
+                                 bool is_throw);
+ecma_value_t ecma_op_object_delete (ecma_object_t *obj_p, ecma_string_t *property_name_p, bool is_throw);
+ecma_value_t ecma_op_object_default_value (ecma_object_t *obj_p, ecma_preferred_type_hint_t hint);
+ecma_value_t ecma_op_object_define_own_property (ecma_object_t *obj_p, ecma_string_t *property_name_p,
+                                                 const ecma_property_descriptor_t *property_desc_p, bool is_throw);
+bool ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, ecma_string_t *property_name_p,
+                                                 ecma_property_descriptor_t *prop_desc_p);
+ecma_value_t ecma_op_object_has_instance (ecma_object_t *obj_p, ecma_value_t value);
+bool ecma_op_object_is_prototype_of (ecma_object_t *base_p, ecma_object_t *target_p);
+ecma_collection_header_t * ecma_op_object_get_property_names (ecma_object_t *obj_p, bool is_array_indices_only,
+                                                              bool is_enumerable_only, bool is_with_prototype_chain);
 
-lit_magic_string_id_t ecma_object_get_class_name (ecma_object_t *);
-bool ecma_object_class_is (ecma_object_t *, uint32_t);
+lit_magic_string_id_t ecma_object_get_class_name (ecma_object_t *obj_p);
+bool ecma_object_class_is (ecma_object_t *object_p, uint32_t class_id);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-reference.h
+++ b/jerry-core/ecma/operations/ecma-reference.h
@@ -26,8 +26,8 @@
  * @{
  */
 
-ecma_object_t *ecma_op_resolve_reference_base (ecma_object_t *, ecma_string_t *);
-ecma_value_t ecma_op_resolve_reference_value (ecma_object_t *, ecma_string_t *);
+ecma_object_t *ecma_op_resolve_reference_base (ecma_object_t *lex_env_p, ecma_string_t *name_p);
+ecma_value_t ecma_op_resolve_reference_value (ecma_object_t *lex_env_p, ecma_string_t *name_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -52,13 +52,14 @@ typedef struct
   uint16_t flags;                       /**< RegExp flags */
 } re_matcher_ctx_t;
 
-ecma_value_t ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *);
-ecma_value_t ecma_op_create_regexp_object (ecma_string_t *, ecma_string_t *);
-ecma_value_t ecma_regexp_exec_helper (ecma_value_t, ecma_value_t, bool);
-ecma_char_t re_canonicalize (ecma_char_t, bool);
-void re_set_result_array_properties (ecma_object_t *, ecma_string_t *, uint32_t, int32_t);
-ecma_value_t re_parse_regexp_flags (ecma_string_t *, uint16_t *);
-void re_initialize_props (ecma_object_t *, ecma_string_t *, uint16_t);
+ecma_value_t ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *bytecode_p);
+ecma_value_t ecma_op_create_regexp_object (ecma_string_t *pattern_p, ecma_string_t *flags_str_p);
+ecma_value_t ecma_regexp_exec_helper (ecma_value_t regexp_value, ecma_value_t input_string, bool ignore_global);
+ecma_char_t re_canonicalize (ecma_char_t ch, bool is_ignorecase);
+void re_set_result_array_properties (ecma_object_t *array_obj_p, ecma_string_t *input_str_p, uint32_t num_of_elements,
+                                     int32_t index);
+ecma_value_t re_parse_regexp_flags (ecma_string_t *flags_str_p, uint16_t *flags_p);
+void re_initialize_props (ecma_object_t *re_obj_p, ecma_string_t *source_p, uint16_t flags);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -26,13 +26,13 @@
  */
 
 ecma_value_t
-ecma_op_create_string_object (const ecma_value_t *, ecma_length_t);
+ecma_op_create_string_object (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 
 void
-ecma_op_string_list_lazy_property_names (ecma_object_t *,
-                                         bool,
-                                         ecma_collection_header_t *,
-                                         ecma_collection_header_t *);
+ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p,
+                                         bool separate_enumerable,
+                                         ecma_collection_header_t *main_collection_p,
+                                         ecma_collection_header_t *non_enum_collection_p);
 
 
 /**

--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -171,19 +171,20 @@ typedef bool (*jerry_object_property_foreach_t) (const jerry_value_t property_na
 /**
  * General engine functions
  */
-void jerry_init (jerry_init_flag_t);
+void jerry_init (jerry_init_flag_t flags);
 void jerry_cleanup (void);
-void jerry_register_magic_strings (const jerry_char_ptr_t *, uint32_t, const jerry_length_t *);
-void jerry_get_memory_limits (size_t *, size_t *);
+void jerry_register_magic_strings (const jerry_char_ptr_t *ex_str_items_p, uint32_t count,
+                                   const jerry_length_t *str_lengths_p);
+void jerry_get_memory_limits (size_t *out_data_bss_brk_limit_p, size_t *out_stack_limit_p);
 void jerry_gc (void);
 
 /**
  * Parser and executor functions
  */
-bool jerry_run_simple (const jerry_char_t *, size_t, jerry_init_flag_t);
-jerry_value_t jerry_parse (const jerry_char_t *, size_t, bool);
-jerry_value_t jerry_run (const jerry_value_t);
-jerry_value_t jerry_eval (const jerry_char_t *, size_t, bool);
+bool jerry_run_simple (const jerry_char_t *script_source_p, size_t script_source_size, jerry_init_flag_t flags);
+jerry_value_t jerry_parse (const jerry_char_t *source_p, size_t source_size, bool is_strict);
+jerry_value_t jerry_run (const jerry_value_t func_val);
+jerry_value_t jerry_eval (const jerry_char_t *source_p, size_t source_size, bool is_strict);
 
 /**
  * Get the global context
@@ -193,124 +194,132 @@ jerry_value_t jerry_get_global_object (void);
 /**
  * Checker functions of 'jerry_value_t'
  */
-bool jerry_value_is_array (const jerry_value_t);
-bool jerry_value_is_boolean (const jerry_value_t);
-bool jerry_value_is_constructor (const jerry_value_t);
-bool jerry_value_is_function (const jerry_value_t);
-bool jerry_value_is_number (const jerry_value_t);
-bool jerry_value_is_null (const jerry_value_t);
-bool jerry_value_is_object (const jerry_value_t);
-bool jerry_value_is_string (const jerry_value_t);
-bool jerry_value_is_undefined (const jerry_value_t);
+bool jerry_value_is_array (const jerry_value_t value);
+bool jerry_value_is_boolean (const jerry_value_t value);
+bool jerry_value_is_constructor (const jerry_value_t value);
+bool jerry_value_is_function (const jerry_value_t value);
+bool jerry_value_is_number (const jerry_value_t value);
+bool jerry_value_is_null (const jerry_value_t value);
+bool jerry_value_is_object (const jerry_value_t value);
+bool jerry_value_is_string (const jerry_value_t value);
+bool jerry_value_is_undefined (const jerry_value_t value);
 
 /**
  * Checker function of whether the specified compile feature is enabled
  */
-bool jerry_is_feature_enabled (const jerry_feature_t);
+bool jerry_is_feature_enabled (const jerry_feature_t feature);
 
 /**
  * Error flag manipulation functions
  */
-bool jerry_value_has_error_flag (const jerry_value_t);
-void jerry_value_clear_error_flag (jerry_value_t *);
-void jerry_value_set_error_flag (jerry_value_t *);
+bool jerry_value_has_error_flag (const jerry_value_t value);
+void jerry_value_clear_error_flag (jerry_value_t *value_p);
+void jerry_value_set_error_flag (jerry_value_t *value_p);
 
 /**
  * Getter functions of 'jerry_value_t'
  */
-bool jerry_get_boolean_value (const jerry_value_t);
-double jerry_get_number_value (const jerry_value_t);
+bool jerry_get_boolean_value (const jerry_value_t value);
+double jerry_get_number_value (const jerry_value_t value);
 
 /**
  * Functions for string values
  */
-jerry_size_t jerry_get_string_size (const jerry_value_t);
-jerry_size_t jerry_get_utf8_string_size (const jerry_value_t);
-jerry_length_t jerry_get_string_length (const jerry_value_t);
-jerry_length_t jerry_get_utf8_string_length (const jerry_value_t);
-jerry_size_t jerry_string_to_char_buffer (const jerry_value_t, jerry_char_t *, jerry_size_t);
+jerry_size_t jerry_get_string_size (const jerry_value_t value);
+jerry_size_t jerry_get_utf8_string_size (const jerry_value_t value);
+jerry_length_t jerry_get_string_length (const jerry_value_t value);
+jerry_length_t jerry_get_utf8_string_length (const jerry_value_t value);
+jerry_size_t jerry_string_to_char_buffer (const jerry_value_t value, jerry_char_t *buffer_p, jerry_size_t buffer_size);
 
 /**
  * Functions for array object values
  */
-uint32_t jerry_get_array_length (const jerry_value_t);
+uint32_t jerry_get_array_length (const jerry_value_t value);
 
 /**
  * Converters of 'jerry_value_t'
  */
-bool jerry_value_to_boolean (const jerry_value_t);
-jerry_value_t jerry_value_to_number (const jerry_value_t);
-jerry_value_t jerry_value_to_object (const jerry_value_t);
-jerry_value_t jerry_value_to_primitive (const jerry_value_t);
-jerry_value_t jerry_value_to_string (const jerry_value_t);
+bool jerry_value_to_boolean (const jerry_value_t value);
+jerry_value_t jerry_value_to_number (const jerry_value_t value);
+jerry_value_t jerry_value_to_object (const jerry_value_t value);
+jerry_value_t jerry_value_to_primitive (const jerry_value_t value);
+jerry_value_t jerry_value_to_string (const jerry_value_t value);
 
 /**
  * Acquire types with reference counter (increase the references)
  */
-jerry_value_t jerry_acquire_value (jerry_value_t);
+jerry_value_t jerry_acquire_value (jerry_value_t value);
 
 /**
  * Release the referenced values
  */
-void jerry_release_value (jerry_value_t);
+void jerry_release_value (jerry_value_t value);
 
 /**
  * Create functions of API values
  */
-jerry_value_t jerry_create_array (uint32_t);
-jerry_value_t jerry_create_boolean (bool);
-jerry_value_t jerry_create_error (jerry_error_t, const jerry_char_t *);
-jerry_value_t jerry_create_error_sz (jerry_error_t, const jerry_char_t *, jerry_size_t);
-jerry_value_t jerry_create_external_function (jerry_external_handler_t);
-jerry_value_t jerry_create_number (double);
-jerry_value_t jerry_create_number_infinity (bool);
+jerry_value_t jerry_create_array (uint32_t size);
+jerry_value_t jerry_create_boolean (bool value);
+jerry_value_t jerry_create_error (jerry_error_t error_type, const jerry_char_t *message_p);
+jerry_value_t jerry_create_error_sz (jerry_error_t error_type, const jerry_char_t *message_p,
+                                     jerry_size_t message_size);
+jerry_value_t jerry_create_external_function (jerry_external_handler_t handler_p);
+jerry_value_t jerry_create_number (double value);
+jerry_value_t jerry_create_number_infinity (bool sign);
 jerry_value_t jerry_create_number_nan (void);
 jerry_value_t jerry_create_null (void);
 jerry_value_t jerry_create_object (void);
-jerry_value_t jerry_create_string_from_utf8 (const jerry_char_t *);
-jerry_value_t jerry_create_string_sz_from_utf8 (const jerry_char_t *, jerry_size_t);
-jerry_value_t jerry_create_string (const jerry_char_t *);
-jerry_value_t jerry_create_string_sz (const jerry_char_t *, jerry_size_t);
+jerry_value_t jerry_create_string_from_utf8 (const jerry_char_t *str_p);
+jerry_value_t jerry_create_string_sz_from_utf8 (const jerry_char_t *str_p, jerry_size_t str_size);
+jerry_value_t jerry_create_string (const jerry_char_t *str_p);
+jerry_value_t jerry_create_string_sz (const jerry_char_t *str_p, jerry_size_t str_size);
 jerry_value_t jerry_create_undefined (void);
 
 /**
  * General API functions of JS objects
  */
-bool jerry_has_property (const jerry_value_t, const jerry_value_t);
-bool jerry_has_own_property (const jerry_value_t, const jerry_value_t);
-bool jerry_delete_property (const jerry_value_t, const jerry_value_t);
+bool jerry_has_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
+bool jerry_has_own_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
+bool jerry_delete_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
 
-jerry_value_t jerry_get_property (const jerry_value_t, const jerry_value_t);
-jerry_value_t jerry_get_property_by_index (const jerry_value_t , uint32_t);
-jerry_value_t jerry_set_property (const jerry_value_t, const jerry_value_t, const jerry_value_t);
-jerry_value_t jerry_set_property_by_index (const jerry_value_t, uint32_t, const jerry_value_t);
+jerry_value_t jerry_get_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
+jerry_value_t jerry_get_property_by_index (const jerry_value_t  obj_val, uint32_t index);
+jerry_value_t jerry_set_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val,
+                                  const jerry_value_t value_to_set);
+jerry_value_t jerry_set_property_by_index (const jerry_value_t obj_val, uint32_t index,
+                                           const jerry_value_t value_to_set);
 
-void jerry_init_property_descriptor_fields (jerry_property_descriptor_t *);
-jerry_value_t jerry_define_own_property (const jerry_value_t,
-                                         const jerry_value_t,
-                                         const jerry_property_descriptor_t *);
+void jerry_init_property_descriptor_fields (jerry_property_descriptor_t *prop_desc_p);
+jerry_value_t jerry_define_own_property (const jerry_value_t obj_val,
+                                         const jerry_value_t prop_name_val,
+                                         const jerry_property_descriptor_t *prop_desc_p);
 
-bool jerry_get_own_property_descriptor (const jerry_value_t,
-                                        const jerry_value_t,
-                                        jerry_property_descriptor_t *);
-void jerry_free_property_descriptor_fields (const jerry_property_descriptor_t *);
+bool jerry_get_own_property_descriptor (const jerry_value_t obj_val,
+                                        const jerry_value_t prop_name_val,
+                                        jerry_property_descriptor_t *prop_desc_p);
+void jerry_free_property_descriptor_fields (const jerry_property_descriptor_t *prop_desc_p);
 
-jerry_value_t jerry_call_function (const jerry_value_t, const jerry_value_t, const jerry_value_t[], jerry_size_t);
-jerry_value_t jerry_construct_object (const jerry_value_t, const jerry_value_t[], jerry_size_t);
+jerry_value_t jerry_call_function (const jerry_value_t func_obj_val, const jerry_value_t this_val,
+                                   const jerry_value_t args_p[], jerry_size_t args_count);
+jerry_value_t jerry_construct_object (const jerry_value_t func_obj_val, const jerry_value_t args_p[],
+                                      jerry_size_t args_count);
 
-jerry_value_t jerry_get_object_keys (const jerry_value_t);
-jerry_value_t jerry_get_prototype (const jerry_value_t);
-jerry_value_t jerry_set_prototype (const jerry_value_t, const jerry_value_t);
+jerry_value_t jerry_get_object_keys (const jerry_value_t obj_val);
+jerry_value_t jerry_get_prototype (const jerry_value_t obj_val);
+jerry_value_t jerry_set_prototype (const jerry_value_t obj_val, const jerry_value_t proto_obj_val);
 
-bool jerry_get_object_native_handle (const jerry_value_t, uintptr_t *);
-void jerry_set_object_native_handle (const jerry_value_t, uintptr_t, jerry_object_free_callback_t);
-bool jerry_foreach_object_property (const jerry_value_t, jerry_object_property_foreach_t, void *);
+bool jerry_get_object_native_handle (const jerry_value_t obj_val, uintptr_t *out_handle_p);
+void jerry_set_object_native_handle (const jerry_value_t obj_val, uintptr_t handle_p,
+                                     jerry_object_free_callback_t freecb_p);
+bool jerry_foreach_object_property (const jerry_value_t obj_val, jerry_object_property_foreach_t foreach_p,
+                                    void *user_data_p);
 
 /**
  * Snapshot functions
  */
-size_t jerry_parse_and_save_snapshot (const jerry_char_t *, size_t, bool, bool, uint8_t *, size_t);
-jerry_value_t jerry_exec_snapshot (const void *, size_t, bool);
+size_t jerry_parse_and_save_snapshot (const jerry_char_t *source_p, size_t source_size, bool is_for_global,
+                                      bool is_strict, uint8_t *buffer_p, size_t buffer_size);
+jerry_value_t jerry_exec_snapshot (const void *snapshot_p, size_t snapshot_size, bool copy_bytecode);
 
 /**
  * @}

--- a/jerry-core/jerry-internal.h
+++ b/jerry-core/jerry-internal.h
@@ -24,13 +24,13 @@
 #include "jerry-api.h"
 
 ecma_value_t
-jerry_dispatch_external_function (ecma_object_t *,
-                                  ecma_external_pointer_t,
-                                  ecma_value_t,
-                                  const ecma_value_t *,
-                                  ecma_length_t);
+jerry_dispatch_external_function (ecma_object_t *function_object_p,
+                                  ecma_external_pointer_t handler_p,
+                                  ecma_value_t this_arg_value,
+                                  const ecma_value_t *arguments_list_p,
+                                  ecma_length_t arguments_list_len);
 
 void
-jerry_dispatch_object_free_callback (ecma_external_pointer_t, ecma_external_pointer_t);
+jerry_dispatch_object_free_callback (ecma_external_pointer_t freecb_p, ecma_external_pointer_t native_p);
 
 #endif /* !JERRY_INTERNAL_H */

--- a/jerry-core/jmem/jmem-allocator-internal.h
+++ b/jerry-core/jmem/jmem-allocator-internal.h
@@ -24,7 +24,7 @@
  * @{
  */
 
-void jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t);
+void jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t severity);
 
 /**
  * @}

--- a/jerry-core/jmem/jmem-allocator.h
+++ b/jerry-core/jmem/jmem-allocator.h
@@ -154,11 +154,11 @@ typedef void (*jmem_free_unused_memory_callback_t) (jmem_free_unused_memory_seve
 void jmem_init (void);
 void jmem_finalize (void);
 
-jmem_cpointer_t jmem_compress_pointer (const void *);
-void *jmem_decompress_pointer (uintptr_t);
+jmem_cpointer_t jmem_compress_pointer (const void *pointer_p);
+void *jmem_decompress_pointer (uintptr_t compressed_pointer);
 
-void jmem_register_free_unused_memory_callback (jmem_free_unused_memory_callback_t);
-void jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t);
+void jmem_register_free_unused_memory_callback (jmem_free_unused_memory_callback_t callback);
+void jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t callback);
 
 #ifdef JMEM_STATS
 void jmem_stats_reset_peak (void);

--- a/jerry-core/jmem/jmem-heap.h
+++ b/jerry-core/jmem/jmem-heap.h
@@ -30,10 +30,10 @@
 
 void jmem_heap_init (void);
 void jmem_heap_finalize (void);
-void *jmem_heap_alloc_block (const size_t);
-void *jmem_heap_alloc_block_null_on_error (const size_t);
-void jmem_heap_free_block (void *, const size_t);
-bool jmem_is_heap_pointer (const void *);
+void *jmem_heap_alloc_block (const size_t size);
+void *jmem_heap_alloc_block_null_on_error (const size_t size);
+void jmem_heap_free_block (void *ptr, const size_t size);
+bool jmem_is_heap_pointer (const void *pointer);
 
 #ifdef JMEM_STATS
 /**

--- a/jerry-core/jmem/jmem-poolman.h
+++ b/jerry-core/jmem/jmem-poolman.h
@@ -29,8 +29,8 @@
  */
 
 void jmem_pools_finalize (void);
-void *jmem_pools_alloc (size_t);
-void jmem_pools_free (void *, size_t);
+void *jmem_pools_alloc (size_t size);
+void jmem_pools_free (void *chunk_p, size_t size);
 void jmem_pools_collect_empty (void);
 
 #ifdef JMEM_STATS

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -81,8 +81,8 @@
   enum { JERRY_STATIC_ASSERT_GLUE (static_assertion_failed_, __LINE__, msg) = 1 / (!!(x)) }
 
 #ifndef JERRY_NDEBUG
-void __noreturn jerry_assert_fail (const char *, const char *, const char *, const uint32_t);
-void __noreturn jerry_unreachable (const char *, const char *, const uint32_t);
+void __noreturn jerry_assert_fail (const char *assertion, const char *file, const char *function, const uint32_t line);
+void __noreturn jerry_unreachable (const char *file, const char *function, const uint32_t line);
 
 #define JERRY_ASSERT(x) \
   do \
@@ -114,7 +114,7 @@ void __noreturn jerry_unreachable (const char *, const char *, const uint32_t);
 /**
  * Exit on fatal error
  */
-void __noreturn jerry_fatal (jerry_fatal_code_t);
+void __noreturn jerry_fatal (jerry_fatal_code_t code);
 
 /*
  * Logging

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -27,7 +27,7 @@
 #define LIT_CHAR_ZWJ  ((ecma_char_t) 0x200D) /* zero width joiner */
 #define LIT_CHAR_BOM  ((ecma_char_t) 0xFEFF) /* byte order mark */
 
-bool lit_char_is_format_control (ecma_char_t);
+bool lit_char_is_format_control (ecma_char_t c);
 
 /*
  * Whitespace characters (ECMA-262 v5, Table 2)
@@ -39,7 +39,7 @@ bool lit_char_is_format_control (ecma_char_t);
 #define LIT_CHAR_NBSP ((ecma_char_t) 0x00A0) /* no-break space */
 /* LIT_CHAR_BOM is defined above */
 
-bool lit_char_is_white_space (ecma_char_t);
+bool lit_char_is_white_space (ecma_char_t c);
 
 /*
  * Line terminator characters (ECMA-262 v5, Table 3)
@@ -49,7 +49,7 @@ bool lit_char_is_white_space (ecma_char_t);
 #define LIT_CHAR_LS ((ecma_char_t) 0x2028) /* line separator */
 #define LIT_CHAR_PS ((ecma_char_t) 0x2029) /* paragraph separator */
 
-bool lit_char_is_line_terminator (ecma_char_t);
+bool lit_char_is_line_terminator (ecma_char_t c);
 
 /*
  * String Single Character Escape Sequences (ECMA-262 v5, Table 4)
@@ -77,10 +77,10 @@ bool lit_char_is_line_terminator (ecma_char_t);
 #define LIT_CHAR_UNDERSCORE  ((ecma_char_t) '_')  /* low line (underscore) */
 /* LIT_CHAR_BACKSLASH defined above */
 
-bool lit_char_is_identifier_start (const uint8_t *);
-bool lit_char_is_identifier_part (const uint8_t *);
-bool lit_char_is_identifier_start_character (ecma_char_t);
-bool lit_char_is_identifier_part_character (ecma_char_t);
+bool lit_char_is_identifier_start (const uint8_t *src_p);
+bool lit_char_is_identifier_part (const uint8_t *src_p);
+bool lit_char_is_identifier_start_character (ecma_char_t chr);
+bool lit_char_is_identifier_part_character (ecma_char_t chr);
 
 /*
  * Punctuator characters (ECMA-262 v5, 7.7)
@@ -213,15 +213,16 @@ bool lit_char_is_identifier_part_character (ecma_char_t);
 
 #define LEXER_TO_ASCII_LOWERCASE(character) ((character) | LIT_CHAR_SP)
 
-bool lit_char_is_octal_digit (ecma_char_t);
-bool lit_char_is_decimal_digit (ecma_char_t);
-bool lit_char_is_hex_digit (ecma_char_t);
-uint32_t lit_char_hex_to_int (ecma_char_t);
-size_t lit_char_to_utf8_bytes (uint8_t *, ecma_char_t);
-size_t lit_char_get_utf8_length (ecma_char_t);
+bool lit_char_is_octal_digit (ecma_char_t c);
+bool lit_char_is_decimal_digit (ecma_char_t c);
+bool lit_char_is_hex_digit (ecma_char_t c);
+uint32_t lit_char_hex_to_int (ecma_char_t c);
+size_t lit_char_to_utf8_bytes (uint8_t *dst_p, ecma_char_t chr);
+size_t lit_char_get_utf8_length (ecma_char_t chr);
 
 /* read a hex encoded code point from a zero terminated buffer */
-bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *, lit_utf8_size_t, ecma_char_ptr_t);
+bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *buf_p, lit_utf8_size_t number_of_characters,
+                                  ecma_char_ptr_t out_code_unit_p);
 
 /**
  * Null character
@@ -231,7 +232,7 @@ bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *, lit_utf8_size_t, ecma
 /*
  * Part of IsWordChar abstract operation (ECMA-262 v5, 15.10.2.6, step 3)
  */
-bool lit_char_is_word_char (ecma_char_t);
+bool lit_char_is_word_char (ecma_char_t c);
 
 /*
  * Utility functions for uppercasing / lowercasing
@@ -242,7 +243,7 @@ bool lit_char_is_word_char (ecma_char_t);
  */
 #define LIT_MAXIMUM_OTHER_CASE_LENGTH (3)
 
-ecma_length_t lit_char_to_lower_case (ecma_char_t, ecma_char_t *, ecma_length_t);
-ecma_length_t lit_char_to_upper_case (ecma_char_t, ecma_char_t *, ecma_length_t);
+ecma_length_t lit_char_to_lower_case (ecma_char_t character, ecma_char_t *output_buffer_p, ecma_length_t buffer_size);
+ecma_length_t lit_char_to_upper_case (ecma_char_t character, ecma_char_t *output_buffer_p, ecma_length_t buffer_size);
 
 #endif /* !LIT_CHAR_HELPERS_H */

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -44,23 +44,27 @@ typedef uint32_t lit_magic_string_ex_id_t;
 
 uint32_t lit_get_magic_string_ex_count (void);
 
-const lit_utf8_byte_t *lit_get_magic_string_utf8 (lit_magic_string_id_t);
-lit_utf8_size_t lit_get_magic_string_size (lit_magic_string_id_t);
-lit_magic_string_id_t lit_get_magic_string_size_block_start (lit_utf8_size_t);
+const lit_utf8_byte_t *lit_get_magic_string_utf8 (lit_magic_string_id_t id);
+lit_utf8_size_t lit_get_magic_string_size (lit_magic_string_id_t id);
+lit_magic_string_id_t lit_get_magic_string_size_block_start (lit_utf8_size_t size);
 
-const lit_utf8_byte_t *lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t);
-lit_utf8_size_t lit_get_magic_string_ex_size (lit_magic_string_ex_id_t);
+const lit_utf8_byte_t *lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id);
+lit_utf8_size_t lit_get_magic_string_ex_size (lit_magic_string_ex_id_t id);
 
-void lit_magic_strings_ex_set (const lit_utf8_byte_t **, uint32_t, const lit_utf8_size_t *);
+void lit_magic_strings_ex_set (const lit_utf8_byte_t **ex_str_items, uint32_t count,
+                               const lit_utf8_size_t *ex_str_sizes);
 
-lit_magic_string_id_t lit_is_utf8_string_magic (const lit_utf8_byte_t *, lit_utf8_size_t);
-lit_magic_string_id_t lit_is_utf8_string_pair_magic (const lit_utf8_byte_t *, lit_utf8_size_t,
-                                                     const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_magic_string_id_t lit_is_utf8_string_magic (const lit_utf8_byte_t *string_p, lit_utf8_size_t string_size);
+lit_magic_string_id_t lit_is_utf8_string_pair_magic (const lit_utf8_byte_t *string1_p, lit_utf8_size_t string1_size,
+                                                     const lit_utf8_byte_t *string2_p, lit_utf8_size_t string2_size);
 
-lit_magic_string_ex_id_t lit_is_ex_utf8_string_magic (const lit_utf8_byte_t *, lit_utf8_size_t);
-lit_magic_string_ex_id_t lit_is_ex_utf8_string_pair_magic (const lit_utf8_byte_t *, lit_utf8_size_t,
-                                                           const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_magic_string_ex_id_t lit_is_ex_utf8_string_magic (const lit_utf8_byte_t *string_p, lit_utf8_size_t string_size);
+lit_magic_string_ex_id_t lit_is_ex_utf8_string_pair_magic (const lit_utf8_byte_t *string1_p,
+                                                           lit_utf8_size_t string1_size,
+                                                           const lit_utf8_byte_t *string2_p,
+                                                           lit_utf8_size_t string2_size);
 
-lit_utf8_byte_t *lit_copy_magic_string_to_buffer (lit_magic_string_id_t, lit_utf8_byte_t *, lit_utf8_size_t);
+lit_utf8_byte_t *lit_copy_magic_string_to_buffer (lit_magic_string_id_t id, lit_utf8_byte_t *buffer_p,
+                                                  lit_utf8_size_t buffer_size);
 
 #endif /* !LIT_MAGIC_STRINGS_H */

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -85,52 +85,55 @@
 #define LIT_UTF8_FIRST_BYTE_MAX LIT_UTF8_5_BYTE_MARKER
 
 /* validation */
-bool lit_is_utf8_string_valid (const lit_utf8_byte_t *, lit_utf8_size_t);
-bool lit_is_cesu8_string_valid (const lit_utf8_byte_t *, lit_utf8_size_t);
+bool lit_is_utf8_string_valid (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t buf_size);
+bool lit_is_cesu8_string_valid (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t buf_size);
 
 /* checks */
-bool lit_is_code_point_utf16_low_surrogate (lit_code_point_t);
-bool lit_is_code_point_utf16_high_surrogate (lit_code_point_t);
+bool lit_is_code_point_utf16_low_surrogate (lit_code_point_t code_point);
+bool lit_is_code_point_utf16_high_surrogate (lit_code_point_t code_point);
 
 /* size */
-lit_utf8_size_t lit_zt_utf8_string_size (const lit_utf8_byte_t *);
-lit_utf8_size_t lit_get_utf8_size_of_cesu8_string (const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_utf8_size_t lit_zt_utf8_string_size (const lit_utf8_byte_t *utf8_str_p);
+lit_utf8_size_t lit_get_utf8_size_of_cesu8_string (const lit_utf8_byte_t *cesu8_buf_p, lit_utf8_size_t cesu8_buf_size);
 
 /* length */
-ecma_length_t lit_utf8_string_length (const lit_utf8_byte_t *, lit_utf8_size_t);
-ecma_length_t lit_get_utf8_length_of_cesu8_string (const lit_utf8_byte_t *, lit_utf8_size_t);
+ecma_length_t lit_utf8_string_length (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t utf8_buf_size);
+ecma_length_t lit_get_utf8_length_of_cesu8_string (const lit_utf8_byte_t *cesu8_buf_p, lit_utf8_size_t cesu8_buf_size);
 
 /* hash */
-lit_string_hash_t lit_utf8_string_calc_hash (const lit_utf8_byte_t *, lit_utf8_size_t);
-lit_string_hash_t lit_utf8_string_hash_combine (lit_string_hash_t, const lit_utf8_byte_t *, lit_utf8_size_t);
+lit_string_hash_t lit_utf8_string_calc_hash (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t utf8_buf_size);
+lit_string_hash_t lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, const lit_utf8_byte_t *utf8_buf_p,
+                                                lit_utf8_size_t utf8_buf_size);
 
 /* code unit access */
-ecma_char_t lit_utf8_string_code_unit_at (const lit_utf8_byte_t *, lit_utf8_size_t, ecma_length_t);
-lit_utf8_size_t lit_get_unicode_char_size_by_utf8_first_byte (lit_utf8_byte_t);
+ecma_char_t lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t utf8_buf_size,
+                                          ecma_length_t code_unit_offset);
+lit_utf8_size_t lit_get_unicode_char_size_by_utf8_first_byte (lit_utf8_byte_t first_byte);
 
 /* conversion */
-lit_utf8_size_t lit_code_unit_to_utf8 (ecma_char_t, lit_utf8_byte_t *);
-lit_utf8_size_t lit_code_point_to_utf8 (lit_code_point_t, lit_utf8_byte_t *);
-lit_utf8_size_t lit_code_point_to_cesu8 (lit_code_point_t, lit_utf8_byte_t *);
-lit_code_point_t lit_convert_surrogate_pair_to_code_point (ecma_char_t, ecma_char_t);
+lit_utf8_size_t lit_code_unit_to_utf8 (ecma_char_t code_unit, lit_utf8_byte_t *buf_p);
+lit_utf8_size_t lit_code_point_to_utf8 (lit_code_point_t code_point, lit_utf8_byte_t *buf);
+lit_utf8_size_t lit_code_point_to_cesu8 (lit_code_point_t code_point, lit_utf8_byte_t *buf);
+lit_code_point_t lit_convert_surrogate_pair_to_code_point (ecma_char_t high_surrogate, ecma_char_t low_surrogate);
 
-bool lit_compare_utf8_strings_relational (const lit_utf8_byte_t *string1_p, lit_utf8_size_t,
-                                          const lit_utf8_byte_t *string2_p, lit_utf8_size_t);
+bool lit_compare_utf8_strings_relational (const lit_utf8_byte_t *string1_p, lit_utf8_size_t string1_size,
+                                          const lit_utf8_byte_t *string2_p, lit_utf8_size_t string2_size);
 
 /* read code point from buffer */
-lit_utf8_size_t lit_read_code_point_from_utf8 (const lit_utf8_byte_t *, lit_utf8_size_t, lit_code_point_t *);
+lit_utf8_size_t lit_read_code_point_from_utf8 (const lit_utf8_byte_t *buf_p, lit_utf8_size_t buf_size,
+                                               lit_code_point_t *code_point);
 
-lit_utf8_size_t lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *,
-                                              ecma_char_t *);
+lit_utf8_size_t lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p,
+                                              ecma_char_t *code_point);
 
-lit_utf8_size_t lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *,
-                                                   ecma_char_t *);
+lit_utf8_size_t lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p,
+                                                   ecma_char_t *code_point);
 
-ecma_char_t lit_utf8_read_next (const lit_utf8_byte_t **);
-ecma_char_t lit_utf8_read_prev (const lit_utf8_byte_t **);
-ecma_char_t lit_utf8_peek_next (const lit_utf8_byte_t *);
-ecma_char_t lit_utf8_peek_prev (const lit_utf8_byte_t *);
-void lit_utf8_incr (const lit_utf8_byte_t **);
-void lit_utf8_decr (const lit_utf8_byte_t **);
+ecma_char_t lit_utf8_read_next (const lit_utf8_byte_t **buf_p);
+ecma_char_t lit_utf8_read_prev (const lit_utf8_byte_t **buf_p);
+ecma_char_t lit_utf8_peek_next (const lit_utf8_byte_t *buf_p);
+ecma_char_t lit_utf8_peek_prev (const lit_utf8_byte_t *buf_p);
+void lit_utf8_incr (const lit_utf8_byte_t **buf_p);
+void lit_utf8_decr (const lit_utf8_byte_t **buf_p);
 
 #endif /* !LIT_STRINGS_H */

--- a/jerry-core/parser/js/common.h
+++ b/jerry-core/parser/js/common.h
@@ -99,7 +99,7 @@ typedef struct
   uint8_t status_flags;                  /**< status flags */
 } lexer_literal_t;
 
-void util_free_literal (lexer_literal_t *);
+void util_free_literal (lexer_literal_t *literal_p);
 
 #ifdef PARSER_DUMP_BYTE_CODE
 void util_print_literal (lexer_literal_t *);

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -286,41 +286,41 @@ typedef struct
 
 /* Memory management.
  * Note: throws an error if unsuccessful. */
-void *parser_malloc (parser_context_t *, size_t);
-void parser_free (void *, size_t);
-void *parser_malloc_local (parser_context_t *, size_t);
-void parser_free_local (void *, size_t);
+void *parser_malloc (parser_context_t *context_p, size_t size);
+void parser_free (void *ptr, size_t size);
+void *parser_malloc_local (parser_context_t *context_p, size_t size);
+void parser_free_local (void *ptr, size_t size);
 
 /* Parser byte stream. */
 
-void parser_cbc_stream_init (parser_mem_data_t *);
-void parser_cbc_stream_free (parser_mem_data_t *);
-void parser_cbc_stream_alloc_page (parser_context_t *, parser_mem_data_t *);
+void parser_cbc_stream_init (parser_mem_data_t *data_p);
+void parser_cbc_stream_free (parser_mem_data_t *data_p);
+void parser_cbc_stream_alloc_page (parser_context_t *context_p, parser_mem_data_t *data_p);
 
 /* Parser list. Ensures pointer alignment. */
 
-void parser_list_init (parser_list_t *, uint32_t, uint32_t);
-void parser_list_free (parser_list_t *);
-void parser_list_reset (parser_list_t *);
-void *parser_list_append (parser_context_t *, parser_list_t *);
-void *parser_list_get (parser_list_t *, size_t);
-void parser_list_iterator_init (parser_list_t *, parser_list_iterator_t *);
-void *parser_list_iterator_next (parser_list_iterator_t *);
+void parser_list_init (parser_list_t *list_p, uint32_t item_size, uint32_t item_count);
+void parser_list_free (parser_list_t *list_p);
+void parser_list_reset (parser_list_t *list_p);
+void *parser_list_append (parser_context_t *context_p, parser_list_t *list_p);
+void *parser_list_get (parser_list_t *list_p, size_t index);
+void parser_list_iterator_init (parser_list_t *list_p, parser_list_iterator_t *iterator_p);
+void *parser_list_iterator_next (parser_list_iterator_t *iterator_p);
 
 /* Parser stack. Optimized for pushing bytes.
  * Pop functions never throws error. */
 
-void parser_stack_init (parser_context_t *);
-void parser_stack_free (parser_context_t *);
-void parser_stack_push_uint8 (parser_context_t *, uint8_t);
-void parser_stack_pop_uint8 (parser_context_t *);
-void parser_stack_push_uint16 (parser_context_t *, uint16_t);
-uint16_t parser_stack_pop_uint16 (parser_context_t *);
-void parser_stack_push (parser_context_t *, const void *, uint32_t);
-void parser_stack_pop (parser_context_t *, void *, uint32_t);
-void parser_stack_iterator_skip (parser_stack_iterator_t *, size_t);
-void parser_stack_iterator_read (parser_stack_iterator_t *, void *, size_t);
-void parser_stack_iterator_write (parser_stack_iterator_t *, const void *, size_t);
+void parser_stack_init (parser_context_t *context_p);
+void parser_stack_free (parser_context_t *context_p);
+void parser_stack_push_uint8 (parser_context_t *context_p, uint8_t uint8_value);
+void parser_stack_pop_uint8 (parser_context_t *context_p);
+void parser_stack_push_uint16 (parser_context_t *context_p, uint16_t uint16_value);
+uint16_t parser_stack_pop_uint16 (parser_context_t *context_p);
+void parser_stack_push (parser_context_t *context_p, const void *data_p, uint32_t length);
+void parser_stack_pop (parser_context_t *context_p, void *data_p, uint32_t length);
+void parser_stack_iterator_skip (parser_stack_iterator_t *iterator, size_t length);
+void parser_stack_iterator_read (parser_stack_iterator_t *iterator, void *data_p, size_t length);
+void parser_stack_iterator_write (parser_stack_iterator_t *iterator, const void *data_p, size_t length);
 
 /**
  * @}
@@ -338,18 +338,19 @@ void parser_stack_iterator_write (parser_stack_iterator_t *, const void *, size_
 
 /* Compact byte code emitting functions. */
 
-void parser_flush_cbc (parser_context_t *);
-void parser_emit_cbc (parser_context_t *, uint16_t);
-void parser_emit_cbc_literal (parser_context_t *, uint16_t, uint16_t);
-void parser_emit_cbc_literal_from_token (parser_context_t *, uint16_t);
-void parser_emit_cbc_call (parser_context_t *, uint16_t, size_t);
-void parser_emit_cbc_push_number (parser_context_t *, bool);
-void parser_emit_cbc_forward_branch (parser_context_t *, uint16_t, parser_branch_t *);
-parser_branch_node_t *parser_emit_cbc_forward_branch_item (parser_context_t *, uint16_t, parser_branch_node_t *);
-void parser_emit_cbc_backward_branch (parser_context_t *, uint16_t, uint32_t);
-void parser_set_branch_to_current_position (parser_context_t *, parser_branch_t *);
-void parser_set_breaks_to_current_position (parser_context_t *, parser_branch_node_t *);
-void parser_set_continues_to_current_position (parser_context_t *, parser_branch_node_t *);
+void parser_flush_cbc (parser_context_t *context_p);
+void parser_emit_cbc (parser_context_t *context_p, uint16_t opcode);
+void parser_emit_cbc_literal (parser_context_t *context_p, uint16_t opcode, uint16_t literal_index);
+void parser_emit_cbc_literal_from_token (parser_context_t *context_p, uint16_t opcode);
+void parser_emit_cbc_call (parser_context_t *context_p, uint16_t opcode, size_t call_arguments);
+void parser_emit_cbc_push_number (parser_context_t *context_p, bool is_negative_number);
+void parser_emit_cbc_forward_branch (parser_context_t *context_p, uint16_t opcode, parser_branch_t *branch_p);
+parser_branch_node_t *parser_emit_cbc_forward_branch_item (parser_context_t *context_p, uint16_t opcode,
+                                                           parser_branch_node_t *next_p);
+void parser_emit_cbc_backward_branch (parser_context_t *context_p, uint16_t opcode, uint32_t offset);
+void parser_set_branch_to_current_position (parser_context_t *context_p, parser_branch_t *branch_p);
+void parser_set_breaks_to_current_position (parser_context_t *context_p, parser_branch_node_t *current_p);
+void parser_set_continues_to_current_position (parser_context_t *context_p, parser_branch_node_t *current_p);
 
 /* Convenience macros. */
 #define parser_emit_cbc_ext(context_p, opcode) \
@@ -372,16 +373,17 @@ void parser_set_continues_to_current_position (parser_context_t *, parser_branch
 
 /* Lexer functions */
 
-void lexer_next_token (parser_context_t *);
-void lexer_expect_identifier (parser_context_t *, uint8_t);
-void lexer_scan_identifier (parser_context_t *, bool);
+void lexer_next_token (parser_context_t *context_p);
+void lexer_expect_identifier (parser_context_t *context_p, uint8_t literal_type);
+void lexer_scan_identifier (parser_context_t *context_p, bool propety_name);
 ecma_char_t lexer_hex_to_character (parser_context_t *context_p, const uint8_t *source_p, int length);
-void lexer_expect_object_literal_id (parser_context_t *, bool);
-void lexer_construct_literal_object (parser_context_t *, lexer_lit_location_t *, uint8_t);
-bool lexer_construct_number_object (parser_context_t *, bool, bool);
-void lexer_construct_function_object (parser_context_t *, uint32_t);
-void lexer_construct_regexp_object (parser_context_t *, bool);
-bool lexer_compare_identifier_to_current (parser_context_t *, const lexer_lit_location_t *);
+void lexer_expect_object_literal_id (parser_context_t *context_p, bool must_be_identifier);
+void lexer_construct_literal_object (parser_context_t *context_p, lexer_lit_location_t *literal_p,
+                                     uint8_t literal_type);
+bool lexer_construct_number_object (parser_context_t *context_p, bool push_number_allowed, bool is_negative_number);
+void lexer_construct_function_object (parser_context_t *context_p, uint32_t extra_status_flags);
+void lexer_construct_regexp_object (parser_context_t *context_p, bool parse_only);
+bool lexer_compare_identifier_to_current (parser_context_t *context_p, const lexer_lit_location_t *right);
 
 /**
  * @}
@@ -392,7 +394,7 @@ bool lexer_compare_identifier_to_current (parser_context_t *, const lexer_lit_lo
 
 /* Parser functions. */
 
-void parser_parse_expression (parser_context_t *, int);
+void parser_parse_expression (parser_context_t *context_p, int options);
 
 /**
  * @}
@@ -401,7 +403,7 @@ void parser_parse_expression (parser_context_t *, int);
  * @{
  */
 
-void parser_scan_until (parser_context_t *, lexer_range_t *, lexer_token_type_t);
+void parser_scan_until (parser_context_t *context_p, lexer_range_t *range_p, lexer_token_type_t end_type);
 
 /**
  * @}
@@ -410,8 +412,8 @@ void parser_scan_until (parser_context_t *, lexer_range_t *, lexer_token_type_t)
  * @{
  */
 
-void parser_parse_statements (parser_context_t *);
-void parser_free_jumps (parser_stack_iterator_t);
+void parser_parse_statements (parser_context_t *context_p);
+void parser_free_jumps (parser_stack_iterator_t iterator);
 
 /**
  * @}
@@ -420,11 +422,11 @@ void parser_free_jumps (parser_stack_iterator_t);
  * @{
  */
 
-ecma_compiled_code_t *parser_parse_function (parser_context_t *, uint32_t);
+ecma_compiled_code_t *parser_parse_function (parser_context_t *context_p, uint32_t status_flags);
 
 /* Error management. */
 
-void parser_raise_error (parser_context_t *, parser_error_t);
+void parser_raise_error (parser_context_t *context_p, parser_error_t error);
 
 /**
  * @}

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -128,7 +128,8 @@ typedef struct
 } parser_error_location_t;
 
 /* Note: source must be a valid UTF-8 string */
-ecma_value_t parser_parse_script (const uint8_t *, size_t, bool, ecma_compiled_code_t **);
+ecma_value_t parser_parse_script (const uint8_t *source_p, size_t size, bool is_strict,
+                                  ecma_compiled_code_t **bytecode_data_p);
 
 const char *parser_error_to_string (parser_error_t);
 

--- a/jerry-core/parser/regexp/re-bytecode.h
+++ b/jerry-core/parser/regexp/re-bytecode.h
@@ -100,19 +100,19 @@ typedef struct
   uint8_t *current_p;          /**< current position in bytecode */
 } re_bytecode_ctx_t;
 
-re_opcode_t re_get_opcode (uint8_t **);
-ecma_char_t re_get_char (uint8_t **);
-uint32_t re_get_value (uint8_t **);
-uint32_t re_get_bytecode_length (re_bytecode_ctx_t *);
+re_opcode_t re_get_opcode (uint8_t **bc_p);
+ecma_char_t re_get_char (uint8_t **bc_p);
+uint32_t re_get_value (uint8_t **bc_p);
+uint32_t re_get_bytecode_length (re_bytecode_ctx_t *bc_ctx_p);
 
-void re_append_opcode (re_bytecode_ctx_t *, re_opcode_t);
-void re_append_u32 (re_bytecode_ctx_t *, uint32_t);
-void re_append_char (re_bytecode_ctx_t *, ecma_char_t);
-void re_append_jump_offset (re_bytecode_ctx_t *, uint32_t);
+void re_append_opcode (re_bytecode_ctx_t *bc_ctx_p, re_opcode_t opcode);
+void re_append_u32 (re_bytecode_ctx_t *bc_ctx_p, uint32_t value);
+void re_append_char (re_bytecode_ctx_t *bc_ctx_p, ecma_char_t input_char);
+void re_append_jump_offset (re_bytecode_ctx_t *bc_ctx_p, uint32_t value);
 
-void re_insert_opcode (re_bytecode_ctx_t *, uint32_t, re_opcode_t);
-void re_insert_u32 (re_bytecode_ctx_t *, uint32_t, uint32_t);
-void re_bytecode_list_insert (re_bytecode_ctx_t *, size_t, uint8_t *, size_t);
+void re_insert_opcode (re_bytecode_ctx_t *bc_ctx_p, uint32_t offset, re_opcode_t opcode);
+void re_insert_u32 (re_bytecode_ctx_t *bc_ctx_p, uint32_t offset, uint32_t value);
+void re_bytecode_list_insert (re_bytecode_ctx_t *bc_ctx_p, size_t offset, uint8_t *bytecode_p, size_t length);
 
 #ifdef REGEXP_DUMP_BYTE_CODE
 void re_dump_bytecode (re_bytecode_ctx_t *bc_ctx);

--- a/jerry-core/parser/regexp/re-compiler.h
+++ b/jerry-core/parser/regexp/re-compiler.h
@@ -47,7 +47,7 @@ typedef struct
 } re_compiler_ctx_t;
 
 ecma_value_t
-re_compile_bytecode (const re_compiled_code_t **, ecma_string_t *, uint16_t);
+re_compile_bytecode (const re_compiled_code_t **out_bytecode_p, ecma_string_t *pattern_str_p, uint16_t flags);
 
 void re_cache_gc_run ();
 

--- a/jerry-core/parser/regexp/re-parser.h
+++ b/jerry-core/parser/regexp/re-parser.h
@@ -101,10 +101,11 @@ typedef struct
 typedef void (*re_char_class_callback) (void *re_ctx_p, ecma_char_t start, ecma_char_t end);
 
 ecma_value_t
-re_parse_char_class (re_parser_ctx_t *, re_char_class_callback, void *, re_token_t *);
+re_parse_char_class (re_parser_ctx_t *parser_ctx_p, re_char_class_callback append_char_class, void *re_ctx_p,
+                     re_token_t *out_token_p);
 
 ecma_value_t
-re_parse_next_token (re_parser_ctx_t *, re_token_t *);
+re_parse_next_token (re_parser_ctx_t *parser_ctx_p, re_token_t *out_token_p);
 
 /**
  * @}

--- a/jerry-core/vm/opcodes.h
+++ b/jerry-core/vm/opcodes.h
@@ -52,64 +52,64 @@ typedef enum
 } number_bitwise_logic_op;
 
 ecma_value_t
-vm_var_decl (vm_frame_ctx_t *, ecma_string_t *);
+vm_var_decl (vm_frame_ctx_t *frame_ctx_p, ecma_string_t *var_name_str_p);
 
 ecma_value_t
-opfunc_equal_value (ecma_value_t, ecma_value_t);
+opfunc_equal_value (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_not_equal_value (ecma_value_t, ecma_value_t);
+opfunc_not_equal_value (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-do_number_arithmetic (number_arithmetic_op, ecma_value_t, ecma_value_t);
+do_number_arithmetic (number_arithmetic_op op, ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_unary_plus (ecma_value_t);
+opfunc_unary_plus (ecma_value_t left_value);
 
 ecma_value_t
-opfunc_unary_minus (ecma_value_t);
+opfunc_unary_minus (ecma_value_t left_value);
 
 ecma_value_t
-do_number_bitwise_logic (number_bitwise_logic_op, ecma_value_t, ecma_value_t);
+do_number_bitwise_logic (number_bitwise_logic_op op, ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_addition (ecma_value_t, ecma_value_t);
+opfunc_addition (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_less_than (ecma_value_t, ecma_value_t);
+opfunc_less_than (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_greater_than (ecma_value_t, ecma_value_t);
+opfunc_greater_than (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_less_or_equal_than (ecma_value_t, ecma_value_t);
+opfunc_less_or_equal_than (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_greater_or_equal_than (ecma_value_t, ecma_value_t);
+opfunc_greater_or_equal_than (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_in (ecma_value_t, ecma_value_t);
+opfunc_in (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_instanceof (ecma_value_t, ecma_value_t);
+opfunc_instanceof (ecma_value_t left_value, ecma_value_t right_value);
 
 ecma_value_t
-opfunc_logical_not (ecma_value_t);
+opfunc_logical_not (ecma_value_t left_value);
 
 ecma_value_t
-opfunc_typeof (ecma_value_t);
+opfunc_typeof (ecma_value_t left_value);
 
 void
-opfunc_set_accessor (bool, ecma_value_t, ecma_value_t, ecma_value_t);
+opfunc_set_accessor (bool is_getter, ecma_value_t object, ecma_value_t accessor_name, ecma_value_t accessor);
 
 ecma_value_t
-vm_op_delete_prop (ecma_value_t, ecma_value_t, bool);
+vm_op_delete_prop (ecma_value_t object, ecma_value_t property, bool is_strict);
 
 ecma_value_t
-vm_op_delete_var (jmem_cpointer_t, ecma_object_t *);
+vm_op_delete_var (jmem_cpointer_t name_literal, ecma_object_t *lex_env_p);
 
 ecma_collection_header_t *
-opfunc_for_in (ecma_value_t, ecma_value_t *);
+opfunc_for_in (ecma_value_t left_value, ecma_value_t *result_obj_p);
 
 /**
  * @}

--- a/jerry-core/vm/vm-stack.h
+++ b/jerry-core/vm/vm-stack.h
@@ -66,9 +66,9 @@ typedef enum
   VM_CONTEXT_FOR_IN,                          /**< for-in context */
 } vm_stack_context_type_t;
 
-ecma_value_t *vm_stack_context_abort (vm_frame_ctx_t *, ecma_value_t *);
-bool vm_stack_find_finally (vm_frame_ctx_t *, ecma_value_t **,
-                            vm_stack_context_type_t, uint32_t);
+ecma_value_t *vm_stack_context_abort (vm_frame_ctx_t *frame_ctx_p, ecma_value_t *vm_stack_top_p);
+bool vm_stack_find_finally (vm_frame_ctx_t *frame_ctx_p, ecma_value_t **vm_stack_top_ref_p,
+                            vm_stack_context_type_t finally_type, uint32_t search_limit);
 
 /**
  * @}

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -274,12 +274,12 @@ typedef enum
   VM_EXEC_CONSTRUCT,             /**< construct a new object */
 } vm_call_operation;
 
-ecma_value_t vm_run_global (const ecma_compiled_code_t *);
-ecma_value_t vm_run_eval (ecma_compiled_code_t *, bool);
+ecma_value_t vm_run_global (const ecma_compiled_code_t *bytecode_p);
+ecma_value_t vm_run_eval (ecma_compiled_code_t *bytecode_data_p, bool is_direct);
 
-ecma_value_t vm_run (const ecma_compiled_code_t *, ecma_value_t,
-                     ecma_object_t *, bool, const ecma_value_t *,
-                     ecma_length_t);
+ecma_value_t vm_run (const ecma_compiled_code_t *bytecode_header_p, ecma_value_t this_binding_value,
+                     ecma_object_t *lex_env_p, bool is_eval_code, const ecma_value_t *arg_list_p,
+                     ecma_length_t arg_list_len);
 
 bool vm_is_strict_mode (void);
 bool vm_is_direct_eval_form_call (void);

--- a/jerry-libm/jerry-libm-internal.h
+++ b/jerry-libm/jerry-libm-internal.h
@@ -49,34 +49,34 @@
 /*
  * ANSI/POSIX
  */
-double acos (double);
-double asin (double);
-double atan (double);
-double atan2 (double, double);
-double cos (double);
-double sin (double);
-double tan (double);
+double acos (double x);
+double asin (double x);
+double atan (double x);
+double atan2 (double y, double x);
+double cos (double x);
+double sin (double x);
+double tan (double x);
 
-double exp (double);
-double log (double);
+double exp (double x);
+double log (double x);
 
-double pow (double, double);
-double sqrt (double);
+double pow (double x, double y);
+double sqrt (double x);
 
-double ceil (double);
-double fabs (double);
-double floor (double);
-double fmod (double, double);
+double ceil (double x);
+double fabs (double x);
+double floor (double x);
+double fmod (double x, double y);
 
-int isnan (double);
-int finite (double);
+int isnan (double x);
+int finite (double x);
 
-double nextafter (double, double);
+double nextafter (double x, double y);
 
 /*
  * Functions callable from C, intended to support IEEE arithmetic.
  */
-double copysign (double, double);
-double scalbn (double, int);
+double copysign (double x, double y);
+double scalbn (double x, int n);
 
 #endif /* !JERRY_LIBM_INTERNAL_H */

--- a/targets/default/jerry-port-default.h
+++ b/targets/default/jerry-port-default.h
@@ -30,11 +30,11 @@ extern "C"
  * @{
  */
 
-void jerry_port_default_set_abort_on_fail (bool);
+void jerry_port_default_set_abort_on_fail (bool flag);
 bool jerry_port_default_is_abort_on_fail (void);
 
 jerry_log_level_t jerry_port_default_get_log_level (void);
-void jerry_port_default_set_log_level (jerry_log_level_t);
+void jerry_port_default_set_log_level (jerry_log_level_t level);
 
 /**
  * @}


### PR DESCRIPTION
It's generally considered a bad programming practice to have function declarations without parameter names.

This is another legacy from the early days of the project. Fix in one go to minimize history disruption.

Used a custom clang-tidy check to create the bulk of the change.

JerryScript-DCO-1.0-Signed-off-by: Tilmann Scheller t.scheller@samsung.com