### PR TITLE
target: mbedos5: Update to mbed OS 5.4.5

### DIFF
--- a/targets/mbedos5/Makefile
+++ b/targets/mbedos5/Makefile
@@ -19,9 +19,9 @@
 BOARD=$(subst [mbed] ,,$(shell mbed target))
 HEAPSIZE=16
 
-DEBUG=0
-NO_JS=0
-MBED_VERBOSE=0
+DEBUG?=0
+NO_JS?=0
+MBED_VERBOSE?=0
 
 MBED_CLI_FLAGS=-j0 --source . --source ../../
 

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
@@ -19,6 +19,7 @@
 #include "jerryscript-mbed-drivers/DigitalOut-js.h"
 #include "jerryscript-mbed-drivers/setInterval-js.h"
 #include "jerryscript-mbed-drivers/setTimeout-js.h"
+#include "jerryscript-mbed-drivers/print-js.h"
 #include "jerryscript-mbed-drivers/assert-js.h"
 #include "jerryscript-mbed-drivers/I2C-js.h"
 #include "jerryscript-mbed-drivers/gc-js.h"
@@ -32,6 +33,7 @@ DECLARE_JS_WRAPPER_REGISTRATION (base) {
     REGISTER_GLOBAL_FUNCTION(setTimeout);
     REGISTER_GLOBAL_FUNCTION(clearInterval);
     REGISTER_GLOBAL_FUNCTION(clearTimeout);
+    REGISTER_GLOBAL_FUNCTION(print);
     REGISTER_CLASS_CONSTRUCTOR(DigitalOut);
     REGISTER_CLASS_CONSTRUCTOR(I2C);
     REGISTER_CLASS_CONSTRUCTOR(InterruptIn);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/print-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/print-js.h
@@ -12,17 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _JERRYSCRIPT_MBED_UTIL_LOGGING_H
-#define _JERRYSCRIPT_MBED_UTIL_LOGGING_H
+#ifndef _JERRYSCRIPT_MBED_DRIVERS_PRINT_H
+#define _JERRYSCRIPT_MBED_DRIVERS_PRINT_H
 
-#include "mbed.h"
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
 
-#ifdef DEBUG_WRAPPER
-#define LOG_PRINT(...) printf(__VA_ARGS__)
-#else
-#define LOG_PRINT(...) while(0) { }
-#endif
+DECLARE_GLOBAL_FUNCTION(print);
 
-#define LOG_PRINT_ALWAYS(...) printf(__VA_ARGS__)
-
-#endif  // _JERRYSCRIPT_MBED_UTIL_LOGGING_H
+#endif  // _JERRYSCRIPT_MBED_DRIVERS_PRINT_H

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/print-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/print-js.cpp
@@ -12,17 +12,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _JERRYSCRIPT_MBED_UTIL_LOGGING_H
-#define _JERRYSCRIPT_MBED_UTIL_LOGGING_H
-
 #include "mbed.h"
+#include "jerryscript-mbed-drivers/print-js.h"
 
-#ifdef DEBUG_WRAPPER
-#define LOG_PRINT(...) printf(__VA_ARGS__)
-#else
-#define LOG_PRINT(...) while(0) { }
-#endif
+/**
+ * print (native JavaScript function)
+ *
+ * Print a string over serial (baud rate 115,200)
+ *
+ * @param string String to print
+ */
+DECLARE_GLOBAL_FUNCTION(print) {
+    CHECK_ARGUMENT_COUNT(global, print, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(global, print, 0, string);
 
-#define LOG_PRINT_ALWAYS(...) printf(__VA_ARGS__)
+    jerry_size_t szArg0 = jerry_get_string_size(args[0]);
+    jerry_char_t *sArg0 = (jerry_char_t*) calloc(szArg0 + 1, sizeof(jerry_char_t));
+    jerry_string_to_char_buffer(args[0], sArg0, szArg0);
 
-#endif  // _JERRYSCRIPT_MBED_UTIL_LOGGING_H
+    printf("%s\n", (const char*)sArg0);
+
+    return jerry_create_undefined();
+}

--- a/targets/mbedos5/mbed-os.lib
+++ b/targets/mbedos5/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#d5de476f74dd4de27012eb74ede078f6330dfc3f
+https://github.com/ARMmbed/mbed-os/#8d21974ba35e04c4854e5090c0f8283171664175

--- a/targets/mbedos5/template-mbedignore.txt
+++ b/targets/mbedos5/template-mbedignore.txt
@@ -6,3 +6,4 @@ targets/*
 tests/*
 third-party/*
 tools/*
+jerry-port/default/*


### PR DESCRIPTION
Also ignore the default jerry-port - see also #1847

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com 

Tested programs:

* mbed-js-example on K64F
* mbed-js-repl-example on K64F and DISCO_F429NG
* mbed-js-ble-example on F411RE + IDB04A1