### PR TITLE
target: mbedos5: Change to debug profiles

### DIFF
--- a/targets/mbedos5/Makefile
+++ b/targets/mbedos5/Makefile
@@ -39,7 +39,7 @@ MBED_CLI_FLAGS += --build $(EXTERN_BUILD_DIR)
 endif
 
 ifeq ($(DEBUG), 1)
-MBED_CLI_FLAGS += -o debug-info
+MBED_CLI_FLAGS += --profile ./mbed-os/tools/profiles/debug.json
 endif
 
 ifeq ($(MBED_VERBOSE), 1)


### PR DESCRIPTION
In mbed OS 5.3 (which we target with JerryScript on mbed) we change the way debug builds are created. This patch changes the Makefile in JerryScript to reflect this.

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com

/cc @thegecko 