### PR TITLE
Bug fix for the debugger python client 'quit' command

### DIFF
--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -172,6 +172,7 @@ class DebuggerPrompt(Cmd):
     def do_quit(self, args):
         """ Exit JerryScript debugger """
         self.do_delete("all")
+        self.do_exception("0")  # disable the exception handler
         self.exec_command(args, JERRY_DEBUGGER_CONTINUE)
         self.stop = True
         self.quit = True


### PR DESCRIPTION
After merge the #1693 pull request, the exception handler in initial state was enabled. Disabled the exception handler in `quit` command. 

JerryScript-DCO-1.0-Signed-off-by: Levente Orban orbanl@inf.u-szeged.hu