### PR TITLE
Revise the mistake in the example function described in "Step 5. Desc…

### DIFF
--- a/docs/03.API-EXAMPLE.md
+++ b/docs/03.API-EXAMPLE.md
@@ -221,7 +221,7 @@ print_value (const jerry_value_t value)
   {
     /* Determining required buffer size */
     jerry_size_t req_sz = jerry_get_string_size (value);
-    jerry_char_t str_buf_p[req_sz];
+    jerry_char_t str_buf_p[req_sz + 1];
 
     jerry_string_to_char_buffer (value, str_buf_p, req_sz);
     str_buf_p[req_sz] = '\0';


### PR DESCRIPTION
In the current  https://github.com/jerryscript-project/jerryscript/blob/master/docs/03.API-EXAMPLE.md#step-5-description-of-jerryscript-value-descriptors, there is the mistake that should cause stack corruption. For more detail, please refer to #1916. This PR is the fix for this issue. 

JerryScript-DCO-1.0-Signed-off-by: Osamu Nakamura osamu.nakamura.xt@renesas.com