### PR TITLE
target: mbedos5: unnecessary acquire

### DIFF
--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
@@ -29,7 +29,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
     CHECK_ARGUMENT_COUNT(InterruptIn, rise, (args_count == 1));
 
     // Detach the rise callback when InterruptIn::rise(null) is called
-    if (jerry_value_is_null(args[1])) {
+    if (jerry_value_is_null(args[0])) {
         uintptr_t native_handle;
         jerry_get_object_native_handle(this_obj, &native_handle);
 
@@ -44,6 +44,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
             // Ensure that the EventLoop frees memory used by the callback.
             mbed::js::EventLoop::getInstance().dropCallback(cb_func);
         }
+        jerry_release_value(cb_func);
 
         this_interruptin->rise(0);
 
@@ -82,7 +83,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
     CHECK_ARGUMENT_COUNT(InterruptIn, fall, (args_count == 1));
 
     // Detach the fall callback when InterruptIn::fall(null) is called
-    if (jerry_value_is_null(args[1])) {
+    if (jerry_value_is_null(args[0])) {
         uintptr_t native_handle;
         jerry_get_object_native_handle(this_obj, &native_handle);
 
@@ -97,6 +98,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
             // Ensure that the EventLoop frees memory used by the callback.
             mbed::js::EventLoop::getInstance().dropCallback(cb_func);
         }
+        jerry_release_value(cb_func);
 
         this_interruptin->fall(0);
 

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/EventLoop.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-event-loop/EventLoop.h
@@ -52,9 +52,6 @@ class EventLoop {
     Callback<void()> wrapFunction(jerry_value_t f) {
         MBED_ASSERT(jerry_value_is_function(f));
 
-        // not sure if this is necessary?
-        jerry_acquire_value(f);
-
         // we need to return a callback that'll schedule this
         Callback<void(uint32_t)> cb_raw(this, &EventLoop::callback);
         BoundCallback<void(uint32_t)> *cb = new BoundCallback<void(uint32_t)>(cb_raw, f);
@@ -65,8 +62,6 @@ class EventLoop {
     }
 
     void dropCallback(jerry_value_t f) {
-        jerry_release_value(f);
-
         for (std::vector<std::pair<jerry_value_t, BoundCallback<void(uint32_t)>*> >::iterator it = bound_callbacks.begin(); it != bound_callbacks.end(); it++) {
             std::pair<jerry_value_t, BoundCallback<void(uint32_t)>*> element = *it;
 


### PR DESCRIPTION
When you cleanup the engine you got an `ECMA_STRING_IS_REF_EQUALS_TO_ONE (string_p)` error.
There is an unnecessary call of jerry_acquire_value which causes the problem.

Also in the InterruptIn-js.cpp file there is a wrong check of an argument.

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu