### PR TITLE
jerryx_arg: add '\0' when transforming string

### DIFF
--- a/jerry-ext/arg/arg-transform-functions.c
+++ b/jerry-ext/arg/arg-transform-functions.c
@@ -145,15 +145,19 @@ static jerry_value_t
 jerryx_arg_string_common_routine (jerry_value_t js_arg, /**< JS arg */
                                   const jerryx_arg_t *c_arg_p) /**< native arg */
 {
+  jerry_char_t *target_p = (jerry_char_t *) c_arg_p->dest;
+  jerry_size_t target_buf_size = (jerry_size_t) c_arg_p->extra_info;
   jerry_size_t size = jerry_string_to_char_buffer (js_arg,
-                                                   (jerry_char_t *) c_arg_p->dest,
-                                                   (jerry_size_t) c_arg_p->extra_info);
+                                                   target_p,
+                                                   target_buf_size);
 
-  if (size == 0)
+  if (size == 0 || size == target_buf_size)
   {
     return jerry_create_error (JERRY_ERROR_TYPE,
                                (jerry_char_t *) "The size of the buffer is not large enough.");
   }
+
+  target_p[size] = '\0';
 
   return jerry_create_undefined ();
 } /* jerryx_arg_string_common_routine */

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -86,7 +86,7 @@ test_validator1_handler (const jerry_value_t func_obj_val __attribute__((unused)
 
   bool arg1;
   double arg2 = 0.0;
-  char arg3[5] = { 0 };
+  char arg3[5] = "1234";
   jerry_value_t arg4 = jerry_create_undefined ();
 
   jerryx_arg_t mapping[] =
@@ -114,8 +114,7 @@ test_validator1_handler (const jerry_value_t func_obj_val __attribute__((unused)
     TEST_ASSERT (!jerry_value_has_error_flag (is_ok));
     TEST_ASSERT (arg1);
     TEST_ASSERT (arg2 == 10.5);
-    TEST_ASSERT (arg3[0] == 'a' && arg3[1] == 'b'
-                 && arg3[2] == 'c' && arg3[4] == '\0');
+    TEST_ASSERT (strcmp (arg3, "abc") == 0);
     TEST_ASSERT (jerry_value_is_function (arg4));
   }
   else if (validator1_count == 1)
@@ -123,8 +122,7 @@ test_validator1_handler (const jerry_value_t func_obj_val __attribute__((unused)
     TEST_ASSERT (!jerry_value_has_error_flag (is_ok));
     TEST_ASSERT (arg1);
     TEST_ASSERT (arg2 == 10.5);
-    TEST_ASSERT (arg3[0] == 'a' && arg3[1] == 'b'
-                 && arg3[2] == 'c' && arg3[4] == '\0');
+    TEST_ASSERT (strcmp (arg3, "abc") == 0);
     TEST_ASSERT (jerry_value_is_undefined (arg4));
   }
   else


### PR DESCRIPTION
Related issue: #1824

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com