### PR TITLE
Handle negative zero in number multiplication

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1772,7 +1772,9 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             if (-ECMA_INTEGER_MULTIPLY_MAX <= left_integer
                 && left_integer <= ECMA_INTEGER_MULTIPLY_MAX
                 && -ECMA_INTEGER_MULTIPLY_MAX <= right_integer
-                && right_integer <= ECMA_INTEGER_MULTIPLY_MAX)
+                && right_integer <= ECMA_INTEGER_MULTIPLY_MAX
+                && left_value != 0
+                && right_value != 0)
             {
               result = ecma_make_integer_value (left_integer * right_integer);
               break;

--- a/tests/jerry/regression-test-issue-1855.js
+++ b/tests/jerry/regression-test-issue-1855.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert ((1 / 0*(-1)) == -Infinity);
+assert ((1 / 0*1) == Infinity);


### PR DESCRIPTION
Keep sign for zero.
For example, 1 / (0 * (-1)) should be -Infinity, not +Infinity.

JerryScript-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com