### PR TITLE
out_native_pointer_p in jerry_get_object_native_pointer can be NULL

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3629,6 +3629,9 @@ The pointer and the type information are previously associated with the object b
         `out_native_pointer_p` is of the expected type, before casting
         and dereferencing `out_native_pointer_p`.
 
+*Note*: `out_native_pointer_p` and `out_native_info_p` can be NULL, and it means the
+        caller doesn't want to get the native_pointer or type infomation.
+
 **Prototype**
 
 ```c

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2100,9 +2100,12 @@ jerry_get_object_native_pointer (const jerry_value_t obj_val, /**< object to get
     return false;
   }
 
-  *out_native_pointer_p = native_pointer_p->data_p;
+  if (out_native_pointer_p != NULL)
+  {
+    *out_native_pointer_p = native_pointer_p->data_p;
+  }
 
-  if (out_native_info_p)
+  if (out_native_info_p != NULL)
   {
     *out_native_info_p = (const jerry_object_native_info_t *) native_pointer_p->u.info_p;
   }


### PR DESCRIPTION
In some cases, user just want to know whether the JS object has native pointer, but doesn't care what the pointer is.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com