### PR TITLE
Enable dummy time zone in nuttx-stm32f4 target.

### DIFF
--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -555,15 +555,16 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
 /**
  * Dummy function to get the time zone.
  *
- * @return false
+ * @return true
  */
 bool
 jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 {
+  /* We live in UTC. */
   tz_p->offset = 0;
   tz_p->daylight_saving_time = 0;
 
-  return false;
+  return true;
 } /* jerry_port_get_time_zone */
 
 /**


### PR DESCRIPTION
If `jerry_port_get_time_zone` returns with **false**, some date function returns with NaN. Since this affects some tests on stm32f4, I've enabled dummy time zone values as the Zephyr port does.

This modification fixes the following tests on stm32f4:
  * date-tostring.js
  * date-annexb.js
  * date-construct.js
  * date-getters.js
  * date-setters.js
  * regression-test-issue-1071.js