### PR TITLE
 Change the default build type to MinSizeRel.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(ENABLE_STRIP              ON                                    CACHE BOOL  
 set(PORT_DIR                  "${CMAKE_SOURCE_DIR}/targets/default" CACHE STRING "Use default or external port?")
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Release")
+  set(CMAKE_BUILD_TYPE "MinSizeRel")
 endif()
 
 if("${PLATFORM}" STREQUAL "DARWIN")
@@ -100,9 +100,6 @@ endmacro()
 macro(jerry_add_link_flags)
   jerry_add_flags(LINKER_FLAGS_COMMON ${ARGV})
 endmacro()
-
-# build mode specific compile/link flags
-set(CMAKE_C_FLAGS_RELEASE "-Os")
 
 # Architecture-specific compile/link flags
 jerry_add_compile_flags(${FLAGS_COMMON_ARCH})

--- a/tools/build.py
+++ b/tools/build.py
@@ -51,7 +51,7 @@ def get_arguments():
     parser.add_argument('--cmake-param', metavar='OPT', action='append', default=[], help='add custom argument to CMake')
     parser.add_argument('--compile-flag', metavar='OPT', action='append', default=[], help='add custom compile flag')
     parser.add_argument('--cpointer-32bit', metavar='X', choices=['ON', 'OFF'], default='OFF', type=str.upper, help='enable 32 bit compressed pointers (%(choices)s; default: %(default)s)')
-    parser.add_argument('--debug', action='store_const', const='Debug', default='Release', dest='build_type', help='debug build')
+    parser.add_argument('--debug', action='store_const', const='Debug', default='MinSizeRel', dest='build_type', help='debug build')
     parser.add_argument('--error-messages', metavar='X', choices=['ON', 'OFF'], default='OFF', type=str.upper, help='enable error messages (%(choices)s; default: %(default)s)')
     parser.add_argument('-j', '--jobs', metavar='N', action='store', type=int, default=multiprocessing.cpu_count() + 1, help='Allowed N build jobs at once (default: %(default)s)')
     parser.add_argument('--jerry-cmdline', metavar='X', choices=['ON', 'OFF'], default='ON', type=str.upper, help='build jerry command line tool (%(choices)s; default: %(default)s)')


### PR DESCRIPTION
The CMAKE_C_FLAGS_RELEASE  had been overwritten earlier to change the optimization level (from -O3 to -Os), but missed to add -DNDEBUG flag. The MinSizeRel build type ensure these flags and it is exactly the same that was the original plan.
