### PR TITLE
Add JERRY_FEATURE_DEBUGGER

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -618,6 +618,9 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature)
 #ifdef JERRY_ENABLE_SNAPSHOT_EXEC
           || feature == JERRY_FEATURE_SNAPSHOT_EXEC
 #endif /* JERRY_ENABLE_SNAPSHOT_EXEC */
+#ifdef JERRY_DEBUGGER
+          || feature == JERRY_FEATURE_DEBUGGER
+#endif /* JERRY_DEBUGGER */
           );
 } /* jerry_is_feature_enabled */
 

--- a/jerry-core/jerryscript.h
+++ b/jerry-core/jerryscript.h
@@ -85,6 +85,7 @@ typedef enum
   JERRY_FEATURE_REGEXP_DUMP, /**< regexp byte-code dumps */
   JERRY_FEATURE_SNAPSHOT_SAVE, /**< saving snapshot files */
   JERRY_FEATURE_SNAPSHOT_EXEC, /**< executing snapshot files */
+  JERRY_FEATURE_DEBUGGER, /**< debugging */
   JERRY_FEATURE__COUNT /**< number of features. NOTE: must be at the end of the list */
 } jerry_feature_t;
 

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -483,7 +483,16 @@ main (int argc,
     }
     else if (!strcmp ("--start-debug-server", argv[i]))
     {
-      flags |= JERRY_INIT_DEBUGGER;
+      if (jerry_is_feature_enabled (JERRY_FEATURE_DEBUGGER))
+      {
+        flags |= JERRY_INIT_DEBUGGER;
+      }
+      else
+      {
+        jerry_port_default_set_log_level (JERRY_LOG_LEVEL_WARNING);
+        jerry_port_log (JERRY_LOG_LEVEL_WARNING,
+                        "Ignoring 'start-debug-server' option because this feature is disabled!\n");
+      }
     }
     else if (!strcmp ("--save-snapshot-for-global", argv[i])
              || !strcmp ("--save-snapshot-for-eval", argv[i]))


### PR DESCRIPTION
Until now, it was not possible to query the engine whether its
build configuration contained debugging support. This commit adds
the `JERRY_FEATURE_DEBUGGER` label to `jerry_feature_t` and extends
`jerry_is_feature_enabled` to support the new feature flag.
Additionally, the command line tool `jerry` was enhanced to report
a warning when invoked with `--start-debug-server` but linked to a
non-debuggable engine.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu