### PR TITLE
Remove `global` from the list of external magic strings in the api test

### DIFF
--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -149,7 +149,6 @@ handler_construct (const jerry_value_t func_obj_val, /**< function object */
  * Extended Magic Strings
  */
 #define JERRY_MAGIC_STRING_ITEMS \
-  JERRY_MAGIC_STRING_DEF (GLOBAL, global) \
   JERRY_MAGIC_STRING_DEF (GREEK_ZERO_SIGN, \xed\xa0\x80\xed\xb6\x8a) \
   JERRY_MAGIC_STRING_DEF (CONSOLE, console)
 


### PR DESCRIPTION
The `global` is already in the list of ECMA magic strings, so it doesn't have to be
an external magic string because the defined magic string id will be found at first.