### PR TITLE
Fix issue #1613

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1667,6 +1667,38 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 } /* ecma_op_object_get_property_names */
 
 /**
+ * The function is used in the assert of ecma_object_get_class_name
+ */
+inline static bool
+ecma_object_check_class_name_is_object (ecma_object_t *obj_p) /**< object */
+{
+#ifndef JERRY_NDEBUG
+  return (ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_GLOBAL)
+#ifndef CONFIG_DISABLE_ARRAYBUFFER_BUILTIN
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_ARRAYBUFFER_PROTOTYPE)
+#endif /* !CONFIG_DISABLE_ARRAYBUFFER_BUILTIN */
+#ifndef CONFIG_DISABLE_TYPEDARRAY_BUILTIN
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_TYPEDARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_INT8ARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_UINT8ARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_INT16ARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_UINT16ARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_INT32ARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_UINT32ARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_FLOAT32ARRAY_PROTOTYPE)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_UINT8CLAMPEDARRAY_PROTOTYPE)
+#if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_FLOAT64ARRAY_PROTOTYPE)
+#endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
+#endif /* !CONFIG_DISABLE_TYPEDARRAY_BUILTIN */
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_OBJECT_PROTOTYPE));
+#else /* JERRY_NDEBUG */
+  JERRY_UNUSED (obj_p);
+  return true;
+#endif /* !JERRY_NDEBUG */
+} /* ecma_object_check_class_name_is_object */
+
+/**
  * Get [[Class]] string of specified object
  *
  * @return class name magic string
@@ -1729,10 +1761,6 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
 
         switch (ext_obj_p->u.built_in.id)
         {
-          case ECMA_BUILTIN_ID_OBJECT_PROTOTYPE:
-          {
-            return LIT_MAGIC_STRING_OBJECT_UL;
-          }
 #ifndef CONFIG_DISABLE_MATH_BUILTIN
           case ECMA_BUILTIN_ID_MATH:
           {
@@ -1759,7 +1787,7 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
           }
           default:
           {
-            JERRY_ASSERT (ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_GLOBAL));
+            JERRY_ASSERT (ecma_object_check_class_name_is_object (obj_p));
 
             return LIT_MAGIC_STRING_OBJECT_UL;
           }

--- a/tests/jerry-test-suite/es2015/22/22.02/22.02.01/22.02.01-020.js
+++ b/tests/jerry-test-suite/es2015/22/22.02/22.02.01/22.02.01-020.js
@@ -1,0 +1,27 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var name = "";
+
+try
+{
+  new Int16Array(Float32Array.prototype);
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "TypeError");


### PR DESCRIPTION
I forget to implement the get_class_name_method of arraybuffer.prototype and typedarray.prototype.

For now, we don't need to distinguish their class name from general object, so I just set their class name as "object". In the future, when we need to know the specific class name, we can add some magic lit and modify them.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com