### PR TITLE
Add missing argument of `jerry_parse_and_save_snapshot` in API reference

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3287,6 +3287,7 @@ jerry_exec_snapshot (const void *snapshot_p,
   size_t global_mode_snapshot_size = jerry_parse_and_save_snapshot (code_to_snapshot_p,
                                                                     strlen ((const char *) code_to_snapshot_p),
                                                                     true,
+                                                                    false,
                                                                     global_mode_snapshot_buffer,
                                                                     sizeof (global_mode_snapshot_buffer));
   jerry_cleanup ();


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com