### PR TITLE
Add Python wrapper for the HTML-based debugger

### DIFF
--- a/jerry-debugger/jerry-client-ws-html.py
+++ b/jerry-debugger/jerry-client-ws-html.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import webbrowser
+
+
+def main():
+    parser = argparse.ArgumentParser(description="JerryScript debugger client in HTML")
+    parser.add_argument("address", action="store", nargs="?", default="localhost:5001",
+                        help="specify a unique network address for connection (default: %(default)s)")
+    args = parser.parse_args()
+
+    webbrowser.open_new("file://%s?address=%s" % (os.path.abspath("jerry-client-ws.html"), args.address))
+
+
+if __name__ == "__main__":
+    main()

--- a/jerry-debugger/jerry-client-ws.html
+++ b/jerry-debugger/jerry-client-ws.html
@@ -72,8 +72,20 @@ var textBox = document.getElementById("log");
 var commandBox = document.getElementById("command");
 var socket = null;
 
+var address = "localhost";
+var params = window.location.search.slice(1).split("&");
+for (var i = 0; i < params.length; i++)
+{
+  var nv = params[i].split("=");
+  var name = nv[0], value = nv[1];
+  if (name == "address")
+  {
+    address = value;
+  }
+}
+
 textBox.value = ""
-commandBox.value = "connect localhost"
+commandBox.value = "connect " + address
 
 function appendLog(str)
 {


### PR DESCRIPTION
The patch aims at easing the startup of the HTML-based JerryScript
debugger client by adding a python script that starts the default
browser with the HTML page implementing the debugger client.
Additionally, the pyton script encodes the host:port address
information of the debug server in the file url and the HTML client
is extended to retrieve this information. Thus, both the console
and the browser-based debugger client can be started similarly.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu