### PR TITLE
Implement %TypedArray%.from

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -26,6 +26,7 @@
 #include "jrt-bit-fields.h"
 #include "byte-code.h"
 #include "re-compiler.h"
+#include "ecma-builtins.h"
 
 /** \addtogroup ecma ECMA
  * @{
@@ -300,6 +301,33 @@ ecma_set_object_is_builtin (ecma_object_t *object_p) /**< object */
 
   object_p->type_flags_refs = (uint16_t) (object_p->type_flags_refs | ECMA_OBJECT_FLAG_BUILT_IN_OR_LEXICAL_ENV);
 } /* ecma_set_object_is_builtin */
+
+/**
+ * Get the builtin id of the object.
+ * If the object is not builtin, return ECMA_BUILTIN_ID__COUNT
+ */
+inline uint8_t
+ecma_get_object_builtin_id (ecma_object_t *object_p) /**< object */
+{
+  if (!ecma_get_object_is_builtin (object_p))
+  {
+    return ECMA_BUILTIN_ID__COUNT;
+  }
+
+  ecma_built_in_props_t *built_in_props_p;
+  ecma_object_type_t object_type = ecma_get_object_type (object_p);
+
+  if (object_type == ECMA_OBJECT_TYPE_CLASS || object_type == ECMA_OBJECT_TYPE_ARRAY)
+  {
+    built_in_props_p = &((ecma_extended_built_in_object_t *) object_p)->built_in;
+  }
+  else
+  {
+    built_in_props_p = &((ecma_extended_object_t *) object_p)->u.built_in;
+  }
+
+  return built_in_props_p->id;
+} /* ecma_get_object_builtin_id */
 
 /**
  * Get type of lexical environment.

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -293,6 +293,7 @@ void ecma_set_object_type (ecma_object_t *object_p, ecma_object_type_t type);
 ecma_object_t *ecma_get_object_prototype (const ecma_object_t *object_p) __attr_pure___;
 bool ecma_get_object_is_builtin (const ecma_object_t *object_p) __attr_pure___;
 void ecma_set_object_is_builtin (ecma_object_t *object_p);
+uint8_t ecma_get_object_builtin_id (ecma_object_t *object_p);
 ecma_lexical_environment_type_t ecma_get_lex_env_type (const ecma_object_t *object_p) __attr_pure___;
 ecma_object_t *ecma_get_lex_env_outer_reference (const ecma_object_t *object_p) __attr_pure___;
 ecma_property_header_t *ecma_get_property_list (const ecma_object_t *object_p) __attr_pure___;

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
@@ -20,6 +20,7 @@
 #include "ecma-helpers.h"
 #include "ecma-typedarray-object.h"
 #include "ecma-try-catch-macro.h"
+#include "ecma-function-object.h"
 #include "jrt.h"
 
 #ifndef CONFIG_DISABLE_TYPEDARRAY_BUILTIN
@@ -55,13 +56,128 @@ ecma_builtin_typedarray_from (ecma_value_t this_arg, /**< 'this' argument */
                               const ecma_value_t *arguments_list_p, /**< arguments list */
                               ecma_length_t arguments_list_len) /**< number of arguments */
 {
-  JERRY_UNUSED (this_arg);
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_list_len);
+  JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  /* TODO: inplement 'from' */
+  if (!ecma_is_constructor (this_arg))
+  {
+    return ecma_raise_type_error (ECMA_ERR_MSG ("'this' is not a constructor."));
+  }
 
-  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
+  ecma_value_t source;
+  ecma_value_t map_fn = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+  ecma_value_t this_in_fn = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+
+  if (arguments_list_len == 0)
+  {
+    return ecma_raise_type_error (ECMA_ERR_MSG ("no source argument"));
+  }
+
+  source = arguments_list_p[0];
+
+  if (arguments_list_len > 1)
+  {
+    map_fn = arguments_list_p[1];
+
+    if (!ecma_op_is_callable (map_fn))
+    {
+      return ecma_raise_type_error (ECMA_ERR_MSG ("mapfn argument is not callable"));
+    }
+
+    if (arguments_list_len > 2)
+    {
+      this_in_fn = arguments_list_p[2];
+    }
+  }
+
+  ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
+
+  uint8_t builtin_id = ecma_get_object_builtin_id (obj_p);
+  ecma_object_t *proto_p;
+  uint8_t element_size_shift;
+  lit_magic_string_id_t class_id;
+
+  switch (builtin_id)
+  {
+    case ECMA_BUILTIN_ID_INT8ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_INT8ARRAY_PROTOTYPE);
+      element_size_shift = 0;
+      class_id = LIT_MAGIC_STRING_INT8_ARRAY_UL;
+      break;
+    }
+    case ECMA_BUILTIN_ID_UINT8ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_UINT8ARRAY_PROTOTYPE);
+      element_size_shift = 0;
+      class_id = LIT_MAGIC_STRING_UINT8_ARRAY_UL;
+      break;
+    }
+    case ECMA_BUILTIN_ID_UINT8CLAMPEDARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_UINT8CLAMPEDARRAY_PROTOTYPE);
+      element_size_shift = 0;
+      class_id = LIT_MAGIC_STRING_UINT8_CLAMPED_ARRAY_UL;
+      break;
+    }
+    case ECMA_BUILTIN_ID_INT16ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_INT16ARRAY_PROTOTYPE);
+      element_size_shift = 1;
+      class_id = LIT_MAGIC_STRING_INT16_ARRAY_UL;
+      break;
+    }
+    case ECMA_BUILTIN_ID_UINT16ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_UINT16ARRAY_PROTOTYPE);
+      element_size_shift = 1;
+      class_id = LIT_MAGIC_STRING_UINT16_ARRAY_UL;
+      break;
+    }
+    case ECMA_BUILTIN_ID_INT32ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_INT32ARRAY_PROTOTYPE);
+      element_size_shift = 2;
+      class_id = LIT_MAGIC_STRING_INT32_ARRAY_UL;
+      break;
+    }
+    case ECMA_BUILTIN_ID_UINT32ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_UINT32ARRAY_PROTOTYPE);
+      element_size_shift = 2;
+      class_id = LIT_MAGIC_STRING_UINT32_ARRAY_UL;
+      break;
+    }
+    case ECMA_BUILTIN_ID_FLOAT32ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_FLOAT32ARRAY_PROTOTYPE);
+      element_size_shift = 2;
+      class_id = LIT_MAGIC_STRING_FLOAT32_ARRAY_UL;
+      break;
+    }
+#if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64
+    case ECMA_BUILTIN_ID_FLOAT64ARRAY:
+    {
+      proto_p = ecma_builtin_get (ECMA_BUILTIN_ID_FLOAT64ARRAY_PROTOTYPE);
+      element_size_shift = 3;
+      class_id = LIT_MAGIC_STRING_FLOAT64_ARRAY_UL;
+      break;
+    }
+#endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
+    default:
+    {
+      return ecma_raise_type_error (ECMA_ERR_MSG ("'this' is not a typedarray constructor"));
+    }
+  }
+
+  ecma_deref_object (proto_p);
+
+  return ecma_op_typedarray_from (source,
+                                  map_fn,
+                                  this_in_fn,
+                                  proto_p,
+                                  element_size_shift,
+                                  class_id);
+
 } /* ecma_builtin_typedarray_from */
 
 /**
@@ -82,9 +198,9 @@ ecma_builtin_typedarray_of (ecma_value_t this_arg, /**< 'this' argument */
   JERRY_UNUSED (arguments_list_p);
   JERRY_UNUSED (arguments_list_len);
 
-  /* TODO: inplement 'of' */
+  /* TODO: implement 'of' */
 
-  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
 } /* ecma_builtin_typedarray_of */
 
 /**

--- a/tests/jerry-test-suite/es2015/22/22.02/22.02.02/22.02.02-004.js
+++ b/tests/jerry-test-suite/es2015/22/22.02/22.02.02/22.02.02-004.js
@@ -1,0 +1,25 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function foo(v, k)
+{
+  return this.num + v + k;
+}
+
+var a = Float32Array.from([10,20,30], foo, {num:0.5});
+
+assert(a[0] === 10.5);
+assert(a[1] === 21.5);
+assert(a[2] === 32.5);

--- a/tests/jerry-test-suite/es2015/22/22.02/22.02.02/22.02.02-005.js
+++ b/tests/jerry-test-suite/es2015/22/22.02/22.02.02/22.02.02-005.js
@@ -1,0 +1,66 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var name = "";
+
+try
+{
+  Int16Array.from.call(1);
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "TypeError");
+
+name = "";
+
+try
+{
+  Int16Array.from.call(Float32Array);
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "TypeError");
+
+name = "";
+
+try
+{
+  Int16Array.from.call(Float32Array, [1,2,3], 1);
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "TypeError");
+
+name = "";
+
+try
+{
+  Int16Array.from.call(Number, [1,2,3]);
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "TypeError");

--- a/tests/jerry/es2015/regression-test-issue-1670.js
+++ b/tests/jerry/es2015/regression-test-issue-1670.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var name = "";
+
+try
+{
+  Int16Array.from();
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "TypeError");
+
+Int16Array.of();


### PR DESCRIPTION
* Implement the TypedArray.from routine
* add a helper function: `ecma_get_object_builtin_id`
* fix issue #1670 : the return value of builtin object's routine can not be empty, and I use undefined instead.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com