### PR TITLE
Fix the missing inline specifier if compiling with -fPIC

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -238,7 +238,7 @@ ecma_number_get_sign_field (ecma_number_t num) /**< ecma-number */
                   fraction is filled with anything but not all zero bits,
  *         false - otherwise
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_number_is_nan (ecma_number_t num) /**< ecma-number */
 {
   bool is_nan = (num != num);
@@ -291,7 +291,7 @@ ecma_number_make_infinity (bool sign) /**< true - for negative Infinity,
  * @return true - if sign bit of ecma-number is set
  *         false - otherwise
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_number_is_negative (ecma_number_t num) /**< ecma-number */
 {
   JERRY_ASSERT (!ecma_number_is_nan (num));

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -1195,7 +1195,7 @@ ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, /**< ecm
  * It is the caller's responsibility to make sure that the string fits in the buffer.
  * Check if the size of the string is equal with the size of the buffer.
  */
-void __attr_always_inline___
+inline void __attr_always_inline___
 ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, /**< ecma-string descriptor */
                            lit_utf8_byte_t *buffer_p, /**< destination buffer pointer
                                                        * (can be NULL if buffer_size == 0) */
@@ -1575,7 +1575,7 @@ ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /* ecma-stri
  * @return true - if strings are equal;
  *         false - otherwise.
  */
-bool __attr_always_inline___
+inline bool __attr_always_inline___
 ecma_compare_ecma_strings (const ecma_string_t *string1_p, /* ecma-string */
                            const ecma_string_t *string2_p) /* ecma-string */
 {

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -400,7 +400,7 @@ jmem_heap_gc_and_alloc_block (const size_t size,      /**< required memory size 
  * @return NULL, if the required memory is 0
  *         pointer to allocated memory block, otherwise
  */
-void * __attr_hot___ __attr_always_inline___
+inline void * __attr_hot___ __attr_always_inline___
 jmem_heap_alloc_block (const size_t size)  /**< required memory size */
 {
   return jmem_heap_gc_and_alloc_block (size, false);
@@ -416,7 +416,7 @@ jmem_heap_alloc_block (const size_t size)  /**< required memory size */
  *         also NULL, if the allocation has failed
  *         pointer to the allocated memory block, otherwise
  */
-void * __attr_hot___ __attr_always_inline___
+inline void * __attr_hot___ __attr_always_inline___
 jmem_heap_alloc_block_null_on_error (const size_t size) /**< required memory size */
 {
   return jmem_heap_gc_and_alloc_block (size, true);

--- a/jerry-core/parser/regexp/re-bytecode.c
+++ b/jerry-core/parser/regexp/re-bytecode.c
@@ -123,7 +123,7 @@ re_bytecode_list_insert (re_bytecode_ctx_t *bc_ctx_p, /**< RegExp bytecode conte
  *
  * @return ecma character
  */
-ecma_char_t __attr_always_inline___
+inline ecma_char_t __attr_always_inline___
 re_get_char (uint8_t **bc_p) /**< pointer to bytecode start */
 {
   ecma_char_t chr = *((ecma_char_t *) *bc_p);
@@ -136,7 +136,7 @@ re_get_char (uint8_t **bc_p) /**< pointer to bytecode start */
  *
  * @return current RegExp opcode
  */
-re_opcode_t __attr_always_inline___
+inline re_opcode_t __attr_always_inline___
 re_get_opcode (uint8_t **bc_p) /**< pointer to bytecode start */
 {
   uint8_t bytecode = **bc_p;
@@ -149,7 +149,7 @@ re_get_opcode (uint8_t **bc_p) /**< pointer to bytecode start */
  *
  * @return opcode parameter
  */
-uint32_t __attr_always_inline___
+inline uint32_t __attr_always_inline___
 re_get_value (uint8_t **bc_p) /**< pointer to bytecode start */
 {
   uint32_t value = *((uint32_t *) *bc_p);
@@ -162,7 +162,7 @@ re_get_value (uint8_t **bc_p) /**< pointer to bytecode start */
  *
  * @return bytecode length (unsigned integer)
  */
-uint32_t __attr_pure___ __attr_always_inline___
+inline uint32_t __attr_pure___ __attr_always_inline___
 re_get_bytecode_length (re_bytecode_ctx_t *bc_ctx_p) /**< RegExp bytecode context */
 {
   return ((uint32_t) (bc_ctx_p->current_p - bc_ctx_p->block_start_p));


### PR DESCRIPTION
There is compilation issue when you are about to use `-fPIC` compiler option.

Simple use case:
`tools/build.py --compile-flag="-fPIC"`

Error report (part of it):
```
jerryscript/jerry-core/ecma/base/ecma-helpers-number.c: In function ‘ecma_number_get_next’:
jerryscript/jerry-core/ecma/base/ecma-helpers-number.c:295:1: error: inlining failed in call to always_inline ‘ecma_number_is_negative’: function body can be overwritten at link time
```

Environment:
Ubuntu 16.04, GCC 5.4.0

How to fix:
It can be fixed by adding an `inline` specifier for those functions.