### PR TITLE
Use external print handler in riot-stm32f4 target

### DIFF
--- a/targets/riot-stm32f4/Makefile
+++ b/targets/riot-stm32f4/Makefile
@@ -37,14 +37,14 @@ CFLAGS += -DDEVELHELP
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
-INCLUDES += -I$(JERRYDIR)/jerry-core/include
+INCLUDES += -I$(JERRYDIR)/jerry-core/include -I$(JERRYDIR)/jerry-ext/include
 
 # Add the shell and some shell commands
 USEMODULE += shell
 USEMODULE += shell_commands
 
 # Add the jerry libs
-USEMODULE += libjerrycore libjerryport-minimal
+USEMODULE += libjerrycore libjerryport-minimal libjerryext
 
 
 include $(RIOTBASE)/Makefile.include

--- a/targets/riot-stm32f4/Makefile.riot
+++ b/targets/riot-stm32f4/Makefile.riot
@@ -42,9 +42,10 @@ libjerry:
 	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
-	make -C$(BUILD_DIR) jerry-core jerry-port-default-minimal
+	make -C$(BUILD_DIR) jerry-core jerry-port-default-minimal jerry-ext
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(COPYTARGET)/libjerrycore.a
 	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(COPYTARGET)/libjerryport-minimal.a
+	cp $(BUILD_DIR)/lib/libjerry-ext.a $(COPYTARGET)/libjerryext.a
 
 
 riot-jerry: libjerry

--- a/targets/riot-stm32f4/source/main-riotos.c
+++ b/targets/riot-stm32f4/source/main-riotos.c
@@ -17,6 +17,30 @@
 #include <string.h>
 #include "shell.h"
 #include "jerryscript.h"
+#include "jerryscript-ext/handler.h"
+
+/**
+ * Standalone Jerry exit codes
+ */
+#define JERRY_STANDALONE_EXIT_CODE_OK   (0)
+#define JERRY_STANDALONE_EXIT_CODE_FAIL (1)
+
+/**
+ * Register a JavaScript function in the global object.
+ */
+static void
+register_js_function (const char *name_p, /**< name of the function */
+                      jerry_external_handler_t handler_p) /**< function callback */
+{
+  jerry_value_t result_val = jerryx_handler_register_global ((const jerry_char_t *) name_p, handler_p);
+
+  if (jerry_value_has_error_flag (result_val))
+  {
+    printf ("Warning: failed to register '%s' method.", name_p);
+  }
+
+  jerry_release_value (result_val);
+} /* register_js_function */
 
 /**
  * Jerryscript simple test
@@ -26,13 +50,44 @@ int test_jerry (int argc, char **argv)
   /* Suppress compiler errors */
   (void) argc;
   (void) argv;
+
+  jerry_value_t ret_value = jerry_create_undefined ();
+
   const jerry_char_t script[] = "print ('Hello, World!');";
+  size_t script_size = strlen ((const char *) script);
   printf ("This test run the following script code: [%s]\n\n", script);
 
-  size_t script_size = strlen ((const char *) script);
-  bool ret_value = jerry_run_simple (script, script_size, JERRY_INIT_EMPTY);
+  /* Initialize engine */
+  jerry_init (JERRY_INIT_EMPTY);
 
-  return (ret_value ? 1 : 0);
+  /* Register the print function in the global object. */
+  register_js_function ("print", jerryx_handler_print);
+
+  /* Setup Global scope code */
+  ret_value = jerry_parse (script, script_size, false);
+
+  if (!jerry_value_has_error_flag (ret_value))
+  {
+    /* Execute the parsed source code in the Global scope */
+    ret_value = jerry_run (ret_value);
+  }
+
+  int ret_code = JERRY_STANDALONE_EXIT_CODE_OK;
+
+  if (jerry_value_has_error_flag (ret_value))
+  {
+    printf ("Script Error!");
+
+    ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
+  }
+
+  jerry_release_value (ret_value);
+
+  /* Cleanup engine */
+  jerry_cleanup ();
+
+  return ret_code;
+
 } /* test_jerry */
 
 const shell_command_t shell_commands[] = {


### PR DESCRIPTION
Extend example code with registering the `print` function in the global object.
