### PR TITLE
target: mbedos5: fix mbedignore

### DIFF
--- a/targets/mbedos5/template-mbedignore.txt
+++ b/targets/mbedos5/template-mbedignore.txt
@@ -9,4 +9,3 @@ targets/*
 tests/*
 third-party/*
 tools/*
-jerry-port/default/*


### PR DESCRIPTION
Ignoring the entire jerry-port/default library causes a link error, because of the need for the defaultx-handler.c source file.

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu