### PR TITLE
Add 'type' argument to set/get native handle API

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -167,12 +167,42 @@ typedef jerry_value_t (*jerry_external_handler_t) (const jerry_value_t function_
 
 **Summary**
 
-Native free callback of an object
+**Deprecated: Please use jerry_object_native_free_callback_t instead.**
+
+Native free callback of an object.
 
 **Prototype**
 
 ```c
 typedef void (*jerry_object_free_callback_t) (const uintptr_t native_p);
+```
+
+## jerry_object_native_free_callback_t
+
+**Summary**
+
+Native free callback of an object. It is used in jerry_object_native_info_t.
+
+**Prototype**
+
+```c
+typedef void (*jerry_object_native_free_callback_t) (void *native_p);
+```
+
+## jerry_object_native_info_t
+
+**Summary**
+
+The type infomation of the native pointer.
+It includes the free callback that will be called when associated JavaScript object is garbage collected. It can be left NULL in case it is not needed.
+
+**Prototype**
+
+```c
+typedef struct
+{
+  jerry_object_native_free_callback_t free_cb;
+} jerry_object_native_info_t;
 ```
 
 ## jerry_object_property_foreach_t
@@ -3173,6 +3203,8 @@ jerry_set_prototype (const jerry_value_t obj_val,
 
 **Summary**
 
+**Deprecated: Please use jerry_get_object_native_pointer instead.**
+
 Get native handle, previously associated with specified object.
 
 **Prototype**
@@ -3211,12 +3243,16 @@ jerry_get_object_native_handle (const jerry_value_t obj_val,
 
 - [jerry_create_object](#jerry_create_object)
 - [jerry_set_object_native_handle](#jerry_set_object_native_handle)
+- [jerry_get_object_native_pointer](#jerry_get_object_native_pointer)
+
 
 ## jerry_set_object_native_handle
 
 **Summary**
 
-Set native handle and an optional free callback for the specified object
+**Deprecated: Please use jerry_set_object_native_pointer instead.**
+
+Set native handle and an optional free callback for the specified object.
 
 *Note*: If native handle was already set for the object, its value is updated.
 
@@ -3260,6 +3296,146 @@ jerry_set_object_native_handle (const jerry_value_t obj_val,
 
 - [jerry_create_object](#jerry_create_object)
 - [jerry_get_object_native_handle](#jerry_get_object_native_handle)
+- [jerry_set_object_native_pointer](#jerry_set_object_native_pointer)
+
+
+## jerry_get_object_native_pointer
+
+**Summary**
+
+Get native pointer and its type information.
+The pointer and the type information are previously associated with the object by jerry_set_object_native_pointer.
+Users can check the pointer's type before processing it.
+
+**Prototype**
+
+```c
+bool
+jerry_get_object_native_pointer (const jerry_value_t obj_val,
+                                 void **out_native_p,
+                                 const jerry_object_native_info_t **out_info_p)
+```
+
+- `obj_val` - object value to get native pointer from.
+- `out_native_p` - native pointer (output parameter).
+- `out_info_p` - native pointer's type infomation (output parameter).
+- return value
+  - true, if there is native pointer associated with the object
+  - false, otherwise
+
+**Example**
+
+```c
+static void native_freecb (uintptr_t native_p)
+{
+  ... // free the native pointer
+}
+
+static const jerry_object_native_info_t type_info =
+{
+  .free_cb = native_freecb
+};
+
+{
+  jerry_value_t object;
+  uintptr_t native_set;
+
+  ... // receive or construct object and native_set value
+
+  jerry_set_object_native_pointer (object, native_set, &type_info);
+
+  ...
+
+  uintptr_t native_get;
+  const jerry_object_native_info_t *type_get_p;
+  bool is_there_associated_native = jerry_get_object_native_pointer (object, &native_get, &type_get_p);
+
+  if (is_there_associated_native)
+  {
+    if (out_info_p == &type_info)
+    {
+      ... // the type of object's native pointer is expected, and then process the native pointer.
+    }
+  }
+}
+```
+
+**See also**
+
+- [jerry_create_object](#jerry_create_object)
+- [jerry_set_object_native_pointer](#jerry_set_object_native_pointer)
+- [jerry_object_native_info_t](#jerry_object_native_info_t)
+
+
+## jerry_set_object_native_pointer
+
+**Summary**
+
+Set native pointer and an optional type information for the specified object.
+You can get them by calling jerry_get_object_native_pointer later.
+
+*Note*: If native pointer was already set for the object, its value is updated.
+
+*Note*: If a non-NULL free callback is specified in the native type information,
+        it will be called by the garbage collector when the object is freed.
+        The type info is always overwrites the previous value, so passing
+        a NULL value deletes the current type info.
+
+**Prototype**
+
+```c
+bool
+jerry_set_object_native_pointer (const jerry_value_t obj_val,
+                                 void *native_p,
+                                 const jerry_object_native_info_t *info_p)
+```
+
+- `obj_val` - object to set native pointer in.
+- `native_p` - native pointer.
+- `info_p` - native pointer's type infomation or NULL.
+
+**Example**
+
+```c
+static void native_freecb (uintptr_t native_p)
+{
+  ... // free the native pointer
+}
+
+static const jerry_object_native_info_t type_info =
+{
+  .free_cb = native_freecb
+};
+
+{
+  jerry_value_t object;
+  uintptr_t native_set;
+
+  ... // receive or construct object and native_set value
+
+  jerry_set_object_native_pointer (object, native_set, &type_info);
+
+  ...
+
+  uintptr_t native_get;
+  const jerry_object_native_info_t *type_get_p;
+  bool is_there_associated_native = jerry_get_object_native_pointer (object, &native_get, &type_get_p);
+
+  if (is_there_associated_native)
+  {
+    if (out_info_p == &type_info)
+    {
+      ... // the type of object's native pointer is expected, and then process the native pointer.
+    }
+  }
+}
+```
+
+**See also**
+
+- [jerry_create_object](#jerry_create_object)
+- [jerry_get_object_native_pointer](#jerry_get_object_native_pointer)
+- [jerry_object_native_info_t](#jerry_object_native_info_t)
 
 
 ## jerry_foreach_object_property

--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -86,7 +86,6 @@ DECLARE_ROUTINES_FOR (collection_header)
 DECLARE_ROUTINES_FOR (collection_chunk)
 DECLARE_ROUTINES_FOR (string)
 DECLARE_ROUTINES_FOR (getter_setter_pointers)
-DECLARE_ROUTINES_FOR (external_pointer)
 
 /**
  * Allocate memory for extended object

--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -97,18 +97,6 @@ ecma_getter_setter_pointers_t *ecma_alloc_getter_setter_pointers (void);
  */
 void ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *getter_setter_pointers_p);
 
-/**
-* Allocate memory for external pointer
-*
-* @return pointer to allocated memory
-*/
-ecma_external_pointer_t *ecma_alloc_external_pointer (void);
-
-/**
-* Dealloc memory from external pointer
-*/
-void ecma_dealloc_external_pointer (ecma_external_pointer_t *external_pointer_p);
-
 /*
  * Allocate memory for extended object
  *

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -347,6 +347,47 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
 } /* ecma_gc_mark */
 
 /**
+ * Free the native handle/pointer by calling its free callback
+ */
+static void
+ecma_gc_free_native_pointer (ecma_property_t *property_p, /**< property */
+                             lit_magic_string_id_t id) /**< identifier of internal property */
+{
+  JERRY_ASSERT (property_p != NULL);
+
+  JERRY_ASSERT (id == LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE
+                || id == LIT_INTERNAL_MAGIC_STRING_NATIVE_POINTER);
+
+  ecma_property_value_t *value_p = ECMA_PROPERTY_VALUE_PTR (property_p);
+  ecma_external_pointer_t native_p;
+  ecma_external_pointer_t free_cb;
+  void *package_p;
+
+  package_p = ECMA_GET_INTERNAL_VALUE_POINTER (void, value_p->value);
+
+  if (id == LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE)
+  {
+    native_p = ((ecma_native_handle_package_t *) package_p)->handle_p;
+    free_cb = ((ecma_native_handle_package_t *) package_p)->free_cb;
+
+    if ((jerry_object_free_callback_t) free_cb != NULL)
+    {
+      ((jerry_object_free_callback_t) free_cb) ((uintptr_t) native_p);
+    }
+  }
+  else
+  {
+    native_p = ((ecma_native_pointer_package_t *) package_p)->native_p;
+    free_cb = *(ecma_external_pointer_t *) (((ecma_native_pointer_package_t *) package_p)->info_p);
+
+    if ((jerry_object_native_free_callback_t) free_cb != NULL)
+    {
+      ((jerry_object_native_free_callback_t) free_cb) ((void *) native_p);
+    }
+  }
+} /* ecma_gc_free_native_pointer */
+
+/**
  * Free specified object
  */
 void
@@ -357,28 +398,6 @@ ecma_gc_sweep (ecma_object_t *object_p) /**< object to free */
                 && object_p->type_flags_refs < ECMA_OBJECT_REF_ONE);
 
   bool obj_is_not_lex_env = !ecma_is_lexical_environment (object_p);
-
-  if (obj_is_not_lex_env)
-  {
-    /* if the object provides free callback, invoke it with handle stored in the object */
-
-    ecma_external_pointer_t freecb_p;
-    ecma_external_pointer_t native_p;
-
-    bool is_retrieved = ecma_get_external_pointer_value (object_p,
-                                                         LIT_INTERNAL_MAGIC_STRING_FREE_CALLBACK,
-                                                         &freecb_p);
-
-    if (is_retrieved && ((jerry_object_free_callback_t) freecb_p) != NULL)
-    {
-      is_retrieved = ecma_get_external_pointer_value (object_p,
-                                                      LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE,
-                                                      &native_p);
-      JERRY_ASSERT (is_retrieved);
-
-      jerry_dispatch_object_free_callback (freecb_p, native_p);
-    }
-  }
 
   if (obj_is_not_lex_env
       || ecma_get_lex_env_type (object_p) == ECMA_LEXICAL_ENVIRONMENT_DECLARATIVE)
@@ -403,9 +422,20 @@ ecma_gc_sweep (ecma_object_t *object_p) /**< object to free */
 
       for (int i = 0; i < ECMA_PROPERTY_PAIR_ITEM_COUNT; i++)
       {
+        ecma_property_t *property_p = (ecma_property_t *) (prop_iter_p->types + i);
+        jmem_cpointer_t name_cp = prop_pair_p->names_cp[i];
+
+        /* Call the native's free callback. */
+        if (ECMA_PROPERTY_GET_NAME_TYPE (*property_p) == ECMA_STRING_CONTAINER_MAGIC_STRING
+            && (name_cp == LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE
+                || name_cp == LIT_INTERNAL_MAGIC_STRING_NATIVE_POINTER))
+        {
+          ecma_gc_free_native_pointer (property_p, (lit_magic_string_id_t) name_cp);
+        }
+
         if (prop_iter_p->types[i] != ECMA_PROPERTY_TYPE_DELETED)
         {
-          ecma_free_property (object_p, prop_pair_p->names_cp[i], prop_iter_p->types + i);
+          ecma_free_property (object_p, name_cp, property_p);
         }
       }
 

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -196,6 +196,28 @@ typedef int32_t ecma_integer_value_t;
 typedef uintptr_t ecma_external_pointer_t;
 
 /**
+ * Representation for native handle package.
+ *
+ * Note: It is for the deprecated api:
+ *       jerry_get_object_native_handle and jerry_set_object_native_handle
+ */
+
+typedef struct
+{
+  ecma_external_pointer_t handle_p; /**< points to the external native object */
+  ecma_external_pointer_t free_cb; /**< free callback of the native handle */
+} ecma_native_handle_package_t;
+
+/**
+ * Representation of the native pointer package.
+ */
+typedef struct
+{
+  ecma_external_pointer_t native_p; /**< points to the external native object */
+  ecma_external_pointer_t info_p; /**< type info of the native pointer */
+} ecma_native_pointer_package_t;
+
+/**
  * Special property identifiers.
  */
 typedef enum

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -744,9 +744,9 @@ ecma_free_property (ecma_object_t *object_p, /**< object the property belongs to
       if (ECMA_PROPERTY_GET_NAME_TYPE (*property_p) == ECMA_STRING_CONTAINER_MAGIC_STRING)
       {
         if (name_cp == LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE
-            || name_cp == LIT_INTERNAL_MAGIC_STRING_FREE_CALLBACK)
+            || name_cp == LIT_INTERNAL_MAGIC_STRING_NATIVE_POINTER)
         {
-          ecma_free_external_pointer_in_property (property_p);
+          ecma_free_native_package_property (property_p, (lit_magic_string_id_t) name_cp);
           break;
         }
       }

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -344,11 +344,17 @@ void ecma_bytecode_ref (ecma_compiled_code_t *bytecode_p);
 void ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p);
 
 /* ecma-helpers-external-pointers.c */
-bool ecma_create_external_pointer_property (ecma_object_t *obj_p, lit_magic_string_id_t id,
-                                            ecma_external_pointer_t ptr_value);
-bool ecma_get_external_pointer_value (ecma_object_t *obj_p, lit_magic_string_id_t id,
-                                      ecma_external_pointer_t *out_pointer_p);
-void ecma_free_external_pointer_in_property (ecma_property_t *prop_p);
+bool ecma_create_native_handle_property (ecma_object_t *obj_p,
+                                         ecma_external_pointer_t handle_p,
+                                         ecma_external_pointer_t free_cb);
+bool ecma_create_native_pointer_property (ecma_object_t *obj_p,
+                                          ecma_external_pointer_t native_p,
+                                          ecma_external_pointer_t info_p);
+bool ecma_get_native_package_value (ecma_object_t *obj_p,
+                                    lit_magic_string_id_t id,
+                                    void **out_pointer_p);
+void ecma_free_native_package_property (ecma_property_t *prop_p,
+                                        lit_magic_string_id_t id);
 
 /* ecma-helpers-conversion.c */
 ecma_number_t ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, lit_utf8_size_t str_size);

--- a/jerry-core/jerryscript.h
+++ b/jerry-core/jerryscript.h
@@ -25,6 +25,12 @@ extern "C"
 {
 #endif /* __cplusplus */
 
+#ifdef __GNUC__
+#define JERRY_DEPRECATED_API __attribute__((deprecated))
+#else /* !__GNUC__ */
+/* TODO: for other compilers */
+#define JERRY_DEPRECATED_API
+#endif /* __GNUC__ */
 /** \addtogroup jerry Jerry engine interface
  * @{
  */
@@ -156,9 +162,14 @@ typedef jerry_value_t (*jerry_external_handler_t) (const jerry_value_t function_
                                                    const jerry_length_t args_count);
 
 /**
- * Native free callback of an object
+ * Native free callback of an object (deprecated)
  */
 typedef void (*jerry_object_free_callback_t) (const uintptr_t native_p);
+
+/**
+ * Native free callback of an object
+ */
+typedef void (*jerry_object_native_free_callback_t) (void *native_p);
 
 /**
  * Function type applied for each data property of an object
@@ -166,6 +177,13 @@ typedef void (*jerry_object_free_callback_t) (const uintptr_t native_p);
 typedef bool (*jerry_object_property_foreach_t) (const jerry_value_t property_name,
                                                  const jerry_value_t property_value,
                                                  void *user_data_p);
+/**
+ * Type information of a native pointer.
+ */
+typedef struct
+{
+  jerry_object_native_free_callback_t free_cb; /**< the free callback of the native pointer */
+} jerry_object_native_info_t;
 
 /**
  * General engine functions
@@ -322,9 +340,19 @@ jerry_value_t jerry_get_object_keys (const jerry_value_t obj_val);
 jerry_value_t jerry_get_prototype (const jerry_value_t obj_val);
 jerry_value_t jerry_set_prototype (const jerry_value_t obj_val, const jerry_value_t proto_obj_val);
 
+JERRY_DEPRECATED_API
 bool jerry_get_object_native_handle (const jerry_value_t obj_val, uintptr_t *out_handle_p);
+JERRY_DEPRECATED_API
 void jerry_set_object_native_handle (const jerry_value_t obj_val, uintptr_t handle_p,
                                      jerry_object_free_callback_t freecb_p);
+
+bool jerry_get_object_native_pointer (const jerry_value_t obj_val,
+                                      void **out_native_p,
+                                      const jerry_object_native_info_t **out_info_p);
+void jerry_set_object_native_pointer (const jerry_value_t obj_val,
+                                      void *native_p,
+                                      const jerry_object_native_info_t *info_p);
+
 bool jerry_foreach_object_property (const jerry_value_t obj_val, jerry_object_property_foreach_t foreach_p,
                                     void *user_data_p);
 

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -36,10 +36,9 @@ typedef enum
 #undef LIT_MAGIC_STRING_FIRST_STRING_WITH_SIZE
   LIT_NON_INTERNAL_MAGIC_STRING__COUNT, /**< number of non-internal magic strings */
 
-  LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE = LIT_NON_INTERNAL_MAGIC_STRING__COUNT, /**< native handle associated
-                                                                                   *   with an object */
-  LIT_INTERNAL_MAGIC_STRING_FREE_CALLBACK, /**< object's native free callback */
-
+  LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE = LIT_NON_INTERNAL_MAGIC_STRING__COUNT, /**< native handle package
+                                                                                   *   associated with an object */
+  LIT_INTERNAL_MAGIC_STRING_NATIVE_POINTER, /**< native pointer package associated with an object */
   LIT_MAGIC_STRING__COUNT /**< number of magic strings */
 } lit_magic_string_id_t;
 


### PR DESCRIPTION
ecma-object have native handle type inside, so that binding code could use the type info to validate native handle's type.

#1681 talks about the purpose of this patch,

~~**Note:** This patch is not backward compatible, old binding code might cannot work after this patch. The easiest way is change  `jerry_get_object_native_handle` to `jerry_get_object_native_handle_deprecated`, and change `jerry_set_object_native_handle` to `jerry_set_object_native_handle_deprecated`.~~

