### PR TITLE
New extension: module

### DIFF
--- a/docs/11.EXT-REFERENCE-MODULE.md
+++ b/docs/11.EXT-REFERENCE-MODULE.md
@@ -1,0 +1,133 @@
+#  Modules API
+
+## jerryx_module_resolve
+
+**Summary**
+
+Load a copy of a module into the current context or return one that was already loaded if it is found.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerryx_module_resolve (const jerry_char_t *name);
+```
+
+- `name` - the name of the module to load.
+- return value - `jerry_value_t` representing the module that was loaded, or the error that occurred in the process.
+
+
+# Modules data types
+
+## jerryx_module_t
+
+**Summary**
+
+Structure to define a module
+
+**Prototype**
+
+```c
+typedef struct
+{
+  jerry_char_t *name; /**< name of the module */
+  jerry_value_t (*on_resolve)(void); /**< function that returns a new instance of the module */
+} jerryx_module_t;
+```
+
+# Modules helper macros
+
+## JERRYX_MODULE
+
+**Summary**
+
+Helper macro to define a module. Declares a variable of type `jerryx_module_t` as global static and places it into the
+appropriate linker section of the executable.
+
+**Note**: The helper macro must appear at the bottom of a source file, and no semicolon must follow it.
+
+**Prototype**
+```c
+#define JERRYX_MODULE(module_name, on_resolve_cb)
+```
+
+- `module_name` - the name of the module without quotes
+- `on_resolve_cb` - the function that will be called when the module needs to be loaded.
+
+**Example**
+
+```c
+#include "jerryscript.h"
+#include "jerryscript-ext/module.h"
+
+static jerry_value_t
+my_module_on_resolve (void)
+{
+  return jerry_create_external_function (very_useful_function);
+} /* my_module_on_resolve */
+
+/* Note that there is no semicolon at the end of the next line. This is how it must be. */
+JERRYX_MODULE (my_module, my_module_on_resolve)
+```
+
+**See also**
+
+- [jerryx_module_t](#jerryx_module_t)
+
+
+## JERRYX_MODULE_RESOLVER
+
+**Summary**
+
+Define a module resolver. An invocation of this macro is to be followed by the body of a module resolver. The macro
+declares a function of the name given in `cb_name` which accepts a single parameter `const jerry_char_t *name`. It is
+expected that the function returns a non-zero value of type `jerry_value_t` if the resolver is able to associate `name`
+with such a value, or zero if it is not. If the function returns non-zero, it is expected to cache the result so that if
+called again with the same `name`, it will return the same result.
+
+**Prototype**
+
+```c
+JERRYX_MODULE_RESOLVER(cb_name)
+```
+
+- `cb_name` - the name of the module resolver function to declare.
+
+**Example**
+
+```c
+#include <string.h>
+#include "jerryscript.h"
+#include "jerryscript-ext/module.h"
+
+JERRYX_MODULE_RESOLVER (my_resolver)
+{
+  jerry_value_t ret = 0;
+
+  /* This example resolver only knows how to resolve one name: "my_special_module" */
+  if (!strcmp (name, "my_special_module"))
+  {
+    /*
+     * This attempts to retrieve the jerry_value_t that was computed for "my_special_module" during a previous call to
+     * this resolver.
+     */
+    ret = my_special_module_get_cached ();
+
+    /* "my_special_module" has never been loaded in this context before */
+    if (ret == 0)
+    {
+      /* Do the heavy lifting of loading the module for the first time */
+      ret = my_special_module_load_for_the_first_time ();
+
+      /*
+       * Add the module to a cache that will cause my_special_module_get_cached () to return the value of ret on
+       * subsequent calls to this resolver, removing the need to call my_special_module_load_for_the_first_time () in
+       * the future.
+       */
+      my_special_module_cache (ret);
+    }
+  }
+
+  return ret;
+}
+```

--- a/jerry-ext/include/jerryscript-ext/module.h
+++ b/jerry-ext/include/jerryscript-ext/module.h
@@ -1,0 +1,55 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYX_MODULE_H
+#define JERRYX_MODULE_H
+
+#include "jerryscript.h"
+#include "jerryscript-ext/section.impl.h"
+
+/**
+ * Structure to define a module
+ */
+typedef struct
+{
+  jerry_char_t *name; /**< name of the module */
+  jerry_value_t (*on_resolve)(void); /**< function that returns a new instance of the module */
+} jerryx_module_t;
+
+/**
+ * Load a copy of a module into the current context or return one that was already loaded if it is found.
+ */
+jerry_value_t jerryx_module_resolve (const jerry_char_t *name);
+
+/**
+ * Define a module. The section name is cryptic ("jxm") because it has to be less than 16 bytes on Mach-O.
+ */
+#define JERRYX_MODULE(module_name, on_resolve_cb)                        \
+  static jerryx_module_t _module JERRYX_SECTION_ATTRIBUTE(jxm_modules) = \
+  {                                                                      \
+    .name = ((jerry_char_t *)#module_name),                              \
+    .on_resolve = (on_resolve_cb)                                        \
+  };
+
+/**
+ * Define a module resolver. The section name is cryptic ("jxm") because it has to be less than 16 bytes on Mach-O.
+ */
+#define JERRYX_MODULE_RESOLVER(cb_name)                                      \
+  static jerry_value_t cb_name (const jerry_char_t *name);                   \
+  static jerry_value_t (*__static_global_ ## cb_name) (const jerry_char_t *) \
+  JERRYX_SECTION_ATTRIBUTE(jxm_resolvers) = cb_name;                         \
+  static jerry_value_t cb_name (const jerry_char_t *name)
+
+#endif /* !JERRYX_MODULE_H */

--- a/jerry-ext/include/jerryscript-ext/section.impl.h
+++ b/jerry-ext/include/jerryscript-ext/section.impl.h
@@ -1,0 +1,84 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYX_SECTION_IMPL_H
+#define JERRYX_SECTION_IMPL_H
+
+/**
+ * Define the name of a section
+ *
+ * @param name the name of the section without quotes
+ */
+#ifdef __MACH__
+#define JERRYX_SECTION_NAME(name) "__DATA," #name
+#else /* !__MACH__ */
+#define JERRYX_SECTION_NAME(name) #name
+#endif /* __MACH__ */
+
+/**
+ * Expands to the proper __attribute__(()) qualifier for appending a variable to a section.
+ */
+#define JERRYX_SECTION_ATTRIBUTE(name) \
+  __attribute__ ((used, section (JERRYX_SECTION_NAME (name)), aligned (sizeof (void *))))
+
+/**
+ * Declare references to a section that contains an array of items.
+ *
+ * @param name the name of the section (without quotes)
+ * @param type the type of the elements stored in the array
+ *
+ * This macro needs to be placed before any occurrence of JERRYX_SECTION_ITERATE, for a given section.
+ */
+#ifdef __MACH__
+#define JERRYX_SECTION_DECLARE(name, type)                                   \
+  extern const type __start_ ## name[] __asm("section$start$__DATA$" #name); \
+  extern const type __stop_ ## name[] __asm("section$end$__DATA$" #name);
+#else /* !__MACH__ */
+#define JERRYX_SECTION_DECLARE(name, type)                    \
+  extern const type __start_ ## name[] __attribute__((weak)); \
+  extern const type __stop_ ## name[] __attribute__((weak));
+#endif /* __MACH__ */
+
+/**
+ * Produces the for loop header for iterating over items in an array stored in a section
+ *
+ * @param name is the name of the section without quotes.
+ * @param index is the name of a variable declared in the scope to be used as the index into the array.
+ * @param item_p is a variable to be used as a pointer to an item in the array.
+ *
+ * The macro assumes that JERRYX_SECTION_DECLARE was used at the top of the file to make the section available.
+ *
+ * The macro is to be succeeded by the body of a for-loop. Inside the body of the loop, the macro sets @p index and
+ * @p item_p as follows:
+ *
+ * @p index will be set to the index of the current item.
+ * @p item_p will point to the current item.
+ *
+ * Usage example:
+ * @code
+ * int index;
+ * widget_t *current_widget_p;
+ * for JERRYX_SECTION_ITERATE (widget_array, index, current_widget_p)
+ * {
+ *    printf("widget %d in the array has name %s\n", index, current_widget_p->name);
+ * }
+ * @endcode
+ */
+#define JERRYX_SECTION_ITERATE(name, index, item_p) \
+  (index = 0, item_p = &__start_ ## name[index];    \
+  &__start_ ## name[index] < __stop_ ## name;       \
+  index++, item_p = &__start_ ## name[index])
+
+#endif /* !JERRYX_SECTION_IMPL_H */

--- a/jerry-ext/module/module.c
+++ b/jerry-ext/module/module.c
@@ -1,0 +1,225 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jmem.h"
+#include "jerryscript.h"
+#include "jerryscript-ext/module.h"
+
+static const jerry_char_t *module_name_property_name = (jerry_char_t *) "moduleName";
+static const jerry_char_t *on_resolve_absent = (jerry_char_t *) "Module on_resolve () must not be NULL";
+static const jerry_char_t *module_not_found = (jerry_char_t *) "Module not found";
+
+/**
+ * Create an error related to modules
+ *
+ * Creates an error object of the requested type with the additional property "moduleName" the value of which is a
+ * string containing the name of the module that was requested when the error occurred.
+ *
+ * @return the error
+ */
+static jerry_value_t
+jerryx_module_create_error (jerry_error_t error_type, /**< the type of error to create */
+                            const jerry_char_t *message, /**< the error message */
+                            const jerry_char_t *module_name) /**< the module_name */
+{
+  jerry_value_t ret = jerry_create_error (error_type, message);
+  jerry_value_t property_name = jerry_create_string (module_name_property_name);
+  jerry_value_t property_value = jerry_create_string_from_utf8 (module_name);
+  jerry_release_value (jerry_set_property (ret, property_name, property_value));
+  jerry_release_value (property_name);
+  jerry_release_value (property_value);
+  return ret;
+} /* jerryx_module_create_error */
+
+/**
+ * Structure used for caching module instances
+ */
+typedef struct jerryx_module_instance
+{
+  struct jerryx_module_instance *next_p; /**< pointer to next item */
+  jerry_char_t *name; /**< name of item */
+  jerry_value_t exports; /**< The result of the module resolution */
+} jerryx_module_instance_t;
+
+/**
+ * Detach an item from a list
+ *
+ * @instance - the item to detach
+ */
+#define JERRYX_MODULE_INSTANCE_UNLINK(instance) \
+  ((jerryx_module_instance_t *) (instance))->next_p = NULL
+
+/**
+ *  Initialize a dynamically allocated item
+ *
+ * @instance - the item to initialize
+ * @module_name - string representing the module name
+ */
+#define JERRYX_MODULE_INSTANCE_RUNTIME_INIT(instance, module_name) \
+  ((jerryx_module_instance_t *) (instance))->name = (module_name); \
+  JERRYX_MODULE_INSTANCE_UNLINK((instance))
+
+/**
+ * Insert an item into a linked list.
+ */
+static void
+jerryx_module_instance_insert (jerryx_module_instance_t *instance_p, /**< item to insert */
+                               jerryx_module_instance_t **root_pp) /**< pointer to root (as it may change) */
+{
+  if (*root_pp)
+  {
+    instance_p->next_p = (*root_pp);
+  }
+  (*root_pp) = instance_p;
+} /* jerryx_module_instance_insert */
+
+/*
+ * Find an item in a linked list.
+ *
+ * @return the requested item, or NULL if not found
+ */
+static jerryx_module_instance_t *
+jerryx_module_instance_find (jerryx_module_instance_t *root_p, /**< the root of the list */
+                             const jerry_char_t *name) /**< the key item to find */
+{
+  for (;root_p != NULL; root_p = root_p->next_p)
+  {
+    if (!strcmp ((char *) name, ((char *) root_p->name)))
+    {
+      break;
+    }
+  }
+
+  return root_p;
+} /* jerryx_module_instance_find */
+
+/**
+ * Deeply delete a linked list.
+ */
+static void
+jerryx_module_instances_free (jerryx_module_instance_t *root_p) /**< root of the list */
+{
+  jerryx_module_instance_t *next_p = NULL;
+  while (root_p)
+  {
+    next_p = root_p->next_p;
+    jerry_release_value (root_p->exports);
+    jmem_heap_free_block (root_p, sizeof (jerryx_module_instance_t));
+    root_p = next_p;
+  }
+} /* jerryx_module_instances_free */
+
+/**
+ * Deinitialize the module manager extension.
+ */
+static void
+jerryx_module_manager_deinit (void *user_data_p) /**< context pointer to deinitialize */
+{
+  jerryx_module_instances_free (*((jerryx_module_instance_t **) (user_data_p)));
+} /* jerryx_module_manager_deinit */
+
+/**
+ * Declare the context data manager for modules.
+ */
+static const jerry_context_data_manager_t jerryx_module_manager =
+{
+  .init_cb = NULL,
+  .deinit_cb = jerryx_module_manager_deinit,
+  .bytes_needed = sizeof (jerryx_module_instance_t *)
+};
+
+/**
+ * Declare the linker section where module definitions are stored.
+ */
+JERRYX_SECTION_DECLARE (jxm_modules, jerryx_module_t)
+
+/**
+ * Declare and define the default module resolver - one which examines what modules are defined in the above linker
+ * section and loads one that matches the requested name, caching the result for subsequent requests using the context
+ * data mechanism.
+ */
+JERRYX_MODULE_RESOLVER (native_resolver)
+{
+  int index;
+  jerry_value_t ret = 0;
+  const jerryx_module_t *module_p = NULL;
+  jerryx_module_instance_t *instance_p = NULL;
+  jerryx_module_instance_t **instances_pp =
+  (jerryx_module_instance_t **) jerry_get_context_data (&jerryx_module_manager);
+
+  instance_p = jerryx_module_instance_find (*instances_pp, name);
+
+  if (instance_p)
+  {
+    return instance_p->exports;
+  }
+
+  for JERRYX_SECTION_ITERATE (jxm_modules, index, module_p)
+  {
+    if (!strcmp ((char *) module_p->name, (char *) name))
+    {
+      if (module_p->on_resolve)
+      {
+        ret = module_p->on_resolve ();
+        instance_p = (jerryx_module_instance_t *) jmem_heap_alloc_block (sizeof (jerryx_module_instance_t));
+        JERRYX_MODULE_INSTANCE_RUNTIME_INIT (instance_p, module_p->name);
+        instance_p->exports = jerry_acquire_value (ret);
+        jerryx_module_instance_insert (instance_p, instances_pp);
+      }
+      else
+      {
+        ret = jerryx_module_create_error (JERRY_ERROR_TYPE, on_resolve_absent, name);
+      }
+      break;
+    }
+  }
+
+  return ret;
+} /* JERRYX_MODULE_RESOLVER */
+
+/**
+ * Declare the section where we expect to find module resolvers - at least the one above will be there.
+ */
+typedef jerry_value_t (*jerryx_module_resolver_t)(const jerry_char_t *);
+JERRYX_SECTION_DECLARE (jxm_resolvers, jerryx_module_resolver_t)
+
+/**
+ * Resolve a single module using the module resolvers available in the section declared above and load it into the
+ * current context.
+ *
+ * @return a jerry_value_t containing one of the followings:
+ *   - the result of having loaded the module named @p name, or
+ *   - the result of a previous successful load, or
+ *   - an error indicating that something went wrong during the attempt to load the module.
+ */
+jerry_value_t
+jerryx_module_resolve (const jerry_char_t *name) /**< name of the module to load */
+{
+  jerry_value_t ret;
+  int index;
+  const jerryx_module_resolver_t *resolver_p;
+
+  for JERRYX_SECTION_ITERATE (jxm_resolvers, index, resolver_p)
+  {
+    ret = (**resolver_p) (name);
+    if (ret)
+    {
+      return ret;
+    }
+  }
+
+  return jerryx_module_create_error (JERRY_ERROR_COMMON, module_not_found, name);
+} /* jerryx_module_resolve */
+

--- a/tests/unit-ext/CMakeLists.txt
+++ b/tests/unit-ext/CMakeLists.txt
@@ -15,6 +15,8 @@
 cmake_minimum_required (VERSION 2.8.12)
 project (unit-ext C)
 
+set(INCLUDE_UNIT_EXT ${CMAKE_CURRENT_SOURCE_DIR})
+
 # Unit tests main modules
 file(GLOB SOURCE_UNIT_TEST_EXT_MODULES *.c)
 
@@ -34,4 +36,11 @@ foreach(SOURCE_UNIT_TEST_EXT ${SOURCE_UNIT_TEST_EXT_MODULES})
   target_link_libraries(${TARGET_NAME} jerry-ext jerry-core jerry-port-default-minimal)
 
   add_dependencies(unittests-ext ${TARGET_NAME})
+endforeach()
+
+file(GLOB CONTENTS_UNIT_TEST_EXT *)
+foreach(CONTENT_UNIT_TEST_EXT ${CONTENTS_UNIT_TEST_EXT})
+  if(IS_DIRECTORY ${CONTENT_UNIT_TEST_EXT})
+    add_subdirectory(${CONTENT_UNIT_TEST_EXT})
+  endif()
 endforeach()

--- a/tests/unit-ext/module/CMakeLists.txt
+++ b/tests/unit-ext/module/CMakeLists.txt
@@ -13,27 +13,12 @@
 # limitations under the License.
 
 cmake_minimum_required (VERSION 2.8.12)
-set(JERRY_EXT_NAME jerry-ext)
-project (${JERRY_EXT_NAME} C)
+set(JERRYX_MODULE_UNITTEST_NAME unit-test-jerry-module)
+project (${JERRYX_MODULE_UNITTEST_NAME} C)
 
-# Include directories
-set(INCLUDE_EXT "${CMAKE_CURRENT_SOURCE_DIR}/include")
+file(GLOB JERRYX_MODULE_UNIT_TEST_SOURCES *.c)
 
-# Source directories
-file(GLOB SOURCE_EXT_ARG      arg/*.c)
-file(GLOB SOURCE_EXT_MODULE   module/*.c)
-file(GLOB SOURCE_EXT_HANDLER  handler/*.c)
-
-set(SOURCE_EXT
-    ${SOURCE_EXT_ARG}
-    ${SOURCE_EXT_MODULE}
-    ${SOURCE_EXT_HANDLER})
-
-add_library(${JERRY_EXT_NAME} STATIC ${SOURCE_EXT})
-
-target_include_directories(${JERRY_EXT_NAME} PUBLIC ${INCLUDE_EXT})
-
-target_link_libraries(${JERRY_EXT_NAME} jerry-core)
-
-install(TARGETS ${JERRY_EXT_NAME} DESTINATION lib)
-install(DIRECTORY ${INCLUDE_EXT}/ DESTINATION include)
+add_executable(${JERRYX_MODULE_UNITTEST_NAME} ${JERRYX_MODULE_UNIT_TEST_SOURCES})
+set_property(TARGET ${JERRYX_MODULE_UNITTEST_NAME} PROPERTY LINK_FLAGS "${LINKER_FLAGS_COMMON}")
+target_link_libraries(${JERRYX_MODULE_UNITTEST_NAME} jerry-ext jerry-core jerry-port-default-minimal)
+target_include_directories(${JERRYX_MODULE_UNITTEST_NAME} PRIVATE ${INCLUDE_UNIT_EXT})

--- a/tests/unit-ext/module/jerry-module-test.c
+++ b/tests/unit-ext/module/jerry-module-test.c
@@ -1,0 +1,118 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+
+#include "jerryscript.h"
+#include "test-common.h"
+#include "jerryscript-ext/module.h"
+
+const char eval_string1[] = "require ('my_custom_module');";
+
+const char eval_string2[] = "require ('differently-handled-module');";
+
+const char eval_string3[] =
+"(function() {"
+"  var theError;"
+"  try {"
+"    require ('my_broken_module');"
+"  } catch (anError) {"
+"    theError = anError;"
+"  }"
+"  return (((theError.message === 'Module on_resolve () must not be NULL') &&"
+"    (theError.moduleName === 'my_broken_module') &&"
+"    (theError instanceof TypeError)) ? 1 : 0);"
+"}) ();";
+
+const char eval_string4[] =
+"(function() {"
+"  var theError;"
+"  try {"
+"    require ('some_missing_module_xyzzy');"
+"  } catch (anError) {"
+"    theError = anError;"
+"  }"
+"  return (((theError.message === 'Module not found') &&"
+"    (theError.moduleName === 'some_missing_module_xyzzy')) ? 1 : 0);"
+"}) ();";
+
+JERRYX_MODULE_RESOLVER (resolve_differently_handled_module)
+{
+  if (!strcmp ((char *) name, "differently-handled-module"))
+  {
+    return jerry_create_number (29);
+  }
+  return 0;
+} /* JERRYX_MODULE_RESOLVER */
+
+static jerry_value_t
+handle_require (const jerry_value_t js_function,
+                const jerry_value_t this_val,
+                const jerry_value_t args_p[],
+                const jerry_length_t args_count)
+{
+  (void) js_function;
+  (void) this_val;
+  (void) args_count;
+
+  jerry_value_t return_value = 0;
+  jerry_char_t module_name[256] = "";
+  jerry_size_t bytes_copied = 0;
+
+  TEST_ASSERT (args_count == 1);
+  bytes_copied = jerry_string_to_char_buffer (args_p[0], module_name, 256);
+  if (bytes_copied < 256)
+  {
+    module_name[bytes_copied] = 0;
+    return_value = jerryx_module_resolve (module_name);
+  }
+
+  return return_value;
+} /* handle_require */
+
+static void
+eval_one (const char *the_string, double expected_result)
+{
+  jerry_value_t js_eval_result = jerry_eval ((const jerry_char_t *) the_string, strlen (the_string), true);
+  TEST_ASSERT (!jerry_value_has_error_flag (js_eval_result));
+  TEST_ASSERT (jerry_get_number_value (js_eval_result) == expected_result);
+  jerry_release_value (js_eval_result);
+} /* eval_one */
+
+int
+main (int argc, char **argv)
+{
+  (void) argc;
+  (void) argv;
+  jerry_value_t js_global = 0, js_function = 0, js_property_name = 0;
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  js_global = jerry_get_global_object ();
+  js_function = jerry_create_external_function (handle_require);
+  js_property_name = jerry_create_string ((const jerry_char_t *) "require");
+  jerry_set_property (js_global, js_property_name, js_function);
+
+  eval_one (eval_string1, 42);
+  eval_one (eval_string2, 29);
+  eval_one (eval_string3, 1);
+  eval_one (eval_string4, 1);
+
+  jerry_release_value (js_property_name);
+  jerry_release_value (js_function);
+  jerry_release_value (js_global);
+
+  jerry_cleanup ();
+} /* main */

--- a/tests/unit-ext/module/my-broken-module.c
+++ b/tests/unit-ext/module/my-broken-module.c
@@ -1,0 +1,22 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "jerryscript-ext/module.h"
+
+/*
+ * A broken module to test that the loader complains about the absence of on_resolve ()
+ */
+JERRYX_MODULE (my_broken_module, NULL)

--- a/tests/unit-ext/module/my-custom-module.c
+++ b/tests/unit-ext/module/my-custom-module.c
@@ -1,0 +1,25 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "jerryscript-ext/module.h"
+
+static jerry_value_t
+my_custom_module_on_resolve (void)
+{
+  return jerry_create_number (42);
+} /* my_custom_module_on_resolve */
+
+JERRYX_MODULE (my_custom_module, my_custom_module_on_resolve)


### PR DESCRIPTION
This extension provides two facilities: one for registering modules, and
one for registering module resolvers.

A module is defined as a global static structure containing a pointer
to a string which is the name of the module, and a pointer to a function
which will be called when an instance of the module is needed.

A module resolver is a function that accepts a string holding the name
of the module and returns a `jerry_value_t` if the module was found, or
zero if it was not. The resolver is expected to cache the
`jerry_value_t` it returns for a given string such that, if called with
the same string again, it will return the same `jerry_value_t`.

This extension provides a built-in module resolver which attempts to
load and cache modules that follow the above module definition.

Additionally, this extension provides an API for invoking all module
resolvers in sequence to attempt to resolve the name of a single module.
After one resolver returns a non-zero `jerry_value_t`, the API stops
iterating over the remaining resolvers and returns the `jerry_value_t`.
The API will return a `jerry_value_t` containing an error indicating
that the module was not found if it reaches the end of the list of
resolvers. The error it returns has an extra property `"moduleName"` the
value of which is a string containing the name of the module that the
API was asked to resolve.

JerryScript-DCO-1.0-Signed-off-by: Gabriel Schulhof gabriel.schulhof@intel.com