### PR TITLE
Make sure the byteLength of typedarray will not overflow

### DIFF
--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -21,6 +21,7 @@
 #include "ecma-gc.h"
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
+#include "jmem.h"
 
 #ifndef CONFIG_DISABLE_ARRAYBUFFER_BUILTIN
 
@@ -66,6 +67,11 @@ ecma_op_create_arraybuffer_object (const ecma_value_t *arguments_list_p, /**< li
     {
       return ret;
     }
+  }
+
+  if (length > UINT32_MAX - sizeof (ecma_extended_object_t) - JMEM_ALIGNMENT + 1)
+  {
+    return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid ArrayBuffer length."));
   }
 
   ecma_object_t *object_p = ecma_arraybuffer_new_object (length);

--- a/tests/jerry/es2015/regression-test-issue-1616.js
+++ b/tests/jerry/es2015/regression-test-issue-1616.js
@@ -1,0 +1,27 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var name = "";
+
+try
+{
+  var a = new ArrayBuffer (0xfffffffe)
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "RangeError");
+


### PR DESCRIPTION
fix issue #1616 

When allocate new arraybuffer, it need to malloc a buffer. 
if the length is larger than `(UINTPTR_MAX - JMEM_ALIGNMENT - sizeof (ecma_extended_object_t) + 1)`
then the alloc size will be exceed `UINTPTR_MAX`. Since the arg type of size in jmem_heap_alloc_block_internalis `size_t`, size value will overflow.

In this patch, we will check the length to prevent from overflow

build cmd `tools/build.py --clean --debug --profile=es2015-subset --compile-flag=-m32 --system-allocator=on --jerry-libc=off`

`var a = new ArrayBuffer(4294967264)` will cause OUT_OF_MEM
`var a = new ArrayBuffer(4294967265)` will cause range_error

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com