### PR TITLE
Function `jmem_heap_get_region_end` is unused when the system-allocat…

### DIFF
--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -92,6 +92,7 @@
 #define JMEM_HEAP_GET_ADDR_FROM_OFFSET(u) ((jmem_heap_free_t *) (u))
 #endif /* UINTPTR_MAX > UINT32_MAX */
 
+#ifndef JERRY_SYSTEM_ALLOCATOR
 /**
  * Get end of region
  */
@@ -100,6 +101,7 @@ jmem_heap_get_region_end (jmem_heap_free_t *curr_p) /**< current region */
 {
   return (jmem_heap_free_t *)((uint8_t *) curr_p + curr_p->size);
 } /* jmem_heap_get_region_end */
+#endif /* !JERRY_SYSTEM_ALLOCATOR */
 
 /**
  * Check size of heap is corresponding to configuration


### PR DESCRIPTION
…or is enabled

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com