### PR TITLE
Rename files under jerry-core/debugger to avoid build fails

### DIFF
--- a/jerry-core/api/jerry-debugger.c
+++ b/jerry-core/api/jerry-debugger.c
@@ -13,9 +13,9 @@
  * limitations under the License.
  */
 
+#include "debugger.h"
 #include "jcontext.h"
 #include "jerryscript.h"
-#include "jerry-debugger.h"
 
 /**
  * Checks whether the debugger is connected.

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 
+#include "debugger.h"
 #include "ecma-alloc.h"
 #include "ecma-array-object.h"
 #include "ecma-builtin-helpers.h"
@@ -32,7 +33,6 @@
 #include "ecma-promise-object.h"
 #include "jcontext.h"
 #include "jerryscript.h"
-#include "jerry-debugger.h"
 #include "js-parser.h"
 #include "re-compiler.h"
 

--- a/jerry-core/debugger/debugger-sha1.c
+++ b/jerry-core/debugger/debugger-sha1.c
@@ -40,7 +40,7 @@
  *  http://www.itl.nist.gov/fipspubs/fip180-1.htm
  */
 
-#include "jerry-debugger.h"
+#include "debugger.h"
 
 #ifdef JERRY_DEBUGGER
 

--- a/jerry-core/debugger/debugger-ws.c
+++ b/jerry-core/debugger/debugger-ws.c
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
+#include "debugger.h"
 #include "jcontext.h"
-#include "jerry-debugger.h"
 #include "jerryscript-port.h"
 
 #ifdef JERRY_DEBUGGER

--- a/jerry-core/debugger/debugger-ws.h
+++ b/jerry-core/debugger/debugger-ws.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef JERRY_DEBUGGER_WS_H
-#define JERRY_DEBUGGER_WS_H
+#ifndef DEBUGGER_WS_H
+#define DEBUGGER_WS_H
 
 #include "ecma-globals.h"
 
@@ -93,4 +93,4 @@ void jerry_debugger_compute_sha1 (const uint8_t *input1, size_t input1_len,
 
 #endif /* JERRY_DEBUGGER */
 
-#endif /* JERRY_DEBUGGER_WS_H */
+#endif /* DEBUGGER_WS_H */

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -14,12 +14,12 @@
  */
 
 #include "byte-code.h"
+#include "debugger.h"
 #include "ecma-builtin-helpers.h"
 #include "ecma-conversion.h"
 #include "ecma-eval.h"
 #include "ecma-objects.h"
 #include "jcontext.h"
-#include "jerry-debugger.h"
 #include "jerryscript-port.h"
 #include "lit-char-helpers.h"
 

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-#ifndef JERRY_DEBUGGER_H
-#define JERRY_DEBUGGER_H
+#ifndef DEBUGGER_H
+#define DEBUGGER_H
 
-#include "jerry-debugger-ws.h"
+#include "debugger-ws.h"
 #include "ecma-globals.h"
 
 #ifdef JERRY_DEBUGGER
@@ -322,4 +322,4 @@ bool jerry_debugger_send_exception_string (ecma_value_t exception_value);
 
 #endif /* JERRY_DEBUGGER */
 
-#endif /* JERRY_DEBUGGER_H */
+#endif /* DEBUGGER_H */

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -19,14 +19,15 @@
 #include "ecma-helpers.h"
 #include "ecma-lcache.h"
 #include "ecma-property-hashmap.h"
-#ifdef JERRY_DEBUGGER
-#include "jcontext.h"
-#include "jerry-debugger.h"
-#endif /* JERRY_DEBUGGER */
 #include "jrt-bit-fields.h"
 #include "byte-code.h"
 #include "re-compiler.h"
 #include "ecma-builtins.h"
+
+#ifdef JERRY_DEBUGGER
+#include "debugger.h"
+#include "jcontext.h"
+#endif /* JERRY_DEBUGGER */
 
 /** \addtogroup ecma ECMA
  * @{

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -19,10 +19,10 @@
 #ifndef JCONTEXT_H
 #define JCONTEXT_H
 
+#include "debugger.h"
 #include "ecma-builtins.h"
 #include "ecma-jobqueue.h"
 #include "jerryscript-port.h"
-#include "jerry-debugger.h"
 #include "jmem.h"
 #include "re-bytecode.h"
 #include "vm-defines.h"

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -19,7 +19,7 @@
 #include "common.h"
 
 #include "byte-code.h"
-#include "jerry-debugger.h"
+#include "debugger.h"
 #include "js-parser.h"
 #include "js-parser-limits.h"
 #include "js-lexer.h"

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
+#include "debugger.h"
 #include "ecma-exceptions.h"
 #include "ecma-helpers.h"
 #include "ecma-literal-storage.h"
 #include "jcontext.h"
-#include "jerry-debugger.h"
 #include "js-parser-internal.h"
 
 #if JERRY_JS_PARSER


### PR DESCRIPTION
Without the file renaming there are two jerry-debugger.c files.
Thus when the jerry-core archive is created there are two objects
in it with the same name. Generally this does not create any problems.
However if the archive is extracted then the second object file
will overwrite the first one which results in undefined reference
linkage error.

The jerry- prefix was removed from the file names and
fixed the include oreders where it was needed.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com