### PR TITLE
Skip out license-check in case of test262 tests

### DIFF
--- a/tools/check-license.py
+++ b/tools/check-license.py
@@ -17,6 +17,7 @@
 import os
 import re
 import sys
+from settings import *
 
 
 license = re.compile(
@@ -46,7 +47,8 @@ dirs = [
 ]
 
 exclude_dirs = [
-    'targets/esp8266'
+    'targets/esp8266',
+    os.path.relpath (TEST262_TEST_SUITE_DIR, PROJECT_DIR),
 ]
 
 exts = [


### PR DESCRIPTION
Can break testruns, when the test262 folder already present.

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com