### PR TITLE
add transform_object_properties in jerryx/arg

### DIFF
--- a/docs/09.EXT-REFERENCE-ARG.md
+++ b/docs/09.EXT-REFERENCE-ARG.md
@@ -31,6 +31,30 @@ typedef struct
 - [jerryx_arg_function](#jerryx_arg_function)
 - [jerryx_arg_native_pointer](#jerryx_arg_native_pointer)
 - [jerryx_arg_ignore](#jerryx_arg_ignore)
+- [jerryx_arg_object_properties](#jerryx_arg_object_properties)
+
+## jerryx_arg_object_props_t
+
+**Summary**
+
+The structure is used in `jerryx_arg_object_properties`. It provides the properties' names,
+its corresponding JS-to-C mapping and other related information.
+
+**Prototype**
+
+```c
+typedef struct
+{
+  const jerry_char_t **name_p; /**< property name list of the JS object */
+  jerry_length_t name_cnt; /**< count of the name list */
+  const jerryx_arg_t *c_arg_p; /**< points to the array of transformation steps */
+  jerry_length_t c_arg_cnt; /**< the count of the `c_arg_p` array */
+} jerryx_arg_object_props_t;
+```
+
+**See also**
+
+- [jerryx_arg_object_properties](#jerryx_arg_object_properties)
 
 ## jerryx_arg_transform_func_t
 
@@ -128,7 +152,7 @@ jerryx_arg_transform_this_and_args (const jerry_value_t this_val,
 **Example**
 
 ```c
-// JS signature: function (requiredBool, requiredString, optionalNumber)
+/* JS signature: function (requiredBool, requiredString, optionalNumber) */
 static jerry_value_t my_external_handler (const jerry_value_t function_obj,
                                           const jerry_value_t this_val,
                                           const jerry_value_t args_p[],
@@ -138,10 +162,10 @@ static jerry_value_t my_external_handler (const jerry_value_t function_obj,
   char required_str[16];
   double optional_num = 1234.567;  // default value
 
-  // "mapping" defines the steps to transform input arguments to C variables:
+  /* "mapping" defines the steps to transform input arguments to C variables. */
   const jerryx_arg_t mapping[] =
   {
-    // `this` is the first value. No checking needed on `this` for this function.
+    /* `this` is the first value. No checking needed on `this` for this function. */
     jerryx_arg_ignore (),
 
     jerryx_arg_boolean (&required_bool, JERRYX_ARG_NO_COERCE, JERRYX_ARG_REQUIRED),
@@ -149,22 +173,24 @@ static jerry_value_t my_external_handler (const jerry_value_t function_obj,
     jerryx_arg_number (&optional_num, JERRYX_ARG_NO_COERCE, JERRYX_ARG_OPTIONAL),
   };
 
-  // Validate and transform:
+  /* Validate and transform. */
   const jerry_value_t rv = jerryx_arg_transform_this_and_args (this_val,
                                                                args_p,
                                                                args_count,
                                                                mapping,
-                                                               ARRAY_LENGTH (mapping));
+                                                               4);
 
   if (jerry_value_has_error_flag (rv))
   {
-    // Handle error
+    /* Handle error. */
     return rv;
   }
 
-  // Validated and tranformed successfully!
-  // required_bool, required_str and optional_num can now be used.
-  // ...
+  /*
+   * Validated and transformed successfully!
+   * required_bool, required_str and optional_num can now be used.
+   */
+   ...
 }
 ```
 
@@ -177,6 +203,7 @@ static jerry_value_t my_external_handler (const jerry_value_t function_obj,
 - [jerryx_arg_function](#jerryx_arg_function)
 - [jerryx_arg_native_pointer](#jerryx_arg_native_pointer)
 - [jerryx_arg_custom](#jerryx_arg_custom)
+- [jerryx_arg_object_properties](#jerryx_arg_object_properties)
 
 
 ## jerryx_arg_transform_args
@@ -204,6 +231,41 @@ jerryx_arg_transform_args (const jerry_value_t *js_arg_p,
 **See also**
 
 - [jerryx_arg_transform_this_and_args](#jerryx_arg_transform_this_and_args)
+
+
+## jerryx_arg_transform_object_properties
+
+**Summary**
+
+Validate the properties of a JS object and assign them to the native arguments.
+
+*Note*: This function transforms properties of a single JS object into native C values.
+To transform multiple objects in one pass (for example when converting multiple arguments
+to an external handler), please use `jerryx_arg_object_properties` together with
+`jerryx_arg_transform_this_and_args` or `jerryx_arg_transform_args`.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerryx_arg_transform_object_properties (const jerry_value_t obj_val,
+                                        const jerry_char_t **name_p,
+                                        const jerry_length_t name_cnt,
+                                        const jerryx_arg_t *c_arg_p,
+                                        jerry_length_t c_arg_cnt);
+
+```
+
+ - `obj_val` - the JS object.
+ - `name_p` - points to the array of property names.
+ - `name_cnt` - the count of the `name_p` array.
+ - `c_arg_p` - points to the array of validation/transformation steps
+ - `c_arg_cnt` - the count of the `c_arg_p` array.
+ - return value - a `jerry_value_t` representing `undefined` if all validators passed or an `Error` if a validator failed.
+
+**See also**
+
+- [jerryx_arg_object_properties](#jerryx_arg_object_properties)
 
 
 # Helpers for commonly used validations
@@ -314,7 +376,7 @@ jerryx_arg_function (jerry_value_t *dest,
 **Summary**
 
 Create a validation/transformation step (`jerryx_arg_t`) that expects to
-consume one `Object` JS argument that is 'backed' with a native pointer with
+consume one `object` JS argument that is 'backed' with a native pointer with
 a given type info. In case the native pointer info matches, the transform
 will succeed and the object's native pointer will be assigned to `*dest`.
 
@@ -335,6 +397,94 @@ jerryx_arg_native_pointer (void **dest,
 
 - [jerryx_arg_transform_this_and_args](#jerryx_arg_transform_this_and_args)
 
+## jerryx_arg_object_properties
+
+**Summary**
+
+Create a validation/transformation step (`jerryx_arg_t`) that expects to
+consume one `object` JS argument and call `jerryx_arg_transform_object_properties` inside
+to transform its properties to native arguments.
+User should prepare the `jerryx_arg_object_props_t` instance, and pass it to this function.
+
+**Prototype**
+
+```c
+static inline jerryx_arg_t
+jerryx_arg_object_properties (const jerryx_arg_object_props_t *object_props_p,
+                              jerryx_arg_optional_t opt_flag);
+```
+ - return value - the created `jerryx_arg_t` instance.
+ - `object_props_p` - provides information for properties transform.
+ - `opt_flag` - whether the argument is optional.
+
+**Example**
+
+```c
+/**
+ * The binding function expects args_p[0] is an object, which has 3 properties:
+ *     "enable": boolean
+ *     "data": number
+ *     "extra_data": number, optional
+ */
+static jerry_value_t my_external_handler (const jerry_value_t function_obj,
+                                          const jerry_value_t this_val,
+                                          const jerry_value_t args_p[],
+                                          const jerry_length_t args_count)
+{
+  bool required_bool;
+  double required_num;
+  double optional_num = 1234.567;  // default value
+
+  /* "prop_name_p" defines the name list of the expected properties' names. */
+  const char *prop_name_p[] = { "enable", "data", "extra_data" };
+
+  /* "prop_mapping" defines the steps to transform properties to C variables. */
+  const jerryx_arg_t prop_mapping[] =
+    jerryx_arg_boolean (&required_bool, JERRYX_ARG_COERCE, JERRYX_ARG_REQUIRED),
+    jerryx_arg_number (&required_num, JERRYX_ARG_COERCE, JERRYX_ARG_REQUIRED),
+    jerryx_arg_number (&optional_num, JERRYX_ARG_COERCE, JERRYX_ARG_OPTIONAL)
+  };
+
+  /* Prepare the jerryx_arg_object_props_t instance. */
+  const jerryx_arg_object_props_t prop_info =
+  {
+    .name_p = (const jerry_char_t **) prop_name_p,
+    .name_cnt = 3,
+    .c_arg_p = prop_mapping,
+    .c_arg_cnt = 3
+  };
+
+  /* It is the mapping used in the jerryx_arg_transform_args. */
+  const jerryx_arg_t mapping[] =
+  {
+    jerryx_arg_object_properties (&prop_info, JERRYX_ARG_REQUIRED)
+  };
+
+  /* Validate and transform. */
+  const jerry_value_t rv = jerryx_arg_transform_args (args_p,
+                                                      args_count,
+                                                      mapping,
+                                                      1);
+
+  if (jerry_value_has_error_flag (rv))
+  {
+    /* Handle error. */
+    return rv;
+  }
+
+  /*
+   * Validated and transformed successfully!
+   * required_bool, required_num and optional_num can now be used.
+   */
+   ...
+}
+
+```
+
+ **See also**
+
+- [jerryx_arg_transform_this_and_args](#jerryx_arg_transform_this_and_args)
+- [jerryx_arg_transform_object_properties](#jerryx_arg_transform_object_properties)
 
 # Functions to create custom validations
 

--- a/jerry-ext/arg/arg-transform-functions.c
+++ b/jerry-ext/arg/arg-transform-functions.c
@@ -63,7 +63,7 @@ jerryx_arg_transform_number_strict (jerryx_arg_js_iterator_t *js_arg_iter_p, /**
 } /* jerryx_arg_transform_number_strict */
 
 /**
- * Tranform a JS argument to a double. Type coercion is allowed.
+ * Transform a JS argument to a double. Type coercion is allowed.
  *
  * @return jerry undefined: the transformer passes,
  *         jerry error: the transformer fails.
@@ -251,7 +251,7 @@ jerryx_arg_transform_native_pointer (jerryx_arg_js_iterator_t *js_arg_iter_p, /*
   if (!jerry_value_is_object (js_arg))
   {
     return jerry_create_error (JERRY_ERROR_TYPE,
-                               (jerry_char_t *) "It is not a object.");
+                               (jerry_char_t *) "It is not an object.");
   }
 
   const jerry_object_native_info_t *expected_info_p;
@@ -268,6 +268,27 @@ jerryx_arg_transform_native_pointer (jerryx_arg_js_iterator_t *js_arg_iter_p, /*
 
   return jerry_create_undefined ();
 } /* jerryx_arg_transform_native_pointer */
+
+/**
+ * Check whether the JS object's properties have expected types, and transform them into native args.
+ *
+ * @return jerry undefined: the transformer passes,
+ *         jerry error: the transformer fails.
+ */
+jerry_value_t
+jerryx_arg_transform_object_props (jerryx_arg_js_iterator_t *js_arg_iter_p, /**< available JS args */
+                                   const jerryx_arg_t *c_arg_p) /**< the native arg */
+{
+  jerry_value_t js_arg = jerryx_arg_js_iterator_pop (js_arg_iter_p);
+
+  const jerryx_arg_object_props_t *object_props = (const jerryx_arg_object_props_t *) c_arg_p->extra_info;
+
+  return jerryx_arg_transform_object_properties (js_arg,
+                                                 object_props->name_p,
+                                                 object_props->name_cnt,
+                                                 object_props->c_arg_p,
+                                                 object_props->c_arg_cnt);
+} /* jerryx_arg_transform_object_props */
 
 /**
  * Define transformer for optional argument.
@@ -288,6 +309,7 @@ JERRYX_ARG_TRANSFORM_OPTIONAL (string)
 JERRYX_ARG_TRANSFORM_OPTIONAL (string_strict)
 JERRYX_ARG_TRANSFORM_OPTIONAL (function)
 JERRYX_ARG_TRANSFORM_OPTIONAL (native_pointer)
+JERRYX_ARG_TRANSFORM_OPTIONAL (object_props)
 
 /**
  * Ignore the JS argument.

--- a/jerry-ext/include/jerryscript-ext/arg.h
+++ b/jerry-ext/include/jerryscript-ext/arg.h
@@ -16,7 +16,6 @@
 #ifndef JERRYX_ARG_H
 #define JERRYX_ARG_H
 
-#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -44,6 +43,17 @@ typedef jerry_value_t (*jerryx_arg_transform_func_t) (jerryx_arg_js_iterator_t *
                                                       const jerryx_arg_t *c_arg_p); /**< native arg */
 
 /**
+ * The structure used in jerryx_arg_object_properties
+ */
+typedef struct
+{
+  const jerry_char_t **name_p; /**< property name list of the JS object */
+  jerry_length_t name_cnt; /**< count of the name list */
+  const jerryx_arg_t *c_arg_p; /**< points to the array of transformation steps */
+  jerry_length_t c_arg_cnt; /**< the count of the `c_arg_p` array */
+} jerryx_arg_object_props_t;
+
+/**
  * The structure defining a single validation & transformation step.
  */
 struct jerryx_arg_t
@@ -63,6 +73,12 @@ jerry_value_t jerryx_arg_transform_args (const jerry_value_t *js_arg_p,
                                          const jerry_length_t js_arg_cnt,
                                          const jerryx_arg_t *c_arg_p,
                                          jerry_length_t c_arg_cnt);
+
+jerry_value_t jerryx_arg_transform_object_properties (const jerry_value_t obj_val,
+                                                      const jerry_char_t **name_p,
+                                                      const jerry_length_t name_cnt,
+                                                      const jerryx_arg_t *c_arg_p,
+                                                      jerry_length_t c_arg_cnt);
 
 /**
  * Indicates whether an argument is allowed to be coerced into the expected JS type.
@@ -105,6 +121,8 @@ static inline jerryx_arg_t
 jerryx_arg_ignore (void);
 static inline jerryx_arg_t
 jerryx_arg_custom (void *dest, uintptr_t extra_info, jerryx_arg_transform_func_t func);
+static inline jerryx_arg_t
+jerryx_arg_object_properties (const jerryx_arg_object_props_t *object_props_p, jerryx_arg_optional_t opt_flag);
 
 jerry_value_t
 jerryx_arg_transform_optional (jerryx_arg_js_iterator_t *js_arg_iter_p,

--- a/jerry-ext/include/jerryscript-ext/arg.impl.h
+++ b/jerry-ext/include/jerryscript-ext/arg.impl.h
@@ -51,6 +51,10 @@ jerry_value_t jerryx_arg_transform_native_pointer_optional (jerryx_arg_js_iterat
                                                             const jerryx_arg_t *c_arg_p);
 jerry_value_t jerryx_arg_transform_ignore (jerryx_arg_js_iterator_t *js_arg_iter_p,
                                            const jerryx_arg_t *c_arg_p);
+jerry_value_t jerryx_arg_transform_object_props (jerryx_arg_js_iterator_t *js_arg_iter_p,
+                                                 const jerryx_arg_t *c_arg_p);
+jerry_value_t jerryx_arg_transform_object_props_optional (jerryx_arg_js_iterator_t *js_arg_iter_p,
+                                                          const jerryx_arg_t *c_arg_p);
 
 /**
  * Create a validation/transformation step (`jerryx_arg_t`) that expects to
@@ -213,7 +217,7 @@ jerryx_arg_function (jerry_value_t *dest, /**< pointer to the jerry_value_t wher
 
 /**
  * Create a validation/transformation step (`jerryx_arg_t`) that expects to
- * consume one `Object` JS argument that is 'backed' with a native pointer with
+ * consume one `object` JS argument that is 'backed' with a native pointer with
  * a given type info. In case the native pointer info matches, the transform
  * will succeed and the object's native pointer will be assigned to *dest.
  *
@@ -274,5 +278,33 @@ jerryx_arg_custom (void *dest, /**< pointer to the native argument where the res
     .extra_info = extra_info
   };
 } /* jerryx_arg_custom */
+
+/**
+ * Create a jerryx_arg_t instance for object properties.
+ *
+ * @return a jerryx_arg_t instance.
+ */
+static inline jerryx_arg_t
+jerryx_arg_object_properties (const jerryx_arg_object_props_t *object_props, /**< pointer to object property mapping */
+                              jerryx_arg_optional_t opt_flag) /**< whether the argument is optional */
+{
+  jerryx_arg_transform_func_t func;
+
+  if (opt_flag == JERRYX_ARG_OPTIONAL)
+  {
+    func = jerryx_arg_transform_object_props_optional;
+  }
+  else
+  {
+    func = jerryx_arg_transform_object_props;
+  }
+
+  return (jerryx_arg_t)
+  {
+    .func = func,
+    .dest = NULL,
+    .extra_info = (uintptr_t) object_props
+  };
+} /* jerryx_arg_object_properties */
 
 #endif /* !JERRYX_ARG_IMPL_H */


### PR DESCRIPTION
Add a function in jerryx/arg.
```
jerry_value_t jerryx_arg_transform_object_properties (const jerry_value_t taregt,
                                                      const jerry_char_t **name_p,
                                                      const jerry_length_t name_cnt,
                                                      const jerryx_arg_t *c_arg_p,
                                                      jerry_length_t c_arg_cnt);
```
It will validate the properties of a JS object (by given the prop name list), and convert those properties into native type.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com