### PR TITLE
targets: zephyr: Reinstate "print" function and error printing.

### DIFF
--- a/targets/zephyr/Makefile
+++ b/targets/zephyr/Makefile
@@ -34,7 +34,7 @@ ZEPHYRLIB   = $(ZEPHYR_BASE)/lib
 TARGET_ZEPHYR ?= ./targets/zephyr
 SOURCE_DIR = $(TARGET_ZEPHYR)/src
 
-export JERRY_INCLUDE = $(CURDIR)/jerry-core/include
+export JERRY_INCLUDE = -I$(CURDIR)/jerry-core/include -I$(CURDIR)/jerry-ext/include
 
 MDEF_FILE = $(realpath $(SOURCE_DIR)/../prj.mdef)
 CONF_FILE = $(realpath $(SOURCE_DIR)/../prj.conf)

--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -24,7 +24,7 @@ export BOARD
 TARGET_ZEPHYR ?= ./targets/zephyr
 TARGET_ZEPHYR_SRC_DIR = $(TARGET_ZEPHYR)/src
 
-TYPE  ?= jerry-core
+COMPONENTS  ?= jerry-core jerry-ext
 JERRYHEAP ?= 16
 JERRYPROFILE ?= minimal
 
@@ -61,9 +61,9 @@ EXT_CFLAGS += -D_XOPEN_SOURCE=700
 
 EXT_CFLAGS += -Wno-error=conversion
 
-EXTERNAL_LIB = $(INTERM)/lib/libjerry-core.a
+EXTERNAL_LIB = $(INTERM)/lib/libjerry-core.a $(INTERM)/lib/libjerry-ext.a
 
-LIBS = jerry-core
+LIBS = jerry-core jerry-ext
 
 BUILD_CONFIG = O="$(OUTPUT)" V=$(V) USER_LIBS="$(LIBS)" USER_LIB_INCLUDE_DIR="-L $(CURDIR)/$(INTERM)/lib" TARGET_ZEPHYR=$(TARGET_ZEPHYR)
 
@@ -94,7 +94,7 @@ endif
 	 -DJERRY_LIBC=OFF \
 	 $(EXT_JERRY_FLAGS)
 
-	make -C $(INTERM) $(TYPE)$(VARIETY) V=1
+	make -C $(INTERM) $(COMPONENTS) V=1
 
 $(OUTPUT)/Makefile.export: $(OUTPUT)/include/config/auto.conf
 	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) outputexports

--- a/targets/zephyr/src/Makefile
+++ b/targets/zephyr/src/Makefile
@@ -17,6 +17,6 @@ $(info Compiling application)
 endif
 
 # Adding path for jerry script APIs
-ZEPHYRINCLUDE += -I$(JERRY_INCLUDE)
+ZEPHYRINCLUDE += $(JERRY_INCLUDE)
 
 obj-y += main-zephyr.o getline-zephyr.o jerry-port.o

--- a/targets/zephyr/src/jerry-port.c
+++ b/targets/zephyr/src/jerry-port.c
@@ -72,3 +72,13 @@ jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 
   return true;
 } /* jerry_port_get_time_zone */
+
+/**
+ * Provide the implementation of jerryx_port_handler_print_char.
+ * Uses 'printf' to print a single character to standard output.
+ */
+void
+jerryx_port_handler_print_char (char c) /**< the character to print */
+{
+  printf ("%c", c);
+} /* jerryx_port_handler_print_char */

--- a/targets/zephyr/src/main-zephyr.c
+++ b/targets/zephyr/src/main-zephyr.c
@@ -22,8 +22,27 @@
 #include "getline-zephyr.h"
 
 #include "jerryscript.h"
+#include "jerryscript-port.h"
+#include "jerryscript-ext/handler.h"
 
 static jerry_value_t print_function;
+
+/**
+ * Register a JavaScript function in the global object.
+ */
+static void
+register_js_function (const char *name_p, /**< name of the function */
+                      jerry_external_handler_t handler_p) /**< function callback */
+{
+  jerry_value_t result_val = jerryx_handler_register_global ((const jerry_char_t *) name_p, handler_p);
+
+  if (jerry_value_has_error_flag (result_val))
+  {
+    jerry_port_log (JERRY_LOG_LEVEL_WARNING, "Warning: failed to register '%s' method.", name_p);
+  }
+
+  jerry_release_value (result_val);
+} /* register_js_function */
 
 static int shell_cmd_handler (char *source_buffer)
 {
@@ -69,6 +88,7 @@ void main (void)
 
   zephyr_getline_init ();
   jerry_init (JERRY_INIT_EMPTY);
+  register_js_function ("print", jerryx_handler_print);
   jerry_value_t global_obj_val = jerry_get_global_object ();
 
   jerry_value_t print_func_name_val = jerry_create_string ((jerry_char_t *) "print");


### PR DESCRIPTION
Re-add "print" function following resent refactors when it was moved
from jerry-core to jerry-ext. This is done in particular to keep
detailed messages on errors.

JerryScript-DCO-1.0-Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org