### PR TITLE
Fix .gitignore syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ build/*
 
 # IDE related files
 nbproject
-**.sublime-project
-**.sublime-workspace
+*.sublime-project
+*.sublime-workspace
 .idea
 
 # Random Trash
@@ -14,9 +14,9 @@ nbproject
 *~
 core
 vgcore.*
-**.orig
-**.directory
-**.patch
+*.orig
+*.directory
+*.patch
 .tags*
 cscope.*
 __pycache__


### PR DESCRIPTION
Change instances of **.ext in the .gitignore to just *.ext.  I think
the intent was to match these patterns in any directory, which is what
will happen with simple patterns.  The '**' construct is meant to
match zero or more full paths, but it must be the sole component of
the path.

Discovered by a warning from ripgrep.

JerryScript-DCO-1.0-Signed-off-by: David Brown <david.brown@linaro.org>