### PR TITLE
Tizen RT adaptations

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -64,7 +64,7 @@ vm_op_get_value (ecma_value_t object, /**< base object */
 #ifdef JERRY_CPOINTER_32_BIT
       bool limit_check = (int_value >= 0);
 #else /* !JERRY_CPOINTER_32_BIT */
-      bool limit_check = (int_value >= 0 && int_value < (UINT16_MAX + 1));
+      bool limit_check = (int_value >= 0 && int_value < (ecma_integer_value_t) (UINT16_MAX + 1));
 #endif
 
       if (limit_check)


### PR DESCRIPTION
Switching to nuttx sysroot build (with -nostdinc and --sysroot) results in some warnings/error preventing the build to complete.
This patch 'addresses' some of them (others do not belong to this module).
Not sure the pragmas are right,, as those conversions look suspicious to me.

Actual commit message:
Suppress compilation warnings due to:
 - narrowing integral conversions
 - differing signedness in a comparison
Remove unused functions:
 - jerry_has_property
 - jerry_has_own_property

JerryScript-DCO-1.0-Signed-off-by: Tomasz Wozniak <t.wozniak@samsung.com>