### PR TITLE
Modifiying jerry_debugger_send_string method

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -389,7 +389,10 @@ jerry_parse_named_resource (const jerry_char_t *name_p, /**< name (usually a fil
 #ifdef JERRY_DEBUGGER
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
-    jerry_debugger_send_string (JERRY_DEBUGGER_SOURCE_CODE_NAME, name_p, name_length);
+    jerry_debugger_send_string (JERRY_DEBUGGER_SOURCE_CODE_NAME,
+                                JERRY_DEBUGGER_NO_SUBTYPE,
+                                name_p,
+                                name_length);
   }
 #else /* JERRY_DEBUGGER */
   JERRY_UNUSED (name_p);

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -34,6 +34,11 @@
 #define JERRY_DEBUGGER_TIMEOUT 100
 
 /**
+  * This constant represents that the string to be sent has no subtype.
+  */
+#define JERRY_DEBUGGER_NO_SUBTYPE 0
+
+/**
  * Limited resources available for the engine, so it is important to
  * check the maximum buffer size. It needs to be between 64 and 256 bytes.
  */
@@ -114,8 +119,6 @@ typedef enum
   JERRY_DEBUGGER_BACKTRACE_END = 20, /**< last backtrace data */
   JERRY_DEBUGGER_EVAL_RESULT = 21, /**< eval result */
   JERRY_DEBUGGER_EVAL_RESULT_END = 22, /**< last part of eval result */
-  JERRY_DEBUGGER_EVAL_ERROR = 23, /**< eval result when an error is occured */
-  JERRY_DEBUGGER_EVAL_ERROR_END = 24, /**< last part of eval result when an error is occured */
 
   /* Messages sent by the client to server. */
 
@@ -138,6 +141,15 @@ typedef enum
   JERRY_DEBUGGER_EVAL = 12, /**< first message of evaluating a string */
   JERRY_DEBUGGER_EVAL_PART = 13, /**< next message of evaluating a string */
 } jerry_debugger_header_type_t;
+
+/**
+  * Subtypes of send_eval.
+  */
+typedef enum
+{
+  JERRY_DEBUGGER_EVAL_OK = 1, /**< eval result, no error */
+  JERRY_DEBUGGER_EVAL_ERROR = 2, /**< eval result when an error is occured */
+} jerry_debugger_eval_subtype_t;
 
 /**
  * Delayed free of byte code data.
@@ -318,7 +330,7 @@ void jerry_debugger_breakpoint_hit (uint8_t message_type);
 void jerry_debugger_send_type (jerry_debugger_header_type_t type);
 bool jerry_debugger_send_configuration (uint8_t max_message_size);
 void jerry_debugger_send_data (jerry_debugger_header_type_t type, const void *data, size_t size);
-bool jerry_debugger_send_string (uint8_t message_type, const uint8_t *string_p, size_t string_length);
+bool jerry_debugger_send_string (uint8_t message_type, uint8_t sub_type, const uint8_t *string_p, size_t string_length);
 bool jerry_debugger_send_function_cp (jerry_debugger_header_type_t type, ecma_compiled_code_t *compiled_code_p);
 bool jerry_debugger_send_parse_function (uint32_t line, uint32_t column);
 void jerry_debugger_send_memstats (void);

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -406,6 +406,7 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
     jerry_debugger_send_string (JERRY_DEBUGGER_FUNCTION_NAME,
+                                JERRY_DEBUGGER_NO_SUBTYPE,
                                 name_p->u.char_p,
                                 name_p->prop.length);
 

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2194,6 +2194,7 @@ parser_parse_function (parser_context_t *context_p, /**< context */
     if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
     {
       jerry_debugger_send_string (JERRY_DEBUGGER_FUNCTION_NAME,
+                                  JERRY_DEBUGGER_NO_SUBTYPE,
                                   context_p->lit_object.literal_p->u.char_p,
                                   context_p->lit_object.literal_p->prop.length);
     }
@@ -2489,7 +2490,10 @@ parser_parse_script (const uint8_t *source_p, /**< source code */
 #ifdef JERRY_DEBUGGER
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
-    jerry_debugger_send_string (JERRY_DEBUGGER_SOURCE_CODE, source_p, size);
+    jerry_debugger_send_string (JERRY_DEBUGGER_SOURCE_CODE,
+                                JERRY_DEBUGGER_NO_SUBTYPE,
+                                source_p,
+                                size);
   }
 #endif /* JERRY_DEBUGGER */
 

--- a/jerry-debugger/jerry-client-ws.html
+++ b/jerry-debugger/jerry-client-ws.html
@@ -35,6 +35,7 @@ textarea {
   <div>
 </div>
 <script>
+// Messages sent by the server to client.
 var JERRY_DEBUGGER_CONFIGURATION = 1;
 var JERRY_DEBUGGER_PARSE_ERROR = 2;
 var JERRY_DEBUGGER_BYTE_CODE_CP = 3;
@@ -57,9 +58,12 @@ var JERRY_DEBUGGER_BACKTRACE = 19;
 var JERRY_DEBUGGER_BACKTRACE_END = 20;
 var JERRY_DEBUGGER_EVAL_RESULT = 21;
 var JERRY_DEBUGGER_EVAL_RESULT_END = 22;
-var JERRY_DEBUGGER_EVAL_ERROR = 23;
-var JERRY_DEBUGGER_EVAL_ERROR_END = 24;
 
+// Subtypes of eval
+var JERRY_DEBUGGER_EVAL_OK = 1;
+var JERRY_DEBUGGER_EVAL_ERROR = 2;
+
+// Messages sent by the client to server.
 var JERRY_DEBUGGER_FREE_BYTE_CODE_CP = 1;
 var JERRY_DEBUGGER_UPDATE_BREAKPOINT = 2;
 var JERRY_DEBUGGER_EXCEPTION_CONFIG = 3;
@@ -855,7 +859,7 @@ function DebuggerClient(address)
                   + (breakpoint.at ? "at " : "around ")
                   + breakpointInfo
                   + breakpointToString(breakpoint));
-                  
+
         if (debuggerObj.display)
         {
           debuggerObj.printSource(debuggerObj.display);
@@ -896,19 +900,18 @@ function DebuggerClient(address)
 
       case JERRY_DEBUGGER_EVAL_RESULT:
       case JERRY_DEBUGGER_EVAL_RESULT_END:
-      case JERRY_DEBUGGER_EVAL_ERROR:
-      case JERRY_DEBUGGER_EVAL_ERROR_END:
       {
         evalResult = concatUint8Arrays(evalResult, message);
-
-        if (message[0] == JERRY_DEBUGGER_EVAL_RESULT_END)
+        var subType = evalResult[evalResult.length - 1];
+        evalResult = evalResult.slice(0, -1);
+        if (subType == JERRY_DEBUGGER_EVAL_OK)
         {
           appendLog(cesu8ToString(evalResult));
           evalResult = null;
           return;
         }
 
-        if (message[0] == JERRY_DEBUGGER_EVAL_ERROR_END)
+        if (subType == JERRY_DEBUGGER_EVAL_ERROR)
         {
           appendLog("Uncaught exception: " + cesu8ToString(evalResult));
           evalResult = null;

--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -48,8 +48,10 @@ JERRY_DEBUGGER_BACKTRACE = 19
 JERRY_DEBUGGER_BACKTRACE_END = 20
 JERRY_DEBUGGER_EVAL_RESULT = 21
 JERRY_DEBUGGER_EVAL_RESULT_END = 22
-JERRY_DEBUGGER_EVAL_ERROR = 23
-JERRY_DEBUGGER_EVAL_ERROR_END = 24
+
+# Subtypes of eval
+JERRY_DEBUGGER_EVAL_OK = 1
+JERRY_DEBUGGER_EVAL_ERROR = 2
 
 
 # Messages sent by the client to server.
@@ -1064,17 +1066,16 @@ def main():
             prompt.cmdloop()
 
         elif buffer_type in [JERRY_DEBUGGER_EVAL_RESULT,
-                             JERRY_DEBUGGER_EVAL_RESULT_END,
-                             JERRY_DEBUGGER_EVAL_ERROR,
-                             JERRY_DEBUGGER_EVAL_ERROR_END]:
+                             JERRY_DEBUGGER_EVAL_RESULT_END]:
 
             message = b""
             eval_type = buffer_type
             while True:
                 message += data[3:]
 
-                if buffer_type in [JERRY_DEBUGGER_EVAL_RESULT_END,
-                                   JERRY_DEBUGGER_EVAL_ERROR_END]:
+                if buffer_type == JERRY_DEBUGGER_EVAL_RESULT_END:
+                    subtype = ord(message[-1])
+                    message = message[:-1]
                     break
 
                 data = debugger.get_message(True)
@@ -1085,7 +1086,7 @@ def main():
                                        eval_type + 1]:
                     raise Exception("Eval result expected")
 
-            if buffer_type == JERRY_DEBUGGER_EVAL_ERROR_END:
+            if subtype == JERRY_DEBUGGER_EVAL_ERROR:
                 print("Uncaught exception: %s" % (message))
             else:
                 print(message)


### PR DESCRIPTION
From now on, jerry_debugger_send_string can send a subtype of the string, making it more simple to send over strings with special parameters, therefore seperating different types of messages are simpler.
Enumerations for various subtypes can be made, while there's only need to have 2 entries for the header type.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu