### PR TITLE
Turn port implementations into proper libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,19 +25,25 @@ set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS )
 # Components
 set(JERRY_CMDLINE         ON  CACHE BOOL "Build jerry command line tool?")
 set(JERRY_CMDLINE_MINIMAL OFF CACHE BOOL "Build jerry minimal command line tool?")
+set(JERRY_PORT_DEFAULT    ON  CACHE BOOL "Build default jerry port implementation?")
 set(JERRY_LIBC            ON  CACHE BOOL "Build and use jerry-libc?")
 set(JERRY_LIBM            ON  CACHE BOOL "Build and use jerry-libm?")
 set(UNITTESTS             OFF CACHE BOOL "Build unit tests?")
 
 # Optional build settings
-set(ENABLE_ALL_IN_ONE         OFF                                   CACHE BOOL   "Enable all-in-one build?")
-set(ENABLE_LTO                ON                                    CACHE BOOL   "Enable LTO build?")
-set(ENABLE_STATIC_LINK        ON                                    CACHE BOOL   "Enable static linking?")
-set(ENABLE_STRIP              ON                                    CACHE BOOL   "Enable stripping all symbols from release binary?")
-set(PORT_DIR                  "${CMAKE_SOURCE_DIR}/targets/default" CACHE STRING "Use default or external port?")
+set(ENABLE_ALL_IN_ONE  OFF CACHE BOOL "Enable all-in-one build?")
+set(ENABLE_LTO         ON  CACHE BOOL "Enable LTO build?")
+set(ENABLE_STATIC_LINK ON  CACHE BOOL "Enable static linking?")
+set(ENABLE_STRIP       ON  CACHE BOOL "Enable stripping all symbols from release binary?")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "MinSizeRel")
+endif()
+
+if(JERRY_CMDLINE OR JERRY_CMDLINE_MINIMAL)
+  set(JERRY_PORT_DEFAULT "ON")
+
+  set(JERRY_PORT_DEFAULT_MESSAGE " (FORCED BY CMDLINE)")
 endif()
 
 if("${PLATFORM}" STREQUAL "DARWIN")
@@ -85,9 +91,9 @@ message(STATUS "ENABLE_STATIC_LINK        " ${ENABLE_STATIC_LINK} ${ENABLE_STATI
 message(STATUS "ENABLE_STRIP              " ${ENABLE_STRIP} ${ENABLE_STRIP_MESSAGE})
 message(STATUS "JERRY_CMDLINE             " ${JERRY_CMDLINE})
 message(STATUS "JERRY_CMDLINE_MINIMAL     " ${JERRY_CMDLINE_MINIMAL})
+message(STATUS "JERRY_PORT_DEFAULT        " ${JERRY_PORT_DEFAULT} ${JERRY_PORT_DEFAULT_MESSAGE})
 message(STATUS "JERRY_LIBC                " ${JERRY_LIBC} ${JERRY_LIBC_MESSAGE})
 message(STATUS "JERRY_LIBM                " ${JERRY_LIBM} ${JERRY_LIBM_MESSAGE})
-message(STATUS "PORT_DIR                  " ${PORT_DIR})
 message(STATUS "UNITTESTS                 " ${UNITTESTS})
 
 # Setup directories
@@ -154,11 +160,6 @@ if(ENABLE_LTO)
   if(USING_TI)
     jerry_add_link_flags(-lto)
   endif()
-endif()
-
-# Define _BSD_SOURCE and _DEFAULT_SOURCE if we use default port and compiler default libc
-if(${PORT_DIR} STREQUAL "${CMAKE_SOURCE_DIR}/targets/default" AND NOT JERRY_LIBC)
-  set(DEFINES_JERRY ${DEFINES_JERRY} _BSD_SOURCE _DEFAULT_SOURCE)
 endif()
 
 # Compiler / Linker flags
@@ -231,6 +232,11 @@ endif()
 
 # Jerry's core
 add_subdirectory(jerry-core)
+
+# Jerry's default port implementation
+if(JERRY_PORT_DEFAULT)
+  add_subdirectory(jerry-port/default)
+endif()
 
 # Jerry command line tool
 if(JERRY_CMDLINE OR JERRY_CMDLINE_MINIMAL)

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -106,9 +106,6 @@ if(FEATURE_DEBUGGER)
   set(SOURCE_CORE_FILES ${SOURCE_CORE_FILES} ${SOURCE_CORE_DEBUGGER})
 endif()
 
-# Jerry port
-file(GLOB SOURCE_PORT_FILES "${PORT_DIR}/*.c")
-
 # All-in-one build
 if(ENABLE_ALL_IN_ONE)
   set(ALL_IN_FILE "${CMAKE_BINARY_DIR}/jerry-all-in.c")

--- a/jerry-core/jerryscript-port.h
+++ b/jerry-core/jerryscript-port.h
@@ -140,15 +140,30 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p);
  */
 double jerry_port_get_current_time (void);
 
-#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
+/*
+ * JobQueue Port API
+ */
 
-#define JERRY_PORT_ENABLE_JOBQUEUE
-
+/**
+ * Jerry job handler function type
+ */
 typedef uint32_t (*jerry_job_handler_t) (void *);
 
+/**
+ * Enqueue a job described by a pair of function and data pointers. The port is
+ * expected to call the handler function with the given data at some (later)
+ * point of time.
+ *
+ * @param handler the pointer of the handler function associated with the job.
+ * @param job_p the data pointer to be passed to handler when called.
+ *
+ * Note:
+ *      This port function is only called by the implementation of the Promise
+ *      builtin (mandated by the ES2015 standard). If the engine is built with
+ *      Promise disabled (e.g., with ES5.1 profile), then the port does not have
+ *      to implement this function.
+ */
 void jerry_port_jobqueue_enqueue (jerry_job_handler_t handler, void *job_p);
-
-#endif /* !CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
 
 /**
  * @}

--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -48,7 +48,6 @@ macro(jerry_create_executable JERRY_NAME SOURCE_JERRY_STANDALONE_MAIN)
   set_property(TARGET ${JERRY_NAME}
                PROPERTY LINK_FLAGS "${LINKER_FLAGS_COMMON}")
   target_compile_definitions(${JERRY_NAME} PRIVATE ${DEFINES_JERRY})
-  target_include_directories(${JERRY_NAME} PRIVATE ${PORT_DIR})
   link_directories(${CMAKE_BINARY_DIR})
 
   target_link_libraries(${JERRY_NAME} jerry-core)
@@ -59,8 +58,10 @@ endmacro()
 # Jerry standalones
 if(JERRY_CMDLINE)
   jerry_create_executable("jerry" "main-unix.c")
+  target_link_libraries("jerry" jerry-port-default)
 endif()
 
 if(JERRY_CMDLINE_MINIMAL)
   jerry_create_executable("jerry-minimal" "main-unix-minimal.c")
+  target_link_libraries("jerry-minimal" jerry-port-default-minimal)
 endif()

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -593,9 +593,9 @@ main (int argc,
     is_repl_mode = true;
   }
 
-#ifdef JERRY_PORT_ENABLE_JOBQUEUE
-  jerry_port_jobqueue_init ();
-#endif /* JERRY_PORT_ENABLE_JOBQUEUE */
+#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
+  jerry_port_default_jobqueue_init ();
+#endif /* !CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
   jerry_init (flags);
 
   register_js_function ("assert", assert_handler);
@@ -776,15 +776,15 @@ main (int argc,
                                                              args,
                                                              1);
           jerry_release_value (ret_val_print);
-#ifdef JERRY_PORT_ENABLE_JOBQUEUE
+#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
           jerry_release_value (ret_val_eval);
-          ret_val_eval = jerry_port_jobqueue_run ();
+          ret_val_eval = jerry_port_default_jobqueue_run ();
 
           if (jerry_value_has_error_flag (ret_value))
           {
             print_unhandled_exception (ret_value);
           }
-#endif /* JERRY_PORT_ENABLE_JOBQUEUE */
+#endif /* !CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
         }
         else
         {
@@ -807,11 +807,11 @@ main (int argc,
 
     ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
   }
-#ifdef JERRY_PORT_ENABLE_JOBQUEUE
+#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
   else
   {
     jerry_release_value (ret_value);
-    ret_value = jerry_port_jobqueue_run ();
+    ret_value = jerry_port_default_jobqueue_run ();
 
     if (jerry_value_has_error_flag (ret_value))
     {
@@ -819,7 +819,7 @@ main (int argc,
       ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
     }
   }
-#endif /* JERRY_PORT_ENABLE_JOBQUEUE */
+#endif /* !CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
   jerry_release_value (ret_value);
   jerry_cleanup ();
 

--- a/jerry-port/default/CMakeLists.txt
+++ b/jerry-port/default/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required (VERSION 2.8.12)
+set(JERRY_PORT_DEFAULT_NAME jerry-port-default)
+project (${JERRY_PORT_DEFAULT_NAME} C)
+
+# Include directories
+set(INCLUDE_PORT_DEFAULT "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+# Source directories
+file(GLOB SOURCE_PORT_DEFAULT *.c)
+
+# Define _BSD_SOURCE and _DEFAULT_SOURCE
+# (should only be necessary if we used compiler default libc but not checking that)
+set(DEFINES_PORT_DEFAULT _BSD_SOURCE _DEFAULT_SOURCE)
+
+# Default Jerry port implementation library variants:
+#   - default
+#   - default-minimal (no extra termination and log APIs)
+foreach(JERRY_PORT_LIBRARY_NAME ${JERRY_PORT_DEFAULT_NAME} ${JERRY_PORT_DEFAULT_NAME}-minimal)
+  add_library(${JERRY_PORT_LIBRARY_NAME} STATIC ${SOURCE_PORT_DEFAULT})
+  target_include_directories(${JERRY_PORT_LIBRARY_NAME} PUBLIC ${INCLUDE_PORT_DEFAULT})
+  target_compile_definitions(${JERRY_PORT_LIBRARY_NAME} PRIVATE ${DEFINES_PORT_DEFAULT})
+  target_link_libraries(${JERRY_PORT_LIBRARY_NAME} jerry-core)
+endforeach()
+
+target_compile_definitions(${JERRY_PORT_DEFAULT_NAME}-minimal PRIVATE DISABLE_EXTRA_API)
+
+# Installation
+install(TARGETS ${JERRY_PORT_DEFAULT_NAME} ${JERRY_PORT_DEFAULT_NAME}-minimal DESTINATION lib)
+install(DIRECTORY ${INCLUDE_PORT_DEFAULT}/ DESTINATION include)

--- a/jerry-port/default/default-date.c
+++ b/jerry-port/default/default-date.c
@@ -21,9 +21,13 @@
 #include "jerryscript-port-default.h"
 
 /**
- * Default implementation of jerry_port_get_time_zone.
+ * Default implementation of jerry_port_get_time_zone. Uses 'gettimeofday' if
+ * available on the system, does nothing otherwise.
+ *
+ * @return true - if 'gettimeofday' is available and executed successfully,
+ *         false - otherwise.
  */
-bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
+bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p) /**< [out] time zone structure to fill */
 {
 #ifdef __GNUC__
   struct timeval tv;
@@ -48,7 +52,12 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 } /* jerry_port_get_time_zone */
 
 /**
- * Default implementation of jerry_port_get_current_time.
+ * Default implementation of jerry_port_get_current_time. Uses 'gettimeofday' if
+ * available on the system, does nothing otherwise.
+ *
+ * @return milliseconds since Unix epoch - if 'gettimeofday' is available and
+ *                                         executed successfully,
+ *         0 - otherwise.
  */
 double jerry_port_get_current_time (void)
 {

--- a/jerry-port/default/default-fatal.c
+++ b/jerry-port/default/default-fatal.c
@@ -18,11 +18,17 @@
 #include "jerryscript-port.h"
 #include "jerryscript-port-default.h"
 
+#ifndef DISABLE_EXTRA_API
+
 static bool abort_on_fail = false;
 
 /**
  * Sets whether 'abort' should be called instead of 'exit' upon exiting with
  * non-zero exit code in the default implementation of jerry_port_fatal.
+ *
+ * Note:
+ *      This function is only available if the port implementation library is
+ *      compiled without the DISABLE_EXTRA_API macro.
  */
 void jerry_port_default_set_abort_on_fail (bool flag) /**< new value of 'abort on fail' flag */
 {
@@ -35,17 +41,29 @@ void jerry_port_default_set_abort_on_fail (bool flag) /**< new value of 'abort o
  *
  * @return true - if 'abort on fail' flag is set,
  *         false - otherwise
+ *
+ * Note:
+ *      This function is only available if the port implementation library is
+ *      compiled without the DISABLE_EXTRA_API macro.
  */
 bool jerry_port_default_is_abort_on_fail (void)
 {
   return abort_on_fail;
 } /* jerry_port_default_is_abort_on_fail */
 
+#endif /* !DISABLE_EXTRA_API */
+
 /**
- * Default implementation of jerry_port_fatal.
+ * Default implementation of jerry_port_fatal. Calls 'abort' if exit code is
+ * non-zero and "abort-on-fail" behaviour is enabled, 'exit' otherwise.
+ *
+ * Note:
+ *      The "abort-on-fail" behaviour is only available if the port
+ *      implementation library is compiled without the DISABLE_EXTRA_API macro.
  */
 void jerry_port_fatal (jerry_fatal_code_t code)
 {
+#ifndef DISABLE_EXTRA_API
   if (code != 0
       && code != ERR_OUT_OF_MEMORY
       && jerry_port_default_is_abort_on_fail ())
@@ -54,6 +72,9 @@ void jerry_port_fatal (jerry_fatal_code_t code)
   }
   else
   {
+#endif /* !DISABLE_EXTRA_API */
     exit (code);
+#ifndef DISABLE_EXTRA_API
   }
+#endif /* !DISABLE_EXTRA_API */
 } /* jerry_port_fatal */

--- a/jerry-port/default/default-io.c
+++ b/jerry-port/default/default-io.c
@@ -18,30 +18,46 @@
 #include "jerryscript-port.h"
 #include "jerryscript-port-default.h"
 
+#ifndef DISABLE_EXTRA_API
+
 /**
  * Actual log level
  */
-static jerry_log_level_t jerry_log_level = JERRY_LOG_LEVEL_ERROR;
+static jerry_log_level_t jerry_port_default_log_level = JERRY_LOG_LEVEL_ERROR;
+
+#define JERRY_PORT_DEFAULT_LOG_LEVEL jerry_port_default_log_level
 
 /**
  * Get the log level
  *
  * @return current log level
+ *
+ * Note:
+ *      This function is only available if the port implementation library is
+ *      compiled without the DISABLE_EXTRA_API macro.
  */
 jerry_log_level_t
 jerry_port_default_get_log_level (void)
 {
-  return jerry_log_level;
+  return jerry_port_default_log_level;
 } /* jerry_port_default_get_log_level */
 
 /**
  * Set the log level
+ *
+ * Note:
+ *      This function is only available if the port implementation library is
+ *      compiled without the DISABLE_EXTRA_API macro.
  */
 void
 jerry_port_default_set_log_level (jerry_log_level_t level) /**< log level */
 {
-  jerry_log_level = level;
+  jerry_port_default_log_level = level;
 } /* jerry_port_default_set_log_level */
+
+#else /* DISABLE_EXTRA_API */
+#define JERRY_PORT_DEFAULT_LOG_LEVEL JERRY_LOG_LEVEL_ERROR
+#endif /* !DISABLE_EXTRA_API */
 
 /**
  * Provide console message implementation for the engine.
@@ -57,14 +73,21 @@ jerry_port_console (const char *format, /**< format string */
 } /* jerry_port_console */
 
 /**
- * Provide log message implementation for the engine.
+ * Default implementation of jerry_port_log. Prints log message to standard
+ * error with 'vfprintf' if message level is less than or equal to the set log
+ * level.
+ *
+ * Note:
+ *      Changing the log level from JERRY_LOG_LEVEL_ERROR is only possible if
+ *      the port implementation library is compiled without the
+ *      DISABLE_EXTRA_API macro.
  */
 void
 jerry_port_log (jerry_log_level_t level, /**< log level */
                 const char *format, /**< format string */
                 ...)  /**< parameters */
 {
-  if (level <= jerry_log_level)
+  if (level <= JERRY_PORT_DEFAULT_LOG_LEVEL)
   {
     va_list args;
     va_start (args, format);

--- a/jerry-port/default/default-jobqueue.c
+++ b/jerry-port/default/default-jobqueue.c
@@ -19,8 +19,6 @@
 #include "jmem.h"
 #include "jrt.h"
 
-#ifdef JERRY_PORT_ENABLE_JOBQUEUE
-
 typedef struct jerry_port_queueitem_t jerry_port_queueitem_t;
 
 /**
@@ -47,11 +45,11 @@ static jerry_port_jobqueue_t queue;
 /**
  * Initialize the job queue.
  */
-void jerry_port_jobqueue_init (void)
+void jerry_port_default_jobqueue_init (void)
 {
   queue.head_p = NULL;
   queue.tail_p = NULL;
-} /* jerry_port_jobqueue_init */
+} /* jerry_port_default_jobqueue_init */
 
 /**
  * Enqueue a job.
@@ -83,7 +81,7 @@ void jerry_port_jobqueue_enqueue (jerry_job_handler_t handler, /**< the handler 
  *         It should be freed with jmem_heap_free_block.
  */
 static jerry_port_queueitem_t *
-jerry_port_jobqueue_dequeue (void)
+jerry_port_default_jobqueue_dequeue (void)
 {
   if (queue.head_p == NULL)
   {
@@ -94,7 +92,7 @@ jerry_port_jobqueue_dequeue (void)
   queue.head_p = queue.head_p->next_p;
 
   return item_p;
-} /* jerry_port_jobqueue_dequeue */
+} /* jerry_port_default_jobqueue_dequeue */
 
 /**
  * Start the jobqueue.
@@ -105,13 +103,13 @@ jerry_port_jobqueue_dequeue (void)
  *         Otherwise, return undefined.
  */
 jerry_value_t
-jerry_port_jobqueue_run (void)
+jerry_port_default_jobqueue_run (void)
 {
   jerry_value_t ret;
 
   while (true)
   {
-    jerry_port_queueitem_t *item_p = jerry_port_jobqueue_dequeue ();
+    jerry_port_queueitem_t *item_p = jerry_port_default_jobqueue_dequeue ();
 
     if (item_p == NULL)
     {
@@ -130,6 +128,4 @@ jerry_port_jobqueue_run (void)
 
     jerry_release_value (ret);
   }
-} /* jerry_port_jobqueue_run */
-
-#endif /* JERRY_PORT_ENABLE_JOBQUEUE */
+} /* jerry_port_default_jobqueue_run */

--- a/jerry-port/default/include/jerryscript-port-default.h
+++ b/jerry-port/default/include/jerryscript-port-default.h
@@ -37,10 +37,8 @@ bool jerry_port_default_is_abort_on_fail (void);
 jerry_log_level_t jerry_port_default_get_log_level (void);
 void jerry_port_default_set_log_level (jerry_log_level_t level);
 
-#ifdef JERRY_PORT_ENABLE_JOBQUEUE
-void jerry_port_jobqueue_init (void);
-jerry_value_t jerry_port_jobqueue_run (void);
-#endif /* JERRY_PORT_ENABLE_JOBQUEUE */
+void jerry_port_default_jobqueue_init (void);
+jerry_value_t jerry_port_default_jobqueue_run (void);
 
 /**
  * @}

--- a/tests/unit-core/CMakeLists.txt
+++ b/tests/unit-core/CMakeLists.txt
@@ -39,7 +39,7 @@ foreach(SOURCE_UNIT_TEST_MAIN ${SOURCE_UNIT_TEST_MAIN_MODULES})
 
   link_directories(${CMAKE_BINARY_DIR})
 
-  target_link_libraries(${TARGET_NAME} jerry-core)
+  target_link_libraries(${TARGET_NAME} jerry-core jerry-port-default-minimal)
 
   add_dependencies(unittests-core ${TARGET_NAME})
 endforeach()

--- a/tools/build.py
+++ b/tools/build.py
@@ -25,7 +25,6 @@ import sys
 import settings
 
 BUILD_DIR = os.path.join(settings.PROJECT_DIR, 'build')
-DEFAULT_PORT_DIR = os.path.join(settings.PROJECT_DIR, 'targets/default')
 
 DEFAULT_PROFILE = 'es5.1'
 
@@ -79,6 +78,8 @@ def get_arguments():
                         help='build and use jerry-libc (%(choices)s; default: %(default)s)')
     parser.add_argument('--jerry-libm', metavar='X', choices=['ON', 'OFF'], default='ON', type=str.upper,
                         help='build and use jerry-libm (%(choices)s; default: %(default)s)')
+    parser.add_argument('--jerry-port-default', metavar='X', choices=['ON', 'OFF'], default='ON', type=str.upper,
+                        help='build default jerry port implementation (%(choices)s; default: %(default)s)')
     parser.add_argument('--js-parser', metavar='X', choices=['ON', 'OFF'], default='ON', type=str.upper,
                         help='enable js-parser (%(choices)s; default: %(default)s)')
     parser.add_argument('--link-lib', metavar='OPT', action='append', default=[],
@@ -89,8 +90,6 @@ def get_arguments():
                         help='enable link-time optimizations (%(choices)s; default: %(default)s)')
     parser.add_argument('--mem-heap', metavar='SIZE', action='store', type=int, default=512,
                         help='size of memory heap, in kilobytes (default: %(default)s)')
-    parser.add_argument('--port-dir', metavar='DIR', action='store', default=DEFAULT_PORT_DIR,
-                        help='add port directory (default: %(default)s)')
     parser.add_argument('--profile', metavar='FILE', action='store', default=DEFAULT_PROFILE,
                         help='specify profile file (default: %(default)s)')
     parser.add_argument('--snapshot-exec', metavar='X', choices=['ON', 'OFF'], default='OFF', type=str.upper,
@@ -145,6 +144,7 @@ def generate_build_options(arguments):
     build_options.append('-DFEATURE_ERROR_MESSAGES=%s' % arguments.error_messages)
     build_options.append('-DJERRY_CMDLINE=%s' % arguments.jerry_cmdline)
     build_options.append('-DJERRY_CMDLINE_MINIMAL=%s' % arguments.jerry_cmdline_minimal)
+    build_options.append('-DJERRY_PORT_DEFAULT=%s' % arguments.jerry_port_default)
     build_options.append('-DJERRY_LIBC=%s' % arguments.jerry_libc)
     build_options.append('-DJERRY_LIBM=%s' % arguments.jerry_libm)
     build_options.append('-DFEATURE_JS_PARSER=%s' % arguments.js_parser)
@@ -152,7 +152,6 @@ def generate_build_options(arguments):
     build_options.append('-DEXTERNAL_LINKER_FLAGS=' + ' '.join(arguments.linker_flag))
     build_options.append('-DENABLE_LTO=%s' % arguments.lto)
     build_options.append('-DMEM_HEAP_SIZE_KB=%d' % arguments.mem_heap)
-    build_options.append('-DPORT_DIR=%s' % arguments.port_dir)
 
     build_options.append('-DFEATURE_PROFILE=%s' % arguments.profile)
     build_options.append('-DFEATURE_DEBUGGER=%s' % arguments.jerry_debugger)

--- a/tools/check-cppcheck.sh
+++ b/tools/check-cppcheck.sh
@@ -23,12 +23,12 @@ else
 fi
 
 JERRY_CORE_DIRS=`find jerry-core -type d`
-JERRY_PORT_DEFAULT_DIRS=`find targets/default -type d`
+JERRY_PORT_DIRS=`find jerry-port -type d`
 JERRY_LIBC_DIRS=`find jerry-libc -type d`
 JERRY_LIBM_DIRS=`find jerry-libm -type d`
 
 INCLUDE_DIRS=()
-for DIR in $JERRY_CORE_DIRS $JERRY_PORT_DEFAULT_DIRS $JERRY_LIBC_DIRS $JERRY_LIBM_DIRS
+for DIR in $JERRY_CORE_DIRS $JERRY_PORT_DIRS $JERRY_LIBC_DIRS $JERRY_LIBM_DIRS
 do
  INCLUDE_DIRS=("${INCLUDE_DIRS[@]}" "-I$DIR")
 done
@@ -41,4 +41,4 @@ cppcheck -j$CPPCHECK_JOBS --force \
  --exitcode-suppressions=tools/cppcheck/suppressions-list \
  --suppressions-list=tools/cppcheck/suppressions-list \
  "${INCLUDE_DIRS[@]}" \
- jerry-core targets/default jerry-libc jerry-libm jerry-main tests/unit-*
+ jerry-core jerry-port jerry-libc jerry-libm jerry-main tests/unit-*

--- a/tools/check-vera.sh
+++ b/tools/check-vera.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 JERRY_CORE_FILES=`find ./jerry-core -name "*.c" -or -name "*.h"`
-JERRY_PORT_DEFAULT_FILES=`find ./targets/default -name "*.c" -or -name "*.h"`
+JERRY_PORT_FILES=`find ./jerry-port -name "*.c" -or -name "*.h"`
 JERRY_LIBC_FILES=`find ./jerry-libc -name "*.c" -or -name "*.h"`
 JERRY_LIBM_FILES=`find ./jerry-libm -name "*.c" -or -name "*.h"`
 JERRY_MAIN_FILES=`find ./jerry-main -name "*.c" -or -name "*.h"`
@@ -28,4 +28,4 @@ fi
 
 vera++ -r tools/vera++ -p jerry \
  -e --no-duplicate \
- $MANUAL_CHECK_FILES $JERRY_CORE_FILES $JERRY_PORT_DEFAULT_FILES $JERRY_LIBC_FILES $JERRY_LIBM_FILES $JERRY_MAIN_FILES $UNIT_TEST_FILES
+ $MANUAL_CHECK_FILES $JERRY_CORE_FILES $JERRY_PORT_FILES $JERRY_LIBC_FILES $JERRY_LIBM_FILES $JERRY_MAIN_FILES $UNIT_TEST_FILES


### PR DESCRIPTION
This is the first implementation for #1776 to showcase the idea presented there.

*Note that this is a breaking change!*
- If someone used cmake with the `PORT_DIR` option, it will not work anymore.
- An additional library (i.e., the port implementation library) might need to be
  linked to applications that link to jerry.
- Some default port implementation-specific function names changed.

However, most probably it will not break _most_ uses cases.
- No in-tree targets use the `PORT_DIR` cmake option.
- Many in-tree targets implement the port API within the engine-embedding application,
  so there will be no need to link anything else but `jerry-core`, just like before.
- No in-tree targets use the jobqueue port API.

-----

This commit changes the concept of JerryScript port implementations
from a simple directory of C source files (which get injected among
the sources of `jerry-core`) into a proper static library (which
may be linked to an application together with `jerry-core`). As a
consequence, this commit introduces a new library to the
JerryScript component architecture: the sources of the default port
implementation form `jerry-port-default`.

Changes in more detail:

- The sources in `targets/default` are moved to `jerry-port/default`
  and are turned into a proper static library.
  - Actually, the default port implementation has two library
    variants, one that implements the bare minimum only
    (`jerry-port-default-minimal`) and one that has some extra
    functionalities specific to this implementation (the "full"
    `jerry-port-default`).
  - The new libraries have an interface header in
    `jerry-port/default/include`, which extends the common
    `jerryscript-port.h` API with functions specific to these
    libraries.
  - All non-standard port functions have now the
    `jerry_port_default_` prefix (this affects `jobqueue_init` and
    `jobqueue_run`).
  - The jobqueue implementation functions became config macro
    independent: it is now the responsibility of the linker to pick
    the needed objects from the library, and omit those (e.g.,
    jobqueue-related code) that are not referenced.
  - Build of the libraries can be controlled with the new
    `JERRY_PORT_DEFAULT` cmake option.

- The cmake option `PORT_DIR` is dropped, and `PORT_DIR/*.c` is not
  appended to `jerry-core` sources.
  - Instead, the `jerry` tool of `jerry-main` links to
    `jerry-port-default`, while `jerry-minimal` links to
    `jerry-port-default-minimal`.
  - `tests/unit-core` tests are also linked to
    `jerry-port-default-minimal`.

- Tools adapted.
  - `build.py` has `--jerry-port-default` instead of `--port-dir`.
  - `check-*.sh` have paths updated (`jerry-port/default` instead
    of `targets/default`).

- Miscellaneous.
  - Dropped `#ifndef`s from `jerryscript-port.h`. It is a public
    header of the `jerry-core` library, which means that it must
    not contain configuration-dependent parts (once the library is
    built with some config macros and the archive and the headers
    are installed, there is no way for the header to tell what
    those config macrose were).
  - Added documentation comments to the JobQueue Port API (in
    `jerryscript-port.h`) and to several default port
    implementation functions (in `jerry-port/default`).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu