### PR TITLE
[native pointer] Check if freecb is NULL before calling it

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -418,9 +418,13 @@ ecma_gc_free_native_pointer (ecma_property_t *property_p, /**< property */
   {
     if (native_pointer_p->info_p != NULL)
     {
-      const jerry_object_native_info_t *native_info_p = (const jerry_object_native_info_t *) native_pointer_p->info_p;
+      jerry_object_free_callback_t free_cb;
+      free_cb = (jerry_object_free_callback_t) ((const jerry_object_native_info_t *) native_pointer_p->info_p)->free_cb;
 
-      native_info_p->free_cb (native_pointer_p->data_p);
+      if (free_cb != NULL)
+      {
+        free_cb ((uintptr_t) native_pointer_p->data_p);
+      }
     }
   }
 } /* ecma_gc_free_native_pointer */

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -132,6 +132,7 @@ handler_construct_freecb (void *native_p)
 
 JERRY_DEFINE_NATIVE_HANDLE_INFO (bind1, handler_construct_freecb);
 JERRY_DEFINE_NATIVE_HANDLE_INFO (bind2, handler_construct_freecb);
+JERRY_DEFINE_NATIVE_HANDLE_INFO (bind3, NULL);
 
 static jerry_value_t
 handler_construct (const jerry_value_t func_obj_val, /**< function object */
@@ -767,6 +768,14 @@ main (void)
                && (uintptr_t) ptr == (uintptr_t) 0x0012345678abcdefull);
 
   jerry_release_value (res);
+
+  /* Test: It is ok to set native pointer's free callback as NULL. */
+  jerry_value_t obj_freecb = jerry_create_object ();
+  jerry_set_object_native_pointer (obj_freecb,
+                                   (void *) 0x1234,
+                                   &JERRY_NATIVE_HANDLE_INFO_FOR_CTYPE (bind3));
+
+  jerry_release_value (obj_freecb);
 
   /* Test: Throwing exception from native handler. */
   throw_test_handler_val = jerry_create_external_function (handler_throw_test);


### PR DESCRIPTION
If the native pointer's free callback is NULL, we should not call it. 

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com