### PR TITLE
Fix maybe-uninitialized warning in ecma-objects.c

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -848,7 +848,7 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
 
     if (proto_p != NULL)
     {
-      ecma_property_ref_t property_ref;
+      ecma_property_ref_t property_ref = { NULL };
 
       ecma_property_t inherited_property = ecma_op_object_get_property (proto_p,
                                                                         property_name_p,


### PR DESCRIPTION
During building jerryscript with arm-gcc-noneeabi 4.9.3,
maybe-uninitialized warning occurred. This patch fixed the warning.

JerryScript-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com