### PR TITLE
Add pending breakpoints feature to python Debugger client

### DIFF
--- a/tests/debugger/do_help.expected
+++ b/tests/debugger/do_help.expected
@@ -4,7 +4,8 @@ Stopped at tests/debugger/do_help.js:15
 
 Documented commands (type help <topic>):
 ========================================
-b          break  c         delete  e     exception  list  next  s    step
-backtrace  bt     continue  dump    eval  help       n     quit  src
+b          bt        delete  eval       help  next        s   
+backtrace  c         dump    exception  list  pendingdel  src 
+break      continue  e       fbreak     n     quit        step
 
 (jerry-debugger) quit

--- a/tests/debugger/do_pending_breakpoints.cmd
+++ b/tests/debugger/do_pending_breakpoints.cmd
@@ -1,0 +1,6 @@
+fbreak f
+list pending
+n
+n
+c
+c

--- a/tests/debugger/do_pending_breakpoints.expected
+++ b/tests/debugger/do_pending_breakpoints.expected
@@ -1,0 +1,16 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_pending_breakpoints.js:15
+(jerry-debugger) fbreak f
+Breakpoint not found
+Pending breakpoint added
+(jerry-debugger) list pending
+0: f
+(jerry-debugger) n
+Stopped at tests/debugger/do_pending_breakpoints.js:17
+(jerry-debugger) n
+Breakpoint 1 at <unknown>:1 (in f() at line:1, col:1)
+Stopped at tests/debugger/do_pending_breakpoints.js:19
+(jerry-debugger) c
+Stopped at breakpoint:1 <unknown>:1 (in f() at line:1, col:1)
+(jerry-debugger) c
+Connection closed.

--- a/tests/debugger/do_pending_breakpoints.js
+++ b/tests/debugger/do_pending_breakpoints.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+print("pending-breakpoints");
+
+eval("function f(){ return 5 }");
+
+var bird = "colibri";
+f();
+var a = 234;

--- a/tests/debugger/do_pending_list.cmd
+++ b/tests/debugger/do_pending_list.cmd
@@ -1,0 +1,6 @@
+fbreak do_pending_breakpoints.js:50
+fbreak do_pending_breakpoints.js:235532
+fbreak do_pending_breakpoints.js:2145
+n
+list pending
+c

--- a/tests/debugger/do_pending_list.expected
+++ b/tests/debugger/do_pending_list.expected
@@ -1,0 +1,18 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_pending_list.js:15
+(jerry-debugger) fbreak do_pending_breakpoints.js:50
+Breakpoint not found
+Pending breakpoint added
+(jerry-debugger) fbreak do_pending_breakpoints.js:235532
+Breakpoint not found
+Pending breakpoint added
+(jerry-debugger) fbreak do_pending_breakpoints.js:2145
+Breakpoint not found
+Pending breakpoint added
+(jerry-debugger) n
+Stopped at tests/debugger/do_pending_list.js:17
+(jerry-debugger) list pending
+0: 50
+1: 235532
+2: 2145
+(jerry-debugger) c

--- a/tests/debugger/do_pending_list.js
+++ b/tests/debugger/do_pending_list.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+print("pending breakpoints list");
+
+var x = 10;
+var y = 10;
+var pi = 3.14;
+var z = x + y;


### PR DESCRIPTION
 - Support to add pending breakpoints
 - Add fbreak command for the prompt
 - Manage this breakpoints
 - Add tests for it

JerryScript-DCO-1.0-Signed-off-by: Levente Orban orbanl@inf.u-szeged.hu