### PR TITLE
Allow "<NUL>" character within string literals in strict mode

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -615,6 +615,16 @@ lexer_parse_string (parser_context_t *context_p) /**< context */
         continue;
       }
 
+      if (*source_p == LIT_CHAR_0
+          && source_p + 1 < source_end_p
+          && (*(source_p + 1) < LIT_CHAR_0 || *(source_p + 1) > LIT_CHAR_9))
+      {
+        source_p++;
+        column++;
+        length++;
+        continue;
+      }
+
       /* Except \x, \u, and octal numbers, everything is
        * converted to a character which has the same byte length. */
       if (*source_p >= LIT_CHAR_0 && *source_p <= LIT_CHAR_3)

--- a/tests/jerry/strict.js
+++ b/tests/jerry/strict.js
@@ -70,6 +70,52 @@ try
   assert (e instanceof TypeError);
 }
 
+try
+{
+  eval ("'\\" + "101'");
+
+  assert (false);
+} catch (e)
+{
+  assert (e instanceof SyntaxError);
+}
+
+try
+{
+  var str1 = "'\\" + "0'";
+  var str2 = "'\\x" + "00'";
+  eval (str1);
+
+  assert (eval (str1) === eval (str2));
+} catch (e)
+{
+  assert (false);
+}
+
+try
+{
+  var str1 = "'\\" + "0" + "\\" + "0" + "\\" + "0'";
+  var str2 = "'\\x" + "00" + "\\x" + "00" + "\\x" + "00'";
+  eval (str1);
+
+  assert (eval (str1) === eval (str2));
+} catch (e)
+{
+  assert (false);
+}
+
+try
+{
+  var str1 = "'foo\\" + "0" + "bar'";
+  var str2 = "'foo\\x" + "00" + "bar'";
+  eval (str1);
+
+  assert (eval (str1) === eval (str2));
+} catch (e)
+{
+  assert (false);
+}
+
 (function (a) {
   (function (a) {
   });


### PR DESCRIPTION
"\0" is a legal character value with a lookahead restriction according to specification:

> The CV of EscapeSequence :: 0 [lookahead ∉ DecimalDigit] is a &lt;NUL&gt; character (Unicode value 0000).

 Therefore, it should not be treated like octal escape sequences in some circumstances.

Test case:

```javascript
'use strict';
var print = print || console.log;
print('\0');
print('\0a');
print('a\0');
print('\0\0\0');
print('foo\0bar');
```

Reference:
- https://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
- https://www.ecma-international.org/ecma-262/5.1/#sec-B.1.2
- https://github.com/nodejs/node/blob/98ddab411523f83eca9b5311529f8288379e550f/deps/v8/src/parsing/scanner.cc#L1050
- https://github.com/svaarala/duktape/blob/aa401554460db5c006fdb76715dd66467e5c4c3d/src-input/duk_lexer.c#L785