### PR TITLE
Isolate GCC specific code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,13 +48,35 @@ if("${PLATFORM}" STREQUAL "DARWIN")
   set(ENABLE_STATIC_LINK "OFF")
 endif()
 
+
+if(CMAKE_C_COMPILER_ID MATCHES "GNU")
+  set(USING_GCC 1)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+  set(USING_CLANG 1)
+endif()
+
+if(CMAKE_C_COMPILER_ID MATCHES "TI")
+  set(USING_TI 1)
+endif()
+
 # Status messages
 message(STATUS "CMAKE_BUILD_TYPE          " ${CMAKE_BUILD_TYPE})
 message(STATUS "CMAKE_SYSTEM_NAME         " ${CMAKE_SYSTEM_NAME})
 message(STATUS "CMAKE_SYSTEM_PROCESSOR    " ${CMAKE_SYSTEM_PROCESSOR})
 message(STATUS "ENABLE_ALL_IN_ONE         " ${ENABLE_ALL_IN_ONE})
 message(STATUS "ENABLE_LTO                " ${ENABLE_LTO})
-message(STATUS "ENABLE_STATIC_LINK        " ${ENABLE_STATIC_LINK})
+
+if(USING_TI)
+# If using a compiler that _only_ does static linking, inform the user
+# of the discrepancy in settings.
+  set(ENABLE_STATIC_LINK "ON")
+  message(STATUS "ENABLE_STATIC_LINK        " ${ENABLE_STATIC_LINK} " (ONLY OPTION FOR THIS COMPILER)")
+else()
+  message(STATUS "ENABLE_STATIC_LINK        " ${ENABLE_STATIC_LINK})
+endif()
+
 message(STATUS "ENABLE_STRIP              " ${ENABLE_STRIP})
 message(STATUS "JERRY_CMDLINE             " ${JERRY_CMDLINE})
 message(STATUS "JERRY_CMDLINE_MINIMAL     " ${JERRY_CMDLINE_MINIMAL})
@@ -91,7 +113,7 @@ endmacro()
 macro(jerry_add_compile_warnings)
   foreach(_warning ${ARGV})
     jerry_add_compile_flags(-W${_warning})
-    if(CMAKE_COMPILER_IS_GNUCC)
+    if(USING_GCC)
       jerry_add_compile_flags(-Werror=${_warning})
     endif()
   endforeach()
@@ -107,20 +129,27 @@ jerry_add_flags(CMAKE_EXE_LINKER_FLAGS ${FLAGS_COMMON_ARCH})
 
 # Enable static build
 if(ENABLE_STATIC_LINK)
-  jerry_add_link_flags("-static")
+  if (USING_GCC OR USING_CLANG)
+    jerry_add_link_flags("-static")
+  endif()
 endif()
 
 # LTO
 if(ENABLE_LTO)
-  jerry_add_compile_flags(-flto)
-  jerry_add_link_flags(-flto)
-  if(CMAKE_COMPILER_IS_GNUCC)
+  if (USING_GCC OR USING_CLANG)
+    jerry_add_compile_flags(-flto)
+    jerry_add_link_flags(-flto)
+  endif()
+  if(USING_GCC)
     if(NOT "${PLATFORM}" STREQUAL "DARWIN")
       jerry_add_compile_flags(-fno-fat-lto-objects)
     endif()
     # Use gcc-ar and gcc-ranlib to support LTO
     set(CMAKE_AR "gcc-ar")
     set(CMAKE_RANLIB "gcc-ranlib")
+  endif()
+  if(USING_TI)
+    jerry_add_link_flags(-lto)
   endif()
 endif()
 
@@ -130,7 +159,9 @@ if(${PORT_DIR} STREQUAL "${CMAKE_SOURCE_DIR}/targets/default" AND NOT JERRY_LIBC
 endif()
 
 # Compiler / Linker flags
-jerry_add_compile_flags(-fno-builtin)
+if (USING_GCC OR USING_CLANG)
+  jerry_add_compile_flags(-fno-builtin)
+endif()
 if(("${PLATFORM}" STREQUAL "DARWIN"))
   jerry_add_link_flags(-lSystem)
 else()
@@ -143,17 +174,18 @@ if(JERRY_LIBC)
 endif()
 
 # Turn off stack protector
+if (USING_GCC OR USING_CLANG)
 jerry_add_compile_flags(-fno-stack-protector)
+endif()
 
-# Debug information
-jerry_add_compile_flags(-g)
+if (USING_GCC OR USING_CLANG)
+  jerry_add_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations)
+  jerry_add_compile_flags(-Wno-stack-protector -Wno-attributes)
+endif()
 
-jerry_add_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations)
-jerry_add_compile_flags(-Wno-stack-protector -Wno-attributes)
-
-if(CMAKE_COMPILER_IS_GNUCC)
+if(USING_GCC)
   jerry_add_compile_warnings(logical-op)
-else()
+elseif(USING_CLANG)
   jerry_add_compile_flags(-Wno-nested-anon-types -Wno-static-in-inline)
 endif()
 
@@ -162,11 +194,17 @@ if(JERRY_LIBC)
 endif()
 
 # C
-jerry_add_compile_flags(-std=c99 -pedantic)
+if (USING_GCC OR USING_CLANG)
+  jerry_add_compile_flags(-std=c99 -pedantic)
+elseif(USING_TI)
+  jerry_add_compile_flags(--c99)
+endif()
 
 # Strip binary
 if(ENABLE_STRIP AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  jerry_add_link_flags(-s)
+  if (USING_GCC OR USING_CLANG)
+    jerry_add_link_flags(-s)
+  endif()
 endif()
 
 # External compiler & linker flags

--- a/cmake/toolchain_mcu_tim4f.cmake
+++ b/cmake/toolchain_mcu_tim4f.cmake
@@ -1,0 +1,33 @@
+# Copyright JS Foundation and other contributors, http://js.foundation 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeForceCompiler)
+
+set(CMAKE_SYSTEM_NAME MCU)
+set(CMAKE_SYSTEM_PROCESSOR armv7l)
+set(CMAKE_SYSTEM_VERSION TIM4F)
+
+set(FLAGS_COMMON_ARCH --little_endian --silicon_version=7M4 --float_support=FPv4SPD16)
+
+CMAKE_FORCE_C_COMPILER(armcl TI)
+
+SET (CMAKE_C_FLAGS_DEBUG_INIT          "-g")
+SET (CMAKE_C_FLAGS_MINSIZEREL_INIT     "-o4 -mf0 -DNDEBUG")
+SET (CMAKE_C_FLAGS_RELEASE_INIT        "-o4 -DNDEBUG")
+SET (CMAKE_C_FLAGS_RELWITHDEBINFO_INIT "-o2 -g")
+
+SET (CMAKE_CXX_FLAGS_DEBUG_INIT          "-g")
+SET (CMAKE_CXX_FLAGS_MINSIZEREL_INIT     "-o4 -mf0 -DNDEBUG")
+SET (CMAKE_CXX_FLAGS_RELEASE_INIT        "-o4 -DNDEBUG")
+SET (CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-o2 -g")

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -313,7 +313,9 @@ ecma_op_general_object_define_own_property (ecma_object_t *object_p, /**< the ob
   JERRY_ASSERT (property_desc_p->is_writable_defined || !property_desc_p->is_writable);
 
   /* 1. */
-  ecma_extended_property_ref_t ext_property_ref;
+  /* This #def just gets around the syntax/style checker... */
+#define extended_property_ref_initialization { { 0 } , 0 }
+  ecma_extended_property_ref_t ext_property_ref = extended_property_ref_initialization;
   ecma_property_t current_prop;
 
   current_prop = ecma_op_object_get_own_property (object_p,

--- a/jerry-core/jerry-api.h
+++ b/jerry-core/jerry-api.h
@@ -20,7 +20,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/jerry-core/jrt/jrt-types.h
+++ b/jerry-core/jrt/jrt-types.h
@@ -20,6 +20,5 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
 
 #endif /* !JRT_TYPES_H */

--- a/targets/default/jerry-port-default-date.c
+++ b/targets/default/jerry-port-default-date.c
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
+#ifdef __GNUC__
 #include <sys/time.h>
+#endif
 
 #include "jerry-port.h"
 #include "jerry-port-default.h"
@@ -23,6 +25,7 @@
  */
 bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 {
+#ifdef __GNUC__
   struct timeval tv;
   struct timezone tz;
 
@@ -39,6 +42,9 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
   tz_p->daylight_saving_time = tz.tz_dsttime > 0 ? 1 : 0;
 
   return true;
+#else /* !__GNUC__ */
+  return false;
+#endif /* __GNUC__ */
 } /* jerry_port_get_time_zone */
 
 /**
@@ -46,12 +52,16 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
  */
 double jerry_port_get_current_time ()
 {
+#ifdef __GNUC__
   struct timeval tv;
 
   if (gettimeofday (&tv, NULL) != 0)
   {
-    return 0;
+    return 0.0;
   }
 
   return ((double) tv.tv_sec) * 1000.0 + ((double) tv.tv_usec) / 1000.0;
+#else /* __!GNUC__ */
+  return 0.0;
+#endif /* __GNUC__ */
 } /* jerry_port_get_current_time */


### PR DESCRIPTION
Folks,
This is the second half of our attempt to enable Jerryscript for compilers other than GCC -- in this case, the TI compilers.

Copied from the commit message:

    These changes are designed to enable the TI compilers to compile
    Jerryscript.  The changes include:
    
    CMakeLists.txt: we added conditionals around GCC-specific flags, added
    support for TI flags, and removed the always-on debugging flag (-g)
    
    /toolchain_mcu_tim4f.cmake: new toolchain file uses TI-specific parameters
    
    jerry-api.h: the sys/types.h file was #include'd but never used, so we
    removed it
    
    jrt-types.h: ditto
    
    jerry-port-default-date.c: the TI toolchain doesn't include
    sys/time.h, so we guarded uses of the package


...thanks for reviewing these changes!
Tim
