### PR TITLE
Fix comments of `ecma_lexical_environment_type_t`

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -544,10 +544,10 @@ typedef enum
 typedef enum
 {
   /* ECMA_OBJECT_TYPE_GENERAL (0) with built-in flag. */
-  /* ECMA_OBJECT_TYPE_FUNCTION (1) with built-in flag. */
-  /* ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION (2) with built-in flag. */
-  /* ECMA_OBJECT_TYPE_ARRAY (3) with built-in flag. */
-  /* ECMA_OBJECT_TYPE_STRING (4) with built-in flag. */
+  /* ECMA_OBJECT_TYPE_CLASS (1) with built-in flag. */
+  /* ECMA_OBJECT_TYPE_FUNCTION (2) with built-in flag. */
+  /* ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION (3) with built-in flag. */
+  /* ECMA_OBJECT_TYPE_ARRAY (4) with built-in flag. */
   ECMA_LEXICAL_ENVIRONMENT_DECLARATIVE = 5, /**< declarative lexical environment */
   ECMA_LEXICAL_ENVIRONMENT_OBJECT_BOUND = 6, /**< object-bound lexical environment */
   ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND = 7, /**< object-bound lexical environment


### PR DESCRIPTION
The comments of `ecma_lexical_environment_type_t` document why the
values of the enum are as they are, while referring to
`ecma_object_type_t`. However, they became out of sync lately and
refer to nonexistent enum labels and/or incorrect values. This
commit gets the two enums in sync.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu