### PR TITLE
Tracking variables to reduce the memory consumption of scope chain.

### DIFF
--- a/jerry-core/parser/js/common.h
+++ b/jerry-core/parser/js/common.h
@@ -67,10 +67,12 @@ typedef enum
 #define LEXER_FLAG_FUNCTION_NAME 0x08
 /* This local identifier is a function argument. */
 #define LEXER_FLAG_FUNCTION_ARGUMENT 0x10
+/* This local identifier is not used in the current context. */
+#define LEXER_FLAG_UNUSED_IDENT 0x20
 /* No space is allocated for this character literal. */
-#define LEXER_FLAG_SOURCE_PTR 0x20
+#define LEXER_FLAG_SOURCE_PTR 0x40
 /* Initialize this variable after the byte code is freed. */
-#define LEXER_FLAG_LATE_INIT 0x40
+#define LEXER_FLAG_LATE_INIT 0x80
 
 /**
  * Literal data.

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -377,7 +377,7 @@ parser_parse_object_literal (parser_context_t *context_p) /**< context */
     {
       uint32_t status_flags;
       cbc_ext_opcode_t opcode;
-      uint16_t literal_index;
+      uint16_t literal_index, function_literal_index;
       parser_object_literal_item_types_t item_type;
 
       if (context_p->token.type == LEXER_PROPERTY_GETTER)
@@ -404,7 +404,7 @@ parser_parse_object_literal (parser_context_t *context_p) /**< context */
       parser_append_object_literal_item (context_p, literal_index, item_type);
 
       parser_flush_cbc (context_p);
-      lexer_construct_function_object (context_p, status_flags);
+      function_literal_index = lexer_construct_function_object (context_p, status_flags);
 
       parser_emit_cbc_literal (context_p,
                                CBC_PUSH_LITERAL,
@@ -412,7 +412,7 @@ parser_parse_object_literal (parser_context_t *context_p) /**< context */
 
       JERRY_ASSERT (context_p->last_cbc_opcode == CBC_PUSH_LITERAL);
       context_p->last_cbc_opcode = PARSER_TO_EXT_OPCODE (opcode);
-      context_p->last_cbc.value = (uint16_t) (context_p->literal_count - 1);
+      context_p->last_cbc.value = function_literal_index;
 
       lexer_next_token (context_p);
     }
@@ -576,6 +576,7 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
       int literals = 0;
       uint16_t literal1 = 0;
       uint16_t literal2 = 0;
+      uint16_t function_literal_index;
 
       if (context_p->last_cbc_opcode == CBC_PUSH_LITERAL)
       {
@@ -602,7 +603,7 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
         status_flags |= PARSER_RESOLVE_THIS_FOR_CALLS;
       }
 
-      lexer_construct_function_object (context_p, status_flags);
+      function_literal_index = lexer_construct_function_object (context_p, status_flags);
 
       JERRY_ASSERT (context_p->last_cbc_opcode == PARSER_CBC_UNAVAILABLE);
 
@@ -610,20 +611,20 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
       {
         context_p->last_cbc_opcode = CBC_PUSH_TWO_LITERALS;
         context_p->last_cbc.literal_index = literal1;
-        context_p->last_cbc.value = (uint16_t) (context_p->literal_count - 1);
+        context_p->last_cbc.value = function_literal_index;
       }
       else if (literals == 2)
       {
         context_p->last_cbc_opcode = CBC_PUSH_THREE_LITERALS;
         context_p->last_cbc.literal_index = literal1;
         context_p->last_cbc.value = literal2;
-        context_p->last_cbc.third_literal_index = (uint16_t) (context_p->literal_count - 1);
+        context_p->last_cbc.third_literal_index = function_literal_index;
       }
       else
       {
         parser_emit_cbc_literal (context_p,
                                  CBC_PUSH_LITERAL,
-                                 (uint16_t) (context_p->literal_count - 1));
+                                 function_literal_index);
       }
 
       context_p->last_cbc.literal_type = LEXER_FUNCTION_LITERAL;

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -399,7 +399,7 @@ void lexer_expect_object_literal_id (parser_context_t *context_p, bool must_be_i
 void lexer_construct_literal_object (parser_context_t *context_p, lexer_lit_location_t *literal_p,
                                      uint8_t literal_type);
 bool lexer_construct_number_object (parser_context_t *context_p, bool push_number_allowed, bool is_negative_number);
-void lexer_construct_function_object (parser_context_t *context_p, uint32_t extra_status_flags);
+uint16_t lexer_construct_function_object (parser_context_t *context_p, uint32_t extra_status_flags);
 void lexer_construct_regexp_object (parser_context_t *context_p, bool parse_only);
 bool lexer_compare_identifier_to_current (parser_context_t *context_p, const lexer_lit_location_t *right);
 

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -393,7 +393,6 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
   }
 
   name_p = context_p->lit_object.literal_p;
-  context_p->status_flags |= PARSER_NO_REG_STORE;
 
   status_flags = PARSER_IS_FUNCTION | PARSER_IS_CLOSURE;
   if (context_p->lit_object.type != LEXER_LITERAL_OBJECT_ANY)


### PR DESCRIPTION
    function f() {
      var a = [];
      for (var i = 0; i < 100; i++)
        a[i] = {};
      return function () {}
    }

    var a = [];
    for (var i = 0; i < 100; i++)
      a[i] = f();

After this patch the memory consumption of this code is reduced from 191.3Kb to 7.9Kb.

This change is far from simple, so I expecting issues caught by fuzzer, but this is the way to go if we want to support node.js like codes efficiently.
