### PR TITLE
Fix: make the FALLTHRU comment compatible with gcc v7.1.0

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -796,8 +796,8 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         }
 
         bc_p = old_bc_p;
-        /* FALLTHRU */
       }
+      /* FALLTHRU */
       case RE_OP_CAPTURE_GROUP_START:
       case RE_OP_CAPTURE_GREEDY_ZERO_GROUP_START:
       case RE_OP_NON_CAPTURE_GROUP_START:
@@ -933,8 +933,8 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         bc_p = old_bc_p;
 
         /* If non-greedy fails and try to iterate... */
-        /* FALLTHRU */
       }
+      /* FALLTHRU */
       case RE_OP_CAPTURE_GREEDY_GROUP_END:
       case RE_OP_NON_CAPTURE_GREEDY_GROUP_END:
       {

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -631,14 +631,14 @@ search_in_conversion_table (ecma_char_t character,        /**< code unit */
           {
             output_buffer_p[2] = array[middle + 3];
             char_sequence++;
-            /* FALLTHRU */
           }
+	  /* FALLTHRU */
           case 2:
           {
             output_buffer_p[1] = array[middle + 2];
             char_sequence++;
-            /* FALLTHRU */
           }
+	  /* FALLTHRU */
           default:
           {
             output_buffer_p[0] = array[middle + 1];

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -127,9 +127,8 @@ skip_spaces (parser_context_t *context_p) /**< context */
         {
           context_p->source_p++;
         }
-        /* FALLTHRU */
       }
-
+      /* FALLTHRU */
       case LIT_CHAR_LF:
       {
         context_p->line++;
@@ -140,9 +139,8 @@ skip_spaces (parser_context_t *context_p) /**< context */
         {
           mode = LEXER_SKIP_SPACES;
         }
-        /* FALLTHRU */
       }
-
+      /* FALLTHRU */
       case LIT_CHAR_VTAB:
       case LIT_CHAR_FF:
       case LIT_CHAR_SP:

--- a/jerry-core/parser/js/js-parser-scanner.c
+++ b/jerry-core/parser/js/js-parser-scanner.c
@@ -542,8 +542,8 @@ parser_scan_until (parser_context_t *context_p, /**< context */
         {
           break;
         }
-        /* FALLTHRU */
       }
+      /* FALLTHRU */
       case SCAN_MODE_PRIMARY_EXPRESSION_AFTER_NEW:
       {
         if (parser_scan_primary_expression (context_p, type, stack_top, &mode))
@@ -558,8 +558,8 @@ parser_scan_until (parser_context_t *context_p, /**< context */
         {
           break;
         }
-        /* FALLTHRU */
       }
+      /* FALLTHRU */
       case SCAN_MODE_PRIMARY_EXPRESSION_END:
       {
         if (parser_scan_primary_expression_end (context_p, type, stack_top, end_type, &mode))

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1966,9 +1966,8 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
           context_p->token.extra_value = context_p->token.type;
           context_p->token.type = LEXER_EXPRESSION_START;
         }
-        /* FALLTHRU */
       }
-
+      /* FALLTHRU */
       default:
       {
         int options = PARSE_EXPR_BLOCK;

--- a/jerry-core/vm/vm-stack.c
+++ b/jerry-core/vm/vm-stack.c
@@ -116,8 +116,8 @@ vm_decode_branch_offset (uint8_t *branch_offset_p, /**< start offset of byte cod
     {
       branch_offset <<= 8;
       branch_offset |= *(++branch_offset_p);
-      /* FALLTHRU */
     }
+    /* FALLTHRU */
     case 2:
     {
       branch_offset <<= 8;

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -838,8 +838,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           case 3:
           {
             branch_offset = *(byte_code_p++);
-            /* FALLTHRU */
           }
+	  /* FALLTHRU */
           default:
           {
             JERRY_ASSERT (CBC_BRANCH_OFFSET_LENGTH (opcode) == 2
@@ -1172,8 +1172,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             *stack_top_p++ = left_value;
             *stack_top_p++ = right_value;
           }
-          /* FALLTHRU */
         }
+	/* FALLTHRU */
         case VM_OC_PROP_GET:
         case VM_OC_PROP_PRE_INCR:
         case VM_OC_PROP_PRE_DECR:
@@ -1206,8 +1206,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           stack_top_p += 2;
           left_value = result;
           right_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
-          /* FALLTHRU */
         }
+	/* FALLTHRU */
         case VM_OC_PRE_INCR:
         case VM_OC_PRE_DECR:
         case VM_OC_POST_INCR:
@@ -1652,8 +1652,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
             left_value = result;
           }
-          /* FALLTHRU */
         }
+	/* FALLTHRU */
         case VM_OC_TYPEOF:
         {
           result = opfunc_typeof (left_value);


### PR DESCRIPTION
testarm-none-eabi-gcc (Fedora 7.1.0-2.fc25) 7.1.0
It seems like gcc changed the way FALLTHRU is used. With some slight modification on the place of FALLTHRU, gcc is happy now and no longer gives any warning.
