### PR TITLE
target: mbedos5: fix requirements.txt

### DIFF
--- a/targets/mbedos5/tools/requirements.txt
+++ b/targets/mbedos5/tools/requirements.txt
@@ -1,3 +1,3 @@
-pycparser
+pycparser<=2.17 # generate_pins.py does not work with 2.18 version
 simpleeval
 pycparserext


### PR DESCRIPTION
tools/generate_pins.py does not work with 2.18 version of pycparser

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu