### PR TITLE
Improve pylint runner script

### DIFF
--- a/tools/check-pylint.sh
+++ b/tools/check-pylint.sh
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find -name "*.py" \
+find ./tools ./jerry-debugger -name "*.py" \
     | xargs pylint --rcfile=tools/pylint/pylintrc


### PR DESCRIPTION
- On OSX, `find` is more picky about its arguments than on Linux
  and requires the start directory(-ies) to be explicitly mentioned
  before the expressions (a.k.a. "primaries"). However, until now,
  the `pylint` runner script called `find` without a start dir,
  which caused an error on OSX.

- Until now, `find` looked for python scripts in all subdirectories
  of the project, causing `pylint` to check scripts under `targets/`
  and `tests/test262` (if `test262` was checked out). However, the
  files under `targets/` are less strictly controlled while
  `test262` is completely beyond the control of the project. This
  caused a lot of superfluous lint warnings.

This patch makes the `pylint` runner script call `find` in the
cross-platform way, and also limits the scope of the lint checks to
the `tools/` and `jerry-debugger/` directories.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu