### PR TITLE
Hotfix exception argument check

### DIFF
--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -901,8 +901,8 @@ def main():
     if args.display:
         prompt.do_display(args.display)
 
-    if args.exception:
-        prompt.do_exception(args.exception)
+    if args.exception is not None:
+        prompt.do_exception(str(args.exception))
 
     while True:
         if not non_interactive and prompt.cont:


### PR DESCRIPTION
The If case didn't work properly when 0 was given to the --exception option.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu