### PR TITLE
Fix the time computations of mbed ports

### DIFF
--- a/targets/mbed/source/port/jerry_port.c
+++ b/targets/mbed/source/port/jerry_port.c
@@ -76,10 +76,12 @@ jerry_port_get_time_zone (jerry_time_zone_t *tz_p) /**< timezone pointer */
 /**
  * Implementation of jerry_port_get_current_time.
  *
- * @return current timer's counter value in microseconds 
+ * @return current timer's counter value in milliseconds
  */
 double
 jerry_port_get_current_time ()
 {
-  return (double) us_ticker_read ();
+  /* Note: if the target has its own RTC, this value should be extended by the
+   * RTC's one. */
+  return (double) us_ticker_read () / 1000;
 } /* jerry_port_get_current_time */


### PR DESCRIPTION
The mbed ports used wrong time computations for the
'jerry_port_get_current_time' function. Microseconds was used instead of
milliseconds.

A quick fix has been done in the Yotta-based mbed port, and an extended one
- with correction - works in the mbed OS 5 port now.

JerryScript-DCO-1.0-Signed-off-by: Gabor Loki loki@inf.u-szeged.hu