### PR TITLE
The main-unix utility should free the return value to avoid leaks.

### DIFF
--- a/jerry-main/main-unix-minimal.c
+++ b/jerry-main/main-unix-minimal.c
@@ -110,6 +110,9 @@ main (int argc,
     {
       break;
     }
+
+    jerry_release_value (ret_value);
+    ret_value = jerry_create_undefined ();
   }
 
   int ret_code = JERRY_STANDALONE_EXIT_CODE_OK;

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -717,6 +717,9 @@ main (int argc,
       {
         break;
       }
+
+      jerry_release_value (ret_value);
+      ret_value = jerry_create_undefined ();
     }
   }
 


### PR DESCRIPTION
Fixes #1545.