### PR TITLE
Ensure that const and pure function attributes are used properly

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -66,7 +66,7 @@ JERRY_STATIC_ASSERT ((ECMA_SIMPLE_VALUE_FALSE | 0x1) == ECMA_SIMPLE_VALUE_TRUE
  *
  * @return type field
  */
-static inline ecma_type_t __attr_pure___ __attr_always_inline___
+static inline ecma_type_t __attr_const___ __attr_always_inline___
 ecma_get_value_type_field (ecma_value_t value) /**< ecma value */
 {
   return value & ECMA_VALUE_TYPE_MASK;
@@ -117,7 +117,7 @@ ecma_get_pointer_from_ecma_value (ecma_value_t value) /**< value */
  * @return true - if the value is a direct value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_direct (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT);
@@ -129,7 +129,7 @@ ecma_is_value_direct (ecma_value_t value) /**< ecma value */
  * @return true - if the value is a simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_simple (ecma_value_t value) /**< ecma value */
 {
   return (value & ECMA_DIRECT_TYPE_MASK) == ECMA_DIRECT_TYPE_SIMPLE_VALUE;
@@ -141,7 +141,7 @@ ecma_is_value_simple (ecma_value_t value) /**< ecma value */
  * @return true - if the value is equal to the given simple value,
  *         false - otherwise
  */
-static inline bool __attr_pure___ __attr_always_inline___
+static inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_equal_to_simple_value (ecma_value_t value, /**< ecma value */
                                      ecma_simple_value_t simple_value) /**< simple value */
 {
@@ -154,7 +154,7 @@ ecma_is_value_equal_to_simple_value (ecma_value_t value, /**< ecma value */
  * @return true - if the value contains implementation-defined empty simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_empty (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_SIMPLE_VALUE_EMPTY);
@@ -166,7 +166,7 @@ ecma_is_value_empty (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-undefined simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -178,7 +178,7 @@ ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-null simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_null (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_SIMPLE_VALUE_NULL);
@@ -190,7 +190,7 @@ ecma_is_value_null (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true or ecma-false simple values,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_true (value | (1 << ECMA_DIRECT_SHIFT));
@@ -202,7 +202,7 @@ ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_true (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_SIMPLE_VALUE_TRUE);
@@ -214,7 +214,7 @@ ecma_is_value_true (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-false simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_false (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_SIMPLE_VALUE_FALSE);
@@ -226,7 +226,7 @@ ecma_is_value_false (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-not-found simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_found (ecma_value_t value) /**< ecma value */
 {
   return value != ecma_make_simple_value (ECMA_SIMPLE_VALUE_NOT_FOUND);
@@ -238,7 +238,7 @@ ecma_is_value_found (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-array-hole simple value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_SIMPLE_VALUE_ARRAY_HOLE);
@@ -250,7 +250,7 @@ ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains an integer ecma-number value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_integer_number (ecma_value_t value) /**< ecma value */
 {
   return (value & ECMA_DIRECT_TYPE_MASK) == ECMA_DIRECT_TYPE_INTEGER_VALUE;
@@ -262,7 +262,7 @@ ecma_is_value_integer_number (ecma_value_t value) /**< ecma value */
  * @return true - if both values contain integer ecma-number values,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_are_values_integer_numbers (ecma_value_t first_value, /**< first ecma value */
                                  ecma_value_t second_value) /**< second ecma value */
 {
@@ -278,7 +278,7 @@ ecma_are_values_integer_numbers (ecma_value_t first_value, /**< first ecma value
  * @return true - if the value contains a floating-point ecma-number value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_float_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_FLOAT);
@@ -290,7 +290,7 @@ ecma_is_value_float_number (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-number value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_is_value_integer_number (value)
@@ -303,7 +303,7 @@ ecma_is_value_number (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-string value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_string (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_STRING);
@@ -315,7 +315,7 @@ ecma_is_value_string (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains object value,
  *         false - otherwise
  */
-inline bool __attr_pure___ __attr_always_inline___
+inline bool __attr_const___ __attr_always_inline___
 ecma_is_value_object (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_OBJECT);
@@ -378,7 +378,7 @@ ecma_make_integer_value (ecma_integer_value_t integer_value) /**< integer number
  *
  * @return ecma-value
  */
-static ecma_value_t __attr_const___
+static ecma_value_t
 ecma_create_float_number (ecma_number_t ecma_number) /**< value of the float number */
 {
   ecma_number_t *ecma_num_p = ecma_alloc_number ();
@@ -485,7 +485,7 @@ ecma_make_uint32_value (uint32_t uint32_number) /**< uint32 number to be encoded
 /**
  * String value constructor
  */
-ecma_value_t __attr_const___
+ecma_value_t __attr_pure___
 ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to reference in value */
 {
   JERRY_ASSERT (ecma_string_p != NULL);
@@ -496,7 +496,7 @@ ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to refer
 /**
  * Object value constructor
  */
-ecma_value_t __attr_const___
+ecma_value_t __attr_pure___
 ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference in value */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -519,7 +519,7 @@ ecma_make_error_value (ecma_value_t value) /**< original ecma value */
 /**
  * Error value constructor
  */
-ecma_value_t __attr_const___
+ecma_value_t __attr_pure___
 ecma_make_error_obj_value (const ecma_object_t *object_p) /**< object to reference in value */
 {
   return ecma_make_error_value (ecma_make_object_value (object_p));
@@ -530,7 +530,7 @@ ecma_make_error_obj_value (const ecma_object_t *object_p) /**< object to referen
  *
  * @return floating point value
  */
-inline ecma_integer_value_t __attr_pure___ __attr_always_inline___
+inline ecma_integer_value_t __attr_const___ __attr_always_inline___
 ecma_get_integer_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_integer_number (value));
@@ -593,7 +593,7 @@ ecma_get_object_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return ecma value
  */
-inline ecma_value_t __attr_pure___ __attr_always_inline___
+inline ecma_value_t __attr_const___ __attr_always_inline___
 ecma_invert_boolean_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_boolean (value));
@@ -606,7 +606,7 @@ ecma_invert_boolean_value (ecma_value_t value) /**< ecma value */
  *
  * @return ecma value
  */
-ecma_value_t __attr_pure___
+ecma_value_t __attr_const___
 ecma_get_value_from_error_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ECMA_IS_VALUE_ERROR (value));

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -111,23 +111,23 @@
   }
 
 /* ecma-helpers-value.c */
-bool ecma_is_value_direct (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_simple (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_empty (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_undefined (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_null (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_boolean (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_true (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_false (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_found (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_array_hole (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_direct (ecma_value_t value) __attr_const___;
+bool ecma_is_value_simple (ecma_value_t value) __attr_const___;
+bool ecma_is_value_empty (ecma_value_t value) __attr_const___;
+bool ecma_is_value_undefined (ecma_value_t value) __attr_const___;
+bool ecma_is_value_null (ecma_value_t value) __attr_const___;
+bool ecma_is_value_boolean (ecma_value_t value) __attr_const___;
+bool ecma_is_value_true (ecma_value_t value) __attr_const___;
+bool ecma_is_value_false (ecma_value_t value) __attr_const___;
+bool ecma_is_value_found (ecma_value_t value) __attr_const___;
+bool ecma_is_value_array_hole (ecma_value_t value) __attr_const___;
 
-bool ecma_is_value_integer_number (ecma_value_t value) __attr_pure___;
-bool ecma_are_values_integer_numbers (ecma_value_t first_value, ecma_value_t second_value) __attr_pure___;
-bool ecma_is_value_float_number (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_number (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_string (ecma_value_t value) __attr_pure___;
-bool ecma_is_value_object (ecma_value_t value) __attr_pure___;
+bool ecma_is_value_integer_number (ecma_value_t value) __attr_const___;
+bool ecma_are_values_integer_numbers (ecma_value_t first_value, ecma_value_t second_value) __attr_const___;
+bool ecma_is_value_float_number (ecma_value_t value) __attr_const___;
+bool ecma_is_value_number (ecma_value_t value) __attr_const___;
+bool ecma_is_value_string (ecma_value_t value) __attr_const___;
+bool ecma_is_value_object (ecma_value_t value) __attr_const___;
 
 void ecma_check_value_type_is_spec_defined (ecma_value_t value);
 
@@ -138,17 +138,17 @@ ecma_value_t ecma_make_nan_value (void);
 ecma_value_t ecma_make_number_value (ecma_number_t ecma_number);
 ecma_value_t ecma_make_int32_value (int32_t int32_number);
 ecma_value_t ecma_make_uint32_value (uint32_t uint32_number);
-ecma_value_t ecma_make_string_value (const ecma_string_t *ecma_string_p);
-ecma_value_t ecma_make_object_value (const ecma_object_t *object_p);
-ecma_value_t ecma_make_error_value (ecma_value_t value);
-ecma_value_t ecma_make_error_obj_value (const ecma_object_t *object_p);
-ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t value) __attr_pure___;
+ecma_value_t ecma_make_string_value (const ecma_string_t *ecma_string_p) __attr_pure___;
+ecma_value_t ecma_make_object_value (const ecma_object_t *object_p) __attr_pure___;
+ecma_value_t ecma_make_error_value (ecma_value_t value) __attr_const___;
+ecma_value_t ecma_make_error_obj_value (const ecma_object_t *object_p) __attr_pure___;
+ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t value) __attr_const___;
 ecma_number_t ecma_get_float_from_value (ecma_value_t value) __attr_pure___;
 ecma_number_t ecma_get_number_from_value (ecma_value_t value) __attr_pure___;
 ecma_string_t *ecma_get_string_from_value (ecma_value_t value) __attr_pure___;
 ecma_object_t *ecma_get_object_from_value (ecma_value_t value) __attr_pure___;
-ecma_value_t ecma_get_value_from_error_value (ecma_value_t value) __attr_pure___;
-ecma_value_t ecma_invert_boolean_value (ecma_value_t value) __attr_pure___;
+ecma_value_t ecma_get_value_from_error_value (ecma_value_t value) __attr_const___;
+ecma_value_t ecma_invert_boolean_value (ecma_value_t value) __attr_const___;
 ecma_value_t ecma_copy_value (ecma_value_t value);
 ecma_value_t ecma_fast_copy_value (ecma_value_t value);
 ecma_value_t ecma_copy_value_if_not_object (ecma_value_t value);

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -56,7 +56,7 @@ jmem_finalize (void)
  *
  * @return packed pointer
  */
-inline jmem_cpointer_t __attr_always_inline___
+inline jmem_cpointer_t __attr_pure___ __attr_always_inline___
 jmem_compress_pointer (const void *pointer_p) /**< pointer to compress */
 {
   JERRY_ASSERT (pointer_p != NULL);
@@ -90,7 +90,7 @@ jmem_compress_pointer (const void *pointer_p) /**< pointer to compress */
  *
  * @return unpacked pointer
  */
-inline void * __attr_always_inline___
+inline void * __attr_pure___ __attr_always_inline___
 jmem_decompress_pointer (uintptr_t compressed_pointer) /**< pointer to decompress */
 {
   JERRY_ASSERT (compressed_pointer != JMEM_CP_NULL);

--- a/jerry-core/jmem/jmem.h
+++ b/jerry-core/jmem/jmem.h
@@ -16,6 +16,8 @@
 #ifndef JMEM_H
 #define JMEM_H
 
+#include "jrt.h"
+
 /** \addtogroup mem Memory allocation
  * @{
  *
@@ -143,8 +145,8 @@ void jmem_stats_reset_peak (void);
 void jmem_stats_print (void);
 #endif /* JMEM_STATS */
 
-jmem_cpointer_t jmem_compress_pointer (const void *pointer_p);
-void *jmem_decompress_pointer (uintptr_t compressed_pointer);
+jmem_cpointer_t jmem_compress_pointer (const void *pointer_p) __attr_pure___;
+void *jmem_decompress_pointer (uintptr_t compressed_pointer) __attr_pure___;
 
 /**
  * A free memory callback routine type.

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -31,13 +31,13 @@
 #define __attr_return_value_should_be_checked___ __attribute__((warn_unused_result))
 #define __attr_hot___ __attribute__((hot))
 #ifndef __attr_always_inline___
-# define __attr_always_inline___ __attribute__((always_inline))
+#define __attr_always_inline___ __attribute__((always_inline))
 #endif /* !__attr_always_inline___ */
 #ifndef __attr_const___
-# define __attr_const___ __attribute__((const))
+#define __attr_const___ __attribute__((const))
 #endif /* !__attr_const___ */
 #ifndef __attr_pure___
-# define __attr_pure___ __attribute__((pure))
+#define __attr_pure___ __attribute__((pure))
 #endif /* !__attr_pure___ */
 
 /*

--- a/jerry-core/parser/regexp/re-bytecode.h
+++ b/jerry-core/parser/regexp/re-bytecode.h
@@ -103,7 +103,7 @@ typedef struct
 re_opcode_t re_get_opcode (uint8_t **bc_p);
 ecma_char_t re_get_char (uint8_t **bc_p);
 uint32_t re_get_value (uint8_t **bc_p);
-uint32_t re_get_bytecode_length (re_bytecode_ctx_t *bc_ctx_p);
+uint32_t re_get_bytecode_length (re_bytecode_ctx_t *bc_ctx_p) __attr_pure___;
 
 void re_append_opcode (re_bytecode_ctx_t *bc_ctx_p, re_opcode_t opcode);
 void re_append_u32 (re_bytecode_ctx_t *bc_ctx_p, uint32_t value);


### PR DESCRIPTION
Some functions were incorrectly marked as const but were pure only
(or not even pure). Some functions were marked as pure but
qualified as const. Some functions were not attributed at all but
qualified either as pure or const. Some functions had attributes
at definition but not at declaration. This commit fixes these
inconsistencies.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu