### PR TITLE
add Vagrantfile & docs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$script = <<SCRIPT
+sudo apt-get update
+sudo apt-get dist-upgrade -y
+sudo apt-get install gcc gcc-arm-none-eabi cmake cppcheck vera++ python -y
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.synced_folder ".", "/home/vagrant/jerryscript"
+  config.vm.provision "shell", inline: $script
+end

--- a/docs/01.GETTING-STARTED.md
+++ b/docs/01.GETTING-STARTED.md
@@ -2,6 +2,8 @@
 
 Currently, only Ubuntu 14.04+ is officially supported as primary development environment.
 
+[Vagrant can also be used](#building-jerryscript-with-vagrant) to build JerryScript.
+
 There are several dependencies, that should be installed manually. The following list is the absolute minimum for building:
 
 - `gcc` or any C99-compliant compiler (native or cross, e.g., arm-none-eabi)
@@ -173,3 +175,35 @@ python tools/run-tests.py --check-vera
 ```bash
 python tools/run-tests.py --help
 ```
+
+## Building JerryScript with Vagrant
+
+[Vagrant](https://vagrantup.com) provides virtual development environments for popular host operating systems (Windows, macOS, Linux).  We can use this to build JerryScript.
+
+1.  Follow the [instructions on how to install Vagrant](https://www.vagrantup.com/intro/getting-started/index.html) for your operating system.
+
+    > TL;DR: install Vagrant and [VirtualBox](https://virtualbox.org) using your method of choice.
+2.  Execute `vagrant up` in your JerryScript working copy:
+
+    ```bash
+    # Windows/PowerShell users will do something similar
+    $ cd /path/to/jerryscript
+    $ vagrant up
+    ```
+    
+    The above command will:
+    
+    1.  Download the Ubuntu 14.04 Vagrant box (think of this as an "image")
+    2.  Start a headless "guest" OS based on the box via VirtualBox
+    3.  Update & upgrade the guest OS' base packages
+    4.  Download and install the [prerequisites](#setting-up-the-prerequisites) to build JerryScript on the guest OS
+3.  The `jerryscript` directory is shared within the guest OS at `/home/vagrant/jerryscript`.  You can use `vagrant ssh` to open a shell.  You can navigate to this directory, and use any of the [above commands](#building-jerryscript) for development:
+  
+    ```bash
+    you@your-computer:/path/to/jerryscript$ vagrant ssh
+    vagrant@vagrant-ubuntu-trusty-64:~$ cd ~/jerryscript
+    vagrant@vagrant-ubuntu-trusty-64:~/jerryscript$ python tools/build.py
+    # (building happens here)
+    ```
+    
+    > PRO TIP: You can execute `vagrant ssh -c 'python ~/jerryscript/tools/build.py'` to run this command directly from your host operating system.


### PR DESCRIPTION
This PR adds a `Vagrantfile` for building JerryScript on non-Ubuntu-14.04+ host operating systems, as well as instructions.