### PR TITLE
Two extensions: An extended context with a compile-time-defined number of pointers, and modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - OPTS="--unittests"
     - OPTS="--test262"
     - OPTS="--check-pylint"
+    - OPTS="--unittests --buildoptions=--cmake-param=-DJERRYX_CONTEXT=ON"
   global:
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
     #   via the "travis encrypt" command using the project repo's public key

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
     - OPTS="--test262"
     - OPTS="--check-pylint"
     - OPTS="--unittests --buildoptions=--cmake-param=-DJERRYX_CONTEXT=ON"
+    - OPTS="--unittests --buildoptions=--cmake-param=-DJERRYX_MODULE=ON,--cmake-param=-DJERRYX_CONTEXT=ON"
+    - OPTS="--unittests --buildoptions=--cmake-param=-DJERRYX_MODULE=ON"
   global:
     # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
     #   via the "travis encrypt" command using the project repo's public key

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,3 +250,5 @@ if(UNITTESTS)
     add_subdirectory(tests/unit-libm)
   endif()
 endif()
+
+add_subdirectory(jerry-ext)

--- a/jerry-core/jerry.c
+++ b/jerry-core/jerry.c
@@ -187,6 +187,11 @@ jerry_cleanup (void)
 {
   jerry_assert_api_available ();
 
+  if (JERRY_CONTEXT (user_context_deinit_cb))
+  {
+    JERRY_CONTEXT (user_context_deinit_cb) (JERRY_CONTEXT (user_context_p));
+  }
+
   ecma_finalize ();
 
 #ifdef JERRY_DEBUGGER
@@ -198,11 +203,6 @@ jerry_cleanup (void)
 
   jmem_finalize ();
   jerry_make_api_unavailable ();
-
-  if (JERRY_CONTEXT (user_context_deinit_cb))
-  {
-    JERRY_CONTEXT (user_context_deinit_cb) (JERRY_CONTEXT (user_context_p));
-  }
 } /* jerry_cleanup */
 
 /**

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(JERRYX_CONTEXT OFF CACHE BOOL "Build context support?")
+
+if("${PLATFORM}" STREQUAL "DARWIN")
+  set(JERRYX_CONTEXT "OFF")
+endif()
+
+# Status messages
+message(STATUS "JERRYX_CONTEXT            " ${JERRYX_CONTEXT})
+
+if(JERRYX_CONTEXT)
+  add_subdirectory(context)
+endif()

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -13,14 +13,21 @@
 # limitations under the License.
 
 set(JERRYX_CONTEXT OFF CACHE BOOL "Build context support?")
+set(JERRYX_MODULE  OFF CACHE BOOL "Build module support?")
 
 if("${PLATFORM}" STREQUAL "DARWIN")
   set(JERRYX_CONTEXT "OFF")
+  set(JERRYX_MODULE "OFF")
 endif()
 
 # Status messages
 message(STATUS "JERRYX_CONTEXT            " ${JERRYX_CONTEXT})
+message(STATUS "JERRYX_MODULE             " ${JERRYX_MODULE})
 
 if(JERRYX_CONTEXT)
   add_subdirectory(context)
+endif()
+
+if(JERRYX_MODULE)
+  add_subdirectory(module)
 endif()

--- a/jerry-ext/context/CMakeLists.txt
+++ b/jerry-ext/context/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required (VERSION 2.8.12)
+set(JERRYX_CONTEXT_NAME jerryx-context)
+project (${JERRYX_CONTEXT_NAME} C)
+
+# Include directories
+set(INCLUDE_CONTEXT "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(DEFINES_CONTEXT "")
+
+# Source directories
+file(GLOB SOURCE_CONTEXT *.c)
+
+add_library(${JERRYX_CONTEXT_NAME} STATIC ${SOURCE_CONTEXT})
+set_property(TARGET ${JERRYX_CONTEXT_NAME}
+             PROPERTY COMPILE_FLAGS "${DEFINES_CONTEXT}")
+
+target_include_directories(${JERRYX_CONTEXT_NAME} PRIVATE ${INCLUDE_CONTEXT})
+target_include_directories(${JERRYX_CONTEXT_NAME} INTERFACE ${INCLUDE_CONTEXT})
+target_include_directories(${JERRYX_CONTEXT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-core")
+target_include_directories(${JERRYX_CONTEXT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-core/jmem")
+target_include_directories(${JERRYX_CONTEXT_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-core/jrt")
+
+install(TARGETS ${JERRYX_CONTEXT_NAME} DESTINATION lib)
+install(DIRECTORY ${INCLUDE_CONTEXT}/ DESTINATION include/jerry-ext)

--- a/jerry-ext/context/include/jerry-context.h
+++ b/jerry-ext/context/include/jerry-context.h
@@ -1,0 +1,52 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYX_CONTEXT_H
+#define JERRYX_CONTEXT_H
+
+#include "jerryscript.h"
+
+/**
+ * Function to pass to jerry_init_with_user_context() as its second parameter
+ */
+void *jerryx_context_init (void);
+
+/**
+ * Function to pass to jerry_init_with_user_context() as its third parameter
+ */
+void jerryx_context_deinit (void *user_context_p);
+
+typedef struct
+{
+  jerry_user_context_init_cb init_cb;
+  jerry_user_context_deinit_cb deinit_cb;
+  int index;
+} jerryx_context_slot_t;
+
+#define JERRYX_CONTEXT_DEFINE_SLOT(slot_name, init_cb_ptr, deinit_cb_ptr)         \
+static jerryx_context_slot_t __jerryx_context_slot_ ## slot_name                  \
+__attribute__((used, section("jerryx_context_slots"), aligned(sizeof(void *)))) = \
+{                                                                                 \
+  .init_cb = (init_cb_ptr),                                                       \
+  .deinit_cb = (deinit_cb_ptr),                                                   \
+  .index = -1                                                                     \
+};
+
+void *jerryx_context_get (int slot);
+
+#define JERRYX_CONTEXT_SLOT(slot_name) \
+  (jerryx_context_get (__jerryx_context_slot_ ## slot_name.index))
+
+#endif /* !JERRYX_CONTEXT_H */

--- a/jerry-ext/context/jerry-context.c
+++ b/jerry-ext/context/jerry-context.c
@@ -1,0 +1,120 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include "jerry-context.h"
+#include "jmem.h"
+
+static int jerryx_context_slot_count = -1;
+extern jerryx_context_slot_t __start_jerryx_context_slots[] __attribute__((weak));
+extern jerryx_context_slot_t __stop_jerryx_context_slots[] __attribute__((weak));
+#define JERRYX_CONTEXT_ITERATE_OVER_SLOTS(index, slot_p)              \
+(index = 0, slot_p = &__start_jerryx_context_slots[index];            \
+  &__start_jerryx_context_slots[index] < __stop_jerryx_context_slots; \
+  index++, slot_p = &__start_jerryx_context_slots[index])
+
+static void jerryx_context_static_init (void);
+static void
+jerryx_context_static_init (void)
+{
+  jerryx_context_slot_t *slot_p;
+  int index;
+
+  if (jerryx_context_slot_count >= 0)
+  {
+    jerry_port_fatal (ERR_FAILED_INTERNAL_ASSERTION);
+  }
+
+  for JERRYX_CONTEXT_ITERATE_OVER_SLOTS (index, slot_p)
+  {
+    slot_p->index = index;
+  }
+
+  jerryx_context_slot_count = index;
+} /* jerryx_context_static_init */
+
+/* Context-free data */
+
+/**
+ * Create a new context. This function can be passed to jerry_init_with_user_context () as its second parameter.
+ *
+ * @return the pointer to store as the user context.
+ */
+void *
+jerryx_context_init (void)
+{
+  void **ret_pp;
+  int index;
+  size_t context_size;
+  jerryx_context_slot_t *slot_p = NULL;
+
+  if (unlikely (jerryx_context_slot_count < 0))
+  {
+    jerryx_context_static_init ();
+  }
+
+  context_size = ((size_t) jerryx_context_slot_count) * sizeof (void *);
+  ret_pp = (void **) jmem_heap_alloc_block (context_size);
+  memset (ret_pp, 0, context_size);
+
+  for JERRYX_CONTEXT_ITERATE_OVER_SLOTS (index, slot_p)
+  {
+    ret_pp[slot_p->index] = slot_p->init_cb ();
+  }
+
+  return ((void *) ret_pp);
+} /* jerryx_context_init */
+
+/**
+ * Free a context. This function can be passed to jerry_init_with_user_context () as its third parameter.
+ */
+void
+jerryx_context_deinit (void *user_context_p) /**< user context to deinit */
+{
+  int index;
+  jerryx_context_slot_t *slot_p = NULL;
+  void **slots_p = NULL;
+
+  if (user_context_p)
+  {
+    slots_p = (void **) user_context_p;
+    for JERRYX_CONTEXT_ITERATE_OVER_SLOTS (index, slot_p)
+    {
+      if (slot_p->deinit_cb)
+      {
+        slot_p->deinit_cb (slots_p[slot_p->index]);
+      }
+    }
+    jmem_heap_free_block (slots_p, ((size_t) jerryx_context_slot_count) * sizeof (void *));
+  }
+} /* jerryx_context_deinit */
+
+/**
+ * Request the slot at the given index.
+ *
+ * @return the user data that was created in the given slot when the context was initialized.
+ */
+void *
+jerryx_context_get (int slot) /**< the slot from which to retrieve the data */
+{
+  void **slots_p = (void **) jerry_get_user_context ();
+
+  if (jerryx_context_slot_count < 0 || !slots_p || slot < 0 || slot >= jerryx_context_slot_count)
+  {
+    jerry_port_fatal (ERR_FAILED_INTERNAL_ASSERTION);
+  }
+
+  return slots_p[slot];
+} /* jerryx_context_get */

--- a/jerry-ext/module/CMakeLists.txt
+++ b/jerry-ext/module/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required (VERSION 2.8.12)
+set(JERRYX_MODULE_NAME jerryx-module)
+project (${JERRYX_MODULE_NAME} C)
+
+# Include directories
+set(INCLUDE_MODULE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+
+if(JERRYX_CONTEXT)
+  set(DEFINES_MODULE "-DJERRYX_MODULE_HAVE_CONTEXT")
+endif()
+
+# Source directories
+file(GLOB SOURCE_MODULE *.c)
+
+add_library(${JERRYX_MODULE_NAME} STATIC ${SOURCE_MODULE})
+if(JERRYX_CONTEXT)
+  target_include_directories(${JERRYX_MODULE_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-ext/context/include")
+endif()
+target_include_directories(${JERRYX_MODULE_NAME} PRIVATE ${INCLUDE_MODULE})
+target_include_directories(${JERRYX_MODULE_NAME} INTERFACE ${INCLUDE_MODULE})
+target_include_directories(${JERRYX_MODULE_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-core")
+target_include_directories(${JERRYX_MODULE_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-core/jmem")
+target_include_directories(${JERRYX_MODULE_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-core/jrt")
+if(NOT "${DEFINES_MODULE}" STREQUAL "")
+  target_compile_definitions(${JERRYX_MODULE_NAME} PRIVATE "${DEFINES_MODULE}")
+endif()
+
+install(TARGETS ${JERRYX_MODULE_NAME} DESTINATION lib)
+install(DIRECTORY ${INCLUDE_MODULE}/ DESTINATION include/jerry-ext)

--- a/jerry-ext/module/include/jerry-module.h
+++ b/jerry-ext/module/include/jerry-module.h
@@ -1,0 +1,56 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYX_MODULE_H
+#define JERRYX_MODULE_H
+
+#include "jerryscript.h"
+
+typedef struct
+{
+  jerry_char_t *name;
+  jerry_value_t (*on_resolve)(void);
+} jerryx_module_t;
+
+/**
+ * Function to create a module manager context
+ */
+void *jerryx_module_manager_init (void);
+
+/**
+ * Function to clean up a given module manager context
+ */
+void jerryx_module_manager_deinit (void *context_p);
+
+/**
+ * Function to load a copy of a module into the current context
+ */
+jerry_value_t jerryx_module_resolve (const jerry_char_t *name);
+
+#define JERRYX_MODULE(module_name, on_resolve_cb)                      \
+static jerryx_module_t _module \
+__attribute__((used, section("jerryx_modules"), aligned(sizeof(void *)))) = \
+{ \
+  .name = ((jerry_char_t *)#module_name), \
+  .on_resolve = (on_resolve_cb) \
+};
+
+#define JERRYX_MODULE_RESOLVER(cb_name)                                              \
+static jerry_value_t cb_name (const jerry_char_t *name);                             \
+static jerry_value_t (*__static_global_ ## cb_name) (const jerry_char_t *)           \
+__attribute__((used)) __attribute__((section("jerryx_module_resolvers"))) = cb_name; \
+static jerry_value_t cb_name (const jerry_char_t *name)
+
+#endif /* !JERRYX_MODULE_H */

--- a/jerry-ext/module/jerry-module.c
+++ b/jerry-ext/module/jerry-module.c
@@ -1,0 +1,198 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jmem.h"
+#include "jerryscript.h"
+#include "jerry-module.h"
+
+typedef struct jerryx_module_header
+{
+  jerry_char_t *name;
+  struct jerryx_module_header *next_p;
+} jerryx_module_header_t;
+
+#define JERRYX_MODULE_HEADER_UNLINK(header) \
+  ((jerryx_module_header_t *) (header))->next_p = NULL
+
+#define JERRYX_MODULE_HEADER_RUNTIME_INIT(header, module_name) \
+  ((jerryx_module_header_t *) (header))->name = (module_name); \
+  JERRYX_MODULE_HEADER_UNLINK((header))
+
+static void
+jerryx_module_header_insert (jerryx_module_header_t *header_p,
+                             jerryx_module_header_t **root_pp)
+{
+  if (*root_pp)
+  {
+    header_p->next_p = (*root_pp);
+  }
+  (*root_pp) = header_p;
+} /* jerryx_module_header_insert */
+
+static jerryx_module_header_t *
+jerryx_module_header_find (jerryx_module_header_t *root_p,
+                           const jerry_char_t *name,
+                         jerryx_module_header_t **previous_pp)
+{
+  for (;root_p && strcmp ((char *) name, ((char *) root_p->name)); root_p = root_p->next_p)
+  {
+    if (previous_pp)
+    {
+      (*previous_pp) = root_p;
+    }
+  }
+
+  return root_p;
+} /* jerryx_module_header_find */
+
+static void
+jerryx_module_header_free (jerryx_module_header_t *root_p,
+                           void (*free_link) (jerryx_module_header_t *))
+{
+  jerryx_module_header_t *next_p = NULL;
+  while (root_p)
+  {
+    next_p = root_p->next_p;
+    free_link (root_p);
+    root_p = next_p;
+  }
+} /* jerryx_module_header_free */
+
+typedef struct
+{
+  jerryx_module_header_t header;
+  jerry_value_t export;
+} jerryx_module_instance_t;
+
+static void
+jerryx_module_free_instance (jerryx_module_header_t *header_p)
+{
+  jerryx_module_instance_t *instance_p = (jerryx_module_instance_t *) header_p;
+  jerry_release_value (instance_p->export);
+  jmem_heap_free_block (instance_p, sizeof (jerryx_module_instance_t));
+} /* jerryx_module_free_instance */
+
+void *
+jerryx_module_manager_init (void)
+{
+  void *ret = jmem_heap_alloc_block (sizeof (jerryx_module_instance_t *));
+  memset (ret, 0, sizeof (jerryx_module_instance_t *));
+  return ret;
+} /* jerryx_module_manager_init */
+
+void
+jerryx_module_manager_deinit (void *context_p)
+{
+  if (context_p)
+  {
+    jerryx_module_header_free (*((jerryx_module_header_t **) (context_p)), jerryx_module_free_instance);
+    jmem_heap_free_block (context_p, sizeof (jerryx_module_header_t *));
+  }
+} /* jerryx_module_manager_deinit */
+
+#ifdef JERRYX_MODULE_HAVE_CONTEXT
+#include "jerry-context.h"
+JERRYX_CONTEXT_DEFINE_SLOT (jerryx_module_slot, jerryx_module_manager_init, jerryx_module_manager_deinit)
+#define JERRYX_MODULE_CONTEXT \
+  JERRYX_CONTEXT_SLOT(jerryx_module_slot)
+#else /* !JERRYX_MODULE_HAVE_CONTEXT */
+#define JERRYX_MODULE_CONTEXT \
+  (jerry_get_user_context ())
+#endif /* JERRYX_MODULE_HAVE_CONTEXT */
+
+/*
+ * These symbols are made available by the linker
+ */
+extern jerryx_module_t __start_jerryx_modules[] __attribute__((weak));
+extern jerryx_module_t __stop_jerryx_modules[] __attribute__((weak));
+#define JERRYX_MODULE_ITERATE_OVER_MODULES(index, module_p) \
+(index = 0, module_p = &__start_jerryx_modules[index];     \
+  &__start_jerryx_modules[index] < __stop_jerryx_modules;  \
+  index++, module_p = &__start_jerryx_modules[index])
+
+JERRYX_MODULE_RESOLVER (native_resolver)
+{
+  int index;
+  jerry_value_t ret = 0;
+  jerryx_module_t *module_p = NULL;
+  jerryx_module_instance_t **instances_pp = JERRYX_MODULE_CONTEXT;
+  jerryx_module_instance_t *instance_p = NULL;
+
+  instance_p =
+  (jerryx_module_instance_t *) jerryx_module_header_find (*((jerryx_module_header_t **) instances_pp), name, NULL);
+
+  if (instance_p)
+  {
+    return instance_p->export;
+  }
+
+  for JERRYX_MODULE_ITERATE_OVER_MODULES (index, module_p)
+  {
+    if (!strcmp ((char *) module_p->name, (char *) name))
+    {
+      ret = module_p->on_resolve ();
+      instance_p = (jerryx_module_instance_t *) jmem_heap_alloc_block (sizeof (jerryx_module_instance_t));
+      JERRYX_MODULE_HEADER_RUNTIME_INIT (instance_p, module_p->name);
+      instance_p->export = jerry_acquire_value (ret);
+      jerryx_module_header_insert ((jerryx_module_header_t *) instance_p, (jerryx_module_header_t **) instances_pp);
+      return ret;
+    }
+  }
+
+  return 0;
+} /* JERRYX_MODULE_RESOLVER */
+
+static const char not_found_prologue[] = "Module '";
+static const char not_found_epilogue[] = "' not found";
+
+/*
+ * These symbols are made available by the linker
+ */
+typedef jerry_value_t (*jerryx_module_resolver_t)(const jerry_char_t *);
+extern jerryx_module_resolver_t __start_jerryx_module_resolvers[] __attribute__((weak));
+extern jerryx_module_resolver_t __stop_jerryx_module_resolvers[] __attribute__((weak));
+
+jerry_value_t
+jerryx_module_resolve (const jerry_char_t *name)
+{
+  jerry_value_t ret;
+  char *error_message = NULL;
+  size_t error_message_size = 0, name_length = strlen ((char *) name);
+  size_t index, resolver_count = (size_t) (__stop_jerryx_module_resolvers - __start_jerryx_module_resolvers);
+
+  for (index = 0; index < resolver_count; index++)
+  {
+    ret = __start_jerryx_module_resolvers[index] (name);
+    if (ret)
+    {
+      return ret;
+    }
+  }
+
+  error_message_size = name_length + sizeof (not_found_prologue) + sizeof (not_found_epilogue) - 1;
+  error_message = jmem_heap_alloc_block_null_on_error (error_message_size);
+  if (error_message)
+  {
+    memcpy (error_message, not_found_prologue, sizeof (not_found_prologue) - 1);
+    memcpy (&error_message[sizeof (not_found_prologue) - 1], ((char *) name), name_length);
+    memcpy (&error_message[sizeof (not_found_prologue) - 1 + name_length], not_found_epilogue,
+            sizeof (not_found_epilogue) - 1);
+    error_message[error_message_size - 1] = 0;
+    ret = jerry_create_error (JERRY_ERROR_COMMON, (jerry_char_t *) error_message);
+    jmem_heap_free_block (error_message, error_message_size);
+  }
+
+  return ret;
+} /* jerryx_module_resolve */

--- a/tests/unit-core/CMakeLists.txt
+++ b/tests/unit-core/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 cmake_minimum_required (VERSION 2.8.12)
 project (unit-core C)
+set(INCLUDE_UNITTESTS ${CMAKE_CURRENT_LIST_DIR})
 
 if (NOT IS_ABSOLUTE ${FEATURE_PROFILE})
   set(FEATURE_PROFILE "${CMAKE_SOURCE_DIR}/jerry-core/profiles/${FEATURE_PROFILE}.profile")
@@ -43,3 +44,5 @@ foreach(SOURCE_UNIT_TEST_MAIN ${SOURCE_UNIT_TEST_MAIN_MODULES})
 
   add_dependencies(unittests-core ${TARGET_NAME})
 endforeach()
+
+add_subdirectory(jerry-ext)

--- a/tests/unit-core/jerry-ext/CMakeLists.txt
+++ b/tests/unit-core/jerry-ext/CMakeLists.txt
@@ -15,3 +15,7 @@
 if(JERRYX_CONTEXT)
   add_subdirectory(context)
 endif()
+
+if(JERRYX_MODULE)
+  add_subdirectory(module)
+endif()

--- a/tests/unit-core/jerry-ext/CMakeLists.txt
+++ b/tests/unit-core/jerry-ext/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(JERRYX_CONTEXT)
+  add_subdirectory(context)
+endif()

--- a/tests/unit-core/jerry-ext/context/CMakeLists.txt
+++ b/tests/unit-core/jerry-ext/context/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required (VERSION 2.8.12)
+set(JERRYX_CONTEXT_UNITTEST_NAME unit-test-jerry-context)
+
+project (${JERRYX_CONTEXT_UNITTEST_NAME} C)
+
+file(GLOB JERRYX_CONTEXT_UNIT_TEST_SOURCES *.c)
+
+add_executable(${JERRYX_CONTEXT_UNITTEST_NAME} ${JERRYX_CONTEXT_UNIT_TEST_SOURCES})
+set_property(TARGET ${JERRYX_CONTEXT_UNITTEST_NAME} PROPERTY LINK_FLAGS "${LINKER_FLAGS_COMMON}")
+target_link_libraries(${JERRYX_CONTEXT_UNITTEST_NAME} jerryx-context jerry-core jerry-port-default-minimal)
+target_include_directories(${JERRYX_CONTEXT_UNITTEST_NAME} PRIVATE ${INCLUDE_UNITTESTS})
+target_include_directories(${JERRYX_CONTEXT_UNITTEST_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-ext/context/include")

--- a/tests/unit-core/jerry-ext/context/jerry-context-test.c
+++ b/tests/unit-core/jerry-ext/context/jerry-context-test.c
@@ -1,0 +1,70 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "test-common.h"
+#include "jerry-context.h"
+
+static char *static_slot1 = "static slot 1";
+static char *static_slot2 = "static slot 2";
+
+static int deinit_called_count = 0;
+
+static void *
+init_slot1 (void)
+{
+  return static_slot1;
+} /* init_slot1 */
+
+static void
+deinit_slot1 (void *slot)
+{
+  TEST_ASSERT (slot == static_slot1);
+  deinit_called_count++;
+} /* deinit_slot1 */
+
+JERRYX_CONTEXT_DEFINE_SLOT (slot1, init_slot1, deinit_slot1)
+
+static void *
+init_slot2 (void)
+{
+  return static_slot2;
+} /* init_slot2 */
+
+static void
+deinit_slot2 (void *slot)
+{
+  TEST_ASSERT (slot == static_slot2);
+  deinit_called_count++;
+} /* deinit_slot2 */
+
+JERRYX_CONTEXT_DEFINE_SLOT (slot2, init_slot2, deinit_slot2)
+
+int
+main (int argc, char **argv)
+{
+  (void) argc;
+  (void) argv;
+  TEST_INIT ();
+
+  jerry_init_with_user_context (JERRY_INIT_EMPTY, jerryx_context_init, jerryx_context_deinit);
+
+  TEST_ASSERT (JERRYX_CONTEXT_SLOT (slot1) == static_slot1);
+  TEST_ASSERT (JERRYX_CONTEXT_SLOT (slot2) == static_slot2);
+
+  jerry_cleanup ();
+
+  TEST_ASSERT (deinit_called_count == 2);
+} /* main */

--- a/tests/unit-core/jerry-ext/module/CMakeLists.txt
+++ b/tests/unit-core/jerry-ext/module/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required (VERSION 2.8.12)
+set(JERRYX_MODULE_UNITTEST_NAME unit-test-jerry-module)
+project (${JERRYX_MODULE_UNITTEST_NAME} C)
+
+if(JERRYX_CONTEXT)
+  set(DEFINES_MODULE_UNITTEST "-DJERRYX_MODULE_HAVE_CONTEXT")
+endif()
+
+file(GLOB JERRYX_MODULE_UNIT_TEST_SOURCES *.c)
+
+add_executable(${JERRYX_MODULE_UNITTEST_NAME} ${JERRYX_MODULE_UNIT_TEST_SOURCES})
+set_property(TARGET ${JERRYX_MODULE_UNITTEST_NAME} PROPERTY LINK_FLAGS "${LINKER_FLAGS_COMMON}")
+target_link_libraries(${JERRYX_MODULE_UNITTEST_NAME} jerryx-module jerry-core jerry-port-default-minimal)
+if(JERRYX_CONTEXT)
+  target_link_libraries(${JERRYX_MODULE_UNITTEST_NAME} jerryx-context)
+  target_include_directories(${JERRYX_MODULE_UNITTEST_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-ext/context/include")
+endif()
+target_include_directories(${JERRYX_MODULE_UNITTEST_NAME} PRIVATE ${INCLUDE_UNITTESTS})
+target_include_directories(${JERRYX_MODULE_UNITTEST_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/jerry-ext/module/include")
+if (NOT "${DEFINES_MODULE_UNITTEST}" STREQUAL "")
+  target_compile_definitions(${JERRYX_MODULE_UNITTEST_NAME} PRIVATE "${DEFINES_MODULE_UNITTEST}")
+endif()

--- a/tests/unit-core/jerry-ext/module/jerry-module-test.c
+++ b/tests/unit-core/jerry-ext/module/jerry-module-test.c
@@ -1,0 +1,97 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "test-common.h"
+#ifdef JERRYX_MODULE_HAVE_CONTEXT
+#include "jerry-context.h"
+#endif /* JERRYX_MODULE_HAVE_CONTEXT */
+#include "jerry-module.h"
+
+const char eval_string1[] = "require ('my_custom_module');";
+const char eval_string2[] = "require ('differently-handled-module');";
+
+JERRYX_MODULE_RESOLVER (resolve_differently_handled_module)
+{
+  if (!strcmp ((char *) name, "differently-handled-module"))
+  {
+    return jerry_create_number (29);
+  }
+  return 0;
+} /* JERRYX_MODULE_RESOLVER */
+
+static jerry_value_t
+handle_require (const jerry_value_t js_function,
+                const jerry_value_t this_val,
+                const jerry_value_t args_p[],
+                const jerry_length_t args_count)
+{
+  (void) js_function;
+  (void) this_val;
+  (void) args_count;
+
+  jerry_value_t return_value = 0;
+  jerry_char_t module_name[256] = "";
+  jerry_size_t bytes_copied = 0;
+
+  TEST_ASSERT (args_count == 1);
+  bytes_copied = jerry_string_to_char_buffer (args_p[0], module_name, 256);
+  if (bytes_copied < 256)
+  {
+    module_name[bytes_copied] = 0;
+    return_value = jerryx_module_resolve (module_name);
+  }
+
+  return return_value;
+} /* handle_require */
+
+static void
+eval_one (const char *the_string, double expected_result)
+{
+  jerry_value_t js_eval_result = jerry_eval ((const jerry_char_t *) the_string, strlen (the_string), true);
+  TEST_ASSERT (!jerry_value_has_error_flag (js_eval_result));
+  TEST_ASSERT (jerry_get_number_value (js_eval_result) == expected_result);
+  jerry_release_value (js_eval_result);
+} /* eval_one */
+
+int
+main (int argc, char **argv)
+{
+  (void) argc;
+  (void) argv;
+  jerry_value_t js_global = 0, js_function = 0, js_property_name = 0;
+
+  TEST_INIT ();
+
+#ifdef JERRYX_MODULE_HAVE_CONTEXT
+  jerry_init_with_user_context (JERRY_INIT_EMPTY, jerryx_context_init, jerryx_context_deinit);
+#else /* !JERRYX_MODULE_HAVE_CONTEXT */
+  jerry_init_with_user_context (JERRY_INIT_EMPTY, jerryx_module_manager_init, jerryx_module_manager_deinit);
+#endif /* JERRYX_MODULE_HAVE_CONTEXT */
+
+  js_global = jerry_get_global_object ();
+  js_function = jerry_create_external_function (handle_require);
+  js_property_name = jerry_create_string ((const jerry_char_t *) "require");
+  jerry_set_property (js_global, js_property_name, js_function);
+
+  eval_one (eval_string1, 42);
+  eval_one (eval_string2, 29);
+
+  jerry_release_value (js_property_name);
+  jerry_release_value (js_function);
+  jerry_release_value (js_global);
+
+  jerry_cleanup ();
+} /* main */

--- a/tests/unit-core/jerry-ext/module/my-custom-module.c
+++ b/tests/unit-core/jerry-ext/module/my-custom-module.c
@@ -1,0 +1,25 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "jerry-module.h"
+
+static jerry_value_t
+my_custom_module_init (void)
+{
+  return jerry_create_number (42);
+} /* my_custom_module_init */
+
+JERRYX_MODULE (my_custom_module, my_custom_module_init)

--- a/tools/check-license.py
+++ b/tools/check-license.py
@@ -44,6 +44,7 @@ INCLUDE_DIRS = [
     'jerry-libm',
     'jerry-main',
     'jerry-port',
+    'jerry-ext',
     'targets',
     'tests',
     'tools',

--- a/tools/check-vera.sh
+++ b/tools/check-vera.sh
@@ -20,6 +20,7 @@ JERRY_LIBC_FILES=`find ./jerry-libc -name "*.c" -or -name "*.h"`
 JERRY_LIBM_FILES=`find ./jerry-libm -name "*.c" -or -name "*.h"`
 JERRY_MAIN_FILES=`find ./jerry-main -name "*.c" -or -name "*.h"`
 UNIT_TEST_FILES=`find ./tests/unit-* -name "*.c" -or -name "*.h"`
+JERRY_EXT_FILES=`find ./jerry-ext -name "*.c" -or -name "*.h"`
 
 if [ -n "$1" ]
 then
@@ -28,4 +29,4 @@ fi
 
 vera++ -r tools/vera++ -p jerry \
  -e --no-duplicate \
- $MANUAL_CHECK_FILES $JERRY_CORE_FILES $JERRY_PORT_FILES $JERRY_LIBC_FILES $JERRY_LIBM_FILES $JERRY_MAIN_FILES $UNIT_TEST_FILES
+ $MANUAL_CHECK_FILES $JERRY_CORE_FILES $JERRY_PORT_FILES $JERRY_LIBC_FILES $JERRY_LIBM_FILES $JERRY_MAIN_FILES $JERRY_EXT_FILES $UNIT_TEST_FILES


### PR DESCRIPTION
Much like #1740 this also introduces infrastructure for multiple extensions, taking into account my [comment](https://github.com/jerryscript-project/jerryscript/pull/1740#issuecomment-297245510). It also moves the user context deinit to the top of `jerry_cleanup ()` because the context has to be functional when deinit the user context, since the user context may contain `jerry_value_t` variables and may need to make API calls.