### PR TITLE
Shouldn't use `jerry_value_t` in ecma-exceptions.c

### DIFF
--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -210,7 +210,7 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
       }
       else
       {
-        jerry_value_t str_val = ecma_op_to_string (arg_val);
+        ecma_value_t str_val = ecma_op_to_string (arg_val);
         arg_string_p = ecma_get_string_from_value (str_val);
       }
 


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu