### PR TITLE
Fix for python debugger client

### DIFF
--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -316,6 +316,8 @@ class JerryDebugger(object):
 
         if len_result > len_expected:
             result = result[len_expected:]
+        else:
+            result = b""
 
         len_expected = 6
         # Network configurations, which has the following struct:


### PR DESCRIPTION
Clear the 'result' buffer when its length is equal to the 'expected' message length.