### PR TITLE
Include jerry-ext/handler only in nuttx-stm32f4 target

### DIFF
--- a/targets/nuttx-stm32f4/Makefile
+++ b/targets/nuttx-stm32f4/Makefile
@@ -60,7 +60,7 @@ jerry_libm_allin.c:
 
 .PHONY: jerry_ext_allin.c
 jerry_ext_allin.c:
-	find $(ROOT_DIR)/jerryscript/jerry-ext -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' > jerry_ext_allin.c
+	find $(ROOT_DIR)/jerryscript/jerry-ext/handler -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' > jerry_ext_allin.c
 
 ASRCS = setjmp.S
 CSRCS = jerry_core_allin.c jerry_libm_allin.c jerry_ext_allin.c


### PR DESCRIPTION
I included jerry-ext/handler only, rather than including all in jerry-ext.
Currently only handler is used in nuttx-stm32f4 repl.
nuttx.bin binary size is reduced from 231576 to 230456 bytes.

JerryScript-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com