### PR TITLE
Unify timeout mechanism in test runners and ensure that they work on OSX

### DIFF
--- a/tools/runners/run-test-suite-test262.sh
+++ b/tools/runners/run-test-suite-test262.sh
@@ -19,6 +19,11 @@ PATH_TO_TEST262="$2"
 OUTPUT_DIR=`dirname $ENGINE`
 REPORT_PATH="${OUTPUT_DIR}/test262.report"
 TIMEOUT="90s"
+TIMEOUT_CMD=`which timeout`
+if [ $? -ne 0 ]
+then
+    TIMEOUT_CMD=`which gtimeout`
+fi
 
 if [ $# -lt 2 ]
 then
@@ -51,7 +56,7 @@ rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T6.js"
 
 echo "Starting test262 testing for ${ENGINE}. Running test262 may take a several minutes."
 
-"${PATH_TO_TEST262}"/tools/packaging/test262.py --command "timeout ${TIMEOUT} ${ENGINE}" \
+"${PATH_TO_TEST262}"/tools/packaging/test262.py --command "${TIMEOUT_CMD} ${TIMEOUT} ${ENGINE}" \
                                                 --tests="${PATH_TO_TEST262}" --summary \
                                                 &> "${REPORT_PATH}"
 

--- a/tools/runners/run-test-suite.sh
+++ b/tools/runners/run-test-suite.sh
@@ -18,6 +18,11 @@
 #       ./tools/runners/run-test-suite.sh ENGINE TESTS [--skip-list=item1,item2] [--snapshot] ENGINE_ARGS....
 
 TIMEOUT=${TIMEOUT:=5}
+TIMEOUT_CMD=`which timeout`
+if [ $? -ne 0 ]
+then
+    TIMEOUT_CMD=`which gtimeout`
+fi
 
 ENGINE="$1"
 shift
@@ -130,7 +135,7 @@ do
         SNAPSHOT_TEMP=`mktemp $(basename -s .js $test).snapshot.XXXXXXXXXX`
 
         cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP ${full_test#$ROOT_DIR}"
-        ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP $full_test &> $ENGINE_TEMP )
+        $TIMEOUT_CMD $TIMEOUT $ENGINE $ENGINE_ARGS --save-snapshot-for-global $SNAPSHOT_TEMP $full_test &> $ENGINE_TEMP
         status_code=$?
 
         if [ $status_code -eq 0 ]
@@ -138,14 +143,14 @@ do
             echo "[$tested/$TOTAL] $cmd_line: PASS"
 
             cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS --exec-snapshot $SNAPSHOT_TEMP"
-            ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS --exec-snapshot $SNAPSHOT_TEMP &> $ENGINE_TEMP )
+            $TIMEOUT_CMD $TIMEOUT $ENGINE $ENGINE_ARGS --exec-snapshot $SNAPSHOT_TEMP &> $ENGINE_TEMP
             status_code=$?
         fi
 
         rm -f $SNAPSHOT_TEMP
     else
         cmd_line="${ENGINE#$ROOT_DIR} $ENGINE_ARGS ${full_test#$ROOT_DIR}"
-        ( ulimit -t $TIMEOUT; $ENGINE $ENGINE_ARGS $full_test &> $ENGINE_TEMP )
+        $TIMEOUT_CMD $TIMEOUT $ENGINE $ENGINE_ARGS $full_test &> $ENGINE_TEMP
         status_code=$?
     fi
 


### PR DESCRIPTION
On OSX, the traditional GNU `timeout` command is available as
`gtimeout`. So, this commit adds some logic to the test runners to
try and find the right command name on the host.

Moreover, the commit also unifies the timeout mechanism across all
test runners by rewriting occurrences of `ulimit`-based timeouting
to use the `[g]timeout` command.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu