### PR TITLE
Add timeout to jerry_debugger_receive

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -181,6 +181,16 @@ if(FEATURE_DEBUGGER)
     message(FATAL_ERROR "This configuration is not supported. Please build against your system libc to enable the JerryScript debugger.")
   endif()
 
+  # Sleep function availability check
+  INCLUDE (CheckIncludeFiles)
+  CHECK_INCLUDE_FILES (time.h HAVE_TIME_H)
+  CHECK_INCLUDE_FILES (unistd.h HAVE_UNISTD_H)
+  if(HAVE_TIME_H)
+    set(DEFINES_JERRY ${DEFINES_JERRY} HAVE_TIME_H)
+  elseif(HAVE_UNISTD_H)
+    set(DEFINES_JERRY ${DEFINES_JERRY} HAVE_UNISTD_H)
+  endif()
+
   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_DEBUGGER)
   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_DEBUGGER_PORT=${FEATURE_DEBUGGER_PORT})
 endif()


### PR DESCRIPTION
Fixed when debug server uses a CPU core on 100%.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu