### PR TITLE
Fix gcc 7 fallthrough warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,12 @@ if(ENABLE_STRIP AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
   jerry_add_link_flags(-s)
 endif()
 
+# TODO: Remove workaround for gcc 7 bug if the
+# fallthrough comment detection is fixed.
+if (USING_GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 7.0)
+  jerry_add_compile_flags(-Wno-implicit-fallthrough)
+endif()
+
 # External compiler & linker flags
 if(DEFINED EXTERNAL_COMPILE_FLAGS)
   jerry_add_compile_flags(${EXTERNAL_COMPILE_FLAGS})


### PR DESCRIPTION
 When compiling with gcc 7 the current fallthrough comments
are not accepted. This is a bug in gcc 7.

For now disable the fallthrough comment detection.
Disabling the check does not introduce any risk
as previously it was not enabled by default and
vera++ already check these kind of comments.
