### PR TITLE
Add `setjmp` and `longjmp` functions for tizenrt-artik05x

### DIFF
--- a/targets/tizenrt-artik05x/apps/jerryscript/Makefile
+++ b/targets/tizenrt-artik05x/apps/jerryscript/Makefile
@@ -100,7 +100,7 @@ EXTRA_LIBS += libjerry-core.a libjerry-libm.a
 LINKLIBS=$(EXTRA_LIBS)
 
 
-ASRCS =
+ASRCS = setjmp.S
 CSRCS =
 MAINSRC = jerry_main.c
 

--- a/targets/tizenrt-artik05x/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik05x/apps/jerryscript/jerry_main.c
@@ -16,12 +16,12 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <setjmp.h>
 
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
 #include "jerryscript-port.h"
 #include "jmem.h"
+#include "setjmp.h"
 
 #include <apps/shell/tash.h> // To register tash command
 
@@ -546,28 +546,3 @@ jerry_register_cmd (void) {
   tash_cmdlist_install(tash_cmds);
   return 0;
 }
-
-/**
- * Compiler built-in setjmp function.
- *
- * @return 0 when called the first time
- *         1 when returns from a longjmp call
- */
-int
-setjmp (jmp_buf buf)
-{
-  return __builtin_setjmp (buf);
-} /* setjmp */
-
-/**
- * Compiler built-in longjmp function.
- *
- * Note:
- *   ignores value argument
- */
-void
-longjmp (jmp_buf buf, int value)
-{
-  /* Must be called with 1. */
-  __builtin_longjmp (buf, 1);
-} /* longjmp */

--- a/targets/tizenrt-artik05x/apps/jerryscript/setjmp.S
+++ b/targets/tizenrt-artik05x/apps/jerryscript/setjmp.S
@@ -1,0 +1,63 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.syntax unified
+
+.macro func _name
+.global \_name
+.type \_name, %function
+\_name:
+.endm
+.macro endfunc _name
+.size \_name, .-\_name
+.endm
+
+/**
+ * setjmp (jmp_buf env)
+ *
+ * See also:
+ *          longjmp
+ *
+ * @return 0 - if returns from direct call,
+ *         nonzero - if returns after longjmp.
+ */
+func setjmp
+  stmia r0!, {r4 - r11, lr}
+  str sp, [r0], #4
+  mov r0, #0
+  bx lr
+endfunc setjmp
+
+/**
+ * longjmp (jmp_buf env, int val)
+ *
+ * Note:
+ *      if val is not 0, then it would be returned from setjmp,
+ *      otherwise - 0 would be returned.
+ *
+ * See also:
+ *          setjmp
+ */
+func longjmp
+  ldmia r0!, {r4 - r11, lr}
+  ldr sp, [r0]
+  add r0, r0, #4
+  mov r0, r1
+  cmp r0, #0
+  bne 1f
+  mov r0, #1
+  1:
+  bx lr
+endfunc longjmp

--- a/targets/tizenrt-artik05x/apps/jerryscript/setjmp.h
+++ b/targets/tizenrt-artik05x/apps/jerryscript/setjmp.h
@@ -1,0 +1,25 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SETJMP_H
+#define SETJMP_H
+
+#include <stdint.h>
+
+typedef uint64_t jmp_buf[14];
+
+int setjmp (jmp_buf env);
+void longjmp (jmp_buf env, int val);
+
+#endif /* !SETJMP_H */


### PR DESCRIPTION
This patch is based on nuttx-stm32f4 implementation.
However, I removed vldm and vstm since artik05x has no FPU.
It fixes the following error on running some testcases under tests/jerry/fail:

System Information:
        Versionarm_dataabort:
        Data abort. PC: 0410d9d8 DFAR: 0a00001d DFSR: 00000008
        up_assert: Assertion failed at file:armv7-r/arm_dataabort.c
        line: 111 task: appmain

JerryScript-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com