### PR TITLE
Fix minor inconsistencies in the API documentation

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -2062,7 +2062,8 @@ handler (const jerry_value_t function_obj,
 
   // after this, script can invoke the native handler through "handler_field (1, 2, 3);"
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "handler_field");
-  jerry_set_property (glob_obj, prop_name, func_val);
+  // set property and release the return value without any check
+  jerry_release_value (jerry_set_property (glob_obj, prop_name, func_val));
   jerry_release_value (prop_name);
 
   jerry_release_value (func_val);
@@ -2685,8 +2686,11 @@ jerry_set_property (const jerry_value_t obj_val,
   jerry_value_t glob_obj = jerry_get_global_object ();
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "my_prop");
 
-  jerry_set_property (glob_obj, prop_name, value_to_set);
+  jerry_value_t set_result = jerry_set_property (glob_obj, prop_name, value_to_set);
 
+  ... // check result of property set call
+
+  jerry_release_value (set_result);
   jerry_release_value (prop_name);
 
   ...
@@ -3133,7 +3137,7 @@ Set the prototype of the specified object.
 
 ```c
 jerry_value_t
-jerry_get_prototype (const jerry_value_t obj_val,
+jerry_set_prototype (const jerry_value_t obj_val,
                      const jerry_value_t proto_obj_val);
 ```
 


### PR DESCRIPTION
In the jerry_set_prototype part the method was described
as jerry_get_prototype. Minor typo fix.

The usage of jerry_set_property was incorrect. Each
call to the jerry_set_property returns a value which must be freed.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com