### PR TITLE
Fix issue #1605

### DIFF
--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -214,6 +214,9 @@ ecma_typedarray_create_object_with_length (ecma_length_t array_length, /**< leng
                                            lit_magic_string_id_t class_id) /**< class name of the typedarray */
 {
   ecma_length_t byte_length = array_length << element_size_shift;
+
+  ecma_value_t new_arraybuffer_p = ecma_make_object_value (ecma_arraybuffer_new_object (byte_length));
+
   ecma_object_t *object_p = ecma_create_object (proto_p,
                                                 sizeof (ecma_extended_object_t),
                                                 ECMA_OBJECT_TYPE_PSEUDO_ARRAY);
@@ -222,8 +225,9 @@ ecma_typedarray_create_object_with_length (ecma_length_t array_length, /**< leng
   ext_object_p->u.pseudo_array.u1.class_id = class_id;
   ext_object_p->u.pseudo_array.type = ECMA_PSEUDO_ARRAY_TYPEDARRAY;
   ext_object_p->u.pseudo_array.extra_info = element_size_shift;
-  ext_object_p->u.pseudo_array.u2.arraybuffer = ecma_make_object_value (ecma_arraybuffer_new_object (byte_length));
-  ecma_free_value (ext_object_p->u.pseudo_array.u2.arraybuffer);
+  ext_object_p->u.pseudo_array.u2.arraybuffer = new_arraybuffer_p;
+
+  ecma_free_value (new_arraybuffer_p);
 
   return object_p;
 } /* !ecma_typedarray_create_object_with_length */


### PR DESCRIPTION
Fix issue #1605 

We should avoid allocating other objects during we create a typedarray.

Because typearray objects has a member: arraybuffer. when we run gc_mark, it should also mark the arraybuffer. But during we create a typedarray, the typedarray.arraybuffer is not set yet, and it is a wild pointer. We just avoid gc during typedarray creataion.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com