### PR TITLE
Refactoring several array buffer and typed array functions.

### DIFF
--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -34,8 +34,6 @@ ecma_op_create_arraybuffer_object (const ecma_value_t *, ecma_length_t);
  */
 ecma_object_t *
 ecma_arraybuffer_new_object (ecma_length_t lengh);
-ecma_object_t *
-ecma_arraybuffer_clone_arraybuffer (ecma_object_t *src_p, ecma_length_t offset);
 lit_utf8_byte_t *
 ecma_arraybuffer_get_buffer (ecma_object_t *obj_p) __attr_pure___;
 ecma_length_t

--- a/tests/jerry-test-suite/es2015/22/22.02/22.02.01/22.02.01-015.js
+++ b/tests/jerry-test-suite/es2015/22/22.02/22.02.01/22.02.01-015.js
@@ -13,12 +13,22 @@
  * limitations under the License.
  */
 
-var a = new Int32Array(3);
+var a = new Int32Array(8);
 
 a[0] = 0xffffffff;
 a[1] = 0xff00000001;
-a[2] = -2.3;
+a[2] = 0xff80000001;
+a[3] = -2.3;
+a[4] = Number.NEGATIVE_INFINITY;
+a[5] = NaN;
+a[6] = 10e17;
+a[7] = -10e17;
 
 assert(a[0] === -1);
 assert(a[1] === 1);
-assert(a[2] === -2);
+assert(a[2] === -2147483647);
+assert(a[3] === -2);
+assert(a[4] === 0);
+assert(a[5] === 0);
+assert(a[6] === -1486618624);
+assert(a[7] === 1486618624);


### PR DESCRIPTION
Binary size unchanged (148056 bytes) but .text is reduced from 133088 -> 132936 = 152 bytes.