### PR TITLE
Python debugger source & display command

### DIFF
--- a/tests/debugger/do_display.cmd
+++ b/tests/debugger/do_display.cmd
@@ -1,0 +1,13 @@
+b a
+b b
+b c
+b d
+display
+c
+display 2
+c
+display 5435
+c
+display 0
+c
+c

--- a/tests/debugger/do_display.expected
+++ b/tests/debugger/do_display.expected
@@ -1,0 +1,53 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_display.js:20
+(jerry-debugger) b a
+Breakpoint 1 at tests/debugger/do_display.js:15 (in a() at line:15, col:1)
+(jerry-debugger) b b
+Breakpoint 2 at tests/debugger/do_display.js:16 (in b() at line:16, col:1)
+(jerry-debugger) b c
+Breakpoint 3 at tests/debugger/do_display.js:17 (in c() at line:17, col:1)
+(jerry-debugger) b d
+Breakpoint 4 at tests/debugger/do_display.js:18 (in d() at line:18, col:1)
+(jerry-debugger) display
+Non-negative integer number expected, 0 turns off this function
+(jerry-debugger) c
+Stopped at breakpoint:1 tests/debugger/do_display.js:15 (in a() at line:15, col:1)
+(jerry-debugger) display 2
+(jerry-debugger) c
+Stopped at breakpoint:2 tests/debugger/do_display.js:16 (in b() at line:16, col:1)
+Source: tests/debugger/do_display.js
+  15   function a() { print("hi"); }
+  16 > function b() { print("welcome"); }
+  17   function c() { print("hello"); }
+(jerry-debugger) display 5435
+(jerry-debugger) c
+Stopped at breakpoint:3 tests/debugger/do_display.js:17 (in c() at line:17, col:1)
+Source: tests/debugger/do_display.js
+   1   // Copyright JS Foundation and other contributors, http://js.foundation
+   2   //
+   3   // Licensed under the Apache License, Version 2.0 (the "License");
+   4   // you may not use this file except in compliance with the License.
+   5   // You may obtain a copy of the License at
+   6   //
+   7   //     http://www.apache.org/licenses/LICENSE-2.0
+   8   //
+   9   // Unless required by applicable law or agreed to in writing, software
+  10   // distributed under the License is distributed on an "AS IS" BASIS
+  11   // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  12   // See the License for the specific language governing permissions and
+  13   // limitations under the License.
+  14   
+  15   function a() { print("hi"); }
+  16   function b() { print("welcome"); }
+  17 > function c() { print("hello"); }
+  18   function d() { print("goodbye"); }
+  19   
+  20   a();
+  21   b();
+  22   c();
+  23   d();
+(jerry-debugger) display 0
+(jerry-debugger) c
+Stopped at breakpoint:4 tests/debugger/do_display.js:18 (in d() at line:18, col:1)
+(jerry-debugger) c
+Connection closed.

--- a/tests/debugger/do_display.js
+++ b/tests/debugger/do_display.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function a() { print("hi"); }
+function b() { print("welcome"); }
+function c() { print("hello"); }
+function d() { print("goodbye"); }
+
+a();
+b();
+c();
+d();

--- a/tests/debugger/do_help.expected
+++ b/tests/debugger/do_help.expected
@@ -4,8 +4,9 @@ Stopped at tests/debugger/do_help.js:15
 
 Documented commands (type help <topic>):
 ========================================
-b          bt        delete  eval       help      ms    pendingdel  src 
-backtrace  c         dump    exception  list      n     quit        step
-break      continue  e       fbreak     memstats  next  s         
+b          c         dump       fbreak    ms          quit    step
+backtrace  continue  e          help      n           s     
+break      delete    eval       list      next        source
+bt         display   exception  memstats  pendingdel  src   
 
 (jerry-debugger) quit

--- a/tests/debugger/do_src.cmd
+++ b/tests/debugger/do_src.cmd
@@ -2,7 +2,7 @@ b f
 n
 next
 s
-src
+source 0
 n
 step
 src

--- a/tests/debugger/do_src.expected
+++ b/tests/debugger/do_src.expected
@@ -8,15 +8,12 @@ Stopped at breakpoint:1 tests/debugger/do_src.js:16 (in f() at line:15, col:1)
 Stopped at tests/debugger/do_src.js:20
 (jerry-debugger) s
 Stopped at <unknown>:1
-(jerry-debugger) src
-f = function f() {
-print('F2') }
+(jerry-debugger) source 0
+   1 > f = function f() {
 (jerry-debugger) n
 Stopped at tests/debugger/do_src.js:21
 (jerry-debugger) step
 Stopped at <unknown>:2 (in f() at line:1, col:5)
 (jerry-debugger) src
-f = function f() {
-print('F2') }
 (jerry-debugger) c
 Connection closed.


### PR DESCRIPTION
Reworked source(src) command to display a given range of the code, defaults to 3.
Added display command which does the same as the source, except it displays the source code everytime a breakpoint is hit.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu