### PR TITLE
Fix: make jerryx_module_resolve resolvers argument const

### DIFF
--- a/docs/12.EXT-REFERENCE-MODULE.md
+++ b/docs/12.EXT-REFERENCE-MODULE.md
@@ -38,7 +38,7 @@ called.
 ```c
 jerry_value_t
 jerryx_module_resolve (const jerry_char_t *name,
-                       jerryx_module_resolver_t *resolvers_p,
+                       const jerryx_module_resolver_t *resolvers_p,
                        size_t resolver_count);
 ```
 
@@ -134,7 +134,7 @@ load_and_evaluate_js_file (const jerry_char_t *name, jerry_value_t *result)
 
 We can now load JavaScript files:
 ```c
-static const jerryx_module_resolver_t resolvers =
+static const jerryx_module_resolver_t resolvers[] =
 {
   /* Consult the JerryScript module resolver first, in case the requested module is a compiled-in JerryScript module. */
   jerryx_module_native_resolver,

--- a/jerry-ext/include/jerryscript-ext/module.h
+++ b/jerry-ext/include/jerryscript-ext/module.h
@@ -69,6 +69,6 @@ typedef bool (*jerryx_module_resolver_t) (const jerry_char_t *name, jerry_value_
  * Load a copy of a module into the current context using the provided module resolvers, or return one that was already
  * loaded if it is found.
  */
-jerry_value_t jerryx_module_resolve (const jerry_char_t *name, jerryx_module_resolver_t *resolvers, size_t count);
+jerry_value_t jerryx_module_resolve (const jerry_char_t *name, const jerryx_module_resolver_t *resolvers, size_t count);
 
 #endif /* !JERRYX_MODULE_H */

--- a/jerry-ext/module/module.c
+++ b/jerry-ext/module/module.c
@@ -181,7 +181,7 @@ jerryx_module_native_resolver (const jerry_char_t *name, /**< name of the module
  */
 jerry_value_t
 jerryx_module_resolve (const jerry_char_t *name, /**< name of the module to load */
-                       jerryx_module_resolver_t *resolvers_p, /**< list of resolvers */
+                       const jerryx_module_resolver_t *resolvers_p, /**< list of resolvers */
                        size_t resolver_count) /**< number of resolvers in @p resolvers */
 {
   size_t index;

--- a/tests/unit-ext/module/jerry-module-test.c
+++ b/tests/unit-ext/module/jerry-module-test.c
@@ -91,7 +91,7 @@ cache_check (const jerry_char_t *name,
   return false;
 } /* cache_check */
 
-static jerryx_module_resolver_t resolvers[3] =
+static const jerryx_module_resolver_t resolvers[3] =
 {
   jerryx_module_native_resolver,
   resolve_differently_handled_module,


### PR DESCRIPTION
The resolvers argument that is passed to jerryx_module_resolve() is
not mutated by the function. Therefore the argument should be const.
In the docs, a static const array is passed, but this currently does not
work w/o a cast. This patch fixes this.

JerryScript-DCO-1.0-Signed-off-by: Martijn The martijn.the@intel.com