### PR TITLE
Update paths in check tools

### DIFF
--- a/jerry-main/main-unix-minimal.c
+++ b/jerry-main/main-unix-minimal.c
@@ -80,11 +80,9 @@ main (int argc,
   jerry_init (JERRY_INIT_EMPTY);
   jerry_value_t ret_value = jerry_create_undefined ();
 
-  const char *file_name;
-
   for (int i = 1; i < argc; i++)
   {
-    file_name = argv[i];
+    const char *file_name = argv[i];
     size_t source_size;
 
     const jerry_char_t *source_p = read_file (file_name, &source_size);

--- a/tools/check-cppcheck.sh
+++ b/tools/check-cppcheck.sh
@@ -41,4 +41,4 @@ cppcheck -j$CPPCHECK_JOBS --force \
  --exitcode-suppressions=tools/cppcheck/suppressions-list \
  --suppressions-list=tools/cppcheck/suppressions-list \
  "${INCLUDE_DIRS[@]}" \
- jerry-core targets/default jerry-libc jerry-libm *.c *h tests/unit
+ jerry-core targets/default jerry-libc jerry-libm jerry-main tests/unit-*

--- a/tools/check-vera.sh
+++ b/tools/check-vera.sh
@@ -19,7 +19,7 @@ JERRY_PORT_DEFAULT_FILES=`find ./targets/default -name "*.c" -or -name "*.h"`
 JERRY_LIBC_FILES=`find ./jerry-libc -name "*.c" -or -name "*.h"`
 JERRY_LIBM_FILES=`find ./jerry-libm -name "*.c" -or -name "*.h"`
 JERRY_MAIN_FILES=`find ./jerry-main -name "*.c" -or -name "*.h"`
-UNIT_TEST_FILES=`find ./tests/unit -name "*.c" -or -name "*.h"`
+UNIT_TEST_FILES=`find ./tests/unit-* -name "*.c" -or -name "*.h"`
 
 if [ -n "$1" ]
 then

--- a/tools/cppcheck/suppressions-list
+++ b/tools/cppcheck/suppressions-list
@@ -1,4 +1,4 @@
-wrongmathcall:tests/unit/test-libm.inc.h
+wrongmathcall:tests/unit-libm/test-libm.inc.h
 variableScope:jerry-libm/*.c
 invalidPointerCast:jerry-libm/*.c
 arithOperationsOnVoidPointer:jerry-libc/*.c


### PR DESCRIPTION
In #1761, not all unit test paths have been updated in check tools.
This triggers no errors as `check-vera` emits a warning only while
`check-cppcheck` signals nothing. Still, this means that some of
the code in the repository that has been quality-assured, is now
avoiding checks. This patch fixes this.

Moreover, `check-cppcheck` has had incorrect paths for a while: it
looked for source files in the root of the repository, but those
files have been in `jerry-main` for almost a year now. This patch
fixes this, too.

Fallout of the above: `main-unix-minimal.c` had to be improved to
make `check-cppcheck` pass.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu