### PR TITLE
Rename internal debugger identifiers

### DIFF
--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -136,11 +136,11 @@ lit_char_is_white_space (ecma_char_t c) /**< code unit */
   {
     return (c == LIT_CHAR_NBSP
             || c == LIT_CHAR_BOM
-            || (c >= jerry_unicode_separator_char_interval_sps[0]
-                && c <= jerry_unicode_separator_char_interval_sps[0] + jerry_unicode_separator_char_interval_lengths[0])
+            || (c >= lit_unicode_separator_char_interval_sps[0]
+                && c <= lit_unicode_separator_char_interval_sps[0] + lit_unicode_separator_char_interval_lengths[0])
             || search_char_in_char_array (c,
-                                          jerry_unicode_separator_chars,
-                                          NUM_OF_ELEMENTS (jerry_unicode_separator_chars)));
+                                          lit_unicode_separator_chars,
+                                          NUM_OF_ELEMENTS (lit_unicode_separator_chars)));
   }
 } /* lit_char_is_white_space */
 
@@ -181,10 +181,10 @@ static bool
 lit_char_is_unicode_letter (ecma_char_t c) /**< code unit */
 {
   return (search_char_in_interval_array (c,
-                                         jerry_unicode_letter_interval_sps,
-                                         jerry_unicode_letter_interval_lengths,
-                                         NUM_OF_ELEMENTS (jerry_unicode_letter_interval_sps))
-          || search_char_in_char_array (c, jerry_unicode_letter_chars, NUM_OF_ELEMENTS (jerry_unicode_letter_chars)));
+                                         lit_unicode_letter_interval_sps,
+                                         lit_unicode_letter_interval_lengths,
+                                         NUM_OF_ELEMENTS (lit_unicode_letter_interval_sps))
+          || search_char_in_char_array (c, lit_unicode_letter_chars, NUM_OF_ELEMENTS (lit_unicode_letter_chars)));
 } /* lit_char_is_unicode_letter */
 
 /**
@@ -205,12 +205,12 @@ static bool
 lit_char_is_unicode_non_letter_ident_part (ecma_char_t c) /**< code unit */
 {
   return (search_char_in_interval_array (c,
-                                         jerry_unicode_non_letter_ident_part_interval_sps,
-                                         jerry_unicode_non_letter_ident_part_interval_lengths,
-                                         NUM_OF_ELEMENTS (jerry_unicode_non_letter_ident_part_interval_sps))
+                                         lit_unicode_non_letter_ident_part_interval_sps,
+                                         lit_unicode_non_letter_ident_part_interval_lengths,
+                                         NUM_OF_ELEMENTS (lit_unicode_non_letter_ident_part_interval_sps))
           || search_char_in_char_array (c,
-                                        jerry_unicode_non_letter_ident_part_chars,
-                                        NUM_OF_ELEMENTS (jerry_unicode_non_letter_ident_part_chars)));
+                                        lit_unicode_non_letter_ident_part_chars,
+                                        NUM_OF_ELEMENTS (lit_unicode_non_letter_ident_part_chars)));
 } /* lit_char_is_unicode_non_letter_ident_part */
 
 /**
@@ -481,8 +481,8 @@ search_in_bidirectional_conversion_tables (ecma_char_t character,        /**< co
                                            ecma_char_t *output_buffer_p, /**< [out] buffer for the result characters */
                                            bool is_lowercase)            /**< is lowercase conversion */
 {
-  /* 1, Check if the specified character is part of the jerry_character_case_ranges table. */
-  int number_of_case_ranges = NUM_OF_ELEMENTS (jerry_character_case_ranges);
+  /* 1, Check if the specified character is part of the lit_character_case_ranges table. */
+  int number_of_case_ranges = NUM_OF_ELEMENTS (lit_character_case_ranges);
   int conv_counter = 0;
 
   for (int i = 0; i < number_of_case_ranges; i++)
@@ -492,8 +492,8 @@ search_in_bidirectional_conversion_tables (ecma_char_t character,        /**< co
       conv_counter++;
     }
 
-    int range_length = jerry_character_case_range_lengths[conv_counter];
-    ecma_char_t start_point = jerry_character_case_ranges[i];
+    int range_length = lit_character_case_range_lengths[conv_counter];
+    ecma_char_t start_point = lit_character_case_ranges[i];
 
     if (start_point > character || character >= start_point + range_length)
     {
@@ -504,11 +504,11 @@ search_in_bidirectional_conversion_tables (ecma_char_t character,        /**< co
 
     if (i % 2 == 0)
     {
-      output_buffer_p[0] = is_lowercase ? (ecma_char_t) (jerry_character_case_ranges[i + 1] + char_dist) : character;
+      output_buffer_p[0] = is_lowercase ? (ecma_char_t) (lit_character_case_ranges[i + 1] + char_dist) : character;
     }
     else
     {
-      output_buffer_p[0] = is_lowercase ? character : (ecma_char_t) (jerry_character_case_ranges[i - 1] + char_dist);
+      output_buffer_p[0] = is_lowercase ? character : (ecma_char_t) (lit_character_case_ranges[i - 1] + char_dist);
     }
 
     return 1;
@@ -516,14 +516,14 @@ search_in_bidirectional_conversion_tables (ecma_char_t character,        /**< co
 
   /* 2, Check if the specified character is part of the character_pair_ranges table. */
   int bottom = 0;
-  int top = NUM_OF_ELEMENTS (jerry_character_pair_ranges) - 1;
+  int top = NUM_OF_ELEMENTS (lit_character_pair_ranges) - 1;
 
   while (bottom <= top)
   {
     int middle = (bottom + top) / 2;
-    ecma_char_t current_sp = jerry_character_pair_ranges[middle];
+    ecma_char_t current_sp = lit_character_pair_ranges[middle];
 
-    if (current_sp <= character && character < current_sp + jerry_character_pair_range_lengths[middle])
+    if (current_sp <= character && character < current_sp + lit_character_pair_range_lengths[middle])
     {
       int char_dist = character - current_sp;
 
@@ -550,22 +550,22 @@ search_in_bidirectional_conversion_tables (ecma_char_t character,        /**< co
   }
 
   /* 3, Check if the specified character is part of the character_pairs table. */
-  int number_of_character_pairs = NUM_OF_ELEMENTS (jerry_character_pairs);
+  int number_of_character_pairs = NUM_OF_ELEMENTS (lit_character_pairs);
 
   for (int i = 0; i < number_of_character_pairs; i++)
   {
-    if (character != jerry_character_pairs[i])
+    if (character != lit_character_pairs[i])
     {
       continue;
     }
 
     if (i % 2 == 0)
     {
-      output_buffer_p[0] = is_lowercase ? jerry_character_pairs[i + 1] : character;
+      output_buffer_p[0] = is_lowercase ? lit_character_pairs[i + 1] : character;
     }
     else
     {
-      output_buffer_p[0] = is_lowercase ? character : jerry_character_pairs[i - 1];
+      output_buffer_p[0] = is_lowercase ? character : lit_character_pairs[i - 1];
     }
 
     return 1;
@@ -676,24 +676,24 @@ lit_char_to_lower_case (ecma_char_t character, /**< input character value */
     return lowercase_sequence;
   }
 
-  int num_of_lowercase_ranges = NUM_OF_ELEMENTS (jerry_lower_case_ranges);
+  int num_of_lowercase_ranges = NUM_OF_ELEMENTS (lit_lower_case_ranges);
 
   for (int i = 0, j = 0; i < num_of_lowercase_ranges; i += 2, j++)
   {
-    int range_length = jerry_lower_case_range_lengths[j] - 1;
-    ecma_char_t start_point = jerry_lower_case_ranges[i];
+    int range_length = lit_lower_case_range_lengths[j] - 1;
+    ecma_char_t start_point = lit_lower_case_ranges[i];
 
     if (start_point <= character && character <= start_point + range_length)
     {
-      output_buffer_p[0] = (ecma_char_t) (jerry_lower_case_ranges[i + 1] + (character - start_point));
+      output_buffer_p[0] = (ecma_char_t) (lit_lower_case_ranges[i + 1] + (character - start_point));
       return 1;
     }
   }
 
   lowercase_sequence = search_in_conversion_table (character,
                                                    output_buffer_p,
-                                                   jerry_lower_case_conversions,
-                                                   jerry_lower_case_conversion_counters);
+                                                   lit_lower_case_conversions,
+                                                   lit_lower_case_conversion_counters);
 
   if (lowercase_sequence != 0)
   {
@@ -736,25 +736,25 @@ lit_char_to_upper_case (ecma_char_t character, /**< input character value */
     return uppercase_sequence;
   }
 
-  int num_of_upper_case_special_ranges = NUM_OF_ELEMENTS (jerry_upper_case_special_ranges);
+  int num_of_upper_case_special_ranges = NUM_OF_ELEMENTS (lit_upper_case_special_ranges);
 
   for (int i = 0, j = 0; i < num_of_upper_case_special_ranges; i += 3, j++)
   {
-    int range_length = jerry_upper_case_special_range_lengths[j];
-    ecma_char_t start_point = jerry_upper_case_special_ranges[i];
+    int range_length = lit_upper_case_special_range_lengths[j];
+    ecma_char_t start_point = lit_upper_case_special_ranges[i];
 
     if (start_point <= character && character <= start_point + range_length)
     {
-      output_buffer_p[0] = (ecma_char_t) (jerry_upper_case_special_ranges[i + 1] + (character - start_point));
-      output_buffer_p[1] = (ecma_char_t) (jerry_upper_case_special_ranges[i + 2]);
+      output_buffer_p[0] = (ecma_char_t) (lit_upper_case_special_ranges[i + 1] + (character - start_point));
+      output_buffer_p[1] = (ecma_char_t) (lit_upper_case_special_ranges[i + 2]);
       return 2;
     }
   }
 
   uppercase_sequence = search_in_conversion_table (character,
                                                    output_buffer_p,
-                                                   jerry_upper_case_conversions,
-                                                   jerry_upper_case_conversion_counters);
+                                                   lit_upper_case_conversions,
+                                                   lit_upper_case_conversion_counters);
 
   if (uppercase_sequence != 0)
   {

--- a/jerry-core/lit/lit-unicode-conversions.inc.h
+++ b/jerry-core/lit/lit-unicode-conversions.inc.h
@@ -17,7 +17,7 @@
  * from UnicodeData-9.0.0.txt and SpecialCasing-9.0.0.txt files. Do not edit! */
 
 /* Contains start points of character case ranges (these are bidirectional conversions). */
-static const uint16_t jerry_character_case_ranges[] JERRY_CONST_DATA =
+static const uint16_t lit_character_case_ranges[] JERRY_CONST_DATA =
 {
   0x00c0, 0x00e0, 0x00d8, 0x00f8, 0x0189, 0x0256, 0x01b1, 0x028a, 0x0388, 0x03ad,
   0x038e, 0x03cd, 0x0391, 0x03b1, 0x03a3, 0x03c3, 0x03fd, 0x037b, 0x0400, 0x0450,
@@ -29,7 +29,7 @@ static const uint16_t jerry_character_case_ranges[] JERRY_CONST_DATA =
 };
 
 /* Interval lengths of start points in `character_case_ranges` table. */
-static const uint8_t jerry_character_case_range_lengths[] JERRY_CONST_DATA =
+static const uint8_t lit_character_case_range_lengths[] JERRY_CONST_DATA =
 {
   0x0017, 0x0007, 0x0002, 0x0002, 0x0003, 0x0002, 0x0011, 0x0009, 0x0003, 0x0010,
   0x0020, 0x0026, 0x0026, 0x0050, 0x0006, 0x0008, 0x0006, 0x0008, 0x0008, 0x0006,
@@ -38,7 +38,7 @@ static const uint8_t jerry_character_case_range_lengths[] JERRY_CONST_DATA =
 };
 
 /* Contains the start points of bidirectional conversion ranges. */
-static const uint16_t jerry_character_pair_ranges[] JERRY_CONST_DATA =
+static const uint16_t lit_character_pair_ranges[] JERRY_CONST_DATA =
 {
   0x0100, 0x0132, 0x0139, 0x014a, 0x0179, 0x0182, 0x0187, 0x018b, 0x0191, 0x0198,
   0x01a0, 0x01a7, 0x01ac, 0x01af, 0x01b3, 0x01b8, 0x01bc, 0x01cd, 0x01de, 0x01f4,
@@ -49,7 +49,7 @@ static const uint16_t jerry_character_pair_ranges[] JERRY_CONST_DATA =
 };
 
 /* Interval lengths of start points in `character_pair_ranges` table. */
-static const uint8_t jerry_character_pair_range_lengths[] JERRY_CONST_DATA =
+static const uint8_t lit_character_pair_range_lengths[] JERRY_CONST_DATA =
 {
   0x0030, 0x0006, 0x0010, 0x002e, 0x0006, 0x0004, 0x0002, 0x0002, 0x0002, 0x0002,
   0x0006, 0x0002, 0x0002, 0x0002, 0x0004, 0x0002, 0x0002, 0x0010, 0x0012, 0x0002,
@@ -60,7 +60,7 @@ static const uint8_t jerry_character_pair_range_lengths[] JERRY_CONST_DATA =
 };
 
 /* Contains lower/upper case bidirectional conversion pairs. */
-static const uint16_t jerry_character_pairs[] JERRY_CONST_DATA =
+static const uint16_t lit_character_pairs[] JERRY_CONST_DATA =
 {
   0x0178, 0x00ff, 0x0181, 0x0253, 0x0186, 0x0254, 0x018e, 0x01dd, 0x018f, 0x0259,
   0x0190, 0x025b, 0x0193, 0x0260, 0x0194, 0x0263, 0x0196, 0x0269, 0x0197, 0x0268,
@@ -80,20 +80,20 @@ static const uint16_t jerry_character_pairs[] JERRY_CONST_DATA =
 /* Contains start points of one-to-two uppercase ranges where the second character
  * is always the same.
  */
-static const uint16_t jerry_upper_case_special_ranges[] JERRY_CONST_DATA =
+static const uint16_t lit_upper_case_special_ranges[] JERRY_CONST_DATA =
 {
   0x1f80, 0x1f08, 0x0399, 0x1f88, 0x1f08, 0x0399, 0x1f90, 0x1f28, 0x0399, 0x1f98,
   0x1f28, 0x0399, 0x1fa0, 0x1f68, 0x0399, 0x1fa8, 0x1f68, 0x0399
 };
 
 /* Interval lengths for start points in `upper_case_special_ranges` table. */
-static const uint8_t jerry_upper_case_special_range_lengths[] JERRY_CONST_DATA =
+static const uint8_t lit_upper_case_special_range_lengths[] JERRY_CONST_DATA =
 {
   0x0007, 0x0007, 0x0007, 0x0007, 0x0007, 0x0007
 };
 
 /* Contains start points of lowercase ranges. */
-static const uint16_t jerry_lower_case_ranges[] JERRY_CONST_DATA =
+static const uint16_t lit_lower_case_ranges[] JERRY_CONST_DATA =
 {
   0x1e96, 0x1e96, 0x1f80, 0x1f80, 0x1f88, 0x1f80, 0x1f90, 0x1f90, 0x1f98, 0x1f90,
   0x1fa0, 0x1fa0, 0x1fa8, 0x1fa0, 0x1fb2, 0x1fb2, 0x1fb6, 0x1fb6, 0x1fc2, 0x1fc2,
@@ -102,14 +102,14 @@ static const uint16_t jerry_lower_case_ranges[] JERRY_CONST_DATA =
 };
 
 /* Interval lengths for start points in `lower_case_ranges` table. */
-static const uint8_t jerry_lower_case_range_lengths[] JERRY_CONST_DATA =
+static const uint8_t lit_lower_case_range_lengths[] JERRY_CONST_DATA =
 {
   0x0005, 0x0008, 0x0008, 0x0008, 0x0008, 0x0008, 0x0008, 0x0003, 0x0002, 0x0003,
   0x0002, 0x0002, 0x0002, 0x0003, 0x0002, 0x0003, 0x0002, 0x0007, 0x0005
 };
 
 /* The remaining lowercase conversions. The lowercase variant can be one-to-three character long. */
-static const uint16_t jerry_lower_case_conversions[] JERRY_CONST_DATA =
+static const uint16_t lit_lower_case_conversions[] JERRY_CONST_DATA =
 {
   0x00df, 0x00df, 0x0149, 0x0149, 0x01c5, 0x01c6, 0x01c8, 0x01c9, 0x01cb, 0x01cc,
   0x01f0, 0x01f0, 0x01f2, 0x01f3, 0x0390, 0x0390, 0x03b0, 0x03b0, 0x03f4, 0x03b8,
@@ -119,13 +119,13 @@ static const uint16_t jerry_lower_case_conversions[] JERRY_CONST_DATA =
 };
 
 /* Number of one-to-one, one-to-two, and one-to-three lowercase conversions. */
-static const uint8_t jerry_lower_case_conversion_counters[] JERRY_CONST_DATA =
+static const uint8_t lit_lower_case_conversion_counters[] JERRY_CONST_DATA =
 {
   0x0016, 0x0001, 0x0000
 };
 
 /* The remaining uppercase conversions. The uppercase variant can be one-to-three character long. */
-static const uint16_t jerry_upper_case_conversions[] JERRY_CONST_DATA =
+static const uint16_t lit_upper_case_conversions[] JERRY_CONST_DATA =
 {
   0x00b5, 0x039c, 0x0130, 0x0130, 0x0131, 0x0049, 0x017f, 0x0053, 0x01c5, 0x01c4,
   0x01c8, 0x01c7, 0x01cb, 0x01ca, 0x01f2, 0x01f1, 0x0345, 0x0399, 0x03c2, 0x03a3,
@@ -156,7 +156,7 @@ static const uint16_t jerry_upper_case_conversions[] JERRY_CONST_DATA =
 };
 
 /* Number of one-to-one, one-to-two, and one-to-three uppercase conversions. */
-static const uint8_t jerry_upper_case_conversion_counters[] JERRY_CONST_DATA =
+static const uint8_t lit_upper_case_conversion_counters[] JERRY_CONST_DATA =
 {
   0x001c, 0x002c, 0x0010
 };

--- a/jerry-core/lit/lit-unicode-ranges.inc.h
+++ b/jerry-core/lit/lit-unicode-ranges.inc.h
@@ -22,7 +22,7 @@
  * The characters covered by these intervals are from
  * the following Unicode categories: Lu, Ll, Lt, Lm, Lo, Nl
  */
-static const uint16_t jerry_unicode_letter_interval_sps[] JERRY_CONST_DATA =
+static const uint16_t lit_unicode_letter_interval_sps[] JERRY_CONST_DATA =
 {
   0x00c0, 0x00d8, 0x00f8, 0x01f8, 0x02c6, 0x02e0, 0x0370, 0x0376, 0x037a, 0x0388,
   0x038e, 0x03a3, 0x03f7, 0x048a, 0x0531, 0x0561, 0x05d0, 0x05f0, 0x0620, 0x066e,
@@ -63,7 +63,7 @@ static const uint16_t jerry_unicode_letter_interval_sps[] JERRY_CONST_DATA =
  * The characters covered by these intervals are from
  * the following Unicode categories: Lu, Ll, Lt, Lm, Lo, Nl
  */
-static const uint8_t jerry_unicode_letter_interval_lengths[] JERRY_CONST_DATA =
+static const uint8_t lit_unicode_letter_interval_lengths[] JERRY_CONST_DATA =
 {
   0x0016, 0x001e, 0x00ff, 0x00c9, 0x000b, 0x0004, 0x0004, 0x0001, 0x0003, 0x0002,
   0x0013, 0x0052, 0x008a, 0x00a5, 0x0025, 0x0026, 0x001a, 0x0002, 0x002a, 0x0001,
@@ -100,12 +100,12 @@ static const uint8_t jerry_unicode_letter_interval_lengths[] JERRY_CONST_DATA =
 
 /**
  * Those unicode letter characters that are not inside any of
- * the intervals specified in jerry_unicode_letter_interval_sps array.
+ * the intervals specified in lit_unicode_letter_interval_sps array.
  *
  * The characters are from the following Unicode categories:
  * Lu, Ll, Lt, Lm, Lo, Nl
  */
-static const uint16_t jerry_unicode_letter_chars[] JERRY_CONST_DATA =
+static const uint16_t lit_unicode_letter_chars[] JERRY_CONST_DATA =
 {
   0x00aa, 0x00b5, 0x00ba, 0x02ec, 0x02ee, 0x037f, 0x0386, 0x038c, 0x0559, 0x06d5,
   0x06ff, 0x0710, 0x07b1, 0x07fa, 0x081a, 0x0824, 0x0828, 0x093d, 0x0950, 0x09b2,
@@ -125,7 +125,7 @@ static const uint16_t jerry_unicode_letter_chars[] JERRY_CONST_DATA =
  * The characters covered by these intervals are from
  * the following Unicode categories: Nd, Mn, Mc, Pc
  */
-static const uint16_t jerry_unicode_non_letter_ident_part_interval_sps[] JERRY_CONST_DATA =
+static const uint16_t lit_unicode_non_letter_ident_part_interval_sps[] JERRY_CONST_DATA =
 {
   0x0300, 0x0483, 0x0591, 0x05c1, 0x05c4, 0x0610, 0x064b, 0x06d6, 0x06df, 0x06e7,
   0x06ea, 0x06f0, 0x0730, 0x07a6, 0x07c0, 0x07eb, 0x0816, 0x081b, 0x0825, 0x0829,
@@ -155,7 +155,7 @@ static const uint16_t jerry_unicode_non_letter_ident_part_interval_sps[] JERRY_C
  * The characters covered by these intervals are from
  * the following Unicode categories: Nd, Mn, Mc, Pc
  */
-static const uint8_t jerry_unicode_non_letter_ident_part_interval_lengths[] JERRY_CONST_DATA =
+static const uint8_t lit_unicode_non_letter_ident_part_interval_lengths[] JERRY_CONST_DATA =
 {
   0x006f, 0x0004, 0x002c, 0x0001, 0x0001, 0x000a, 0x001e, 0x0006, 0x0005, 0x0001,
   0x0003, 0x0009, 0x001a, 0x000a, 0x0009, 0x0008, 0x0003, 0x0008, 0x0002, 0x0004,
@@ -181,12 +181,12 @@ static const uint8_t jerry_unicode_non_letter_ident_part_interval_lengths[] JERR
 /**
  * Those non-letter characters that can be used as a non-first
  * character of an identifier and not included in any of the intervals
- * specified in jerry_unicode_non_letter_ident_part_interval_sps array.
+ * specified in lit_unicode_non_letter_ident_part_interval_sps array.
  *
  * The characters are from the following Unicode categories:
  * Nd, Mn, Mc, Pc
  */
-static const uint16_t jerry_unicode_non_letter_ident_part_chars[] JERRY_CONST_DATA =
+static const uint16_t lit_unicode_non_letter_ident_part_chars[] JERRY_CONST_DATA =
 {
   0x05bf, 0x05c7, 0x0670, 0x0711, 0x09bc, 0x09d7, 0x0a3c, 0x0a51, 0x0a75, 0x0abc,
   0x0b3c, 0x0b82, 0x0bd7, 0x0cbc, 0x0d57, 0x0dca, 0x0dd6, 0x0e31, 0x0eb1, 0x0f35,
@@ -197,7 +197,7 @@ static const uint16_t jerry_unicode_non_letter_ident_part_chars[] JERRY_CONST_DA
 /**
  * Unicode separator character interval starting points from Unicode category: Zs
  */
-static const uint16_t jerry_unicode_separator_char_interval_sps[] JERRY_CONST_DATA =
+static const uint16_t lit_unicode_separator_char_interval_sps[] JERRY_CONST_DATA =
 {
   0x2000
 };
@@ -205,18 +205,18 @@ static const uint16_t jerry_unicode_separator_char_interval_sps[] JERRY_CONST_DA
 /**
  * Unicode separator character interval lengths from Unicode category: Zs
  */
-static const uint8_t jerry_unicode_separator_char_interval_lengths[] JERRY_CONST_DATA =
+static const uint8_t lit_unicode_separator_char_interval_lengths[] JERRY_CONST_DATA =
 {
   0x000b
 };
 
 /**
  * Unicode separator characters that are not in the
- * jerry_unicode_separator_char_intervals array.
+ * lit_unicode_separator_char_intervals array.
  *
  * Unicode category: Zs
  */
-static const uint16_t jerry_unicode_separator_chars[] JERRY_CONST_DATA =
+static const uint16_t lit_unicode_separator_chars[] JERRY_CONST_DATA =
 {
   0x1680, 0x180e, 0x202f, 0x205f, 0x3000
 };

--- a/tools/gen-unicode.py
+++ b/tools/gen-unicode.py
@@ -46,7 +46,7 @@ class UniCodeSource(object):
 
     def add_table(self, table, table_name, table_type, table_descr):
         self.__data.append(table_descr)
-        self.__data.append("static const %s jerry_%s[] JERRY_CONST_DATA =" % (table_type, table_name))
+        self.__data.append("static const %s lit_%s[] JERRY_CONST_DATA =" % (table_type, table_name))
         self.__data.append("{")
         self.__data.append(format_code(table, 1))
         self.__data.append("};")
@@ -198,7 +198,7 @@ def generate_ranges(script_args):
                        "uint16_t",
                        ("/**\n"
                         " * Those unicode letter characters that are not inside any of\n"
-                        " * the intervals specified in jerry_unicode_letter_interval_sps array.\n"
+                        " * the intervals specified in lit_unicode_letter_interval_sps array.\n"
                         " *\n"
                         " * The characters are from the following Unicode categories:\n"
                         " * Lu, Ll, Lt, Lm, Lo, Nl\n"
@@ -232,7 +232,7 @@ def generate_ranges(script_args):
                        ("/**\n"
                         " * Those non-letter characters that can be used as a non-first\n"
                         " * character of an identifier and not included in any of the intervals\n"
-                        " * specified in jerry_unicode_non_letter_ident_part_interval_sps array.\n"
+                        " * specified in lit_unicode_non_letter_ident_part_interval_sps array.\n"
                         " *\n"
                         " * The characters are from the following Unicode categories:\n"
                         " * Nd, Mn, Mc, Pc\n"
@@ -257,7 +257,7 @@ def generate_ranges(script_args):
                        "uint16_t",
                        ("/**\n"
                         " * Unicode separator characters that are not in the\n"
-                        " * jerry_unicode_separator_char_intervals array.\n"
+                        " * lit_unicode_separator_char_intervals array.\n"
                         " *\n"
                         " * Unicode category: Zs\n"
                         " */"))


### PR DESCRIPTION
We should keep the `jerry_` prefix for public API which is either
declared in jerry-core/include or implemented in jerry-core/api.
Moreover, we should also keep the convention to use short
identifiers for componentization within jerry-core, and use these
identifiers as directory names, file name prefixes, and identifier
prefixes.

Therefore, the jerry-core/debugger directory is renamed as
jerry-core/dbg, the files in that directory are renamed to start
with dbg- instead of jerry-debugger-, and all internal identifiers
that started with `jerry_debugger_` got renamed as `dbg_`.

Note: There is a single enum type with all its labels that did not
get renamed: `jerry_debugger_header_type_t`. The very same
`JERRY_DEBUGGER_` identifiers and associated values are used at
other parts of the project, too: in the two debugger client
implementations (HTML/JS, and Python), to make communication
possible. Not renaming those IDs in jerry-core helps keeping these
in sync.

Also, the tools/gen-unicode.py-generated arrays in
jerry-core/lit are renamed to use `lit_` prefix instead of `jerry_`.
