### PR TITLE
Bugfix: the value in test cases should be invariable

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-1936.js
+++ b/tests/jerry/es2015/regression-test-issue-1936.js
@@ -17,7 +17,7 @@ var name = "";
 try
 {
   Object.defineProperties(constructor.isExtensible, {a: Object.getOwnPropertyDescriptor(Uint8ClampedArray, "length")})
-  new Int32Array(new ArrayBuffer(), undefined, Date.now())
+  new Int32Array(new ArrayBuffer(), undefined, 40000000000)
 }
 catch (e)
 {


### PR DESCRIPTION
Fix the bug imported in #1937 

Reason: the #1936 's regression case use the `Date.now()` as a param of a function, and then cause the assert fail. Then I debug on it and fix the original bug. But the value of Data.now() changes with time changes. Do the patch can pass the CI last time, but failed this time.


JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com