### PR TITLE
target: mbedos5: Support for building on Windows

### DIFF
--- a/targets/mbedos5/Makefile
+++ b/targets/mbedos5/Makefile
@@ -87,4 +87,8 @@ getlibs: .mbed
 	mbed deploy
 
 ../../.mbedignore:
+ifeq ($(OS),Windows_NT)
+	copy template-mbedignore.txt ..\..\.mbedignore
+else
 	cp ./template-mbedignore.txt ../../.mbedignore
+endif


### PR DESCRIPTION
This patch allows users to build for the mbedos5 target on Windows (normal
Windows and Cygwin). Also needs
https://github.com/ARMmbed/mbed-js-gulp/pull/14.

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com

/cc @thegecko 