### PR TITLE
Fix a build error

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -229,6 +229,8 @@ jerry_debugger_sleep (unsigned milliseconds) /**< suspending time */
   , NULL);
 #elif defined (HAVE_UNISTD_H)
   usleep ((useconds_t) milliseconds * 1000);
+#else /* If neither of the libs found */
+  JERRY_UNUSED (milliseconds);
 #endif /* HAVE_TIME_H */
 } /* jerry_debugger_sleep */
 


### PR DESCRIPTION
Fixed an error when neither of libraries are found the build fails.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu