### PR TITLE
target: mbedos5: Improve setInterval and setTimeout

### DIFF
--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setInterval-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setInterval-js.cpp
@@ -28,11 +28,20 @@ DECLARE_GLOBAL_FUNCTION(setInterval) {
     CHECK_ARGUMENT_TYPE_ALWAYS(global, setInterval, 0, function);
     CHECK_ARGUMENT_TYPE_ALWAYS(global, setInterval, 1, number);
 
-    jerry_acquire_value(args[0]);
     int interval = int(jerry_get_number_value(args[1]));
 
     int id = mbed::js::EventLoop::getInstance().getQueue().call_every(interval, jerry_call_function, args[0], jerry_create_null(), (jerry_value_t*)NULL, 0);
 
+    jerry_value_t result = jerry_set_property_by_index(function_obj_p, id, args[0]);
+
+    if (jerry_value_has_error_flag(result)) {
+        jerry_release_value(result);
+        mbed::js::EventLoop::getInstance().getQueue().cancel(id);
+
+        return jerry_create_error(JERRY_ERROR_TYPE, (const jerry_char_t *) "Failed to run setInterval");
+    }
+
+    jerry_release_value(result);
     return jerry_create_number(id);
 }
 
@@ -50,6 +59,13 @@ DECLARE_GLOBAL_FUNCTION(clearInterval) {
     int id = int(jerry_get_number_value(args[0]));
 
     mbed::js::EventLoop::getInstance().getQueue().cancel(id);
+
+    jerry_value_t prop_name = jerry_create_string((const jerry_char_t*)"setInterval");
+    jerry_value_t func_obj = jerry_get_property(this_obj, prop_name);
+    jerry_release_value(prop_name);
+
+    jerry_delete_property_by_index(func_obj, id);
+    jerry_release_value(func_obj);
 
     return jerry_create_undefined();
 }

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setTimeout-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setTimeout-js.cpp
@@ -28,11 +28,20 @@ DECLARE_GLOBAL_FUNCTION(setTimeout) {
     CHECK_ARGUMENT_TYPE_ALWAYS(global, setTimeout, 0, function);
     CHECK_ARGUMENT_TYPE_ALWAYS(global, setTimeout, 1, number);
 
-    jerry_acquire_value(args[0]);
     int interval = int(jerry_get_number_value(args[1]));
 
     int id = mbed::js::EventLoop::getInstance().getQueue().call_in(interval, jerry_call_function, args[0], jerry_create_null(), (jerry_value_t*)NULL, 0);
 
+    jerry_value_t result = jerry_set_property_by_index(function_obj_p, id, args[0]);
+
+    if (jerry_value_has_error_flag(result)) {
+        jerry_release_value(result);
+        mbed::js::EventLoop::getInstance().getQueue().cancel(id);
+
+        return jerry_create_error(JERRY_ERROR_TYPE, (const jerry_char_t *) "Failed to run setTimeout");
+    }
+
+    jerry_release_value(result);
     return jerry_create_number(id);
 }
 
@@ -50,6 +59,13 @@ DECLARE_GLOBAL_FUNCTION(clearTimeout) {
     int id = int(jerry_get_number_value(args[0]));
 
     mbed::js::EventLoop::getInstance().getQueue().cancel(id);
+
+    jerry_value_t prop_name = jerry_create_string((const jerry_char_t*)"setTimeout");
+    jerry_value_t func_obj = jerry_get_property(this_obj, prop_name);
+    jerry_release_value(prop_name);
+
+    jerry_delete_property_by_index(func_obj, id);
+    jerry_release_value(func_obj);
 
     return jerry_create_undefined();
 }

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
@@ -45,19 +45,21 @@ static int load_javascript() {
 
         if (jerry_value_has_error_flag(parsed_code)) {
             LOG_PRINT_ALWAYS("jerry_parse failed [%s]\r\n", js_codes[src].name);
+            jerry_release_value(parsed_code);
             jsmbed_js_exit();
             return -1;
         }
 
         jerry_value_t returned_value = jerry_run(parsed_code);
+        jerry_release_value(parsed_code);
 
         if (jerry_value_has_error_flag(returned_value)) {
             LOG_PRINT_ALWAYS("jerry_run failed [%s]\r\n", js_codes[src].name);
+            jerry_release_value(returned_value);
             jsmbed_js_exit();
             return -1;
         }
 
-        jerry_release_value(parsed_code);
         jerry_release_value(returned_value);
     }
 


### PR DESCRIPTION
In setInterval and setTimeout there must be a reference increase to the given function.
If you use `jerry_acquire` and you want to cleanup the engine, 
you get an assertion, because this value is released nowhere in the code.
In my opinion it is better to set the function as a property, so it is released automatically.

In launcher.cpp there is wrong error handle. If `returned_value` has error flag, `parsed_code` is not released.

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu