### PR TITLE
Factor out common macro un/definitions used for built-in descriptions

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.inc.h
@@ -16,17 +16,8 @@
 /*
  * Array.prototype built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -68,10 +59,4 @@ ROUTINE (LIT_MAGIC_STRING_FILTER, ecma_builtin_array_prototype_object_filter, 2,
 ROUTINE (LIT_MAGIC_STRING_REDUCE, ecma_builtin_array_prototype_object_reduce, NON_FIXED, 1)
 ROUTINE (LIT_MAGIC_STRING_REDUCE_RIGHT_UL, ecma_builtin_array_prototype_object_reduce_right, NON_FIXED, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.inc.h
@@ -16,17 +16,8 @@
 /*
  * Array description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -48,10 +39,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
  *  (property name, C routine name, arguments number or NON_FIXED, value of the routine's length property) */
 ROUTINE (LIT_MAGIC_STRING_IS_ARRAY_UL, ecma_builtin_array_object_is_array, 1, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer-prototype.inc.h
@@ -12,25 +12,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
+/*
+ * ArrayBuffer.prototype built-in description
+ */
 
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
-
-#ifndef ACCESSOR_READ_WRITE
-# define ACCESSOR_READ_WRITE(name, c_getter_func_name, c_setter_func_name, prop_attributes)
-#endif /* !ROUTINE */
-
-#ifndef ACCESSOR_READ_ONLY
-# define ACCESSOR_READ_ONLY(name, c_getter_func_name, prop_attributes)
-#endif /* !ACCESSOR_READ_ONLY */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -48,10 +35,4 @@ ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_BYTE_LENGTH_UL,
  *  (property name, C routine name, arguments number or NON_FIXED, value of the routine's length property) */
 ROUTINE (LIT_MAGIC_STRING_SLICE, ecma_builtin_arraybuffer_prototype_object_slice, 2, 2)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer.inc.h
@@ -16,17 +16,8 @@
 /*
  * ArrayBuffer built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -48,10 +39,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
 /* ES2015 24.1.3.1 */
 ROUTINE (LIT_MAGIC_STRING_IS_VIEW_UL, ecma_builtin_arraybuffer_object_is_view, 1, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * Boolean.prototype description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -37,10 +32,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
 ROUTINE (LIT_MAGIC_STRING_TO_STRING_UL, ecma_builtin_boolean_prototype_object_to_string, 0, 0)
 ROUTINE (LIT_MAGIC_STRING_VALUE_OF_UL,  ecma_builtin_boolean_prototype_object_value_of,  0, 0)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.inc.h
@@ -16,17 +16,8 @@
 /*
  * Boolean description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -44,10 +35,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
               1,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * Date.prototype built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
               ECMA_BUILTIN_ID_DATE,
@@ -80,10 +75,4 @@ ROUTINE (LIT_MAGIC_STRING_TO_GMT_STRING_UL, ECMA_DATE_PROTOTYPE_TO_UTC_STRING, 0
 
 #endif /* !CONFIG_DISABLE_ANNEXB_BUILTIN */
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.inc.h
@@ -16,17 +16,8 @@
 /*
  * Date built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ECMA-262 v5, 15.9.4.1 */
 OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
@@ -41,10 +32,4 @@ ROUTINE (LIT_MAGIC_STRING_PARSE, ecma_builtin_date_parse, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_UTC_U, ecma_builtin_date_utc, NON_FIXED, 7)
 ROUTINE (LIT_MAGIC_STRING_NOW, ecma_builtin_date_now, 0, 0)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.inc.h
@@ -16,17 +16,8 @@
 /*
  * Error.prototype built-in description
  */
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -50,10 +41,4 @@ STRING_VALUE (LIT_MAGIC_STRING_MESSAGE,
  *  (property name, C routine name, arguments number or NON_FIXED, value of the routine's length property) */
 ROUTINE (LIT_MAGIC_STRING_TO_STRING_UL, ecma_builtin_error_prototype_object_to_string, 0, 0)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error.inc.h
@@ -16,17 +16,8 @@
 /*
  * Error built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -44,10 +35,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_ERROR_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * EvalError.prototype built-in description
  */
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -42,10 +37,4 @@ STRING_VALUE (LIT_MAGIC_STRING_MESSAGE,
               LIT_MAGIC_STRING__EMPTY,
               ECMA_PROPERTY_CONFIGURABLE_WRITABLE)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.inc.h
@@ -16,17 +16,8 @@
 /*
  * EvalError built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -44,10 +35,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_EVAL_ERROR_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.inc.h
@@ -16,17 +16,8 @@
 /*
  * Function.prototype built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -51,10 +42,4 @@ ROUTINE (LIT_MAGIC_STRING_APPLY, ecma_builtin_function_prototype_object_apply, 2
 ROUTINE (LIT_MAGIC_STRING_CALL, ecma_builtin_function_prototype_object_call, NON_FIXED, 1)
 ROUTINE (LIT_MAGIC_STRING_BIND, ecma_builtin_function_prototype_object_bind, NON_FIXED, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.inc.h
@@ -16,17 +16,8 @@
 /*
  * Function built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -44,10 +35,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
               1,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.inc.h
@@ -16,21 +16,8 @@
 /*
  * Global built-in description
  */
-#ifndef SIMPLE_VALUE
-# define SIMPLE_VALUE(name, simple_value, prop_attributes)
-#endif /* !SIMPLE_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Simple value properties:
  * (property name, simple value, writable, enumerable, configurable) */
@@ -227,10 +214,4 @@ ROUTINE (LIT_MAGIC_STRING_ESCAPE, ecma_builtin_global_object_escape, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_UNESCAPE, ecma_builtin_global_object_unescape, 1, 1)
 #endif /* !CONFIG_DISABLE_ANNEXB_BUILTIN */
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-macro-defines.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-macro-defines.inc.h
@@ -1,0 +1,42 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SIMPLE_VALUE
+#define SIMPLE_VALUE(name, simple_value, prop_attributes)
+#endif /* !SIMPLE_VALUE */
+
+#ifndef NUMBER_VALUE
+#define NUMBER_VALUE(name, number_value, prop_attributes)
+#endif /* !NUMBER_VALUE */
+
+#ifndef STRING_VALUE
+#define STRING_VALUE(name, magic_string_id, prop_attributes)
+#endif /* !STRING_VALUE */
+
+#ifndef OBJECT_VALUE
+#define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
+#endif /* !OBJECT_VALUE */
+
+#ifndef ROUTINE
+#define ROUTINE(name, c_function_name, args_number, length_prop_value)
+#endif /* !ROUTINE */
+
+#ifndef ACCESSOR_READ_WRITE
+#define ACCESSOR_READ_WRITE(name, c_getter_func_name, c_setter_func_name, prop_attributes)
+#endif /* !ACCESSOR_READ_WRITE */
+
+#ifndef ACCESSOR_READ_ONLY
+#define ACCESSOR_READ_ONLY(name, c_getter_func_name, prop_attributes)
+#endif /* !ACCESSOR_READ_ONLY */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-macro-undefs.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-macro-undefs.inc.h
@@ -13,20 +13,10 @@
  * limitations under the License.
  */
 
-/*
- * RegExp built-in description
- */
-
-#include "ecma-builtin-helpers-macro-defines.inc.h"
-
-/* ECMA-262 v5, 15.10.5 */
-NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
-              2,
-              ECMA_PROPERTY_FIXED)
-
-/* ECMA-262 v5, 15.10.5.1 */
-OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
-              ECMA_BUILTIN_ID_REGEXP_PROTOTYPE,
-              ECMA_PROPERTY_FIXED)
-
-#include "ecma-builtin-helpers-macro-undefs.inc.h"
+#undef SIMPLE_VALUE
+#undef NUMBER_VALUE
+#undef STRING_VALUE
+#undef OBJECT_VALUE
+#undef ROUTINE
+#undef ACCESSOR_READ_WRITE
+#undef ACCESSOR_READ_ONLY

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.inc.h
@@ -16,31 +16,12 @@
 /*
  * JSON built-in description
  */
-#ifndef SIMPLE_VALUE
-# define SIMPLE_VALUE(name, simple_value, prop_attributes)
-#endif /* !SIMPLE_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Routine properties:
  *  (property name, C routine name, arguments number or NON_FIXED, value of the routine's length property) */
 ROUTINE (LIT_MAGIC_STRING_PARSE, ecma_builtin_json_parse, 2, 2)
 ROUTINE (LIT_MAGIC_STRING_STRINGIFY, ecma_builtin_json_stringify, 3, 3)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.inc.h
@@ -16,21 +16,8 @@
 /*
  * Math built-in description
  */
-#ifndef SIMPLE_VALUE
-# define SIMPLE_VALUE(name, simple_value, prop_attributes)
-#endif /* !SIMPLE_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -96,10 +83,4 @@ ROUTINE (LIT_MAGIC_STRING_SIN, ECMA_MATH_OBJECT_SIN, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_SQRT, ECMA_MATH_OBJECT_SQRT, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_TAN, ECMA_MATH_OBJECT_TAN, 1, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * Number.prototype built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -41,10 +36,4 @@ ROUTINE (LIT_MAGIC_STRING_TO_FIXED_UL, ecma_builtin_number_prototype_object_to_f
 ROUTINE (LIT_MAGIC_STRING_TO_EXPONENTIAL_UL, ecma_builtin_number_prototype_object_to_exponential, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_TO_PRECISION_UL, ecma_builtin_number_prototype_object_to_precision, 1, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.inc.h
@@ -16,13 +16,8 @@
 /*
  * Number built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -65,10 +60,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_NUMBER_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * Object.prototype built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -41,10 +36,4 @@ ROUTINE (LIT_MAGIC_STRING_HAS_OWN_PROPERTY_UL, ecma_builtin_object_prototype_obj
 ROUTINE (LIT_MAGIC_STRING_IS_PROTOTYPE_OF_UL, ecma_builtin_object_prototype_object_is_prototype_of, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_PROPERTY_IS_ENUMERABLE_UL, ecma_builtin_object_prototype_object_property_is_enumerable, 1, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.inc.h
@@ -16,17 +16,8 @@
 /*
  * Object built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -64,10 +55,4 @@ ROUTINE (LIT_MAGIC_STRING_DEFINE_PROPERTY_UL, ecma_builtin_object_object_define_
 ROUTINE (LIT_MAGIC_STRING_SET_PROTOTYPE_OF_UL, ecma_builtin_object_object_set_prototype_of, 2, 2)
 #endif /* !CONFIG_DISABLE_ES2015_BUILTIN */
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * RangeError.prototype built-in description
  */
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -42,10 +37,4 @@ STRING_VALUE (LIT_MAGIC_STRING_MESSAGE,
               LIT_MAGIC_STRING__EMPTY,
               ECMA_PROPERTY_CONFIGURABLE_WRITABLE)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.inc.h
@@ -16,17 +16,8 @@
 /*
  * RangeError built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -44,10 +35,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_RANGE_ERROR_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * ReferenceError.prototype built-in description
  */
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -42,10 +37,4 @@ STRING_VALUE (LIT_MAGIC_STRING_MESSAGE,
               LIT_MAGIC_STRING__EMPTY,
               ECMA_PROPERTY_CONFIGURABLE_WRITABLE)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.inc.h
@@ -16,17 +16,8 @@
 /*
  * ReferenceError built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -44,10 +35,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_REFERENCE_ERROR_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.inc.h
@@ -16,25 +16,8 @@
 /*
  * RegExp.prototype built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef SIMPLE_VALUE
-# define SIMPLE_VALUE(name, simple_value, prop_attributes)
-#endif /* !SIMPLE_VALUE */
-
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ECMA-262 v5, 15.10.6.1 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -73,10 +56,4 @@ ROUTINE (LIT_MAGIC_STRING_EXEC, ecma_builtin_regexp_prototype_exec, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_TEST, ecma_builtin_regexp_prototype_test, 1, 1)
 ROUTINE (LIT_MAGIC_STRING_TO_STRING_UL, ecma_builtin_regexp_prototype_to_string, 0, 0)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.inc.h
@@ -16,17 +16,8 @@
 /*
  * String.prototype built-in description
  */
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
 
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -74,10 +65,4 @@ ROUTINE (LIT_MAGIC_STRING_TRIM, ecma_builtin_string_prototype_object_trim, 0, 0)
 ROUTINE (LIT_MAGIC_STRING_SUBSTR, ecma_builtin_string_prototype_object_substr, 2, 2)
 #endif /* !CONFIG_DISABLE_ANNEXB_BUILTIN */
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.inc.h
@@ -16,17 +16,8 @@
 /*
  * String built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -48,10 +39,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
  *  (property name, C routine name, arguments number or NON_FIXED, value of the routine's length property) */
 ROUTINE (LIT_MAGIC_STRING_FROM_CHAR_CODE_UL, ecma_builtin_string_object_from_char_code, NON_FIXED, 1)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * SyntaxError.prototype built-in description
  */
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -42,10 +37,4 @@ STRING_VALUE (LIT_MAGIC_STRING_MESSAGE,
               LIT_MAGIC_STRING__EMPTY,
               ECMA_PROPERTY_CONFIGURABLE_WRITABLE)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.inc.h
@@ -16,17 +16,8 @@
 /*
  * SyntaxError built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -44,10 +35,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_SYNTAX_ERROR_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.inc.h
@@ -18,9 +18,8 @@
  *
  * See also: ECMA-262 v5, 13.2.3
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
+
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -29,10 +28,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
               0,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * TypeError.prototype built-in description
  */
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -42,10 +37,4 @@ STRING_VALUE (LIT_MAGIC_STRING_MESSAGE,
               LIT_MAGIC_STRING__EMPTY,
               ECMA_PROPERTY_CONFIGURABLE_WRITABLE)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.inc.h
@@ -16,17 +16,8 @@
 /*
  * TypeError built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -44,10 +35,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_TYPE_ERROR_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror-prototype.inc.h
@@ -16,13 +16,8 @@
 /*
  * UriError.prototype built-in description
  */
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
 
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Object properties:
  *  (property name, object pointer getter) */
@@ -42,10 +37,4 @@ STRING_VALUE (LIT_MAGIC_STRING_MESSAGE,
               LIT_MAGIC_STRING__EMPTY,
               ECMA_PROPERTY_CONFIGURABLE_WRITABLE)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.inc.h
@@ -16,17 +16,8 @@
 /*
  * UriError built-in description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* Number properties:
  *  (property name, number value, writable, enumerable, configurable) */
@@ -44,10 +35,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_URI_ERROR_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float32array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float32array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Float32Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               4,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float32array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float32array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Float32Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_FLOAT32ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float64array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float64array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Float64Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               8,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float64array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float64array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Float64Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_FLOAT64ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int16array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int16array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Int16Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               2,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int16array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int16array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Int16Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_INT16ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int32array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int32array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Int32Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               4,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int32array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int32array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Int32Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_INT32ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int8array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int8array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Int8Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               1,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int8array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int8array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Int8Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_INT8ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * %TypedArrayPrototype% description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -65,10 +52,4 @@ ROUTINE (LIT_MAGIC_STRING_REDUCE_RIGHT_UL, ecma_builtin_typedarray_prototype_red
 ROUTINE (LIT_MAGIC_STRING_FILTER, ecma_builtin_typedarray_prototype_filter, 2, 1)
 ROUTINE (LIT_MAGIC_STRING_REVERSE, ecma_builtin_typedarray_prototype_reverse, 0, 0)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.inc.h
@@ -16,21 +16,8 @@
 /*
  * %TypedArray% description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.2 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -56,10 +43,4 @@ ROUTINE (LIT_MAGIC_STRING_FROM, ecma_builtin_typedarray_from, NON_FIXED, 1)
 /* ES2015 22.2.2.2 */
 ROUTINE (LIT_MAGIC_STRING_OF, ecma_builtin_typedarray_of, NON_FIXED, 0)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint16array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint16array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint16Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               2,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint16array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint16array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint16Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_UINT16ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint32Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               4,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint32Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_UINT32ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8array-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8array-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint8Array prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               1,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8array.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8array.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint8Array description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_UINT8ARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray-prototype.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint8ClampedArray prototype description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.3.4 */
 OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
@@ -42,10 +29,4 @@ NUMBER_VALUE (LIT_MAGIC_STRING_BYTES_PER_ELEMENT_U,
               1,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray.inc.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray.inc.h
@@ -16,21 +16,8 @@
 /*
  * Uint8ClampedArray description
  */
-#ifndef NUMBER_VALUE
-# define NUMBER_VALUE(name, number_value, prop_attributes)
-#endif /* !NUMBER_VALUE */
 
-#ifndef STRING_VALUE
-# define STRING_VALUE(name, magic_string_id, prop_attributes)
-#endif /* !STRING_VALUE */
-
-#ifndef OBJECT_VALUE
-# define OBJECT_VALUE(name, obj_builtin_id, prop_attributes)
-#endif /* !OBJECT_VALUE */
-
-#ifndef ROUTINE
-# define ROUTINE(name, c_function_name, args_number, length_prop_value)
-#endif /* !ROUTINE */
+#include "ecma-builtin-helpers-macro-defines.inc.h"
 
 /* ES2015 22.2.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LENGTH,
@@ -57,10 +44,4 @@ OBJECT_VALUE (LIT_MAGIC_STRING_PROTOTYPE,
               ECMA_BUILTIN_ID_UINT8CLAMPEDARRAY_PROTOTYPE,
               ECMA_PROPERTY_FIXED)
 
-#undef SIMPLE_VALUE
-#undef NUMBER_VALUE
-#undef STRING_VALUE
-#undef OBJECT_VALUE
-#undef ROUTINE
-#undef ACCESSOR_READ_WRITE
-#undef ACCESSOR_READ_ONLY
+#include "ecma-builtin-helpers-macro-undefs.inc.h"


### PR DESCRIPTION
The default definitions and undefinitions of macros used for built-in
descriptions (SIMPLE_VALUE, NUMBER_VALUE, STRING_VALUE, OBJECT_VALUE,
ROUTINE, ACCESSOR_READ_WRITE, ACCESSOR_READ_ONLY) are heavily cloned
all over the builtin-objects directory. This commit factors them out
into two header files, which are then included in the place of the
clones. This way, maintenance becomes a lot easier: e.g., if a new
macro gets introduced, default definition and undefinition don't have
to be added to all description files (of which there are 56 right now,
and their number will most probably just grow).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu