### PR TITLE
target: mbedos5: mbed CLI refuses to build if no .mbed file present

### DIFF
--- a/targets/mbedos5/.gitignore
+++ b/targets/mbedos5/.gitignore
@@ -2,6 +2,7 @@ mbed-os
 mbed-events
 .build
 .mbed
+.temp/
 mbed_settings.py
 js/pins.js
 source/pins.cpp

--- a/targets/mbedos5/Makefile
+++ b/targets/mbedos5/Makefile
@@ -80,6 +80,7 @@ endif
 getlibs: .mbed
 
 .mbed:
+	echo 'ROOT=.' > .mbed
 	mbed config root .
 	mbed toolchain GCC_ARM
 	mbed target $(BOARD)


### PR DESCRIPTION
With the newest release of mbed CLI (1.0.0) it error's when no .mbed file is present in the project root. This breaks builds for JerryScript on mbed OS 5. With this patch we create this file and builds succeed again. We cannot use `mbed new` because it also creates a new git repository in targets/mbedos5 folder which is not what we want.

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com

/cc @thegecko @LMESTM @zherczeg @limjunsung

Fixes #1511