### PR TITLE
Improve error message

### DIFF
--- a/jerry-core/ecma/operations/ecma-exceptions.h
+++ b/jerry-core/ecma/operations/ecma-exceptions.h
@@ -51,6 +51,9 @@ typedef enum
 ecma_object_t *ecma_new_standard_error (ecma_standard_error_t error_type);
 ecma_object_t *ecma_new_standard_error_with_message (ecma_standard_error_t error_type, ecma_string_t *message_string_p);
 ecma_value_t ecma_raise_standard_error (ecma_standard_error_t error_type, const lit_utf8_byte_t *msg_p);
+#ifdef JERRY_ENABLE_ERROR_MESSAGES
+ecma_value_t ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, const char *msg_p, ...);
+#endif /* JERRY_ENABLE_ERROR_MESSAGES */
 ecma_value_t ecma_raise_common_error (const char *msg_p);
 ecma_value_t ecma_raise_eval_error (const char *msg_p);
 ecma_value_t ecma_raise_range_error (const char *msg_p);

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -52,7 +52,15 @@ ecma_op_get_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
   /* 3. */
   if (unlikely (is_unresolvable_reference))
   {
-    return ecma_raise_reference_error (ECMA_ERR_MSG ("Cannot resolve reference."));
+#ifdef JERRY_ENABLE_ERROR_MESSAGES
+    ecma_value_t var_name_val = ecma_make_string_value (var_name_string_p);
+    ecma_value_t error_value = ecma_raise_standard_error_with_format (ECMA_ERROR_REFERENCE,
+                                                                      "% is not defined",
+                                                                      var_name_val);
+#else /* !JERRY_ENABLE_ERROR_MESSAGES */
+    ecma_value_t error_value = ecma_raise_reference_error (NULL);
+#endif /* JERRY_ENABLE_ERROR_MESSAGES */
+    return error_value;
   }
 
   /* 5. */
@@ -149,7 +157,15 @@ ecma_op_put_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
     /* 3.a. */
     if (is_strict)
     {
-      return ecma_raise_reference_error (ECMA_ERR_MSG ("Cannot resolve reference."));
+#ifdef JERRY_ENABLE_ERROR_MESSAGES
+      ecma_value_t var_name_val = ecma_make_string_value (var_name_string_p);
+      ecma_value_t error_value = ecma_raise_standard_error_with_format (ECMA_ERROR_REFERENCE,
+                                                                        "% is not defined",
+                                                                        var_name_val);
+#else /* !JERRY_ENABLE_ERROR_MESSAGES */
+      ecma_value_t error_value = ecma_raise_reference_error (NULL);
+#endif /* JERRY_ENABLE_ERROR_MESSAGES */
+      return error_value;
     }
     else
     {

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -123,7 +123,15 @@ ecma_op_resolve_reference_value (ecma_object_t *lex_env_p, /**< starting lexical
     lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
   }
 
-  return ecma_raise_reference_error (ECMA_ERR_MSG ("Cannot resolve reference."));
+#ifdef JERRY_ENABLE_ERROR_MESSAGES
+  ecma_value_t name_val = ecma_make_string_value (name_p);
+  ecma_value_t error_value = ecma_raise_standard_error_with_format (ECMA_ERROR_REFERENCE,
+                                                                    "% is not defined",
+                                                                    name_val);
+#else /* !JERRY_ENABLE_ERROR_MESSAGES */
+  ecma_value_t error_value = ecma_raise_reference_error (NULL);
+#endif /* JERRY_ENABLE_ERROR_MESSAGES */
+  return error_value;
 } /* ecma_op_resolve_reference_value */
 
 /**


### PR DESCRIPTION
Many error messages of JerryScript only tell there is an error but without further context, which is vague and makes it difficult to debug.

This patch helps the situtation, for errors related to unexisting properties or bad references, it can remind the property/variable names at least.

With this patch, for the following testing code (also works for `node`):

```javascript
'use strict';

var print = print || console.log;

var printError = (function (i) {
  return function (head, error) {
    print(i + (i <= 9 ? ' ' : ''), head, Array(30 - head.length).join(' '), error);
      print(Array(100).join('-'));
      ++i;
  };
})(1);

[ 'x = 1;',
  'x += 1;',
  'var y = x;',
  'x.y = 1;',
  'var x; x.y;',
  'var x; x[1];',
  'var x; x.y = 1;',
  'var x; x[0] = 1;',
  'var x = null; x[\'y\'];',
  'null.y = 1;'
].forEach(function (src) {
  try {
    eval(src);
  } catch (e) {
    printError(src, e);
  }
});
```

The expected output would be:

```
1  x = 1;                         ReferenceError: x is not defined
---------------------------------------------------------------------------------------------------
2  x += 1;                        ReferenceError: x is not defined
---------------------------------------------------------------------------------------------------
3  var y = x;                     ReferenceError: x is not defined
---------------------------------------------------------------------------------------------------
4  x.y = 1;                       ReferenceError: x is not defined
---------------------------------------------------------------------------------------------------
5  var x; x.y;                    TypeError: Cannot read property 'y' of undefined
---------------------------------------------------------------------------------------------------
6  var x; x[1];                   TypeError: Cannot read property '1' of undefined
---------------------------------------------------------------------------------------------------
7  var x; x.y = 1;                TypeError: Cannot set property 'y' of undefined
---------------------------------------------------------------------------------------------------
8  var x; x[0] = 1;               TypeError: Cannot set property '0' of undefined
---------------------------------------------------------------------------------------------------
9  var x = null; x['y'];          TypeError: Cannot read property 'y' of null
---------------------------------------------------------------------------------------------------
10 null.y = 1;                    TypeError: Cannot set property 'y' of null
---------------------------------------------------------------------------------------------------

```
