### PR TITLE
ecma_delete_property must recreate the hashmap even if one of the properties is still valid

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -821,6 +821,11 @@ ecma_delete_property (ecma_object_t *object_p, /**< object */
         if (cur_prop_p->types[1 - i] != ECMA_PROPERTY_TYPE_DELETED)
         {
           /* The other property is still valid. */
+          if (hashmap_status == ECMA_PROPERTY_HASHMAP_DELETE_RECREATE_HASHMAP)
+          {
+            ecma_property_hashmap_free (object_p);
+            ecma_property_hashmap_create (object_p);
+          }
           return;
         }
 

--- a/tests/jerry/regression-test-issue-1934.js
+++ b/tests/jerry/regression-test-issue-1934.js
@@ -1,0 +1,30 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var devNum = 38;
+var devQueue = [];
+for (var i = 0; i < devNum; i++)
+{
+    devQueue.push(i);
+}
+
+for (var j = 0; j < devNum; j++)
+{
+    devQueue.shift();
+    devQueue.unshift(1);
+    devQueue.shift();
+    assert(j + devQueue.length + 1  == devNum)
+}
+
+assert(devQueue.length == 0);


### PR DESCRIPTION
Fixes #1934.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu