### PR TITLE
[nuttx-stm32f4] Set log level to JERRY_LOG_LEVEL_DEBUG when using show-opcodes

### DIFF
--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -380,6 +380,7 @@ int jerry_main (int argc, char *argv[])
     else if (!strcmp ("--show-opcodes", argv[i]))
     {
       flags |= JERRY_INIT_SHOW_OPCODES | JERRY_INIT_SHOW_REGEXP_OPCODES;
+      jerry_log_level = JERRY_LOG_LEVEL_DEBUG;
     }
     else if (!strcmp ("--log-level", argv[i]))
     {


### PR DESCRIPTION
 It provides detailed output in case of enabled parser byte-code dumps.