### PR TITLE
Fix character escape in character class parsing of RegExp objects.

### DIFF
--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -363,7 +363,7 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
         return ecma_raise_syntax_error (ECMA_ERR_MSG ("invalid character class, end of string after '\\'"));
       }
 
-      ch = *parser_ctx_p->input_curr_p++;
+      ch = lit_utf8_read_next (&parser_ctx_p->input_curr_p);
 
       if (ch == LIT_CHAR_LOWERCASE_B)
       {
@@ -503,7 +503,7 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
       else if (lit_char_is_octal_digit ((ecma_char_t) ch)
                && ch != LIT_CHAR_0)
       {
-        parser_ctx_p->input_curr_p--;
+        lit_utf8_decr (&parser_ctx_p->input_curr_p);
         ch = (ecma_char_t) re_parse_octal (parser_ctx_p);
       }
     } /* ch == LIT_CHAR_BACKSLASH */

--- a/tests/jerry/regression-test-issue-1830.js
+++ b/tests/jerry/regression-test-issue-1830.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/[\꧿]ౘ/
+
+var r = new RegExp ("[\꧿]ౘ");


### PR DESCRIPTION
Fixes #1830

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com