### PR TITLE
Fix old-style function definitions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ jerry_add_compile_flags(-fno-stack-protector)
 endif()
 
 if (USING_GCC OR USING_CLANG)
-  jerry_add_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations shadow strict-prototypes undef)
+  jerry_add_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations shadow strict-prototypes undef old-style-definition)
   jerry_add_compile_flags(-Wno-stack-protector -Wno-attributes)
 endif()
 

--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -196,7 +196,7 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 /**
  * Default implementation of jerry_port_get_current_time.
  */
-double jerry_port_get_current_time ()
+double jerry_port_get_current_time (void)
 {
   struct timeval tv;
 

--- a/jerry-core/debugger/jerry-debugger-ws.c
+++ b/jerry-core/debugger/jerry-debugger-ws.c
@@ -311,7 +311,7 @@ jerry_process_handshake (int client_socket, /**< client socket */
  *         false - otherwise
  */
 bool
-jerry_debugger_accept_connection ()
+jerry_debugger_accept_connection (void)
 {
   int server_socket;
   struct sockaddr_in addr;

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -37,7 +37,7 @@ jmem_init (void)
  * Finalize memory allocators.
  */
 void
-jmem_finalize ()
+jmem_finalize (void)
 {
   jmem_pools_finalize ();
 

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -191,7 +191,7 @@ jmem_pools_free (void *chunk_p, /**< pointer to the chunk */
  *  Collect empty pool chunks
  */
 void
-jmem_pools_collect_empty ()
+jmem_pools_collect_empty (void)
 {
   jmem_pools_chunk_t *chunk_p = JERRY_CONTEXT (jmem_free_8_byte_chunk_p);
   JERRY_CONTEXT (jmem_free_8_byte_chunk_p) = NULL;

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -488,7 +488,7 @@ re_find_bytecode_in_cache (ecma_string_t *pattern_str_p, /**< pattern string */
  * Run gerbage collection in RegExp cache
  */
 void
-re_cache_gc_run ()
+re_cache_gc_run (void)
 {
   for (uint32_t i = 0u; i < RE_CACHE_SIZE; i++)
   {

--- a/targets/curie_bsp/source/curie-bsp-port.c
+++ b/targets/curie_bsp/source/curie-bsp-port.c
@@ -84,7 +84,7 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 /**
  * Curie BSP implementation of jerry_port_get_current_time.
  */
-double jerry_port_get_current_time ()
+double jerry_port_get_current_time (void)
 {
   uint32_t uptime_ms = get_uptime_ms ();
   uint32_t epoch_time = uptime_to_epoch (uptime_ms);

--- a/targets/default/jerry-port-default-date.c
+++ b/targets/default/jerry-port-default-date.c
@@ -50,7 +50,7 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 /**
  * Default implementation of jerry_port_get_current_time.
  */
-double jerry_port_get_current_time ()
+double jerry_port_get_current_time (void)
 {
 #ifdef __GNUC__
   struct timeval tv;

--- a/targets/default/jerry-port-default-fatal.c
+++ b/targets/default/jerry-port-default-fatal.c
@@ -36,7 +36,7 @@ void jerry_port_default_set_abort_on_fail (bool flag) /**< new value of 'abort o
  * @return true - if 'abort on fail' flag is set,
  *         false - otherwise.
  */
-bool jerry_port_default_is_abort_on_fail ()
+bool jerry_port_default_is_abort_on_fail (void)
 {
   return abort_on_fail;
 } /* jerry_port_default_is_abort_on_fail */

--- a/targets/mbed/source/port/jerry_port.c
+++ b/targets/mbed/source/port/jerry_port.c
@@ -79,7 +79,7 @@ jerry_port_get_time_zone (jerry_time_zone_t *tz_p) /**< timezone pointer */
  * @return current timer's counter value in microseconds 
  */
 double
-jerry_port_get_current_time ()
+jerry_port_get_current_time (void)
 {
   return (double) us_ticker_read ();
 } /* jerry_port_get_current_time */

--- a/targets/mbedos5/source/jerry_port_mbed.c
+++ b/targets/mbedos5/source/jerry_port_mbed.c
@@ -93,7 +93,7 @@ jerry_port_get_time_zone (jerry_time_zone_t *tz_p) /**< timezone pointer */
  * @return current timer's counter value in microseconds
  */
 double
-jerry_port_get_current_time ()
+jerry_port_get_current_time (void)
 {
   return (double) us_ticker_read ();
 } /* jerry_port_get_current_time */

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -304,7 +304,7 @@ jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
  * @return 0
  */
 double
-jerry_port_get_current_time ()
+jerry_port_get_current_time (void)
 {
   return 0;
 } /* jerry_port_get_current_time */

--- a/targets/zephyr/src/jerry-port.c
+++ b/targets/zephyr/src/jerry-port.c
@@ -65,7 +65,7 @@ void jerry_port_fatal (jerry_fatal_code_t code)
  * @return current timer's counter value in milliseconds
  */
 double
-jerry_port_get_current_time ()
+jerry_port_get_current_time (void)
 {
   int64_t ms = k_uptime_get();
   return (double) ms;


### PR DESCRIPTION
Function definitions with no parameters should always use the void keyword to allow the compiler to catch invalid calls of those functions at compile time.

Fixes #1649.

JerryScript-DCO-1.0-Signed-off-by: Tilmann Scheller t.scheller@samsung.com