### PR TITLE
Stack data should be freed for while statements after the expression …

### DIFF
--- a/tests/jerry/fail/regression-test-issue-1873.js
+++ b/tests/jerry/fail/regression-test-issue-1873.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+while (
+  {a: a,
+   get a() {}
+ }) continue;


### PR DESCRIPTION
Stack data should be freed for while statements after the expression is parsed.

Fixes #1873 .

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu