### PR TITLE
bugfix: jerry_get_object_native_pointer: accept NULL for out_native_info_p

### DIFF
--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -2032,7 +2032,12 @@ jerry_get_object_native_pointer (const jerry_value_t obj_val, /**< object to get
   }
 
   *out_native_pointer_p = native_pointer_p->data_p;
-  *out_native_info_p = (const jerry_object_native_info_t *) native_pointer_p->info_p;
+
+  if (out_native_info_p)
+  {
+    *out_native_info_p = (const jerry_object_native_info_t *) native_pointer_p->info_p;
+  }
+
   return true;
 } /* jerry_get_object_native_pointer */
 

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -761,6 +761,11 @@ main (void)
                && (uintptr_t) ptr == (uintptr_t) 0x0012345678abcdefull
                && out_info_p == &JERRY_NATIVE_HANDLE_INFO_FOR_CTYPE (bind2));
 
+  /* Passing NULL for out_info_p is allowed. */
+  is_ok = jerry_get_object_native_pointer (res, &ptr, NULL);
+  TEST_ASSERT (is_ok
+               && (uintptr_t) ptr == (uintptr_t) 0x0012345678abcdefull);
+
   jerry_release_value (res);
 
   /* Test: Throwing exception from native handler. */


### PR DESCRIPTION
With the jerry_set_object_native_pointer() the native_info_p is optional, so I think it makes sense that it is optional for the getter as well.

JerryScript-DCO-1.0-Signed-off-by: Martijn The martijn.the@intel.com