### PR TITLE
Add JERRY_FEATURE_DEBUGGER to API docs

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -35,6 +35,7 @@ Possible compile time enabled feature types:
  - JERRY_FEATURE_REGEXP_DUMP - regexp byte-code dumps
  - JERRY_FEATURE_SNAPSHOT_SAVE - saving snapshot files
  - JERRY_FEATURE_SNAPSHOT_EXEC - executing snapshot files
+ - JERRY_FEATURE_DEBUGGER - debugging
 
 ## jerry_char_t
 


### PR DESCRIPTION
In #1738, `JERRY_FEATURE_DEBUGGER` was added to the sources, but
the docs were not updated.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu