### PR TITLE
[jerryx-arg]Check NaN in jerryx_arg_int

### DIFF
--- a/jerry-ext/arg/arg-transform-functions.c
+++ b/jerry-ext/arg/arg-transform-functions.c
@@ -132,6 +132,12 @@ jerryx_arg_helper_process_double (double *d, /**< [in, out] the number to be pro
                                   double max, /**< the max value for clamping */
                                   jerryx_arg_int_option_t option) /**< the converting policies */
 {
+  if (isnan (*d))
+  {
+    return jerry_create_error (JERRY_ERROR_TYPE,
+                               (jerry_char_t *) "The number is NaN.");
+  }
+
   if (option.clamp == JERRYX_ARG_NO_CLAMP)
   {
     if (*d > max || *d < min)


### PR DESCRIPTION
In jerryx_arg_int, we need to check whether the input js number is NaN. If so, the transformation fail.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com