### PR TITLE
Make debugger port runtime configurable

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -19,7 +19,6 @@ project (${JERRY_CORE_NAME} C)
 # Optional features
 set(FEATURE_CPOINTER_32_BIT  OFF     CACHE BOOL   "Enable 32 bit compressed pointers?")
 set(FEATURE_DEBUGGER         OFF     CACHE BOOL   "Enable JerryScript debugger?")
-set(FEATURE_DEBUGGER_PORT    "5001"  CACHE STRING "Set debugger port number (default: 5001)")
 set(FEATURE_ERROR_MESSAGES   OFF     CACHE BOOL   "Enable error messages?")
 set(FEATURE_EXTERNAL_CONTEXT OFF     CACHE BOOL   "Enable external context?")
 set(FEATURE_JS_PARSER        ON      CACHE BOOL   "Enable js-parser?")
@@ -54,7 +53,6 @@ endif()
 # Status messages
 message(STATUS "FEATURE_CPOINTER_32_BIT   " ${FEATURE_CPOINTER_32_BIT} ${FEATURE_CPOINTER_32_BIT_MESSAGE})
 message(STATUS "FEATURE_DEBUGGER          " ${FEATURE_DEBUGGER})
-message(STATUS "FEATURE_DEBUGGER_PORT     " ${FEATURE_DEBUGGER_PORT})
 message(STATUS "FEATURE_ERROR_MESSAGES    " ${FEATURE_ERROR_MESSAGES})
 message(STATUS "FEATURE_EXTERNAL_CONTEXT  " ${FEATURE_EXTERNAL_CONTEXT})
 message(STATUS "FEATURE_JS_PARSER         " ${FEATURE_JS_PARSER})
@@ -192,7 +190,6 @@ if(FEATURE_DEBUGGER)
   endif()
 
   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_DEBUGGER)
-  set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_DEBUGGER_PORT=${FEATURE_DEBUGGER_PORT})
 endif()
 
 # Memory management stress-test mode

--- a/jerry-core/api/jerry-debugger.c
+++ b/jerry-core/api/jerry-debugger.c
@@ -88,3 +88,31 @@ jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint) /**< enable/d
   JERRY_UNUSED (enable_stop_at_breakpoint);
 #endif /* JERRY_DEBUGGER */
 } /* jerry_debugger_stop_at_breakpoint */
+
+/**
+ * Debugger server initialization. Must be called after jerry_init.
+ */
+void
+jerry_debugger_init (uint16_t port) /**< server port number */
+{
+#ifdef JERRY_DEBUGGER
+  JERRY_CONTEXT (debugger_port) = port;
+  jerry_debugger_accept_connection ();
+#else /* !JERRY_DEBUGGER */
+  JERRY_UNUSED (port);
+#endif /* JERRY_DEBUGGER */
+} /* jerry_debugger_init */
+
+/**
+ * Debugger server shutdown. Must be called before jerry_cleanup.
+ */
+void
+jerry_debugger_cleanup (void)
+{
+#ifdef JERRY_DEBUGGER
+  if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
+  {
+    jerry_debugger_close_connection ();
+  }
+#endif /* JERRY_DEBUGGER */
+} /* jerry_debugger_cleanup */

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -51,8 +51,7 @@ JERRY_STATIC_ASSERT ((int) ECMA_ERROR_COMMON == (int) JERRY_ERROR_COMMON
 JERRY_STATIC_ASSERT ((int) ECMA_INIT_EMPTY == (int) JERRY_INIT_EMPTY
                      && (int) ECMA_INIT_SHOW_OPCODES == (int) JERRY_INIT_SHOW_OPCODES
                      && (int) ECMA_INIT_SHOW_REGEXP_OPCODES == (int) JERRY_INIT_SHOW_REGEXP_OPCODES
-                     && (int) ECMA_INIT_MEM_STATS == (int) JERRY_INIT_MEM_STATS
-                     && (int) ECMA_INIT_DEBUGGER == (int) JERRY_INIT_DEBUGGER,
+                     && (int) ECMA_INIT_MEM_STATS == (int) JERRY_INIT_MEM_STATS,
                      ecma_init_flag_t_must_be_equal_to_jerry_init_flag_t);
 
 #ifndef JERRY_JS_PARSER
@@ -157,13 +156,6 @@ jerry_init (jerry_init_flag_t flags) /**< combination of Jerry flags */
 
   jmem_init ();
   ecma_init ();
-
-#ifdef JERRY_DEBUGGER
-  if (flags & JERRY_INIT_DEBUGGER)
-  {
-    jerry_debugger_accept_connection ();
-  }
-#endif /* JERRY_DEBUGGER */
 } /* jerry_init */
 
 /**
@@ -184,14 +176,6 @@ jerry_cleanup (void)
   }
 
   ecma_finalize ();
-
-#ifdef JERRY_DEBUGGER
-  if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
-  {
-    jerry_debugger_close_connection ();
-  }
-#endif /* JERRY_DEBUGGER */
-
   jmem_finalize ();
   jerry_make_api_unavailable ();
 } /* jerry_cleanup */

--- a/jerry-core/debugger/debugger-ws.c
+++ b/jerry-core/debugger/debugger-ws.c
@@ -25,13 +25,6 @@
 #include <unistd.h>
 
 /**
- * Debugger socket communication port.
- */
-#ifndef JERRY_DEBUGGER_PORT
-#define JERRY_DEBUGGER_PORT 5001
-#endif
-
-/**
  * Masking-key is available.
  */
 #define JERRY_DEBUGGER_WEBSOCKET_MASK_BIT 0x80
@@ -314,10 +307,8 @@ jerry_debugger_accept_connection (void)
   struct sockaddr_in addr;
   socklen_t sin_size = sizeof (struct sockaddr_in);
 
-  JERRY_ASSERT (JERRY_CONTEXT (jerry_init_flags) & ECMA_INIT_DEBUGGER);
-
   addr.sin_family = AF_INET;
-  addr.sin_port = htons (JERRY_DEBUGGER_PORT);
+  addr.sin_port = htons (JERRY_CONTEXT (debugger_port));
   addr.sin_addr.s_addr = INADDR_ANY;
 
   if ((server_socket = socket (AF_INET, SOCK_STREAM, 0)) == -1)

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -62,7 +62,6 @@ typedef enum
   ECMA_INIT_SHOW_OPCODES        = (1u << 0), /**< dump byte-code to log after parse */
   ECMA_INIT_SHOW_REGEXP_OPCODES = (1u << 1), /**< dump regexp byte-code to log after compilation */
   ECMA_INIT_MEM_STATS           = (1u << 2), /**< dump memory statistics */
-  ECMA_INIT_DEBUGGER            = (1u << 4), /**< enable all features required by debugging */
 } ecma_init_flag_t;
 
 /**

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -56,7 +56,7 @@ typedef enum
   JERRY_INIT_SHOW_REGEXP_OPCODES = (1u << 1), /**< dump regexp byte-code to log after compilation */
   JERRY_INIT_MEM_STATS           = (1u << 2), /**< dump memory statistics */
   JERRY_INIT_MEM_STATS_SEPARATE  = (1u << 3), /**< deprecated, an unused placeholder now */
-  JERRY_INIT_DEBUGGER            = (1u << 4), /**< enable all features required by debugging */
+  JERRY_INIT_DEBUGGER            = (1u << 4), /**< deprecated, an unused placeholder now */
 } jerry_init_flag_t;
 
 /**

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -35,6 +35,9 @@ void jerry_debugger_stop (void);
 void jerry_debugger_continue (void);
 void jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint);
 
+void jerry_debugger_init (uint16_t port);
+void jerry_debugger_cleanup (void);
+
 /**
  * @}
  */

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -121,6 +121,7 @@ typedef struct
   uint8_t debugger_message_delay; /**< call receive message when reaches zero */
   uint16_t debugger_receive_buffer_offset; /**< receive buffer offset */
   int debugger_connection; /**< holds the file descriptor of the socket communication */
+  uint16_t debugger_port; /**< debugger socket communication port */
 #endif /* JERRY_DEBUGGER */
 
 #ifdef JMEM_STATS

--- a/tests/debugger/do_backtrace.expected
+++ b/tests/debugger/do_backtrace.expected
@@ -28,4 +28,3 @@ Frame 1: tests/debugger/do_backtrace.js:25 (in foo() at line:21, col:1)
 Frame 2: tests/debugger/do_backtrace.js:33 (in test() at line:30, col:1)
 Frame 3: tests/debugger/do_backtrace.js:40
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_break.expected
+++ b/tests/debugger/do_break.expected
@@ -24,4 +24,3 @@ Stopped at breakpoint:2 tests/debugger/do_break.js:36 (in test() at line:20, col
 (jerry-debugger) continue
 Stopped at breakpoint:3 tests/debugger/do_break.js:33 (in f() at line:31, col:3)
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_delete.expected
+++ b/tests/debugger/do_delete.expected
@@ -19,4 +19,3 @@ Breakpoint 3 at tests/debugger/do_delete.js:18
 (jerry-debugger) list
 1: tests/debugger/do_delete.js:17
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_delete_all.expected
+++ b/tests/debugger/do_delete_all.expected
@@ -14,4 +14,3 @@ Breakpoint 3 at tests/debugger/do_delete_all.js:21 (in delete_test() at line:20,
 (jerry-debugger) next
 Stopped at tests/debugger/do_delete_all.js:16
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_display.expected
+++ b/tests/debugger/do_display.expected
@@ -50,4 +50,3 @@ Source: tests/debugger/do_display.js
 (jerry-debugger) c
 Stopped at breakpoint:4 tests/debugger/do_display.js:18 (in d() at line:18, col:1)
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_eval.expected
+++ b/tests/debugger/do_eval.expected
@@ -25,4 +25,3 @@ Stopped at tests/debugger/do_eval.js:24
 (jerry-debugger) e a
 11.3
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_eval_syntax.expected
+++ b/tests/debugger/do_eval_syntax.expected
@@ -5,4 +5,3 @@ Stopped at tests/debugger/do_eval_syntax.js:26
 (jerry-debugger) eval loop
 Uncaught exception: Error
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_next.expected
+++ b/tests/debugger/do_next.expected
@@ -5,4 +5,3 @@ Stopped at tests/debugger/do_next.js:17
 (jerry-debugger) next
 Stopped at tests/debugger/do_next.js:18
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_pending_breakpoints.expected
+++ b/tests/debugger/do_pending_breakpoints.expected
@@ -13,4 +13,3 @@ Stopped at tests/debugger/do_pending_breakpoints.js:19
 (jerry-debugger) c
 Stopped at breakpoint:1 <unknown>:1 (in f() at line:1, col:1)
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_src.expected
+++ b/tests/debugger/do_src.expected
@@ -16,4 +16,3 @@ Stopped at tests/debugger/do_src.js:21
 Stopped at <unknown>:2 (in f() at line:1, col:5)
 (jerry-debugger) src
 (jerry-debugger) c
-Connection closed.

--- a/tests/debugger/do_step.expected
+++ b/tests/debugger/do_step.expected
@@ -23,4 +23,3 @@ Stopped at tests/debugger/do_step.js:29 (in f2() at line:26, col:1)
 Frame 0: tests/debugger/do_step.js:29 (in f2() at line:26, col:1)
 Frame 1: tests/debugger/do_step.js:33
 (jerry-debugger) c
-Connection closed.

--- a/tools/build.py
+++ b/tools/build.py
@@ -74,8 +74,6 @@ def get_arguments():
                         help='build minimal version of the jerry command line tool (%(choices)s; default: %(default)s)')
     parser.add_argument('--jerry-debugger', metavar='X', choices=['ON', 'OFF'], default='OFF', type=str.upper,
                         help='enable the jerry debugger (%(choices)s; default: %(default)s)')
-    parser.add_argument('--jerry-debugger-port', metavar='N', action='store', type=int, default=5001,
-                        help='add custom port number (default: %(default)s)')
     parser.add_argument('--jerry-ext', metavar='X', choices=['ON', 'OFF'], default='ON', type=str.upper,
                         help='build jerry-ext (default: %(default)s)')
     parser.add_argument('--jerry-libc', metavar='X', choices=['ON', 'OFF'], default='ON', type=str.upper,
@@ -162,7 +160,6 @@ def generate_build_options(arguments):
 
     build_options.append('-DFEATURE_PROFILE=%s' % arguments.profile)
     build_options.append('-DFEATURE_DEBUGGER=%s' % arguments.jerry_debugger)
-    build_options.append('-DFEATURE_DEBUGGER_PORT=%d' % arguments.jerry_debugger_port)
     build_options.append('-DFEATURE_EXTERNAL_CONTEXT=%s' % arguments.external_context)
     build_options.append('-DFEATURE_SNAPSHOT_EXEC=%s' % arguments.snapshot_exec)
     build_options.append('-DFEATURE_SNAPSHOT_SAVE=%s' % arguments.snapshot_save)


### PR DESCRIPTION
Convert debug server port from a compile-time constant to a context
variable. This enables each engine instance (either running in the
same process or in different processes) to listen for connections
at different ports, i.e., multiple engines can be debugged at the
same time on the same machine.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu