### PR TITLE
Aftermath of PRs #1505 and #1755

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,10 @@ endif()
 
 if(USING_TI)
   set(ENABLE_STATIC_LINK "ON")
+  set(ENABLE_STRIP       "OFF")
 
   set(ENABLE_STATIC_LINK_MESSAGE " (FORCED BY COMPILER)")
+  set(ENABLE_STRIP_MESSAGE       " (FORCED BY COMPILER)")
 endif()
 
 # Status messages
@@ -205,9 +207,7 @@ endif()
 
 # Strip binary
 if(ENABLE_STRIP AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-  if (USING_GCC OR USING_CLANG)
-    jerry_add_link_flags(-s)
-  endif()
+  jerry_add_link_flags(-s)
 endif()
 
 # External compiler & linker flags

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -313,9 +313,7 @@ ecma_op_general_object_define_own_property (ecma_object_t *object_p, /**< the ob
   JERRY_ASSERT (property_desc_p->is_writable_defined || !property_desc_p->is_writable);
 
   /* 1. */
-  /* This #def just gets around the syntax/style checker... */
-#define extended_property_ref_initialization { { 0 } , 0 }
-  ecma_extended_property_ref_t ext_property_ref = extended_property_ref_initialization;
+  ecma_extended_property_ref_t ext_property_ref = { .property_ref.value_p = NULL, .property_p = NULL };
   ecma_property_t current_prop;
 
   current_prop = ecma_op_object_get_own_property (object_p,


### PR DESCRIPTION
PR #1505 added support for TI compiler. It explicitly added a
message to notify the user that static linking is forced. PR #1755
added a more generic approach to signal such forced settings and
adapted the TI-specific static linking notification to this
approach. However, it turned out that TI forcibly changed another
setting, too: it disabled release binary stripping, but without
notification. This patch fixes this by moving the setting override
to a consistent place and adding a notification.

PR #1505 also added some source code changes, most importantly a
complex struct initialization for a variable in
`ecma-objects-general.c`. However, that initialization was coded
as a macro to trick the style checker. This patch gets rid of that
macro and uses proper C99 struct initializer with designators.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu