### PR TITLE
Clean up property existence check inconsistencies

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -2767,19 +2767,22 @@ jerry_create_undefined (void);
 
 **Summary**
 
-Checks whether the object or it's prototype objects have the given property.
+Checks whether the object or its prototype objects have the given property.
+
+*Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+is no longer needed.
 
 **Prototype**
 
 ```c
-bool
+jerry_value_t
 jerry_has_property (const jerry_value_t obj_val,
                     const jerry_value_t prop_name_val);
 ```
 
 - `obj_val` - object value
 - `prop_name_val` - property name
-- return value
+- return value - JavaScript boolean value that evaluates to
   - true, if the property exists
   - false, otherwise
 
@@ -2790,8 +2793,10 @@ jerry_has_property (const jerry_value_t obj_val,
   jerry_value_t global_object = jerry_get_global_object ();
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "handler_field");
 
-  bool has_prop = jerry_has_property (global_object, prop_name);
+  jerry_value_t has_prop_js = jerry_has_property (global_object, prop_name);
+  bool has_prop = jerry_get_boolean_value (has_prop_js);
 
+  jerry_release_value (has_prop_js);
   jerry_release_value (prop_name);
   jerry_release_value (global_object);
 }
@@ -2809,17 +2814,20 @@ jerry_has_property (const jerry_value_t obj_val,
 
 Checks whether the object has the given property.
 
+*Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+is no longer needed.
+
 **Prototype**
 
 ```c
-bool
+jerry_value_t
 jerry_has_own_property (const jerry_value_t obj_val,
                         const jerry_value_t prop_name_val);
 ```
 
 - `obj_val` - object value
 - `prop_name_val` - property name
-- return value
+- return value - JavaScript boolean value that evaluates to
   - true, if the property exists
   - false, otherwise
 
@@ -2830,8 +2838,10 @@ jerry_has_own_property (const jerry_value_t obj_val,
   jerry_value_t global_object = jerry_get_global_object ();
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "handler_field");
 
-  bool has_prop = jerry_has_own_property (global_object, prop_name);
+  jerry_value_t has_prop_js = jerry_has_own_property (global_object, prop_name);
+  bool has_prop = jerry_get_boolean_value (has_prop_js);
 
+  jerry_release_value (jas_prop_js);
   jerry_release_value (prop_name);
   jerry_release_value (global_object);
 }

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -1424,7 +1424,7 @@ jerry_substring_to_utf8_char_buffer (const jerry_value_t value, /**< input strin
  * @return true  - if the property exists
  *         false - otherwise
  */
-bool
+jerry_value_t
 jerry_has_property (const jerry_value_t obj_val, /**< object value */
                     const jerry_value_t prop_name_val) /**< property name (string value) */
 {
@@ -1448,7 +1448,7 @@ jerry_has_property (const jerry_value_t obj_val, /**< object value */
  * @return true  - if the property exists
  *         false - otherwise
  */
-bool
+jerry_value_t
 jerry_has_own_property (const jerry_value_t obj_val, /**< object value */
                         const jerry_value_t prop_name_val) /**< property name (string value) */
 {

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -354,8 +354,8 @@ jerry_value_t jerry_create_undefined (void);
 /**
  * General API functions of JS objects.
  */
-bool jerry_has_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
-bool jerry_has_own_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
+jerry_value_t jerry_has_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
+jerry_value_t jerry_has_own_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
 bool jerry_delete_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);
 
 jerry_value_t jerry_get_property (const jerry_value_t obj_val, const jerry_value_t prop_name_val);

--- a/tests/unit-core/test-has-property.c
+++ b/tests/unit-core/test-has-property.c
@@ -1,0 +1,71 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "jerryscript.h"
+#include "test-common.h"
+
+static void
+assert_boolean_and_release (jerry_value_t result, bool expected)
+{
+  TEST_ASSERT (jerry_value_is_boolean (result));
+  TEST_ASSERT (jerry_get_boolean_value (result) == expected);
+  jerry_release_value (result);
+} /* assert_boolean_and_release */
+
+int
+main (void)
+{
+  TEST_INIT ();
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t object = jerry_create_object ();
+  jerry_value_t prop_name = jerry_create_string_from_utf8 ((jerry_char_t *) "something");
+  jerry_value_t prop_value = jerry_create_boolean (true);
+  jerry_value_t proto_object = jerry_create_object ();
+
+  /* Assert that an empty object does not have the property in question */
+  assert_boolean_and_release (jerry_has_property (object, prop_name), false);
+  assert_boolean_and_release (jerry_has_own_property (object, prop_name), false);
+
+  assert_boolean_and_release (jerry_set_prototype (object, proto_object), true);
+
+  /* If the object has a prototype, that still means it doesn't have the property */
+  assert_boolean_and_release (jerry_has_property (object, prop_name), false);
+  assert_boolean_and_release (jerry_has_own_property (object, prop_name), false);
+
+  assert_boolean_and_release (jerry_set_property (proto_object, prop_name, prop_value), true);
+
+  /* After setting the property on the prototype, it must be there, but not on the object */
+  assert_boolean_and_release (jerry_has_property (object, prop_name), true);
+  assert_boolean_and_release (jerry_has_own_property (object, prop_name), false);
+
+  TEST_ASSERT (jerry_delete_property (proto_object, prop_name));
+  assert_boolean_and_release (jerry_set_property (object, prop_name, prop_value), true);
+
+  /* After relocating the property onto the object, it must be there */
+  assert_boolean_and_release (jerry_has_property (object, prop_name), true);
+  assert_boolean_and_release (jerry_has_own_property (object, prop_name), true);
+
+  jerry_release_value (object);
+  jerry_release_value (prop_name);
+  jerry_release_value (prop_value);
+  jerry_release_value (proto_object);
+
+  jerry_cleanup ();
+
+  return 0;
+} /* main */


### PR DESCRIPTION
`jerry_has_property ()` and `jerry_has_own_property ()` are inconsistent
in that they squash their return value into a `bool` when in fact it is
a `jerry_value_t`, thereby giving the wrong impression that a property
is there when it isn't and encouraging the leaking of `jerry_value_t`s
by disguising them as `bool`s.

Fixes https://github.com/jerryscript-project/jerryscript/issues/1859

JerryScript-DCO-1.0-Signed-off-by: Gabriel Schulhof gabriel.schulhof@intel.com