### PR TITLE
Stack data should be freed for do-while statements after the expression is parsed.

### DIFF
--- a/tests/jerry/fail/1/regression-test-issue-1550.js
+++ b/tests/jerry/fail/1/regression-test-issue-1550.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+do break; while a


### PR DESCRIPTION
Fixes #1550.