### PR TITLE
target: mbedos5: change all native_handle call to native_pointer

### DIFF
--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut-js.cpp
@@ -18,6 +18,24 @@
 #include "mbed.h"
 
 /**
+ * DigitalOut#destructor
+ *
+ * Called if/when the DigitalOut is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalOut)(void* void_ptr) {
+    delete static_cast<DigitalOut*>(void_ptr);
+}
+
+/**
+ * Type infomation of the native DigitalOut pointer
+ *
+ * Set DigitalOut#destructor as the free callback.
+ */
+static const jerry_object_native_info_t native_obj_type_info = {
+    .free_cb = NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalOut)
+};
+
+/**
  * DigitalOut#write (native JavaScript method)
  *
  * Writes a binary value to a DigitalOut.
@@ -31,11 +49,17 @@ DECLARE_CLASS_FUNCTION(DigitalOut, write) {
     CHECK_ARGUMENT_TYPE_ALWAYS(DigitalOut, write, 0, number);
 
     // Extract native DigitalOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    DigitalOut* native_ptr = reinterpret_cast<DigitalOut*>(ptr_val);
-    
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native DigitalOut pointer");
+    }
+
+    DigitalOut* native_ptr = static_cast<DigitalOut*>(void_ptr);
+
     int arg0 = jerry_get_number_value(args[0]);
     native_ptr->write(arg0);
 
@@ -53,10 +77,16 @@ DECLARE_CLASS_FUNCTION(DigitalOut, read) {
     CHECK_ARGUMENT_COUNT(DigitalOut, read, (args_count == 0));
 
     // Extract native DigitalOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    DigitalOut* native_ptr = reinterpret_cast<DigitalOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native DigitalOut pointer");
+    }
+
+    DigitalOut* native_ptr = static_cast<DigitalOut*>(void_ptr);
 
     int result = native_ptr->read();
     return jerry_create_number(result);
@@ -72,22 +102,19 @@ DECLARE_CLASS_FUNCTION(DigitalOut, is_connected) {
     CHECK_ARGUMENT_COUNT(DigitalOut, is_connected, (args_count == 0));
 
     // Extract native DigitalOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    DigitalOut* native_ptr = reinterpret_cast<DigitalOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native DigitalOut pointer");
+    }
+
+    DigitalOut* native_ptr = static_cast<DigitalOut*>(void_ptr);
 
     int result = native_ptr->is_connected();
     return jerry_create_number(result);
-}
-
-/**
- * DigitalOut#destructor
- * 
- * Called if/when the DigitalOut is GC'ed.
- */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalOut)(const uintptr_t native_handle) {
-    delete reinterpret_cast<DigitalOut*>(native_handle);
 }
 
 /**
@@ -102,7 +129,7 @@ DECLARE_CLASS_CONSTRUCTOR(DigitalOut) {
     CHECK_ARGUMENT_TYPE_ALWAYS(DigitalOut, __constructor, 0, number);
     CHECK_ARGUMENT_TYPE_ON_CONDITION(DigitalOut, __constructor, 1, number, (args_count == 2));
 
-    uintptr_t native_ptr;
+    DigitalOut* native_ptr;
 
     // Call correct overload of DigitalOut::DigitalOut depending on the
     // arguments passed.
@@ -110,17 +137,17 @@ DECLARE_CLASS_CONSTRUCTOR(DigitalOut) {
 
     switch (args_count) {
         case 1:
-            native_ptr = (uintptr_t) new DigitalOut(pin_name);
+            native_ptr = new DigitalOut(pin_name);
             break;
         case 2:
             int value = static_cast<int>(jerry_get_number_value(args[1]));
-            native_ptr = (uintptr_t) new DigitalOut(pin_name, value);
+            native_ptr = new DigitalOut(pin_name, value);
             break;
     }
 
     // create the jerryscript object
     jerry_value_t js_object = jerry_create_object();
-    jerry_set_object_native_handle(js_object, native_ptr, NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalOut));
+    jerry_set_object_native_pointer(js_object, native_ptr, &native_obj_type_info);
 
     // attach methods
     ATTACH_CLASS_FUNCTION(js_object, DigitalOut, write);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C-js.cpp
@@ -19,6 +19,24 @@
 #include "mbed.h"
 
 /**
+ * I2C#destructor
+ *
+ * Called if/when the I2C object is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(I2C) (void *void_ptr) {
+    delete static_cast<I2C*>(void_ptr);
+}
+
+/**
+ * Type infomation of the native I2C pointer
+ *
+ * Set I2C#destructor as the free callback.
+ */
+static const jerry_object_native_info_t native_obj_type_info = {
+    .free_cb = NAME_FOR_CLASS_NATIVE_DESTRUCTOR(I2C)
+};
+
+/**
  * I2C#frequency (native JavaScript method)
  *
  * Set the frequency of the I2C bus.
@@ -30,9 +48,16 @@ DECLARE_CLASS_FUNCTION(I2C, frequency) {
     CHECK_ARGUMENT_TYPE_ALWAYS(I2C, frequency, 0, number);
 
     // Unwrap native I2C object
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
-    I2C* native_ptr = reinterpret_cast<I2C*>(native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native I2C pointer");
+    }
+
+    I2C *native_ptr = static_cast<I2C*>(void_ptr);
 
     int hz = jerry_get_number_value(args[0]);
     native_ptr->frequency(hz);
@@ -66,9 +91,16 @@ DECLARE_CLASS_FUNCTION(I2C, read) {
 
     if (args_count == 1) {
         CHECK_ARGUMENT_TYPE_ALWAYS(I2C, read, 0, number);
-        uintptr_t native_handle;
-        jerry_get_object_native_handle(this_obj, &native_handle);
-        I2C *native_ptr = reinterpret_cast<I2C*>(native_handle);
+        void *void_ptr;
+        const jerry_object_native_info_t *type_ptr;
+        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+        if (!has_ptr || type_ptr != &native_obj_type_info) {
+            return jerry_create_error(JERRY_ERROR_TYPE,
+                                      (const jerry_char_t *) "Failed to get native I2C pointer");
+        }
+
+        I2C *native_ptr = static_cast<I2C*>(void_ptr);
 
         int data = jerry_get_number_value(args[0]);
         int result = native_ptr->read(data);
@@ -81,9 +113,16 @@ DECLARE_CLASS_FUNCTION(I2C, read) {
 
         CHECK_ARGUMENT_TYPE_ON_CONDITION(I2C, read, 3, boolean, (args_count == 4));
 
-        uintptr_t native_handle;
-        jerry_get_object_native_handle(this_obj, &native_handle);
-        I2C *native_ptr = reinterpret_cast<I2C*>(native_handle);
+        void *void_ptr;
+        const jerry_object_native_info_t *type_ptr;
+        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+        if (!has_ptr || type_ptr != &native_obj_type_info) {
+            return jerry_create_error(JERRY_ERROR_TYPE,
+                                      (const jerry_char_t *) "Failed to get native I2C pointer");
+        }
+
+        I2C *native_ptr = static_cast<I2C*>(void_ptr);
 
         const uint32_t data_len = jerry_get_array_length(args[1]);
 
@@ -149,10 +188,16 @@ DECLARE_CLASS_FUNCTION(I2C, write) {
         CHECK_ARGUMENT_TYPE_ALWAYS(I2C, write, 0, number);
 
         // Extract native I2C object
-        uintptr_t native_handle;
-        jerry_get_object_native_handle(this_obj, &native_handle);
+        void *void_ptr;
+        const jerry_object_native_info_t *type_ptr;
+        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-        I2C *native_ptr = reinterpret_cast<I2C*>(native_handle);
+        if (!has_ptr || type_ptr != &native_obj_type_info) {
+            return jerry_create_error(JERRY_ERROR_TYPE,
+                                      (const jerry_char_t *) "Failed to get native I2C pointer");
+        }
+
+        I2C *native_ptr = static_cast<I2C*>(void_ptr);
 
         // Unwrap arguments
         int data = jerry_get_number_value(args[0]);
@@ -167,10 +212,16 @@ DECLARE_CLASS_FUNCTION(I2C, write) {
         CHECK_ARGUMENT_TYPE_ON_CONDITION(I2C, write, 3, boolean, (args_count == 4));
 
         // Extract native I2C object
-        uintptr_t native_handle;
-        jerry_get_object_native_handle(this_obj, &native_handle);
+        void *void_ptr;
+        const jerry_object_native_info_t *type_ptr;
+        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-        I2C *native_ptr = reinterpret_cast<I2C*>(native_handle);
+        if (!has_ptr || type_ptr != &native_obj_type_info) {
+            return jerry_create_error(JERRY_ERROR_TYPE,
+                                      (const jerry_char_t *) "Failed to get native I2C pointer");
+        }
+
+        I2C *native_ptr = static_cast<I2C*>(void_ptr);
 
         // Unwrap arguments
         int address = jerry_get_number_value(args[0]);
@@ -198,15 +249,20 @@ DECLARE_CLASS_FUNCTION(I2C, write) {
  *
  * Creates a start condition on the I2C bus.
  */
-DECLARE_CLASS_FUNCTION(I2C, start)
-{
+DECLARE_CLASS_FUNCTION(I2C, start) {
     CHECK_ARGUMENT_COUNT(I2C, start, (args_count == 0));
 
     // Extract native I2C object
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    I2C *native_ptr = reinterpret_cast<I2C*>(native_handle);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native I2C pointer");
+    }
+
+    I2C *native_ptr = static_cast<I2C*>(void_ptr);
 
     native_ptr->start();
     return jerry_create_undefined();
@@ -217,27 +273,23 @@ DECLARE_CLASS_FUNCTION(I2C, start)
  *
  * Creates a stop condition on the I2C bus.
  */
-DECLARE_CLASS_FUNCTION(I2C, stop)
-{
+DECLARE_CLASS_FUNCTION(I2C, stop) {
     CHECK_ARGUMENT_COUNT(I2C, stop, (args_count == 0));
 
     // Extract native I2C object
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    I2C *native_ptr = reinterpret_cast<I2C*>(native_handle);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native I2C pointer");
+    }
+
+    I2C *native_ptr = static_cast<I2C*>(void_ptr);
 
     native_ptr->stop();
     return jerry_create_undefined();
-}
-
-/**
- * I2C#destructor
- *
- * Called if/when the I2C object is GC'ed.
- */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(I2C) (uintptr_t handle) {
-    delete reinterpret_cast<I2C*>(handle);
 }
 
 /**
@@ -255,10 +307,10 @@ DECLARE_CLASS_CONSTRUCTOR(I2C) {
     int sda = jerry_get_number_value(args[0]);
     int scl = jerry_get_number_value(args[1]);
 
-    uintptr_t native_handle = (uintptr_t)new I2C((PinName)sda, (PinName)scl);
+    I2C *native_ptr = new I2C((PinName)sda, (PinName)scl);
 
     jerry_value_t js_object = jerry_create_object();
-    jerry_set_object_native_handle(js_object, native_handle, NAME_FOR_CLASS_NATIVE_DESTRUCTOR(I2C));
+    jerry_set_object_native_pointer(js_object, native_ptr, &native_obj_type_info);
 
     ATTACH_CLASS_FUNCTION(js_object, I2C, frequency);
     ATTACH_CLASS_FUNCTION(js_object, I2C, read);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
@@ -19,6 +19,28 @@
 #include "mbed.h"
 
 /**
+ * InterruptIn#destructor
+ *
+ * Called if/when the InterruptIn object is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(InterruptIn) (void *void_ptr) {
+    InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
+
+    native_ptr->rise(0);
+    native_ptr->fall(0);
+    delete native_ptr;
+}
+
+/**
+ * Type infomation of the native InterruptIn pointer
+ *
+ * Set InterruptIn#destructor as the free callback.
+ */
+static const jerry_object_native_info_t native_obj_type_info = {
+    .free_cb = NAME_FOR_CLASS_NATIVE_DESTRUCTOR(InterruptIn)
+};
+
+/**
  * InterruptIn#rise (native JavaScript method)
  *
  * Register a rise callback for an InterruptIn
@@ -30,10 +52,16 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
 
     // Detach the rise callback when InterruptIn::rise(null) is called
     if (jerry_value_is_null(args[0])) {
-        uintptr_t native_handle;
-        jerry_get_object_native_handle(this_obj, &native_handle);
+        void *void_ptr;
+        const jerry_object_native_info_t *type_ptr;
+        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-        InterruptIn *this_interruptin = (InterruptIn*) native_handle;
+        if (!has_ptr || type_ptr != &native_obj_type_info) {
+            return jerry_create_error(JERRY_ERROR_TYPE,
+                                      (const jerry_char_t *) "Failed to get native InterruptIn pointer");
+        }
+
+        InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
         jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_rise");
         jerry_value_t cb_func = jerry_get_property(this_obj, property_name);
@@ -46,7 +74,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
         }
         jerry_release_value(cb_func);
 
-        this_interruptin->rise(0);
+        native_ptr->rise(0);
 
         return jerry_create_undefined();
     }
@@ -54,15 +82,22 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
     // Assuming we actually have a callback now...
     CHECK_ARGUMENT_TYPE_ALWAYS(InterruptIn, rise, 0, function);
 
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
-    InterruptIn *this_interruptin = reinterpret_cast<InterruptIn*>(native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native InterruptIn pointer");
+    }
+
+    InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
     jerry_value_t f = args[0];
 
     // Pass the function to EventLoop.
     mbed::Callback<void()> cb = mbed::js::EventLoop::getInstance().wrapFunction(f);
-    this_interruptin->rise(cb);
+    native_ptr->rise(cb);
 
     // Keep track of our callback internally.
     jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_rise");
@@ -84,10 +119,16 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
 
     // Detach the fall callback when InterruptIn::fall(null) is called
     if (jerry_value_is_null(args[0])) {
-        uintptr_t native_handle;
-        jerry_get_object_native_handle(this_obj, &native_handle);
+        void *void_ptr;
+        const jerry_object_native_info_t *type_ptr;
+        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-        InterruptIn *this_interruptin = (InterruptIn*) native_handle;
+        if (!has_ptr || type_ptr != &native_obj_type_info) {
+            return jerry_create_error(JERRY_ERROR_TYPE,
+                                      (const jerry_char_t *) "Failed to get native InterruptIn pointer");
+        }
+
+        InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
         jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_fall");
         jerry_value_t cb_func = jerry_get_property(this_obj, property_name);
@@ -100,7 +141,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
         }
         jerry_release_value(cb_func);
 
-        this_interruptin->fall(0);
+        native_ptr->fall(0);
 
         return jerry_create_undefined();
     }
@@ -108,15 +149,22 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
     // Assuming we actually have a callback now...
     CHECK_ARGUMENT_TYPE_ALWAYS(InterruptIn, fall, 0, function);
 
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
-    InterruptIn *this_interruptin = reinterpret_cast<InterruptIn*>(native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native InterruptIn pointer");
+    }
+
+    InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
     jerry_value_t f = args[0];
 
     // Pass the function to EventLoop.
     mbed::Callback<void()> cb = mbed::js::EventLoop::getInstance().wrapFunction(f);
-    this_interruptin->fall(cb);
+    native_ptr->fall(cb);
 
     // Keep track of our callback internally.
     jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_fall");
@@ -137,10 +185,16 @@ DECLARE_CLASS_FUNCTION(InterruptIn, mode) {
     CHECK_ARGUMENT_COUNT(InterruptIn, mode, (args_count == 1));
     CHECK_ARGUMENT_TYPE_ALWAYS(InterruptIn, mode, 0, number);
 
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    InterruptIn *native_ptr = reinterpret_cast<InterruptIn*>(native_handle);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native InterruptIn pointer");
+    }
+
+    InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
     int pull = jerry_get_number_value(args[0]);
     native_ptr->mode((PinMode)pull);
@@ -156,9 +210,16 @@ DECLARE_CLASS_FUNCTION(InterruptIn, mode) {
 DECLARE_CLASS_FUNCTION(InterruptIn, disable_irq) {
     CHECK_ARGUMENT_COUNT(InterruptIn, disable_irq, (args_count == 0));
 
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
-    InterruptIn *native_ptr = reinterpret_cast<InterruptIn*>(native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native InterruptIn pointer");
+    }
+
+    InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
     native_ptr->disable_irq();
     return jerry_create_undefined();
@@ -172,25 +233,19 @@ DECLARE_CLASS_FUNCTION(InterruptIn, disable_irq) {
 DECLARE_CLASS_FUNCTION(InterruptIn, enable_irq) {
     CHECK_ARGUMENT_COUNT(InterruptIn, enable_irq, (args_count == 0));
 
-    uintptr_t native_handle;
-    jerry_get_object_native_handle(this_obj, &native_handle);
-    InterruptIn *native_ptr = reinterpret_cast<InterruptIn*>(native_handle);
+    void *void_ptr;
+    const jerry_object_native_info_t *type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native InterruptIn pointer");
+    }
+
+    InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
     native_ptr->enable_irq();
     return jerry_create_undefined();
-}
-
-/**
- * InterruptIn#destructor
- *
- * Called if/when the InterruptIn object is GC'ed.
- */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(InterruptIn) (uintptr_t handle) {
-    InterruptIn *native_ptr = reinterpret_cast<InterruptIn*>(handle);
-
-    native_ptr->rise(0);
-    native_ptr->fall(0);
-    delete native_ptr;
 }
 
 /**
@@ -205,10 +260,10 @@ DECLARE_CLASS_CONSTRUCTOR(InterruptIn) {
     CHECK_ARGUMENT_TYPE_ALWAYS(InterruptIn, __constructor, 0, number);
     int pin = jerry_get_number_value(args[0]);
 
-    uintptr_t native_handle = (uintptr_t)new InterruptIn((PinName)pin);
+    InterruptIn *native_ptr = new InterruptIn((PinName)pin);
     jerry_value_t js_object = jerry_create_object();
 
-    jerry_set_object_native_handle(js_object, native_handle, NAME_FOR_CLASS_NATIVE_DESTRUCTOR(InterruptIn));
+    jerry_set_object_native_pointer(js_object, native_ptr, &native_obj_type_info);
 
     ATTACH_CLASS_FUNCTION(js_object, InterruptIn, rise);
     ATTACH_CLASS_FUNCTION(js_object, InterruptIn, fall);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut-js.cpp
@@ -18,6 +18,24 @@
 #include "mbed.h"
 
 /**
+ * PwmOut#destructor
+ *
+ * Called if/when the PwmOut is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut)(void* void_ptr) {
+    delete static_cast<PwmOut*>(void_ptr);
+}
+
+/**
+ * Type infomation of the native PwmOut pointer
+ *
+ * Set PwmOut#destructor as the free callback.
+ */
+static const jerry_object_native_info_t native_obj_type_info = {
+    .free_cb = NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut)
+};
+
+/**
  * PwmOut#write (native JavaScript method)
  *
  * Set the ouput duty-cycle, specified as a percentage (float)
@@ -33,10 +51,16 @@ DECLARE_CLASS_FUNCTION(PwmOut, write) {
     CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, write, 0, number);
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     double arg0 = jerry_get_number_value(args[0]);
     native_ptr->write(static_cast<float>(arg0));
@@ -61,10 +85,16 @@ DECLARE_CLASS_FUNCTION(PwmOut, read) {
     CHECK_ARGUMENT_COUNT(PwmOut, read, (args_count == 0));
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     float result = native_ptr->read();
     return jerry_create_number(result);
@@ -84,10 +114,16 @@ DECLARE_CLASS_FUNCTION(PwmOut, period) {
     CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, period, 0, number);
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     double arg0 = jerry_get_number_value(args[0]);
     native_ptr->period(static_cast<float>(arg0));
@@ -105,10 +141,16 @@ DECLARE_CLASS_FUNCTION(PwmOut, period_ms) {
     CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, period_ms, 0, number);
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     double arg0 = jerry_get_number_value(args[0]);
     native_ptr->period_ms(static_cast<int>(arg0));
@@ -126,10 +168,16 @@ DECLARE_CLASS_FUNCTION(PwmOut, period_us) {
     CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, period_us, 0, number);
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     double arg0 = jerry_get_number_value(args[0]);
     native_ptr->period_us(static_cast<int>(arg0));
@@ -147,10 +195,16 @@ DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth) {
     CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, pulsewidth, 0, number);
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     double arg0 = jerry_get_number_value(args[0]);
     native_ptr->pulsewidth(static_cast<float>(arg0));
@@ -168,10 +222,16 @@ DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth_ms) {
     CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, pulsewidth_ms, 0, number);
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     double arg0 = jerry_get_number_value(args[0]);
     native_ptr->pulsewidth_ms(static_cast<int>(arg0));
@@ -189,24 +249,21 @@ DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth_us) {
     CHECK_ARGUMENT_TYPE_ALWAYS(PwmOut, pulsewidth_us, 0, number);
 
     // Extract native PwmOut pointer
-    uintptr_t ptr_val;
-    jerry_get_object_native_handle(this_obj, &ptr_val);
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
 
-    PwmOut* native_ptr = reinterpret_cast<PwmOut*>(ptr_val);
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native PwmOut pointer");
+    }
+
+    PwmOut* native_ptr = static_cast<PwmOut*>(void_ptr);
 
     double arg0 = jerry_get_number_value(args[0]);
     native_ptr->pulsewidth_us(static_cast<int>(arg0));
 
     return jerry_create_undefined();
-}
-
-/**
- * PwmOut#destructor
- *
- * Called if/when the PwmOut is GC'ed.
- */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut)(const uintptr_t native_handle) {
-    delete reinterpret_cast<PwmOut*>(native_handle);
 }
 
 /**
@@ -222,11 +279,11 @@ DECLARE_CLASS_CONSTRUCTOR(PwmOut) {
     PinName pin_name = PinName(jerry_get_number_value(args[0]));
 
     // Create the native object
-    uintptr_t native_ptr = (uintptr_t) new PwmOut(pin_name);
+    PwmOut* native_ptr = new PwmOut(pin_name);
 
     // create the jerryscript object
     jerry_value_t js_object = jerry_create_object();
-    jerry_set_object_native_handle(js_object, native_ptr, NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut));
+    jerry_set_object_native_pointer(js_object, native_ptr, &native_obj_type_info);
 
     // attach methods
     ATTACH_CLASS_FUNCTION(js_object, PwmOut, write);


### PR DESCRIPTION
Change all jerry_get_object_native_handle and jerry_set_object_native_handle function call to jerry_get_object_native_pointer and jerry_set_object_native_pointer in the mbed objects' source files.

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu