### PR TITLE
Fix the example code of 'jerry_define_own_property' function

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -2837,7 +2837,8 @@ jerry_define_own_property (const jerry_value_t obj_val,
   prop_desc.value = value_to_set;
 
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "my_prop");
-  jerry_define_own_property (global_obj_val, prop_name, &prop_desc);
+  jerry_value_t return_value = jerry_define_own_property (global_obj_val, prop_name, &prop_desc);
+  jerry_release_value (return_value);
   jerry_release_value (prop_name);
 
   jerry_free_property_descriptor_fields (&prop_desc);


### PR DESCRIPTION
Based on the API documentation and the implementation of `jerry_define_own_property`, the return value of this function have to be freed.

JerryScript-DCO-1.0-Signed-off-by: Gabor Loki loki@inf.u-szeged.hu