### PR TITLE
`replace_str_curr_p` must be inspected before dereferencing

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -909,14 +909,17 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
           {
             replace_str_curr_p++;
 
-            ecma_char_t next_character = *replace_str_curr_p;
-
-            if (next_character >= LIT_CHAR_0 && next_character <= LIT_CHAR_9)
+            if (replace_str_curr_p < replace_str_end_p)
             {
-              uint32_t full_index = index * 10 + (uint32_t) (next_character - LIT_CHAR_0);
-              if (full_index > 0 && full_index < match_length)
+              ecma_char_t next_character = *replace_str_curr_p;
+
+              if (next_character >= LIT_CHAR_0 && next_character <= LIT_CHAR_9)
               {
-                index = match_length;
+                uint32_t full_index = index * 10 + (uint32_t) (next_character - LIT_CHAR_0);
+                if (full_index > 0 && full_index < match_length)
+                {
+                  index = match_length;
+                }
               }
             }
 

--- a/tests/jerry/regression-test-issue-1917.js
+++ b/tests/jerry/regression-test-issue-1917.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert('foobar'.replace(/(ob)/g, '$0') == 'fo$0ar')


### PR DESCRIPTION
Fixes #1917.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu