### PR TITLE
Improve toFixed function

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -250,6 +250,9 @@ ecma_number_t ecma_number_substract (ecma_number_t left_num, ecma_number_t right
 ecma_number_t ecma_number_multiply (ecma_number_t left_num, ecma_number_t right_num);
 ecma_number_t ecma_number_divide (ecma_number_t left_num, ecma_number_t right_num);
 lit_utf8_size_t ecma_number_to_decimal (ecma_number_t num, lit_utf8_byte_t *out_digits_p, int32_t *out_decimal_exp_p);
+lit_utf8_size_t ecma_number_to_binary_floating_point_number (ecma_number_t num,
+                                                             lit_utf8_byte_t *out_digits_p,
+                                                             int32_t *out_decimal_exp_p);
 
 /* ecma-helpers-values-collection.c */
 ecma_collection_header_t *ecma_new_values_collection (const ecma_value_t values_buffer[], ecma_length_t values_number,

--- a/tests/jerry/number-prototype-to-fixed.js
+++ b/tests/jerry/number-prototype-to-fixed.js
@@ -31,14 +31,16 @@ assert((-Infinity).toFixed(0) === "-Infinity");
 assert(NaN.toFixed(0) === "NaN");
 assert((0.0).toFixed(0) === "0");
 assert((0.0).toFixed(1) === "0.0");
-assert((-0.0).toFixed(0) === "-0");
-assert((-0.0).toFixed(1) === "-0.0");
-assert((123456789012345678901.0).toFixed(20) === "123456789012345680000.00000000000000000000");
+assert((-0.0).toFixed(0) === "0");
+assert((-0.0).toFixed(1) === "0.0");
+assert((123456789012345678901.0).toFixed(20) === "123456789012345683968.00000000000000000000");
 assert((123.56).toFixed(NaN) === "124");
 assert((123.56).toFixed(-0.9) === "124");
 assert((0.095).toFixed(2) === "0.10");
-//assert((0.995).toFixed(2) === "0.99");
-//assert((9.995).toFixed(2) === "9.99");
+assert((0.995).toFixed(2) === "0.99");
+assert((9.995).toFixed(2) === "9.99");
+assert((7.995).toFixed(2) === "8.00");
+assert((8.995).toFixed(2) === "8.99");
 assert((99.995).toFixed(2) === "100.00");
 
 try {


### PR DESCRIPTION
Fixes #1367.
From now numbers are represented as binary floating-point which guarantees the expected operation of toFixed function.

**Benchmark result** 

Benchmark | RSS (bytes) | Perf (sec) |
----: | ----: | ----: | 
3d-cube.js | 57344 -> 57344 : 0.000% | 0.868 -> 0.863 : +0.615% | 
3d-raytrace.js | 126976 -> 120539 : +5.069% | 1.060 -> 1.049 : +0.994% | 
access-binary-trees.js | 53248 -> 53248 : 0.000% | 0.561 -> 0.565 : -0.573% | 
access-fannkuch.js | 20480 -> 20480 : 0.000% | 2.192 -> 2.184 : +0.327% | 
access-nbody.js | 28672 -> 28672 : 0.000% | 1.105 -> 1.102 : +0.268% | 
bitops-3bit-bits-in-byte.js | 16384 -> 16384 : 0.000% | 0.584 -> 0.583 : +0.106% | 
bitops-bits-in-byte.js | 16384 -> 16384 : 0.000% | 0.863 -> 0.864 : -0.100% | 
bitops-bitwise-and.js | 16384 -> 16384 : 0.000% | 1.007 -> 1.006 : +0.066% | 
bitops-nsieve-bits.js | 114688 -> 114688 : 0.000% | 1.399 -> 1.380 : +1.380% | 
controlflow-recursive.js | 86016 -> 86016 : 0.000% | 0.374 -> 0.371 : +0.886% | 
crypto-aes.js | 69046 -> 69046 : 0.000% | 0.959 -> 0.958 : +0.159% | 
crypto-md5.js | 131072 -> 131072 : 0.000% | 0.663 -> 0.659 : +0.613% | 
crypto-sha1.js | 86016 -> 86016 : 0.000% | 0.649 -> 0.652 : -0.463% | 
date-format-tofte.js | 40960 -> 40960 : 0.000% | 0.746 -> 0.746 : -0.026% | 
date-format-xparb.js | 40960 -> 40960 : 0.000% | 0.411 -> 0.411 : -0.003% | 
math-cordic.js | 16384 -> 16384 : 0.000% | 1.306 -> 1.291 : +1.159% | 
math-partial-sums.js | 16384 -> 16384 : 0.000% | 0.749 -> 0.751 : -0.195% | 
math-spectral-norm.js | 24576 -> 24576 : 0.000% | 0.582 -> 0.584 : -0.198% | 
string-base64.js | 143360 -> 143360 : 0.000% | 1.670 -> 1.541 : +7.740% | 
string-fasta.js | 32768 -> 32768 : 0.000% | 1.210 -> 1.212 : -0.155% | 
Geometric mean: | +0.260% | +0.645% | 

Binary sizes (bytes)
bb8ac29cce:140208
90166803af:140208

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu