### PR TITLE
Modify the snapshot API functions to expect a 32-bit aligned buffer pointer

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3419,7 +3419,7 @@ jerry_parse_and_save_snapshot (const jerry_char_t *source_p,
                                size_t source_size,
                                bool is_for_global,
                                bool is_strict,
-                               uint8_t *buffer_p,
+                               uint32_t *buffer_p,
                                size_t buffer_size);
 ```
 
@@ -3441,7 +3441,7 @@ jerry_parse_and_save_snapshot (const jerry_char_t *source_p,
 {
   jerry_init (JERRY_INIT_EMPTY);
 
-  static uint8_t global_mode_snapshot_buffer[1024];
+  static uint32_t global_mode_snapshot_buffer[256];
   const jerry_char_t *code_to_snapshot_p = "(function () { return 'string from snapshot'; }) ();";
 
   size_t global_mode_snapshot_size = jerry_parse_and_save_snapshot (code_to_snapshot_p,
@@ -3449,7 +3449,7 @@ jerry_parse_and_save_snapshot (const jerry_char_t *source_p,
                                                                     true,
                                                                     false,
                                                                     global_mode_snapshot_buffer,
-                                                                    sizeof (global_mode_snapshot_buffer));
+                                                                    sizeof (global_mode_snapshot_buffer) / sizeof (uint32_t));
 
   jerry_cleanup ();
 }
@@ -3475,7 +3475,7 @@ is no longer needed.
 
 ```c
 jerry_value_t
-jerry_exec_snapshot (const void *snapshot_p,
+jerry_exec_snapshot (const uint32_t *snapshot_p,
                      size_t snapshot_size,
                      bool copy_bytecode);
 ```
@@ -3495,7 +3495,7 @@ jerry_exec_snapshot (const void *snapshot_p,
 ```c
 {
   jerry_value_t res;
-  static uint8_t global_mode_snapshot_buffer[1024];
+  static uint32_t global_mode_snapshot_buffer[256];
   const jerry_char_t *code_to_snapshot_p = "(function () { return 'string from snapshot'; }) ();";
 
   jerry_init (JERRY_INIT_EMPTY);
@@ -3504,7 +3504,7 @@ jerry_exec_snapshot (const void *snapshot_p,
                                                                     true,
                                                                     false,
                                                                     global_mode_snapshot_buffer,
-                                                                    sizeof (global_mode_snapshot_buffer));
+                                                                    sizeof (global_mode_snapshot_buffer) / sizeof (uint32_t));
   jerry_cleanup ();
 
   jerry_init (JERRY_INIT_EMPTY);
@@ -3538,7 +3538,7 @@ size_t
 jerry_parse_and_save_literals (const jerry_char_t *source_p,
                                size_t source_size,
                                bool is_strict,
-                               uint8_t *buffer_p,
+                               uint32_t *buffer_p,
                                size_t buffer_size,
                                bool is_c_format);
 ```
@@ -3560,14 +3560,14 @@ jerry_parse_and_save_literals (const jerry_char_t *source_p,
 {
   jerry_init (JERRY_INIT_EMPTY);
 
-  static uint8_t save_literal_buffer[1024];
+  static uint32_t save_literal_buffer[256];
   const jerry_char_t *code_for_literal_save_p = "var obj = { a:'aa', bb:'Bb' }";
 
   size_t literal_sizes = jerry_parse_and_save_literals (code_for_literal_save_p,
                                                         strlen ((const char *) code_for_literal_save_p),
                                                         false,
                                                         save_literal_buffer,
-                                                        sizeof (save_literal_buffer),
+                                                        sizeof (save_literal_buffer) / sizeof (uint32_t),
                                                         true);
 
   if (literal_sizes != 0)

--- a/jerry-core/ecma/base/ecma-literal-storage.h
+++ b/jerry-core/ecma/base/ecma-literal-storage.h
@@ -43,13 +43,13 @@ jmem_cpointer_t ecma_find_or_create_literal_number (ecma_number_t number_arg);
 
 #ifdef JERRY_ENABLE_SNAPSHOT_SAVE
 bool
-ecma_save_literals_for_snapshot (uint8_t *, size_t, size_t *,
+ecma_save_literals_for_snapshot (uint32_t *, size_t, size_t *,
                                  lit_mem_to_snapshot_id_map_entry_t **, uint32_t *, uint32_t *);
 #endif /* JERRY_ENABLE_SNAPSHOT_SAVE */
 
 #ifdef JERRY_ENABLE_SNAPSHOT_EXEC
 bool
-ecma_load_literals_from_snapshot (const uint8_t *, uint32_t,
+ecma_load_literals_from_snapshot (const uint32_t *, uint32_t,
                                   lit_mem_to_snapshot_id_map_entry_t **, uint32_t *);
 #endif /* JERRY_ENABLE_SNAPSHOT_EXEC */
 

--- a/jerry-core/jerryscript.h
+++ b/jerry-core/jerryscript.h
@@ -339,10 +339,10 @@ bool jerry_is_valid_cesu8_string (const jerry_char_t *cesu8_buf_p, jerry_size_t 
  * Snapshot functions
  */
 size_t jerry_parse_and_save_snapshot (const jerry_char_t *source_p, size_t source_size, bool is_for_global,
-                                      bool is_strict, uint8_t *buffer_p, size_t buffer_size);
-jerry_value_t jerry_exec_snapshot (const void *snapshot_p, size_t snapshot_size, bool copy_bytecode);
+                                      bool is_strict, uint32_t *buffer_p, size_t buffer_size);
+jerry_value_t jerry_exec_snapshot (const uint32_t *snapshot_p, size_t snapshot_size, bool copy_bytecode);
 size_t jerry_parse_and_save_literals (const jerry_char_t *source_p, size_t source_size, bool is_strict,
-                                      uint8_t *buffer_p, size_t buffer_size, bool is_c_format);
+                                      uint32_t *buffer_p, size_t buffer_size, bool is_c_format);
 
 /**
  * @}

--- a/tests/unit/test-api.c
+++ b/tests/unit/test-api.c
@@ -18,6 +18,11 @@
 
 #include "test-common.h"
 
+/**
+ * Maximum size of snapshots buffer
+ */
+#define SNAPSHOT_BUFFER_SIZE (256)
+
 const char *test_source = (
                            "function assert (arg) { "
                            "  if (!arg) { "
@@ -1026,8 +1031,8 @@ main (void)
   if (jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_SAVE)
       && jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_EXEC))
   {
-    static uint8_t global_mode_snapshot_buffer[1024];
-    static uint8_t eval_mode_snapshot_buffer[1024];
+    static uint32_t global_mode_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
+    static uint32_t eval_mode_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
 
     const char *code_to_snapshot_p = "(function () { return 'string from snapshot'; }) ();";
 
@@ -1037,7 +1042,7 @@ main (void)
                                                                       true,
                                                                       false,
                                                                       global_mode_snapshot_buffer,
-                                                                      sizeof (global_mode_snapshot_buffer));
+                                                                      SNAPSHOT_BUFFER_SIZE);
     TEST_ASSERT (global_mode_snapshot_size != 0);
     jerry_cleanup ();
 
@@ -1047,7 +1052,7 @@ main (void)
                                                                     false,
                                                                     false,
                                                                     eval_mode_snapshot_buffer,
-                                                                    sizeof (eval_mode_snapshot_buffer));
+                                                                    SNAPSHOT_BUFFER_SIZE);
     TEST_ASSERT (eval_mode_snapshot_size != 0);
     jerry_cleanup ();
 
@@ -1088,14 +1093,14 @@ main (void)
     /* C format generation */
     jerry_init (JERRY_INIT_EMPTY);
 
-    static jerry_char_t literal_buffer_c[256];
+    static uint32_t literal_buffer_c[SNAPSHOT_BUFFER_SIZE];
     static const char *code_for_c_format_p = "var object = { aa:'fo o', Bb:'max', aaa:'xzy0' };";
 
     size_t literal_sizes_c_format = jerry_parse_and_save_literals ((jerry_char_t *) code_for_c_format_p,
                                                                    strlen (code_for_c_format_p),
                                                                    false,
                                                                    literal_buffer_c,
-                                                                   sizeof (literal_buffer_c),
+                                                                   SNAPSHOT_BUFFER_SIZE,
                                                                    true);
     TEST_ASSERT (literal_sizes_c_format == 203);
 
@@ -1123,15 +1128,16 @@ main (void)
     /* List format generation */
     jerry_init (JERRY_INIT_EMPTY);
 
-    static jerry_char_t literal_buffer_list[256];
+    static uint32_t literal_buffer_list[SNAPSHOT_BUFFER_SIZE];
     static const char *code_for_list_format_p = "var obj = { a:'aa', bb:'Bb' };";
 
     size_t literal_sizes_list_format = jerry_parse_and_save_literals ((jerry_char_t *) code_for_list_format_p,
                                                                       strlen (code_for_list_format_p),
                                                                       false,
                                                                       literal_buffer_list,
-                                                                      sizeof (literal_buffer_list),
+                                                                      SNAPSHOT_BUFFER_SIZE,
                                                                       false);
+
     TEST_ASSERT (literal_sizes_list_format == 25);
     TEST_ASSERT (!strncmp ((char *) literal_buffer_list, "1 a\n2 Bb\n2 aa\n2 bb\n3 obj\n", literal_sizes_list_format));
 


### PR DESCRIPTION
Fix for issue #1647