### PR TITLE
Numbers found in the literal table also has LEXER_LITERAL_OBJECT_ANY type.

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1578,6 +1578,7 @@ lexer_construct_number_object (parser_context_t *context_p, /**< context */
     {
       context_p->lit_object.literal_p = literal_p;
       context_p->lit_object.index = (uint16_t) literal_index;
+      context_p->lit_object.type = LEXER_LITERAL_OBJECT_ANY;
       return false;
     }
 

--- a/tests/jerry/fail/1/regression-test-issue-1615.js
+++ b/tests/jerry/fail/1/regression-test-issue-1615.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+0x10000 && eval(0x10000())


### PR DESCRIPTION
Fixes #1615.