### PR TITLE
[nuttx-stm32f4] Use jerry-libm instead of the math library in NuttX

### DIFF
--- a/targets/nuttx-stm32f4/Makefile
+++ b/targets/nuttx-stm32f4/Makefile
@@ -28,6 +28,7 @@ PRIORITY = $(CONFIG_JERRYSCRIPT_PRIORITY)
 STACKSIZE = $(CONFIG_JERRYSCRIPT_STACKSIZE)
 CFLAGS += -std=c99 -DJERRY_NDEBUG -DJERRY_JS_PARSER '-DCONFIG_MEM_HEAP_AREA_SIZE=$(CONFIG_JERRYSCRIPT_HEAPSIZE)' -DCONFIG_DISABLE_ES2015_PROMISE_BUILTIN
 CFLAGS += -I$(ROOT_DIR)/ $(shell find $(ROOT_DIR)/jerryscript/jerry-core -type d | sed -r -e 's/^/-I/g')
+CFLAGS += -I$(ROOT_DIR)/jerryscript/jerry-libm/include
 
 ifeq ($(CONFIG_JERRYSCRIPT_MEM_STATS),y)
 	CFLAGS += -DJMEM_STATS
@@ -45,11 +46,14 @@ endif
 
 .PHONY: jerry_core_allin.c
 jerry_core_allin.c:
-	echo '#include "jerryscript/jerry-libm/nextafter.c"' > jerry_core_allin.c
-	find $(ROOT_DIR)/jerryscript/jerry-core -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' >> jerry_core_allin.c
+	find $(ROOT_DIR)/jerryscript/jerry-core -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' > jerry_core_allin.c
+
+.PHONY: jerry_libm_allin.c
+jerry_libm_allin.c:
+	find $(ROOT_DIR)/jerryscript/jerry-libm -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' > jerry_libm_allin.c
 
 ASRCS = setjmp.S
-CSRCS = jerry_core_allin.c
+CSRCS = jerry_core_allin.c jerry_libm_allin.c
 MAINSRC = jerry_main.c
 
 CONFIG_JERRYSCRIPT_PROGNAME ?= jerry$(EXEEXT)

--- a/targets/nuttx-stm32f4/README.md
+++ b/targets/nuttx-stm32f4/README.md
@@ -56,7 +56,6 @@ We must set the following options:
 
 * Change `Build Setup -> Build Host Platform` from _Windows_ to _Linux_
 * Enable `System Type -> FPU support`
-* Enable `Library Routines -> Standard Math library`
 * Enable `Application Configuration -> Interpreters -> JerryScript`
 
 If you get `kconfig-mconf: not found` error when you run `make menuconfig` you may have to install kconfig-frontends:


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com