### PR TITLE
targets: zephyr: Remove unused misc/shell.h header.

### DIFF
--- a/targets/zephyr/src/main-zephyr.c
+++ b/targets/zephyr/src/main-zephyr.c
@@ -19,7 +19,6 @@
 
 #include <zephyr.h>
 #include <misc/printk.h>
-#include <misc/shell.h>
 #include "getline-zephyr.h"
 
 #include "jerry-api.h"


### PR DESCRIPTION
It's also gone in Zephyr 1.7.

JerryScript-DCO-1.0-Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org