### PR TITLE
jerry_value must be freed before return

### DIFF
--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -104,6 +104,7 @@ jerry_value_is_syntax_error (jerry_value_t error_value) /**< error value */
   if (jerry_value_has_error_flag (error_name)
       || !jerry_value_is_string (error_name))
   {
+    jerry_release_value (error_name);
     return false;
   }
 

--- a/tests/jerry/fail/regression-test-issue-1918.js
+++ b/tests/jerry/fail/regression-test-issue-1918.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+throw $ = {name: function () {}}


### PR DESCRIPTION
Fixes  #1918 
`error_name` must be freed before return.

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu