### PR TITLE
Fix new ArrayBuffer(length) for various input

### DIFF
--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-001.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-001.js
@@ -15,3 +15,4 @@
 
 var a = new ArrayBuffer();
 assert(typeof a === 'object');
+assert(a.byteLength === 0);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-002.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-002.js
@@ -15,3 +15,4 @@
 
 var a = new ArrayBuffer(5);
 assert(typeof a === 'object');
+assert(a.byteLength === 5);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-003.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-003.js
@@ -15,3 +15,4 @@
 
 var a = new ArrayBuffer("5");
 assert(typeof a === 'object');
+assert(a.byteLength === 5);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-006.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-006.js
@@ -13,15 +13,5 @@
  * limitations under the License.
  */
 
-var name = "";
-
-try
-{
-  var a = new ArrayBuffer(5.5);
-}
-catch (e)
-{
-  name = e.name;
-}
-
-assert(name === "RangeError");
+var a = new ArrayBuffer(5.5);
+assert(a.byteLength === 5);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-008.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-008.js
@@ -13,15 +13,6 @@
  * limitations under the License.
  */
 
-var name = "";
 var obj = {};
-try
-{
-  var a = new ArrayBuffer(obj);
-}
-catch (e)
-{
-  name = e.name;
-}
-
-assert(name === "RangeError");
+var a = new ArrayBuffer(obj);
+assert(a.byteLength === 0);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-009.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-009.js
@@ -13,5 +13,5 @@
  * limitations under the License.
  */
 
-var a = new ArrayBuffer("string");
+var a = new ArrayBuffer(undefined);
 assert(a.byteLength === 0);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-010.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-010.js
@@ -13,5 +13,5 @@
  * limitations under the License.
  */
 
-var a = new ArrayBuffer("string");
+var a = new ArrayBuffer(NaN);
 assert(a.byteLength === 0);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-011.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-011.js
@@ -13,5 +13,8 @@
  * limitations under the License.
  */
 
-var a = new ArrayBuffer("string");
+var a = new ArrayBuffer(-0.3);
 assert(a.byteLength === 0);
+
+var b = new ArrayBuffer(-0.9);
+assert(b.byteLength === 0);

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-012.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-012.js
@@ -13,5 +13,14 @@
  * limitations under the License.
  */
 
-var a = new ArrayBuffer("string");
-assert(a.byteLength === 0);
+var name = "";
+try
+{
+  var a = new ArrayBuffer(-1.9);
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "RangeError");

--- a/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-013.js
+++ b/tests/jerry-test-suite/es2015/24/24.01/24.01.02/24.01.02-013.js
@@ -13,5 +13,14 @@
  * limitations under the License.
  */
 
-var a = new ArrayBuffer("string");
-assert(a.byteLength === 0);
+var name = "";
+try
+{
+  var a = new ArrayBuffer(Math.pow(2, 32) - 1);
+}
+catch (e)
+{
+  name = e.name;
+}
+
+assert(name === "RangeError");


### PR DESCRIPTION
Currently new ArrayBuffer(length) does not conform to ES2015.

For example, new ArrayBuffer(length) should not throw RangeError
for length = NaN, undefined, negative number, floating point, and so on.

JerryScript-DCO-1.0-Signed-off-by: Sanggyu Lee sg5.lee@samsung.com