### PR TITLE
Fix documentation errors

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer-prototype.c
@@ -39,7 +39,7 @@
  * \addtogroup ecmabuiltins
  * @{
  *
- * \addtogroup arraybuffer prototype ECMA ArrayBuffer.prototype object built-in
+ * \addtogroup arraybufferprototype ECMA ArrayBuffer.prototype object built-in
  * @{
  */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer.c
@@ -37,7 +37,7 @@
  * \addtogroup ecmabuiltins
  * @{
  *
- * \addtogroup string ECMA ArrayBuffer object built-in
+ * \addtogroup arraybuffer ECMA ArrayBuffer object built-in
  * @{
  */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -191,7 +191,7 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg) /**< this argument *
 static ecma_value_t
 ecma_builtin_date_prototype_dispatch_get (uint16_t builtin_routine_id, /**< built-in wide routine
                                                                         *   identifier */
-                                          ecma_number_t date_num) /* date converted to number */
+                                          ecma_number_t date_num) /**< date converted to number */
 {
   if (ecma_number_is_nan (date_num))
   {
@@ -302,7 +302,7 @@ static ecma_value_t
 ecma_builtin_date_prototype_dispatch_set (uint16_t builtin_routine_id, /**< built-in wide routine
                                                                         *   identifier */
                                           ecma_extended_object_t *ext_object_p, /**< date extended object */
-                                          ecma_number_t date_num, /* date converted to number */
+                                          ecma_number_t date_num, /**< date converted to number */
                                           const ecma_value_t arguments_list[], /**< list of arguments
                                                                                 *   passed to routine */
                                           ecma_length_t arguments_number) /**< length of arguments' list */
@@ -649,4 +649,3 @@ ecma_builtin_date_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< 
  */
 
 #endif /* !CONFIG_DISABLE_DATE_BUILTIN */
-

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -21,7 +21,7 @@
 /** \addtogroup ecma ECMA
  * @{
  *
- * \addtogroup ecmaarraybufferobject ECMA Arraybuffer object related routines
+ * \addtogroup ecmaarraybufferobject ECMA ArrayBuffer object related routines
  * @{
  */
 


### PR DESCRIPTION
Doxygen reported a few issues, which are fixed by this patch:
* ArrayBuffer-related documentation group names and titles were
  incorrect.
* Some Date-related helper functions used incorrect parameter
  documentation syntax.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu