### PR TITLE
Remove duplicated profile-check from build.py

### DIFF
--- a/jerry-core/profiles/README.md
+++ b/jerry-core/profiles/README.md
@@ -3,7 +3,7 @@
 
 Specify compile definitions in profile files to use when compiling the `jerry-core` target.
 
-The default profile is ``es5.1`` which disables the ArrayBuffer built-in.
+The default profile is ``es5.1`` which disables the ES2015 features.
 
 ### Using profiles with the build system
 
@@ -30,7 +30,7 @@ or
 ./tools/build.py --profile=minimal
 ```
 
-This command selects the profile/minimal.profile file.
+This command selects the profiles/minimal.profile file.
 
 #### 2. Using only CMake build system
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -27,7 +27,6 @@ import settings
 BUILD_DIR = os.path.join(settings.PROJECT_DIR, 'build')
 DEFAULT_PORT_DIR = os.path.join(settings.PROJECT_DIR, 'targets/default')
 
-PROFILE_DIR = os.path.join(settings.PROJECT_DIR, 'jerry-core/profiles')
 DEFAULT_PROFILE = 'es5.1'
 
 def default_toolchain():
@@ -155,13 +154,7 @@ def generate_build_options(arguments):
     build_options.append('-DMEM_HEAP_SIZE_KB=%d' % arguments.mem_heap)
     build_options.append('-DPORT_DIR=%s' % arguments.port_dir)
 
-    if os.path.isabs(arguments.profile):
-        profile = arguments.profile
-    else:
-        profile = os.path.join(PROFILE_DIR, arguments.profile + '.profile')
-
-    build_options.append('-DFEATURE_PROFILE=%s' % profile)
-
+    build_options.append('-DFEATURE_PROFILE=%s' % arguments.profile)
     build_options.append('-DFEATURE_DEBUGGER=%s' % arguments.jerry_debugger)
     build_options.append('-DFEATURE_DEBUGGER_PORT=%d' % arguments.jerry_debugger_port)
     build_options.append('-DFEATURE_SNAPSHOT_EXEC=%s' % arguments.snapshot_exec)


### PR DESCRIPTION
This check is performed in cmake-side too.
The README.md about the profiles is also updated.

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com