### PR TITLE
Add delete all breakpoints feature to debugger (javascript)

### DIFF
--- a/jerry-debugger/jerry-client-ws.html
+++ b/jerry-debugger/jerry-client-ws.html
@@ -828,7 +828,23 @@ function DebuggerClient(address)
   {
     breakpoint = activeBreakpoints[index];
 
-    if (!breakpoint)
+    if (index == "all")
+    {
+      var found = false;
+
+      for (var i in activeBreakpoints)
+      {
+        delete activeBreakpoints[i];
+        found = true;
+      }
+
+      if (!found)
+      {
+        appendLog("No active breakpoints.")
+      }
+    }
+
+    else if (!breakpoint)
     {
       appendLog("No breakpoint found with index " + index);
       return;


### PR DESCRIPTION
Now you can able to use `delete all` command, to clear the breakpoints from the whole project. 

JerryScript-DCO-1.0-Signed-off-by: Levente Orban orbanl@inf.u-szeged.hu