### PR TITLE
.gitignore maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ vgcore.*
 cscope.*
 __pycache__
 *.pyc
+.DS_Store
 
 # ctags and ID database
 tags
@@ -28,10 +29,10 @@ ID
 
 # targets
 jerry-targetjs.h
-targets/mbedk64f/libjerry
-targets/mbedk64f/build
-targets/mbedk64f/yotta_modules
-targets/mbedk64f/yotta_targets
+targets/mbed/libjerry
+targets/mbed/build
+targets/mbed/yotta_modules
+targets/mbed/yotta_targets
 .output
 targets/esp8266/output.map
 targets/esp8266/libs


### PR DESCRIPTION
* OSX Finder leaves `.DS_Store` files around; make them ignored.
* The mbedk64f target has been renamed to mbed a long time ago;
  follow that change in .gitignore, too.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu