### PR TITLE
Allow to skip certain JS-tests under `tests/jerry/` and `tests/jerry-…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
           packages:
             - gcc-5
             - gcc-5-multilib
-      env: OPTS="--jerry-tests --jerry-test-suite --buildoptions=--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-g,--jerry-libc=off,--static-link=off,--strip=off,--system-allocator=on,--linker-flag=-fuse-ld=gold" ASAN_OPTIONS=detect_stack_use_after_return=1:check_initialization_order=true:strict_init_order=true TIMEOUT=600
+      env: OPTS="--jerry-tests --jerry-test-suite --skip-list=parser-oom.js --buildoptions=--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--jerry-libc=off,--static-link=off,--system-allocator=on,--linker-flag=-fuse-ld=gold" ASAN_OPTIONS=detect_stack_use_after_return=1:check_initialization_order=true:strict_init_order=true TIMEOUT=600
     - compiler: gcc-5
       addons:
         apt:
@@ -36,9 +36,8 @@ matrix:
           packages:
             - gcc-5
             - gcc-5-multilib
-      env: OPTS="--jerry-tests --jerry-test-suite --buildoptions=--compile-flag=-fsanitize=undefined,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-g,--jerry-libc=off,--static-link=off,--strip=off,--system-allocator=on,--linker-flag=-fuse-ld=gold" UBSAN_OPTIONS=print_stacktrace=1 TIMEOUT=600
+      env: OPTS="--jerry-tests --jerry-test-suite --skip-list=parser-oom.js --buildoptions=--compile-flag=-fsanitize=undefined,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--debug,--jerry-libc=off,--static-link=off,--system-allocator=on,--linker-flag=-fuse-ld=gold" UBSAN_OPTIONS=print_stacktrace=1 TIMEOUT=600
   allow_failures:
-    - compiler: gcc-5
     - env: OPTS="--check-pylint"
   fast_finish: true
 

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -25,6 +25,7 @@ OUTPUT_DIR = path.join(PROJECT_DIR, 'build', 'tests')
 parser = argparse.ArgumentParser()
 parser.add_argument('--toolchain', action='store', default='', help='Add toolchain file')
 parser.add_argument('--buildoptions', action='store', default='', help='Add a comma separated list of extra build options to each test')
+parser.add_argument('--skip-list', action='store', default='', help='Add a comma separated list of patterns of the excluded JS-tests')
 parser.add_argument('--outdir', action='store', default=OUTPUT_DIR, help='Specify output directory (default: %(default)s)')
 parser.add_argument('--check-signed-off', action='store_true', default=False, help='Run signed-off check')
 parser.add_argument('--check-signed-off-tolerant', action='store_true', default=False, help='Run signed-off check in tolerant mode')
@@ -184,6 +185,9 @@ def run_jerry_tests():
             break
 
         test_cmd = [TEST_RUNNER_SCRIPT, get_binary_path(job.out_dir), JERRY_TESTS_DIR]
+        if script_args.skip_list:
+            test_cmd.append("--skip-list=" + script_args.skip_list)
+
         if job.test_args:
             test_cmd.extend(job.test_args)
 
@@ -206,6 +210,9 @@ def run_jerry_test_suite():
             test_cmd.append(JERRY_TEST_SUITE_DIR)
         else:
             test_cmd.append(JERRY_TEST_SUITE_ES51_LIST)
+
+        if script_args.skip_list:
+            test_cmd.append("--skip-list=" + script_args.skip_list)
 
         if job.test_args:
             test_cmd.extend(job.test_args)


### PR DESCRIPTION
…test-suite/`

Add `--skip-list` option to tools/run-tests.py.

Additional modifications:
 - The test `parser-oom.js` doesn't work when system-allocator is enabled,
   hence we skip it in these jobs.
 - The sanitizer-tasks become mandatory.

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com