### PR TITLE
Fix urls in the example

### DIFF
--- a/docs/03.API-EXAMPLE.md
+++ b/docs/03.API-EXAMPLE.md
@@ -512,4 +512,4 @@ Value of x is 17
 
 ## Further steps
 
-For further API description, please visit [API Reference page](https://samsung.github.io/jerryscript/api-reference/) on [JerryScript home page](https://samsung.github.io/jerryscript/).
+For further API description, please visit [API Reference page](https://jerryscript-project.github.io/jerryscript/api-reference/) on [JerryScript home page](https://jerryscript-project.github.io/jerryscript/).


### PR DESCRIPTION
The urls in the docs/03.API-EXAMPLE.md was pointing to
the old samsung.github.io pages.

JerryScript-DCO-1.0-Signed-off-by: Kristof Kosztyo kkristof@inf.u-szeged.hu