### PR TITLE
Fix/rewrite/darwinize test runner of jerry-debugger

### DIFF
--- a/tools/runners/run-debugger-test.sh
+++ b/tools/runners/run-debugger-test.sh
@@ -24,15 +24,19 @@ echo "$START_DEBUG_SERVER"
 eval "$START_DEBUG_SERVER"
 sleep 1s
 
-RESULT=$((cat "${TEST_CASE}.cmd" | ${DEBUGGER_CLIENT} --non-interactive) 2>&1)
-DIFF=$(diff -u0 ${TEST_CASE}.expected <(echo "$RESULT"))
+RESULT_TEMP=`mktemp ${TEST_CASE}.out.XXXXXXXXXX`
 
-if [ -n "$DIFF" ]
+(cat "${TEST_CASE}.cmd" | ${DEBUGGER_CLIENT} --non-interactive) &> ${RESULT_TEMP}
+diff -U0 ${TEST_CASE}.expected ${RESULT_TEMP}
+STATUS_CODE=$?
+
+rm -f ${RESULT_TEMP}
+
+if [ ${STATUS_CODE} -ne 0 ]
 then
-	echo "$DIFF"
-	echo "${TEST_CASE} failed"
-	exit 1
+  echo "${TEST_CASE} failed"
+else
+  echo "${TEST_CASE} passed"
 fi
 
-echo "${TEST_CASE} passed"
-exit 0
+exit ${STATUS_CODE}


### PR DESCRIPTION
First issue was that `diff -u0` was not supported on OSX, thus got
replaced by `-U0`. Then, it turned out that test outcome was
determined based on diff's stdout, which was empty even though the
exit code was non-0 - this got changed, too.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu