### PR TITLE
Update macro definitions in Curie-BSP target

### DIFF
--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -396,7 +396,7 @@ ecma_property_hashmap_delete (ecma_object_t *object_p, /**< object */
   }
 #else /* CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
   JERRY_UNUSED (object_p);
-  JERRY_UNUSED (name_p);
+  JERRY_UNUSED (name_cp);
   JERRY_UNUSED (property_p);
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 } /* ecma_property_hashmap_delete */

--- a/targets/curie_bsp/setup.py
+++ b/targets/curie_bsp/setup.py
@@ -85,6 +85,7 @@ def build_jerry_data(jerry_path):
     jerry_cflags = [
         '-DCONFIG_MEM_HEAP_AREA_SIZE=10*1024',
         '-DJERRY_NDEBUG',
+        '-DJERRY_JS_PARSER',
         '-DJERRY_DISABLE_HEAVY_DEBUG',
         '-DCONFIG_DISABLE_NUMBER_BUILTIN',
         '-DCONFIG_DISABLE_STRING_BUILTIN',
@@ -96,6 +97,8 @@ def build_jerry_data(jerry_path):
         '-DCONFIG_DISABLE_DATE_BUILTIN',
         '-DCONFIG_DISABLE_REGEXP_BUILTIN',
         '-DCONFIG_DISABLE_ANNEXB_BUILTIN',
+        '-DCONFIG_DISABLE_ARRAYBUFFER_BUILTIN',
+        '-DCONFIG_DISABLE_TYPEDARRAY_BUILTIN',
         '-DCONFIG_ECMA_LCACHE_DISABLE',
         '-DCONFIG_ECMA_PROPERTY_HASHMAP_DISABLE',
     ]


### PR DESCRIPTION
CurieBSP target should change a little because of the recent patches in jerry-core

* add JERRY_JS_PARSER
* add CONFIG_DISABLE_ARRAYBUFFER_BUILTIN
* add CONFIG_DISABLE_TYPEDARRAY_BUILTIN

BTW, change the compiler warning when CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE

there is no variable `name_p` in ecma_property_hashmap_delete, it should be `name_cp`

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com