### PR TITLE
Fix Date objects' YearFromTime helper for out-of-range time values

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -119,6 +119,11 @@ ecma_date_year_from_time (ecma_number_t time) /**< time value */
   ecma_number_t year = (ecma_number_t) (1970 + 285616);
   ecma_number_t lower_year_boundary = (ecma_number_t) (1970 - 285616);
 
+  if (ecma_date_time_from_year (year) < time || ecma_date_time_from_year (lower_year_boundary) > time)
+  {
+    return ecma_number_make_nan ();
+  }
+
   while (ecma_date_time_from_year (year) > time)
   {
     ecma_number_t year_boundary = (ecma_number_t) floor (lower_year_boundary + (year - lower_year_boundary) / 2);
@@ -193,6 +198,12 @@ ecma_date_month_from_time (ecma_number_t time) /**< time value */
   JERRY_ASSERT (!ecma_number_is_nan (time));
 
   ecma_number_t year = ecma_date_year_from_time (time);
+
+  if (ecma_number_is_nan (year))
+  {
+    return ecma_number_make_nan ();
+  }
+
   int day_within_year = (int) (ecma_date_day (time) - ecma_date_day_from_year (year));
 
   JERRY_ASSERT (day_within_year >= 0);
@@ -231,6 +242,12 @@ ecma_date_date_from_time (ecma_number_t time) /**< time value */
   JERRY_ASSERT (!ecma_number_is_nan (time));
 
   ecma_number_t year = ecma_date_year_from_time (time);
+
+  if (ecma_number_is_nan (year))
+  {
+    return ecma_number_make_nan ();
+  }
+
   int day_within_year = (int) (ecma_date_day (time) - ecma_date_day_from_year (year));
 
   JERRY_ASSERT (day_within_year >= 0);

--- a/tests/jerry/regression-test-issue-1657.js
+++ b/tests/jerry/regression-test-issue-1657.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* Negative out-of-range years should NOT cause hangs. */
+new Date(-565224, 1);
+Date.UTC(-565224, 1);
+new Date().setFullYear(-565224);
+new Date().setUTCFullYear(-565224);
+new Date().setYear(-565224);


### PR DESCRIPTION
For negative out-of-range time values, ecma_date_year_from_time
fell into an infinite loop. (Moreover, for positive out-of-range
time values, it returned an incorrect year.) This patch fixes the
helper to return NaN in these cases (and ensures that its call
sites are prepared for NaN values).

Fixes #1657.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu