### PR TITLE
Set JERRY_JS_PARSER to 1 in mbed_app.json

### DIFF
--- a/targets/mbedos5/mbed_app.json
+++ b/targets/mbedos5/mbed_app.json
@@ -4,5 +4,5 @@
             "target.uart_hwfc": 0
         }
     },
-    "macros": ["JERRY_JS_PARSER"]
+    "macros": ["JERRY_JS_PARSER 1"]
 }


### PR DESCRIPTION
If you use make in the mbedos5 target, there is a compile error cause the JERRY_JS_PARSER has no value.

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu