### PR TITLE
Fix empty string issue in ext/args

### DIFF
--- a/jerry-ext/arg/arg-transform-functions.c
+++ b/jerry-ext/arg/arg-transform-functions.c
@@ -259,10 +259,10 @@ jerryx_arg_string_common_routine (jerry_value_t js_arg, /**< JS arg */
                                                    target_p,
                                                    target_buf_size);
 
-  if (size == 0 || size == target_buf_size)
+  if ((size == target_buf_size) || (size == 0 && jerry_get_string_length (js_arg) != 0))
   {
     return jerry_create_error (JERRY_ERROR_TYPE,
-                               (jerry_char_t *) "The size of the buffer is not large enough.");
+                               (jerry_char_t *) "Buffer size is not large enough.");
   }
 
   target_p[size] = '\0';

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -33,6 +33,7 @@ const char *test_source = (
                            "arg1 = new Boolean(true);"
                            "arg3 = new String('abc');"
                            "test_validator1(arg1, arg2, arg3);"
+                           "test_validator1(arg1, arg2, '');"
                            "arg2 = new Number(10.5);"
                            "test_validator1(arg1, arg2, arg3);"
                            "test_validator1(arg1, 10.5, 'abcdef');"
@@ -139,6 +140,14 @@ test_validator1_handler (const jerry_value_t func_obj_val __attribute__((unused)
     TEST_ASSERT (arg1);
     TEST_ASSERT (arg2 == 10.5);
     TEST_ASSERT (strcmp (arg3, "abc") == 0);
+    TEST_ASSERT (jerry_value_is_undefined (arg4));
+  }
+  else if (validator1_count == 2)
+  {
+    TEST_ASSERT (!jerry_value_has_error_flag (is_ok));
+    TEST_ASSERT (arg1);
+    TEST_ASSERT (arg2 == 10.5);
+    TEST_ASSERT (strcmp (arg3, "") == 0);
     TEST_ASSERT (jerry_value_is_undefined (arg4));
   }
   else
@@ -520,7 +529,7 @@ main (void)
 
   jerry_value_t res = jerry_run (parsed_code_val);
   TEST_ASSERT (!jerry_value_has_error_flag (res));
-  TEST_ASSERT (validator1_count == 4);
+  TEST_ASSERT (validator1_count == 5);
   TEST_ASSERT (validator2_count == 3);
   TEST_ASSERT (validator_prop_count == 4);
   TEST_ASSERT (validator_int_count == 2);


### PR DESCRIPTION
Now the js string "" can be converted to C array by jerryx_arg_string

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com