### PR TITLE
Context extension

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -319,8 +319,8 @@ to free the stored pointer when `jerry_cleanup ()` is later called to dispose of
 ```c
 void
 jerry_init_with_user_context (jerry_init_flag_t flags,
-                              jerry_user_context_init_cb init_cb,
-                              jerry_user_context_deinit_cb deinit_cb);
+                              jerry_user_context_init_t init_cb,
+                              jerry_user_context_deinit_t deinit_cb);
 ```
 
 `flags` - combination of various engine configuration flags:

--- a/docs/11.EXT-REFERENCE-CONTEXT.md
+++ b/docs/11.EXT-REFERENCE-CONTEXT.md
@@ -1,0 +1,139 @@
+# Data types
+
+## jerryx_context_slot_t
+
+**Summary**
+
+The structure defining a single slot.
+
+**Prototype**
+
+```c
+typedef struct
+{
+  /** the initialization function */
+  jerry_user_context_init_t init_cb;
+  /** the deinitialization function */
+  jerry_user_context_deinit_t deinit_cb;
+} jerryx_context_slot_t;
+```
+
+**See also**
+
+- [JERRYX_CONTEXT_DEFINE_SLOT](#jerryx_context_define_slot)
+
+# Main functions
+
+## jerryx_context_init
+
+**Summary**
+
+Create a single context. This function can be passed as the second argument to `jerry_init_with_user_context ()`.
+
+**Prototype**
+
+```c
+void *jerryx_context_init (void);
+```
+
+ - return value - a `void *` to be stored in the user context.
+
+**Example**
+
+```c
+#include "jerryscript.h"
+#include "jerryscript-ext/context.h"
+void
+init_with_context(void)
+{
+  jerry_init_with_user_context (JERRY_INIT_EMPTY, jerryx_context_init, jerryx_context_deinit);
+  /* ... */
+  jerry_cleanup();
+}
+```
+
+**See also**
+
+- [jerryx_context_deinit](#jerryx_context_deinit)
+
+
+## jerryx_context_deinit
+
+**Summary**
+
+Free a context. This function iterates over all slots and calls the indicated deinit callback for each slot. This
+function can be passed as the third argument to `jerry_init_with_user_context ()`.
+
+**Prototype**
+
+```c
+void jerryx_context_deinit (void *user_context_p);
+```
+
+ - `user_context_p` - the user context pointer.
+
+**See also**
+
+- [jerryx_context_init](#jerryx_context_init)
+- [JERRYX_CONTEXT_DEFINE_SLOT](#jerryx_context_define_slot)
+
+
+## jerryx_context_get
+
+**Summary**
+
+Retrieve the data stored in a specific slot.
+
+**Prototype**
+
+```c
+void *jerryx_context_get (jerryx_context_slot_t *slot_p);
+```
+
+ - `slot_p` - the slot from which to retrieve the pointer.
+ - return_value - the user data stored at the given slot.
+
+**See also**
+
+- [JERRYX_CONTEXT_SLOT](#jerryx_context_slot)
+
+
+# Helper macros
+
+## JERRYX_CONTEXT_DEFINE_SLOT
+
+**Summary**
+
+Declares a new slot and stores it in the binary's data section named "jerryx_ctx_slots".
+
+**Prototype**
+
+```c
+#define JERRYX_CONTEXT_DEFINE_SLOT(slot_name, init_cb_ptr, deinit_cb_ptr)
+```
+
+ - `slot_name` - the suffix to be given to the global static variable holding the slot information.
+ - `init_cb_ptr` - the function pointer for the slot initializer.
+ - `deinit_cb_ptr` - the function pointer for the slot deinitializer.
+
+
+## JERRYX_CONTEXT_SLOT
+
+**Summary**
+
+Refer to a previously declared slot. Calls `jerryx_context_get ()` with a pointer to the structure stored in the global
+variable whose prefix is provided in the macro's first argument. This means that `JERRYX_CONTEXT_DEFINE_SLOT ()` must
+appear earlier in the file to define the slot first.
+
+**Prototype**
+
+```c
+#define JERRYX_CONTEXT_SLOT(slot_name)
+```
+ - `slot_name` - suffix of the global static variable. This is the same prefix that was given to
+   `JERRYX_CONTEXT_DEFINE_SLOT`.
+
+**See also**
+
+- [jerryx_context_get](#jerryx_context_get)
+- [JERRYX_CONTEXT_DEFINE_SLOT](#jerryx_context_define_slot)

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -196,6 +196,11 @@ jerry_cleanup (void)
 {
   jerry_assert_api_available ();
 
+  if (JERRY_CONTEXT (user_context_deinit_cb))
+  {
+    JERRY_CONTEXT (user_context_deinit_cb) (JERRY_CONTEXT (user_context_p));
+  }
+
   ecma_finalize ();
 
 #ifdef JERRY_DEBUGGER
@@ -207,11 +212,6 @@ jerry_cleanup (void)
 
   jmem_finalize ();
   jerry_make_api_unavailable ();
-
-  if (JERRY_CONTEXT (user_context_deinit_cb))
-  {
-    JERRY_CONTEXT (user_context_deinit_cb) (JERRY_CONTEXT (user_context_p));
-  }
 } /* jerry_cleanup */
 
 /**

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -21,10 +21,12 @@ set(INCLUDE_EXT "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 # Source directories
 file(GLOB SOURCE_EXT_ARG      arg/*.c)
+file(GLOB SOURCE_EXT_CONTEXT  context/*.c)
 file(GLOB SOURCE_EXT_HANDLER  handler/*.c)
 
 set(SOURCE_EXT
     ${SOURCE_EXT_ARG}
+    ${SOURCE_EXT_CONTEXT}
     ${SOURCE_EXT_HANDLER})
 
 add_library(${JERRY_EXT_NAME} STATIC ${SOURCE_EXT})

--- a/jerry-ext/context/context.c
+++ b/jerry-ext/context/context.c
@@ -1,0 +1,97 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include "jerryscript-ext/context.h"
+#include "jmem.h"
+
+static int jerryx_context_slot_count = -1;
+
+/* The section name must not exceed 16 characters on __MACH__, hence the abbreviation "ctx" */
+JERRYX_SECTION_DECLARE (jerryx_ctx_slots, jerryx_context_slot_t)
+
+/**
+ * Create a new context. This function can be passed to jerry_init_with_user_context () as its second parameter.
+ *
+ * @return the pointer to store as the user context.
+ */
+void *
+jerryx_context_init (void)
+{
+  void **ret_pp;
+  int index;
+  size_t context_size;
+  const jerryx_context_slot_t *slot_p = NULL;
+
+  if (jerryx_context_slot_count < 0)
+  {
+    jerryx_context_slot_count = (int) (__stop_jerryx_ctx_slots - __start_jerryx_ctx_slots);
+  }
+
+  context_size = ((size_t) jerryx_context_slot_count) * sizeof (void *);
+  ret_pp = (void **) jmem_heap_alloc_block (context_size);
+  memset (ret_pp, 0, context_size);
+
+  for JERRYX_SECTION_ITERATE (jerryx_ctx_slots, index, slot_p)
+  {
+    ret_pp[index] = slot_p->init_cb ();
+  }
+
+  return ((void *) ret_pp);
+} /* jerryx_context_init */
+
+/**
+ * Free a context. This function can be passed to jerry_init_with_user_context () as its third parameter.
+ */
+void
+jerryx_context_deinit (void *user_context_p) /**< user context to deinit */
+{
+  if (user_context_p)
+  {
+    int index;
+    const jerryx_context_slot_t *slot_p = NULL;
+    void **slots_p = (void **) user_context_p;
+
+    for JERRYX_SECTION_ITERATE (jerryx_ctx_slots, index, slot_p)
+    {
+      if (slot_p->deinit_cb)
+      {
+        slot_p->deinit_cb (slots_p[index]);
+      }
+    }
+    jmem_heap_free_block (slots_p, ((size_t) jerryx_context_slot_count) * sizeof (void *));
+  }
+} /* jerryx_context_deinit */
+
+/**
+ * Request the slot at the given index.
+ *
+ * @return the user data that was created in the given slot when the context was initialized.
+ */
+void *
+jerryx_context_get (const jerryx_context_slot_t *slot_p) /**< the slot from which to retrieve the data */
+{
+  int slot = (int) (slot_p - __start_jerryx_ctx_slots);
+  void **slots_p = (void **) jerry_get_user_context ();
+
+#ifndef JERRY_NDEBUG
+  if (jerryx_context_slot_count < 0 || !slots_p || slot < 0 || slot >= jerryx_context_slot_count)
+  {
+    jerry_port_fatal (ERR_FAILED_INTERNAL_ASSERTION);
+  }
+#endif /* !JERRY_NDEBUG */
+
+  return slots_p[slot];
+} /* jerryx_context_get */

--- a/jerry-ext/include/jerryscript-ext/context.h
+++ b/jerry-ext/include/jerryscript-ext/context.h
@@ -1,0 +1,75 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYX_CONTEXT_H
+#define JERRYX_CONTEXT_H
+
+#include "jerryscript.h"
+#include "jerryscript-ext/section.impl.h"
+
+/**
+ * Function to pass to jerry_init_with_user_context() as its second parameter
+ */
+void *jerryx_context_init (void);
+
+/**
+ * Function to pass to jerry_init_with_user_context() as its third parameter
+ */
+void jerryx_context_deinit (void *user_context_p);
+
+/**
+ * Definition of a context slot.
+ */
+typedef struct
+{
+  jerry_user_context_init_t init_cb; /**< the initialization function */
+  jerry_user_context_deinit_t deinit_cb; /**< the deinitialization function */
+} jerryx_context_slot_t;
+
+/**
+ * Define a slot.
+ *
+ * Use this macro at the global level in a source file to define a slot. Afterwards you can use JERRYX_CONTEXT_SLOT
+ * further down in the same file to retrieve the contents of the slot from the user context.
+ *
+ * @param slot_name the suffix to be given to the global static variable holding the slot definition.
+ * @param init_cb_ptr a pointer to a function of type jerry_user_context_init_t to be called when initializing a slot.
+ * @param deinit_cb_ptr a pointer to a function of type jerry_user_context_deinit_t to be called when freeing a slot.
+ */
+#define JERRYX_CONTEXT_DEFINE_SLOT(slot_name, init_cb_ptr, deinit_cb_ptr)                                             \
+  static const jerryx_context_slot_t __jerryx_context_slot_ ## slot_name JERRYX_SECTION_ATTRIBUTE(jerryx_ctx_slots) = \
+  {                                                                                                                   \
+    .init_cb = (init_cb_ptr),                                                                                         \
+    .deinit_cb = (deinit_cb_ptr)                                                                                      \
+  };
+
+/**
+ * Retrieve the contents of a slot.
+ *
+ * This function is best called via the macro JERRYX_CONTEXT_SLOT.
+ */
+void *jerryx_context_get (const jerryx_context_slot_t *slot_p);
+
+/**
+ * Retrieve the contents of a slot.
+ *
+ * Calls jerryx_context_get () with a pointer to the structure declared earlier using JERRYX_CONTEXT_DEFINE_SLOT ().
+ *
+ * @param slot_name the name of the slot without quotes.
+ */
+#define JERRYX_CONTEXT_SLOT(slot_name) \
+  (jerryx_context_get (&(__jerryx_context_slot_ ## slot_name)))
+
+#endif /* !JERRYX_CONTEXT_H */

--- a/jerry-ext/include/jerryscript-ext/section.impl.h
+++ b/jerry-ext/include/jerryscript-ext/section.impl.h
@@ -1,0 +1,84 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYX_SECTION_IMPL_H
+#define JERRYX_SECTION_IMPL_H
+
+/**
+ * Define the name of a section
+ *
+ * @param name the name of the section without quotes
+ */
+#ifdef __MACH__
+#define JERRYX_SECTION_NAME(name) "__DATA," #name
+#else /* !__MACH__ */
+#define JERRYX_SECTION_NAME(name) #name
+#endif /* __MACH__ */
+
+/**
+ * Expands to the proper __attribute__(()) qualifier for appending a variable to a section.
+ */
+#define JERRYX_SECTION_ATTRIBUTE(name) \
+  __attribute__ ((used, section (JERRYX_SECTION_NAME (name)), aligned (sizeof (void *))))
+
+/**
+ * Declare references to a section that contains an array of items.
+ *
+ * @param name the name of the section (without quotes)
+ * @param type the type of the elements stored in the array
+ *
+ * This macro needs to be placed before any occurrence of JERRYX_SECTION_ITERATE, for a given section.
+ */
+#ifdef __MACH__
+#define JERRYX_SECTION_DECLARE(name, type)                                   \
+  extern const type __start_ ## name[] __asm("section$start$__DATA$" #name); \
+  extern const type __stop_ ## name[] __asm("section$end$__DATA$" #name);
+#else /* !__MACH__ */
+#define JERRYX_SECTION_DECLARE(name, type)                    \
+  extern const type __start_ ## name[] __attribute__((weak)); \
+  extern const type __stop_ ## name[] __attribute__((weak));
+#endif /* __MACH__ */
+
+/**
+ * Produces the for loop header for iterating over items in an array stored in a section
+ *
+ * @param name is the name of the section without quotes.
+ * @param index is the name of a variable declared in the scope to be used as the index into the array.
+ * @param item_p is a variable to be used as a pointer to an item in the array.
+ *
+ * The macro assumes that JERRYX_SECTION_DECLARE was used at the top of the file to make the section available.
+ *
+ * The macro is to be succeeded by the body of a for-loop. Inside the body of the loop, the macro sets @p index and
+ * @p item_p as follows:
+ *
+ * @p index will be set to the index of the current item.
+ * @p item_p will point to the current item.
+ *
+ * Usage example:
+ * @code
+ * int index;
+ * widget_t *current_widget_p;
+ * for JERRYX_SECTION_ITERATE (widget_array, index, current_widget_p)
+ * {
+ *    printf("widget %d in the array has name %s\n", index, current_widget_p->name);
+ * }
+ * @endcode
+ */
+#define JERRYX_SECTION_ITERATE(name, index, item_p) \
+  (index = 0, item_p = &__start_ ## name[index];    \
+  &__start_ ## name[index] < __stop_ ## name;       \
+  index++, item_p = &__start_ ## name[index])
+
+#endif /* !JERRYX_SECTION_IMPL_H */

--- a/tests/unit-ext/jerry-context-test.c
+++ b/tests/unit-ext/jerry-context-test.c
@@ -1,0 +1,69 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "test-common.h"
+#include "jerryscript-ext/context.h"
+
+static char *static_slot1 = "static slot 1";
+static char *static_slot2 = "static slot 2";
+
+static int deinit_called_count = 0;
+
+static void *
+init_slot1 (void)
+{
+  return static_slot1;
+} /* init_slot1 */
+
+static void
+deinit_slot1 (void *slot)
+{
+  TEST_ASSERT (slot == static_slot1);
+  deinit_called_count++;
+} /* deinit_slot1 */
+
+JERRYX_CONTEXT_DEFINE_SLOT (slot1, init_slot1, deinit_slot1)
+
+static void *
+init_slot2 (void)
+{
+  return static_slot2;
+} /* init_slot2 */
+
+static void
+deinit_slot2 (void *slot)
+{
+  TEST_ASSERT (slot == static_slot2);
+  deinit_called_count++;
+} /* deinit_slot2 */
+
+JERRYX_CONTEXT_DEFINE_SLOT (slot2, init_slot2, deinit_slot2)
+
+int
+main (int argc, char **argv)
+{
+  (void) argc;
+  (void) argv;
+
+  jerry_init_with_user_context (JERRY_INIT_EMPTY, jerryx_context_init, jerryx_context_deinit);
+
+  TEST_ASSERT (JERRYX_CONTEXT_SLOT (slot1) == static_slot1);
+  TEST_ASSERT (JERRYX_CONTEXT_SLOT (slot2) == static_slot2);
+
+  jerry_cleanup ();
+
+  TEST_ASSERT (deinit_called_count == 2);
+} /* main */


### PR DESCRIPTION
Move the arg extension into a static library of its own and turn it off by default.

Call user context deinit before context deinit, because the user context deinit needs a still-functioning context.

Add the context extension and turn it off by default.