### PR TITLE
Remove unnecessary string allocations.

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -168,12 +168,11 @@ jerry_debugger_send_eval (const lit_utf8_byte_t *eval_string_p, /**< evaluated s
 
     if (ecma_is_value_object (result))
     {
-      ecma_string_t *message_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE);
+      ecma_string_t magic_string_message;
+      ecma_init_ecma_magic_string (&magic_string_message, LIT_MAGIC_STRING_MESSAGE);
 
       message = ecma_op_object_find (ecma_get_object_from_value (result),
-                                     message_string_p);
-
-      ecma_deref_ecma_string (message_string_p);
+                                     &magic_string_message);
 
       if (!ecma_is_value_string (message)
           || ecma_string_is_empty (ecma_get_string_from_value (message)))

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -361,7 +361,7 @@ ecma_init_ecma_string_from_uint32 (ecma_string_t *string_desc_p, /**< ecma-strin
 /**
  * Initialize a magic ecma-string
  */
-void
+inline void __attr_always_inline___
 ecma_init_ecma_magic_string (ecma_string_t *string_desc_p, /**< ecma-string */
                              lit_magic_string_id_t id) /**< literal id */
 {
@@ -441,38 +441,6 @@ ecma_new_ecma_string_from_number (ecma_number_t num) /**< ecma-number */
   memcpy (data_p, str_buf, str_size);
   return string_desc_p;
 } /* ecma_new_ecma_string_from_number */
-
-/**
- * Allocate new ecma-string and fill it with reference to ECMA magic string
- *
- * @return pointer to ecma-string descriptor
- */
-ecma_string_t *
-ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t id) /**< identifier of magic string */
-{
-  JERRY_ASSERT (id < LIT_MAGIC_STRING__COUNT);
-
-  ecma_string_t *string_desc_p = ecma_alloc_string ();
-  ecma_init_ecma_string_from_magic_string_id (string_desc_p, id);
-
-  return string_desc_p;
-} /* ecma_new_ecma_string_from_magic_string_id */
-
-/**
- * Allocate new ecma-string and fill it with reference to ECMA magic string
- *
- * @return pointer to ecma-string descriptor
- */
-ecma_string_t *
-ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id) /**< identifier of externl magic string */
-{
-  JERRY_ASSERT (id < lit_get_magic_string_ex_count ());
-
-  ecma_string_t *string_desc_p = ecma_alloc_string ();
-  ecma_init_ecma_string_from_magic_string_ex_id (string_desc_p, id);
-
-  return string_desc_p;
-} /* ecma_new_ecma_string_from_magic_string_ex_id */
 
 /**
  * Allocate new ecma-string and fill it with reference to length magic string
@@ -1443,11 +1411,11 @@ ecma_string_from_property_name (ecma_property_t property, /**< property name typ
     }
     case ECMA_STRING_CONTAINER_MAGIC_STRING:
     {
-      return ecma_new_ecma_string_from_magic_string_id ((lit_magic_string_id_t) prop_name_cp);
+      return ecma_get_magic_string ((lit_magic_string_id_t) prop_name_cp);
     }
     case ECMA_STRING_CONTAINER_MAGIC_STRING_EX:
     {
-      return ecma_new_ecma_string_from_magic_string_ex_id ((lit_magic_string_ex_id_t) prop_name_cp);
+      return ecma_get_magic_string_ex ((lit_magic_string_ex_id_t) prop_name_cp);
     }
     default:
     {
@@ -1960,7 +1928,12 @@ ecma_string_get_char_at_pos (const ecma_string_t *string_p, /**< ecma-string */
 ecma_string_t *
 ecma_get_magic_string (lit_magic_string_id_t id) /**< magic string id */
 {
-  return ecma_new_ecma_string_from_magic_string_id (id);
+  JERRY_ASSERT (id < LIT_MAGIC_STRING__COUNT);
+
+  ecma_string_t *string_desc_p = ecma_alloc_string ();
+  ecma_init_ecma_string_from_magic_string_id (string_desc_p, id);
+
+  return string_desc_p;
 } /* ecma_get_magic_string */
 
 /**
@@ -1971,7 +1944,12 @@ ecma_get_magic_string (lit_magic_string_id_t id) /**< magic string id */
 ecma_string_t *
 ecma_get_magic_string_ex (lit_magic_string_ex_id_t id) /**< external magic string id */
 {
-  return ecma_new_ecma_string_from_magic_string_ex_id (id);
+  JERRY_ASSERT (id < lit_get_magic_string_ex_count ());
+
+  ecma_string_t *string_desc_p = ecma_alloc_string ();
+  ecma_init_ecma_string_from_magic_string_ex_id (string_desc_p, id);
+
+  return string_desc_p;
 } /* ecma_get_magic_string_ex */
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -166,8 +166,6 @@ ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8
 ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t code_unit);
 ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t uint32_number);
 ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t num);
-ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t id);
-ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id);
 ecma_string_t *ecma_new_ecma_length_string (void);
 ecma_string_t *ecma_concat_ecma_strings (ecma_string_t *string1_p, ecma_string_t *string2_p);
 void ecma_ref_ecma_string (ecma_string_t *string_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -59,16 +59,16 @@ ecma_builtin_array_prototype_helper_set_length (ecma_object_t *object, /**< obje
                                                 ecma_number_t length) /**< new length */
 {
   ecma_value_t ret_value;
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   ecma_value_t length_value = ecma_make_number_value (length);
   ret_value = ecma_op_object_put (object,
-                                  magic_string_length_p,
+                                  &magic_string_length,
                                   length_value,
                                   true),
 
   ecma_free_value (length_value);
-  ecma_deref_ecma_string (magic_string_length_p);
 
   return ret_value;
 } /* ecma_builtin_array_prototype_helper_set_length */
@@ -94,11 +94,12 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this_value);
 
-  ecma_string_t *join_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_JOIN);
+  ecma_string_t magic_string_join;
+  ecma_init_ecma_magic_string (&magic_string_join, LIT_MAGIC_STRING_JOIN);
 
   /* 2. */
   ECMA_TRY_CATCH (join_value,
-                  ecma_op_object_get (obj_p, join_magic_string_p),
+                  ecma_op_object_get (obj_p, &magic_string_join),
                   ret_value);
 
   if (!ecma_op_is_callable (join_value))
@@ -115,9 +116,6 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
   }
 
   ECMA_FINALIZE (join_value);
-
-  ecma_deref_ecma_string (join_magic_string_p);
-
   ECMA_FINALIZE (obj_this_value);
 
   return ret_value;
@@ -144,11 +142,12 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_value);
 
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (length_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   /* 3. */
@@ -214,8 +213,6 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
   ECMA_OP_TO_NUMBER_FINALIZE (length_number);
 
   ECMA_FINALIZE (length_value);
-
-  ecma_deref_ecma_string (length_magic_string_p);
 
   ECMA_FINALIZE (obj_value);
 
@@ -368,11 +365,12 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_value);
 
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (length_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (length_number,
@@ -446,8 +444,6 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
 
   ECMA_FINALIZE (length_value);
 
-  ecma_deref_ecma_string (length_magic_string_p);
-
   ECMA_FINALIZE (obj_value);
 
   return ret_value;
@@ -473,11 +469,12 @@ ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argume
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -526,7 +523,6 @@ ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argume
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -554,9 +550,10 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this_value);
 
   /* 2. */
-  ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
-  ECMA_TRY_CATCH (length_value, ecma_op_object_get (obj_p, length_str_p), ret_value);
+  ECMA_TRY_CATCH (length_value, ecma_op_object_get (obj_p, &magic_string_length), ret_value);
 
   /* 3. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (length_var, length_value, ret_value);
@@ -596,8 +593,6 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
 
   ECMA_FINALIZE (length_value);
 
-  ecma_deref_ecma_string (length_str_p);
-
   ECMA_FINALIZE (obj_this_value);
 
   return ret_value;
@@ -623,11 +618,13 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this ar
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   /* 3. */
@@ -693,7 +690,6 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this ar
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -719,11 +715,12 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -806,7 +803,6 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -834,10 +830,11 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   /* 3. */
@@ -922,7 +919,6 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (length_magic_string_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1204,10 +1200,12 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1325,7 +1323,6 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1355,10 +1352,11 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
 
   /* 3. */
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   /* 4. */
@@ -1610,7 +1608,6 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (length_magic_string_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1638,11 +1635,12 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1707,7 +1705,6 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1735,11 +1732,13 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1800,8 +1799,6 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
 
   ECMA_FINALIZE (len_value);
 
-  ecma_deref_ecma_string (magic_string_length_p);
-
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1830,11 +1827,13 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1946,7 +1945,6 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1974,11 +1972,13 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2045,7 +2045,6 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2073,11 +2072,13 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2145,7 +2146,6 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2172,11 +2172,13 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2237,7 +2239,6 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2265,11 +2266,13 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2349,7 +2352,6 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2377,11 +2379,12 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   /* 3. */
@@ -2469,7 +2472,6 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2499,11 +2501,13 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2624,7 +2628,6 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2654,11 +2657,13 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2780,7 +2785,6 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -151,12 +151,13 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg) /**< this argument *
 
   if (ecma_is_value_empty (ret_value))
   {
-    ecma_string_t *to_iso_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_ISO_STRING_UL);
+    ecma_string_t magic_string_to_iso_string;
+    ecma_init_ecma_magic_string (&magic_string_to_iso_string, LIT_MAGIC_STRING_TO_ISO_STRING_UL);
     ecma_object_t *value_obj_p = ecma_get_object_from_value (obj);
 
     /* 4. */
     ECMA_TRY_CATCH (to_iso,
-                    ecma_op_object_get (value_obj_p, to_iso_str_p),
+                    ecma_op_object_get (value_obj_p, &magic_string_to_iso_string),
                     ret_value);
 
     /* 5. */
@@ -172,8 +173,6 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg) /**< this argument *
     }
 
     ECMA_FINALIZE (to_iso);
-
-    ecma_deref_ecma_string (to_iso_str_p);
   }
 
   ECMA_FINALIZE (tv);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -65,10 +65,11 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
   else
   {
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
-    ecma_string_t *name_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAME);
+    ecma_string_t magic_string_name;
+    ecma_init_ecma_magic_string (&magic_string_name, LIT_MAGIC_STRING_NAME);
 
     ECMA_TRY_CATCH (name_get_ret_value,
-                    ecma_op_object_get (obj_p, name_magic_string_p),
+                    ecma_op_object_get (obj_p, &magic_string_name),
                     ret_value);
 
     ecma_value_t name_to_str_completion;
@@ -90,10 +91,11 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
     }
     else
     {
-      ecma_string_t *message_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE);
+      ecma_string_t magic_string_message;
+      ecma_init_ecma_magic_string (&magic_string_message, LIT_MAGIC_STRING_MESSAGE);
 
       ECMA_TRY_CATCH (msg_get_ret_value,
-                      ecma_op_object_get (obj_p, message_magic_string_p),
+                      ecma_op_object_get (obj_p, &magic_string_message),
                       ret_value);
 
       ecma_value_t msg_to_str_completion;
@@ -173,15 +175,11 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
       ecma_free_value (msg_to_str_completion);
 
       ECMA_FINALIZE (msg_get_ret_value);
-
-      ecma_deref_ecma_string (message_magic_string_p);
     }
 
     ecma_free_value (name_to_str_completion);
 
     ECMA_FINALIZE (name_get_ret_value);
-
-    ecma_deref_ecma_string (name_magic_string_p);
   }
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -109,11 +109,12 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
       else
       {
         ecma_object_t *obj_p = ecma_get_object_from_value (arg2);
-        ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
+        ecma_string_t magic_string_length;
+        ecma_init_ecma_length_string (&magic_string_length);
 
         /* 4. */
         ECMA_TRY_CATCH (length_value,
-                        ecma_op_object_get (obj_p, length_magic_string_p),
+                        ecma_op_object_get (obj_p, &magic_string_length),
                         ret_value);
 
         ECMA_OP_TO_NUMBER_TRY_CATCH (length_number,
@@ -163,7 +164,6 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
 
         ECMA_OP_TO_NUMBER_FINALIZE (length_number);
         ECMA_FINALIZE (length_value);
-        ecma_deref_ecma_string (length_magic_string_p);
       }
     }
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
@@ -78,16 +78,16 @@ ecma_builtin_function_helper_get_function_expression (const ecma_value_t *argume
   ecma_string_t *function_kw_str_p, *empty_str_p;
   ecma_string_t *expr_str_p, *concated_str_p;
 
-  left_parenthesis_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_LEFT_PARENTHESIS_CHAR);
-  right_parenthesis_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_RIGHT_PARENTHESIS_CHAR);
+  left_parenthesis_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LEFT_PARENTHESIS_CHAR);
+  right_parenthesis_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_RIGHT_PARENTHESIS_CHAR);
 
-  left_brace_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_LEFT_BRACE_CHAR);
-  right_brace_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_RIGHT_BRACE_CHAR);
+  left_brace_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LEFT_BRACE_CHAR);
+  right_brace_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_RIGHT_BRACE_CHAR);
 
   comma_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_COMMA_CHAR);
 
-  function_kw_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_FUNCTION);
-  empty_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
+  function_kw_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_FUNCTION);
+  empty_str_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
 
   /* First, we only process the function arguments skipping the function body */
   ecma_length_t number_of_function_args = (arguments_list_len == 0 ? 0 : arguments_list_len - 1);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -269,9 +269,7 @@ ecma_string_t *
 ecma_builtin_helper_json_create_hex_digit_ecma_string (uint8_t value) /**< value in decimal*/
 {
   /* 2.c.iii */
-  ecma_string_t *hex_str_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-
-  JMEM_DEFINE_LOCAL_ARRAY (hex_buff, 4, lit_utf8_byte_t);
+  lit_utf8_byte_t hex_buff[4];
 
   for (uint32_t i = 0; i < 4; i++)
   {
@@ -293,10 +291,7 @@ ecma_builtin_helper_json_create_hex_digit_ecma_string (uint8_t value) /**< value
     value = value / 16;
   }
 
-  ecma_deref_ecma_string (hex_str_p);
-  hex_str_p = ecma_new_ecma_string_from_utf8 ((lit_utf8_byte_t *) hex_buff, 4);
-
-  JMEM_FINALIZE_LOCAL_ARRAY (hex_buff);
+  ecma_string_t *hex_str_p = ecma_new_ecma_string_from_utf8 ((lit_utf8_byte_t *) hex_buff, 4);
 
   JERRY_ASSERT (ecma_string_get_length (hex_str_p));
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -141,10 +141,11 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
                     ret_value);
 
     ecma_object_t *index_obj_p = ecma_get_object_from_value (index_obj_value);
-    ecma_string_t *locale_string_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_LOCALE_STRING_UL);
+    ecma_string_t magic_string_to_locale_string;
+    ecma_init_ecma_magic_string (&magic_string_to_locale_string, LIT_MAGIC_STRING_TO_LOCALE_STRING_UL);
 
     ECMA_TRY_CATCH (to_locale_value,
-                    ecma_op_object_get (index_obj_p, locale_string_magic_string_p),
+                    ecma_op_object_get (index_obj_p, &magic_string_to_locale_string),
                     ret_value);
 
     if (ecma_op_is_callable (to_locale_value))
@@ -166,9 +167,6 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
     }
 
     ECMA_FINALIZE (to_locale_value);
-
-    ecma_deref_ecma_string (locale_string_magic_string_p);
-
     ECMA_FINALIZE (index_obj_value);
   }
 
@@ -332,11 +330,13 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
   if (ecma_is_value_object (value)
       && (ecma_object_get_class_name (ecma_get_object_from_value (value)) == LIT_MAGIC_STRING_ARRAY_UL))
   {
-    ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
+    ecma_string_t magic_string_length;
+    ecma_init_ecma_length_string (&magic_string_length);
+
     /* 5.b.ii */
     ECMA_TRY_CATCH (arg_len_value,
                     ecma_op_object_get (ecma_get_object_from_value (value),
-                                        magic_string_length_p),
+                                        &magic_string_length),
                     ret_value);
     ECMA_OP_TO_NUMBER_TRY_CATCH (arg_len_number, arg_len_value, ret_value);
 
@@ -383,7 +383,6 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
 
     ECMA_OP_TO_NUMBER_FINALIZE (arg_len_number);
     ECMA_FINALIZE (arg_len_value);
-    ecma_deref_ecma_string (magic_string_length_p);
   }
   else
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -924,10 +924,11 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
     /* 4.b */
     else if (ecma_object_get_class_name (obj_p) == LIT_MAGIC_STRING_ARRAY_UL)
     {
-      ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
+      ecma_string_t magic_string_length;
+      ecma_init_ecma_length_string (&magic_string_length);
 
       ECMA_TRY_CATCH (array_length,
-                      ecma_op_object_get (obj_p, length_str_p),
+                      ecma_op_object_get (obj_p, &magic_string_length),
                       ret_value);
 
       ECMA_OP_TO_NUMBER_TRY_CATCH (array_length_num,
@@ -1007,8 +1008,6 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
 
       ECMA_OP_TO_NUMBER_FINALIZE (array_length_num);
       ECMA_FINALIZE (array_length);
-
-      ecma_deref_ecma_string (length_str_p);
     }
   }
 
@@ -1727,11 +1726,12 @@ ecma_builtin_json_array (ecma_object_t *obj_p, /**< the array object*/
   /* 5. */
   ecma_collection_header_t *partial_p = ecma_new_values_collection (NULL, 0, true);
 
-  ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   /* 6. */
   ECMA_TRY_CATCH (array_length,
-                  ecma_op_object_get (obj_p, length_str_p),
+                  ecma_op_object_get (obj_p, &magic_string_length),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (array_length_num,
@@ -1819,7 +1819,6 @@ ecma_builtin_json_array (ecma_object_t *obj_p, /**< the array object*/
   ECMA_OP_TO_NUMBER_FINALIZE (array_length_num);
   ECMA_FINALIZE (array_length);
 
-  ecma_deref_ecma_string (length_str_p);
   ecma_free_values_collection (partial_p, true);
 
   /* 11. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -93,11 +93,12 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /*
                   return_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_val);
-  ecma_string_t *to_string_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_STRING_UL);
+  ecma_string_t magic_string_to_string;
+  ecma_init_ecma_magic_string (&magic_string_to_string, LIT_MAGIC_STRING_TO_STRING_UL);
 
   /* 2. */
   ECMA_TRY_CATCH (to_string_val,
-                  ecma_op_object_get (obj_p, to_string_magic_string_p),
+                  ecma_op_object_get (obj_p, &magic_string_to_string),
                   return_value);
 
   /* 3. */
@@ -112,8 +113,6 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /*
     return_value = ecma_op_function_call (to_string_func_obj_p, this_arg, NULL, 0);
   }
   ECMA_FINALIZE (to_string_val);
-
-  ecma_deref_ecma_string (to_string_magic_string_p);
 
   ECMA_FINALIZE (obj_val);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -205,10 +205,12 @@ ecma_builtin_promise_do_race (ecma_value_t array, /**< the array for race */
   JERRY_ASSERT (ecma_get_object_type (ecma_get_object_from_value (array)) == ECMA_OBJECT_TYPE_ARRAY);
 
   ecma_value_t ret = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
   ecma_object_t *array_p = ecma_get_object_from_value (array);
-  ecma_value_t len_value = ecma_op_object_get (array_p, magic_string_length_p);
-  ecma_deref_ecma_string (magic_string_length_p);
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
+
+  ecma_value_t len_value = ecma_op_object_get (array_p, &magic_string_length);
   ecma_length_t len = (ecma_length_t) ecma_get_integer_from_value (len_value);
   ecma_fast_free_value (len_value);
 
@@ -416,10 +418,12 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
   JERRY_ASSERT (ecma_get_object_type (ecma_get_object_from_value (array)) == ECMA_OBJECT_TYPE_ARRAY);
 
   ecma_value_t ret = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
   ecma_object_t *array_p = ecma_get_object_from_value (array);
-  ecma_value_t len_value = ecma_op_object_get (array_p, magic_string_length_p);
-  ecma_deref_ecma_string (magic_string_length_p);
+
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
+
+  ecma_value_t len_value = ecma_op_object_get (array_p, &magic_string_length);
   ecma_length_t len = (ecma_length_t) ecma_get_integer_from_value (len_value);
   ecma_fast_free_value (len_value);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -86,15 +86,14 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         ecma_object_t *target_p = ecma_get_object_from_value (pattern_arg);
 
         /* Get source. */
-        ecma_string_t *magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SOURCE);
-        ecma_value_t source_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
+        ecma_string_t magic_string;
+        ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_SOURCE);
+        ecma_value_t source_value = ecma_op_object_get_own_data_prop (target_p, &magic_string);
         ecma_string_t *pattern_string_p = ecma_get_string_from_value (source_value);
 
         /* Get flags. */
-        magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
-        ecma_value_t global_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
+        ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_GLOBAL);
+        ecma_value_t global_value = ecma_op_object_get_own_data_prop (target_p, &magic_string);
 
         JERRY_ASSERT (ecma_is_value_boolean (global_value));
 
@@ -103,9 +102,8 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
           flags |= RE_FLAG_GLOBAL;
         }
 
-        magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL);
-        ecma_value_t ignore_case_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
+        ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_IGNORECASE_UL);
+        ecma_value_t ignore_case_value = ecma_op_object_get_own_data_prop (target_p, &magic_string);
 
         JERRY_ASSERT (ecma_is_value_boolean (ignore_case_value));
 
@@ -114,9 +112,8 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
           flags |= RE_FLAG_IGNORE_CASE;
         }
 
-        magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE);
-        ecma_value_t multiline_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
+        ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_MULTILINE);
+        ecma_value_t multiline_value = ecma_op_object_get_own_data_prop (target_p, &magic_string);
 
         JERRY_ASSERT (ecma_is_value_boolean (multiline_value));
 
@@ -361,9 +358,9 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
 
     /* Get RegExp source from the source property */
-    ecma_string_t *magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SOURCE);
-    ecma_value_t source_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
+    ecma_string_t magic_string;
+    ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_SOURCE);
+    ecma_value_t source_value = ecma_op_object_get_own_data_prop (obj_p, &magic_string);
 
     ecma_string_t *src_sep_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_SLASH_CHAR);
     ecma_string_t *source_str_p = ecma_get_string_from_value (source_value);
@@ -376,9 +373,8 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     output_str_p = concat_p;
 
     /* Check the global flag */
-    magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
-    ecma_value_t global_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
+    ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_GLOBAL);
+    ecma_value_t global_value = ecma_op_object_get_own_data_prop (obj_p, &magic_string);
 
     JERRY_ASSERT (ecma_is_value_boolean (global_value));
 
@@ -392,9 +388,8 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     }
 
     /* Check the ignoreCase flag */
-    magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL);
-    ecma_value_t ignore_case_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
+    ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_IGNORECASE_UL);
+    ecma_value_t ignore_case_value = ecma_op_object_get_own_data_prop (obj_p, &magic_string);
 
     JERRY_ASSERT (ecma_is_value_boolean (ignore_case_value));
 
@@ -408,9 +403,8 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     }
 
     /* Check the multiline flag */
-    magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE);
-    ecma_value_t multiline_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
+    ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_MULTILINE);
+    ecma_value_t multiline_value = ecma_op_object_get_own_data_prop (obj_p, &magic_string);
 
     JERRY_ASSERT (ecma_is_value_boolean (multiline_value));
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -429,11 +429,12 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
   {
     JERRY_ASSERT (!ecma_is_value_empty (regexp_value));
     ecma_object_t *regexp_obj_p = ecma_get_object_from_value (regexp_value);
-    ecma_string_t *global_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
+    ecma_string_t magic_string_global;
+    ecma_init_ecma_magic_string (&magic_string_global, LIT_MAGIC_STRING_GLOBAL);
 
     /* 5. */
     ECMA_TRY_CATCH (global_value,
-                    ecma_op_object_get (regexp_obj_p, global_string_p),
+                    ecma_op_object_get (regexp_obj_p, &magic_string_global),
                     ret_value);
 
     JERRY_ASSERT (ecma_is_value_boolean (global_value));
@@ -448,11 +449,12 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
       /* 8.a. */
       ecma_string_t *index_zero_string_p = ecma_new_ecma_string_from_uint32 (0);
 
-      ecma_string_t *last_index_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
+      ecma_string_t magic_string_last_index;
+      ecma_init_ecma_magic_string (&magic_string_last_index, LIT_MAGIC_STRING_LASTINDEX_UL);
 
       ECMA_TRY_CATCH (put_value,
                       ecma_op_object_put (regexp_obj_p,
-                                          last_index_string_p,
+                                          &magic_string_last_index,
                                           ecma_make_integer_value (0),
                                           true),
                       ret_value);
@@ -488,7 +490,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
         {
           /* 8.f.iii. */
           ECMA_TRY_CATCH (this_index_value,
-                          ecma_op_object_get (regexp_obj_p, last_index_string_p),
+                          ecma_op_object_get (regexp_obj_p, &magic_string_last_index),
                           ret_value);
 
           ECMA_TRY_CATCH (this_index_number,
@@ -503,7 +505,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
             /* 8.f.iii.2.a. */
             ECMA_TRY_CATCH (index_put_value,
                             ecma_op_object_put (regexp_obj_p,
-                                                last_index_string_p,
+                                                &magic_string_last_index,
                                                 ecma_make_number_value (this_index + 1),
                                                 true),
                             ret_value);
@@ -576,13 +578,10 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
 
       ECMA_FINALIZE (put_value);
 
-      ecma_deref_ecma_string (last_index_string_p);
       ecma_deref_ecma_string (index_zero_string_p);
     }
 
     ECMA_FINALIZE (global_value);
-
-    ecma_deref_ecma_string (global_string_p);
 
     ecma_free_value (regexp_value);
   }
@@ -690,11 +689,12 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
       JERRY_ASSERT (ecma_is_value_object (match_value));
 
       ecma_object_t *match_object_p = ecma_get_object_from_value (match_value);
-      ecma_string_t *index_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
+      ecma_string_t magic_string_index;
+      ecma_init_ecma_magic_string (&magic_string_index, LIT_MAGIC_STRING_INDEX);
       ecma_string_t *zero_string_p = ecma_new_ecma_string_from_uint32 (0);
 
       ECMA_TRY_CATCH (index_value,
-                      ecma_op_object_get (match_object_p, index_string_p),
+                      ecma_op_object_get (match_object_p, &magic_string_index),
                       ret_value);
 
       ECMA_TRY_CATCH (result_string_value,
@@ -721,7 +721,7 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
 
       ECMA_FINALIZE (result_string_value);
       ECMA_FINALIZE (index_value);
-      ecma_deref_ecma_string (index_string_p);
+
       ecma_deref_ecma_string (zero_string_p);
     }
     else
@@ -774,11 +774,13 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
                                                          ecma_value_t match_value) /**< returned match value */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_string_t *length_string_p = ecma_new_ecma_length_string ();
   ecma_object_t *match_object_p = ecma_get_object_from_value (match_value);
 
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
+
   ECMA_TRY_CATCH (match_length_value,
-                  ecma_op_object_get (match_object_p, length_string_p),
+                  ecma_op_object_get (match_object_p, &magic_string_length),
                   ret_value);
 
   JERRY_ASSERT (ecma_is_value_number (match_length_value));
@@ -1048,7 +1050,6 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
   }
 
   ECMA_FINALIZE (match_length_value);
-  ecma_deref_ecma_string (length_string_p);
 
   return ret_value;
 } /* ecma_builtin_string_prototype_object_replace_get_string */
@@ -1114,18 +1115,18 @@ ecma_builtin_string_prototype_object_replace_loop (ecma_builtin_replace_search_c
         }
         else
         {
-          ecma_string_t *last_index_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
+          ecma_string_t magic_string_last_index;
+          ecma_init_ecma_magic_string (&magic_string_last_index, LIT_MAGIC_STRING_LASTINDEX_UL);
           ecma_object_t *regexp_obj_p = ecma_get_object_from_value (context_p->regexp_or_search_string);
 
           ECMA_TRY_CATCH (put_value,
                           ecma_op_object_put (regexp_obj_p,
-                                              last_index_string_p,
+                                              &magic_string_last_index,
                                               ecma_make_uint32_value (context_p->match_end + 1),
                                               true),
                           ret_value);
 
           ECMA_FINALIZE (put_value);
-          ecma_deref_ecma_string (last_index_string_p);
         }
       }
     }
@@ -1259,10 +1260,11 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this a
       && ecma_object_class_is (ecma_get_object_from_value (search_value), LIT_MAGIC_STRING_REGEXP_UL))
   {
     ecma_object_t *regexp_obj_p = ecma_get_object_from_value (search_value);
-    ecma_string_t *global_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
+    ecma_string_t magic_string_global;
+    ecma_init_ecma_magic_string (&magic_string_global, LIT_MAGIC_STRING_GLOBAL);
 
     ECMA_TRY_CATCH (global_value,
-                    ecma_op_object_get (regexp_obj_p, global_string_p),
+                    ecma_op_object_get (regexp_obj_p, &magic_string_global),
                     ret_value);
 
     JERRY_ASSERT (ecma_is_value_boolean (global_value));
@@ -1275,17 +1277,17 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this a
 
     if (context.is_global)
     {
-      ecma_string_t *last_index_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
+      ecma_string_t magic_string_last_index;
+      ecma_init_ecma_magic_string (&magic_string_last_index, LIT_MAGIC_STRING_LASTINDEX_UL);
 
       ECMA_TRY_CATCH (put_value,
                       ecma_op_object_put (regexp_obj_p,
-                                          last_index_string_p,
+                                          &magic_string_last_index,
                                           ecma_make_integer_value (0),
                                           true),
                       ret_value);
 
       ECMA_FINALIZE (put_value);
-      ecma_deref_ecma_string (last_index_string_p);
     }
 
     if (ecma_is_value_empty (ret_value))
@@ -1294,7 +1296,6 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this a
     }
 
     ECMA_FINALIZE (global_value);
-    ecma_deref_ecma_string (global_string_p);
   }
   else
   {
@@ -1380,10 +1381,11 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this ar
       JERRY_ASSERT (ecma_is_value_object (match_result));
 
       ecma_object_t *match_object_p = ecma_get_object_from_value (match_result);
-      ecma_string_t *index_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
+      ecma_string_t magic_string_index;
+      ecma_init_ecma_magic_string (&magic_string_index, LIT_MAGIC_STRING_INDEX);
 
       ECMA_TRY_CATCH (index_value,
-                      ecma_op_object_get (match_object_p, index_string_p),
+                      ecma_op_object_get (match_object_p, &magic_string_index),
                       ret_value);
 
       JERRY_ASSERT (ecma_is_value_number (index_value));
@@ -1391,7 +1393,6 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this ar
       offset = ecma_get_number_from_value (index_value);
 
       ECMA_FINALIZE (index_value);
-      ecma_deref_ecma_string (index_string_p);
     }
 
     if (ecma_is_value_empty (ret_value))
@@ -1689,13 +1690,14 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
           {
             ecma_object_t *match_obj_p = ecma_get_object_from_value (match_result);
             ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
-            ecma_string_t *magic_index_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
+            ecma_string_t magic_string_index;
+            ecma_init_ecma_magic_string (&magic_string_index, LIT_MAGIC_STRING_INDEX);
             ecma_property_value_t *index_prop_value_p;
 
 
             if (separator_is_regexp)
             {
-              index_prop_value_p = ecma_get_named_data_property (match_obj_p, magic_index_str_p);
+              index_prop_value_p = ecma_get_named_data_property (match_obj_p, &magic_string_index);
               ecma_number_t index_num = ecma_get_number_from_value (index_prop_value_p->value);
               ecma_value_assign_number (&index_prop_value_p->value, index_num + (ecma_number_t) curr_pos);
             }
@@ -1713,7 +1715,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
               JERRY_ASSERT (ecma_is_value_true (put_comp));
 
               index_prop_value_p = ecma_create_named_data_property (match_obj_p,
-                                                                    magic_index_str_p,
+                                                                    &magic_string_index,
                                                                     ECMA_PROPERTY_FLAG_WRITABLE,
                                                                     NULL);
               ecma_named_data_property_assign_value (match_obj_p,
@@ -1722,15 +1724,13 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
 
             }
 
-            ecma_deref_ecma_string (magic_index_str_p);
-
             ecma_value_t match_comp_value = ecma_op_object_get (match_obj_p, zero_str_p);
             JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (match_comp_value));
 
             ecma_string_t *match_str_p = ecma_get_string_from_value (match_comp_value);
             ecma_length_t match_str_length = ecma_string_get_length (match_str_p);
 
-            ecma_string_t *magic_empty_str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
+            ecma_string_t *magic_empty_str_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
             separator_is_empty = ecma_compare_ecma_strings (magic_empty_str_p, match_str_p);
 
             ecma_deref_ecma_string (magic_empty_str_p);
@@ -1776,10 +1776,12 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
 
             /* 13.c.iii.5 */
             start_pos = end_pos + match_str_length;
-            ecma_string_t *magic_length_str_p = ecma_new_ecma_length_string ();
+
+            ecma_string_t magic_string_length;
+            ecma_init_ecma_length_string (&magic_string_length);
 
             ECMA_TRY_CATCH (array_length_val,
-                            ecma_op_object_get (match_obj_p, magic_length_str_p),
+                            ecma_op_object_get (match_obj_p, &magic_string_length),
                             ret_value);
 
             ECMA_OP_TO_NUMBER_TRY_CATCH (array_length_num, array_length_val, ret_value);
@@ -1832,7 +1834,6 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
 
             ECMA_OP_TO_NUMBER_FINALIZE (array_length_num);
             ECMA_FINALIZE (array_length_val);
-            ecma_deref_ecma_string (magic_length_str_p);
             ecma_deref_ecma_string (array_length_str_p);
             ecma_deref_ecma_string (substr_str_p);
           }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
@@ -123,7 +123,7 @@ ecma_builtin_string_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
 
   if (arguments_list_len == 0)
   {
-    ecma_string_t *str_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
+    ecma_string_t *str_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
     ecma_value_t str_value = ecma_make_string_value (str_p);
 
     ret_value = str_value;

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -461,24 +461,24 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
     /* a. */
     prop_desc.value = src_prop_desc_p->value;
 
-    ecma_string_t *value_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_VALUE);
+    ecma_string_t magic_string_value;
+    ecma_init_ecma_magic_string (&magic_string_value, LIT_MAGIC_STRING_VALUE);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     value_magic_string_p,
+                                                     &magic_string_value,
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (value_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
 
     /* b. */
     const bool is_writable = (src_prop_desc_p->is_writable);
     prop_desc.value = ecma_make_boolean_value (is_writable);
 
-    ecma_string_t *writable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE);
+    ecma_string_t magic_string_writable;
+    ecma_init_ecma_magic_string (&magic_string_writable, LIT_MAGIC_STRING_WRITABLE);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     writable_magic_string_p,
+                                                     &magic_string_writable,
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (writable_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
   }
   else
@@ -497,12 +497,12 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
       prop_desc.value = ecma_make_object_value (src_prop_desc_p->get_p);
     }
 
-    ecma_string_t *get_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GET);
+    ecma_string_t magic_string_get;
+    ecma_init_ecma_magic_string (&magic_string_get, LIT_MAGIC_STRING_GET);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     get_magic_string_p,
+                                                     &magic_string_get,
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (get_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
 
     /* b. */
@@ -515,35 +515,35 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
       prop_desc.value = ecma_make_object_value (src_prop_desc_p->set_p);
     }
 
-    ecma_string_t *set_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SET);
+    ecma_string_t magic_string_set;
+    ecma_init_ecma_magic_string (&magic_string_set, LIT_MAGIC_STRING_SET);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     set_magic_string_p,
+                                                     &magic_string_set,
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (set_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
   }
 
   const bool is_enumerable = src_prop_desc_p->is_enumerable;
   prop_desc.value = ecma_make_boolean_value (is_enumerable);
 
-  ecma_string_t *enumerable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE);
+  ecma_string_t magic_string_enumerable;
+  ecma_init_ecma_magic_string (&magic_string_enumerable, LIT_MAGIC_STRING_ENUMERABLE);
   completion = ecma_op_object_define_own_property (obj_p,
-                                                   enumerable_magic_string_p,
+                                                   &magic_string_enumerable,
                                                    &prop_desc,
                                                    false);
-  ecma_deref_ecma_string (enumerable_magic_string_p);
   JERRY_ASSERT (ecma_is_value_true (completion));
 
   const bool is_configurable = src_prop_desc_p->is_configurable;
   prop_desc.value = ecma_make_boolean_value (is_configurable);
 
-  ecma_string_t *configurable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE);
+  ecma_string_t magic_string_configurable;
+  ecma_init_ecma_magic_string (&magic_string_configurable, LIT_MAGIC_STRING_CONFIGURABLE);
   completion = ecma_op_object_define_own_property (obj_p,
-                                                   configurable_magic_string_p,
+                                                   &magic_string_configurable,
                                                    &prop_desc,
                                                    false);
-  ecma_deref_ecma_string (configurable_magic_string_p);
   JERRY_ASSERT (ecma_is_value_true (completion));
 
   return obj_p;
@@ -579,10 +579,11 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
     ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
     /* 3. */
-    ecma_string_t *enumerable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE);
+    ecma_string_t magic_string_enumerable;
+    ecma_init_ecma_magic_string (&magic_string_enumerable, LIT_MAGIC_STRING_ENUMERABLE);
 
     ECMA_TRY_CATCH (enumerable_prop_value,
-                    ecma_op_object_find (obj_p, enumerable_magic_string_p),
+                    ecma_op_object_find (obj_p, &magic_string_enumerable),
                     ret_value);
 
     if (ecma_is_value_found (enumerable_prop_value))
@@ -593,17 +594,16 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
 
     ECMA_FINALIZE (enumerable_prop_value);
 
-    ecma_deref_ecma_string (enumerable_magic_string_p);
-
     if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 4. */
-      ecma_string_t *configurable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE);
+      ecma_string_t magic_string_configurable;
+      ecma_init_ecma_magic_string (&magic_string_configurable, LIT_MAGIC_STRING_CONFIGURABLE);
 
       ECMA_TRY_CATCH (configurable_prop_value,
-                      ecma_op_object_find (obj_p, configurable_magic_string_p),
+                      ecma_op_object_find (obj_p, &magic_string_configurable),
                       ret_value);
 
       if (ecma_is_value_found (configurable_prop_value))
@@ -613,8 +613,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (configurable_prop_value);
-
-      ecma_deref_ecma_string (configurable_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -622,10 +620,11 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 5. */
-      ecma_string_t *value_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_VALUE);
+      ecma_string_t magic_string_value;
+      ecma_init_ecma_magic_string (&magic_string_value, LIT_MAGIC_STRING_VALUE);
 
       ECMA_TRY_CATCH (value_prop_value,
-                      ecma_op_object_find (obj_p, value_magic_string_p),
+                      ecma_op_object_find (obj_p, &magic_string_value),
                       ret_value);
 
       if (ecma_is_value_found (value_prop_value))
@@ -635,8 +634,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (value_prop_value);
-
-      ecma_deref_ecma_string (value_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -644,10 +641,11 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 6. */
-      ecma_string_t *writable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE);
+      ecma_string_t magic_string_writable;
+      ecma_init_ecma_magic_string (&magic_string_writable, LIT_MAGIC_STRING_WRITABLE);
 
       ECMA_TRY_CATCH (writable_prop_value,
-                      ecma_op_object_find (obj_p, writable_magic_string_p),
+                      ecma_op_object_find (obj_p, &magic_string_writable),
                       ret_value);
 
       if (ecma_is_value_found (writable_prop_value))
@@ -657,8 +655,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (writable_prop_value);
-
-      ecma_deref_ecma_string (writable_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -666,10 +662,11 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 7. */
-      ecma_string_t *get_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GET);
+      ecma_string_t magic_string_get;
+      ecma_init_ecma_magic_string (&magic_string_get, LIT_MAGIC_STRING_GET);
 
       ECMA_TRY_CATCH (get_prop_value,
-                      ecma_op_object_find (obj_p, get_magic_string_p),
+                      ecma_op_object_find (obj_p, &magic_string_get),
                       ret_value);
 
       if (ecma_is_value_found (get_prop_value))
@@ -700,8 +697,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (get_prop_value);
-
-      ecma_deref_ecma_string (get_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -709,10 +704,11 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 8. */
-      ecma_string_t *set_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SET);
+      ecma_string_t magic_string_set;
+      ecma_init_ecma_magic_string (&magic_string_set, LIT_MAGIC_STRING_SET);
 
       ECMA_TRY_CATCH (set_prop_value,
-                      ecma_op_object_find (obj_p, set_magic_string_p),
+                      ecma_op_object_find (obj_p, &magic_string_set),
                       ret_value);
 
       if (ecma_is_value_found (set_prop_value))
@@ -743,8 +739,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (set_prop_value);
-
-      ecma_deref_ecma_string (set_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -116,14 +116,14 @@ ecma_new_standard_error_with_message (ecma_standard_error_t error_type, /**< nat
 {
   ecma_object_t *new_error_obj_p = ecma_new_standard_error (error_type);
 
-  ecma_string_t *message_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE);
+  ecma_string_t magic_string_message;
+  ecma_init_ecma_magic_string (&magic_string_message, LIT_MAGIC_STRING_MESSAGE);
 
   ecma_property_value_t *prop_value_p;
   prop_value_p = ecma_create_named_data_property (new_error_obj_p,
-                                                  message_magic_string_p,
+                                                  &magic_string_message,
                                                   ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                   NULL);
-  ecma_deref_ecma_string (message_magic_string_p);
 
   ecma_ref_ecma_string (message_string_p);
   prop_value_p->value = ecma_make_string_value (message_string_p);

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -291,16 +291,15 @@ ecma_op_create_external_function_object (ecma_external_handler_t handler_cb) /**
   ecma_extended_object_t *ext_func_obj_p = (ecma_extended_object_t *) function_obj_p;
   ext_func_obj_p->u.external_handler_cb = handler_cb;
 
-  ecma_string_t *magic_string_prototype_p = ecma_get_magic_string (LIT_MAGIC_STRING_PROTOTYPE);
+  ecma_string_t magic_string_prototype;
+  ecma_init_ecma_magic_string (&magic_string_prototype, LIT_MAGIC_STRING_PROTOTYPE);
   ecma_builtin_helper_def_prop (function_obj_p,
-                                magic_string_prototype_p,
+                                &magic_string_prototype,
                                 ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),
                                 true, /* Writable */
                                 false, /* Enumerable */
                                 false, /* Configurable */
                                 false); /* Failure handling */
-
-  ecma_deref_ecma_string (magic_string_prototype_p);
 
   return function_obj_p;
 } /* ecma_op_create_external_function_object */
@@ -334,10 +333,11 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
 
     ecma_object_t *v_obj_p = ecma_get_object_from_value (value);
 
-    ecma_string_t *prototype_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_PROTOTYPE);
+    ecma_string_t magic_string_prototype;
+    ecma_init_ecma_magic_string (&magic_string_prototype, LIT_MAGIC_STRING_PROTOTYPE);
 
     ECMA_TRY_CATCH (prototype_obj_value,
-                    ecma_op_object_get (func_obj_p, prototype_magic_string_p),
+                    ecma_op_object_get (func_obj_p, &magic_string_prototype),
                     ret_value);
 
     if (!ecma_is_value_object (prototype_obj_value))
@@ -369,8 +369,6 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
     }
 
     ECMA_FINALIZE (prototype_obj_value);
-
-    ecma_deref_ecma_string (prototype_magic_string_p);
   }
   else
   {
@@ -586,12 +584,13 @@ ecma_op_function_construct_simple_or_external (ecma_object_t *func_obj_p, /**< F
 
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
-  ecma_string_t *prototype_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_PROTOTYPE);
+  ecma_string_t magic_string_prototype;
+  ecma_init_ecma_magic_string (&magic_string_prototype, LIT_MAGIC_STRING_PROTOTYPE);
 
   /* 5. */
   ECMA_TRY_CATCH (func_obj_prototype_prop_value,
                   ecma_op_object_get (func_obj_p,
-                                      prototype_magic_string_p),
+                                      &magic_string_prototype),
                   ret_value);
 
   /* 1., 2., 4. */
@@ -647,8 +646,6 @@ ecma_op_function_construct_simple_or_external (ecma_object_t *func_obj_p, /**< F
   ecma_deref_object (obj_p);
 
   ECMA_FINALIZE (func_obj_prototype_prop_value);
-
-  ecma_deref_ecma_string (prototype_magic_string_p);
 
   return ret_value;
 } /* ecma_op_function_construct_simple_or_external */

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -133,32 +133,30 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   }
 
   /* 7. */
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
+  ecma_string_t magic_string_length;
+  ecma_init_ecma_length_string (&magic_string_length);
 
   prop_value_p = ecma_create_named_data_property (obj_p,
-                                                  length_magic_string_p,
+                                                  &magic_string_length,
                                                   ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                   NULL);
 
   prop_value_p->value = ecma_make_uint32_value (arguments_number);
-
-  ecma_deref_ecma_string (length_magic_string_p);
 
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
   /* 13. */
   if (!is_strict)
   {
-    ecma_string_t *callee_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLEE);
+    ecma_string_t magic_string_callee;
+    ecma_init_ecma_magic_string (&magic_string_callee, LIT_MAGIC_STRING_CALLEE);
 
     prop_value_p = ecma_create_named_data_property (obj_p,
-                                                    callee_magic_string_p,
+                                                    &magic_string_callee,
                                                     ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                     NULL);
 
     prop_value_p->value = ecma_make_object_value (func_obj_p);
-
-    ecma_deref_ecma_string (callee_magic_string_p);
   }
   else
   {
@@ -180,51 +178,51 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
       prop_desc.is_configurable = false;
     }
 
-    ecma_string_t *callee_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLEE);
+    ecma_string_t magic_string_callee;
+    ecma_init_ecma_magic_string (&magic_string_callee, LIT_MAGIC_STRING_CALLEE);
 
     ecma_value_t completion = ecma_op_object_define_own_property (obj_p,
-                                                                  callee_magic_string_p,
+                                                                  &magic_string_callee,
                                                                   &prop_desc,
                                                                   false);
 
     JERRY_ASSERT (ecma_is_value_true (completion));
-    ecma_deref_ecma_string (callee_magic_string_p);
 
-    ecma_string_t *caller_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLER);
+    ecma_string_t magic_string_caller;
+    ecma_init_ecma_magic_string (&magic_string_caller, LIT_MAGIC_STRING_CALLER);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     caller_magic_string_p,
+                                                     &magic_string_caller,
                                                      &prop_desc,
                                                      false);
     JERRY_ASSERT (ecma_is_value_true (completion));
-    ecma_deref_ecma_string (caller_magic_string_p);
 
     ecma_deref_object (thrower_p);
   }
 
-  ecma_string_t *arguments_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ARGUMENTS);
+  ecma_string_t magic_string_arguments;
+  ecma_init_ecma_magic_string (&magic_string_arguments, LIT_MAGIC_STRING_ARGUMENTS);
 
   if (is_strict)
   {
     ecma_op_create_immutable_binding (lex_env_p,
-                                      arguments_string_p,
+                                      &magic_string_arguments,
                                       ecma_make_object_value (obj_p));
   }
   else
   {
     ecma_value_t completion = ecma_op_create_mutable_binding (lex_env_p,
-                                                              arguments_string_p,
+                                                              &magic_string_arguments,
                                                               false);
     JERRY_ASSERT (ecma_is_value_empty (completion));
 
     completion = ecma_op_set_mutable_binding (lex_env_p,
-                                              arguments_string_p,
+                                              &magic_string_arguments,
                                               ecma_make_object_value (obj_p),
                                               false);
 
     JERRY_ASSERT (ecma_is_value_empty (completion));
   }
 
-  ecma_deref_ecma_string (arguments_string_p);
   ecma_deref_object (obj_p);
 } /* ecma_op_create_arguments_object */
 

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -226,11 +226,11 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
       function_name_magic_string_id = LIT_MAGIC_STRING_VALUE_OF_UL;
     }
 
-    ecma_string_t *function_name_p = ecma_get_magic_string (function_name_magic_string_id);
+    ecma_string_t magic_string_function_name;
+    ecma_init_ecma_magic_string (&magic_string_function_name, function_name_magic_string_id);
 
-    ecma_value_t function_value_get_completion = ecma_op_object_get (obj_p, function_name_p);
-
-    ecma_deref_ecma_string (function_name_p);
+    ecma_value_t function_value_get_completion = ecma_op_object_get (obj_p,
+                                                                     &magic_string_function_name);
 
     if (ECMA_IS_VALUE_ERROR (function_value_get_completion))
     {

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -303,8 +303,9 @@ ecma_promise_resolve_handler (const ecma_value_t function, /**< the function its
   }
 
   /* 8. */
-  ecma_string_t *str_then = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_THEN);
-  ecma_value_t then = ecma_op_object_get (ecma_get_object_from_value (argv[0]), str_then);
+  ecma_string_t magic_string_then;
+  ecma_init_ecma_magic_string (&magic_string_then, LIT_MAGIC_STRING_THEN);
+  ecma_value_t then = ecma_op_object_get (ecma_get_object_from_value (argv[0]), &magic_string_then);
 
   if (ECMA_IS_VALUE_ERROR (then))
   {
@@ -322,7 +323,6 @@ ecma_promise_resolve_handler (const ecma_value_t function, /**< the function its
     ecma_enqueue_promise_resolve_thenable_job (promise, argv[0], then);
   }
 
-  ecma_deref_ecma_string (str_then);
   ecma_free_value (then);
 
 end_of_resolve_function:

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -164,47 +164,42 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp object */
                      ecma_string_t *source_p, /**< source string */
                      uint16_t flags) /**< flags */
 {
- /* Set source property. ECMA-262 v5, 15.10.7.1 */
-  ecma_string_t *magic_string_p;
+  /* Set source property. ECMA-262 v5, 15.10.7.1 */
+  ecma_string_t magic_string;
 
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SOURCE);
+  ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_SOURCE);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        &magic_string,
                         ECMA_PROPERTY_FIXED,
                         ecma_make_string_value (source_p));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set global property. ECMA-262 v5, 15.10.7.2 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
+  ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_GLOBAL);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        &magic_string,
                         ECMA_PROPERTY_FIXED,
                         ecma_make_boolean_value (flags & RE_FLAG_GLOBAL));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set ignoreCase property. ECMA-262 v5, 15.10.7.3 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL);
+  ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_IGNORECASE_UL);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        &magic_string,
                         ECMA_PROPERTY_FIXED,
                         ecma_make_boolean_value (flags & RE_FLAG_IGNORE_CASE));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set multiline property. ECMA-262 v5, 15.10.7.4 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE);
+  ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_MULTILINE);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        &magic_string,
                         ECMA_PROPERTY_FIXED,
                         ecma_make_boolean_value (flags & RE_FLAG_MULTILINE));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set lastIndex property. ECMA-262 v5, 15.10.7.5 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
+  ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_LASTINDEX_UL);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        &magic_string,
                         ECMA_PROPERTY_FLAG_WRITABLE,
                         ecma_make_integer_value (0));
-  ecma_deref_ecma_string (magic_string_p);
 } /* re_initialize_props */
 
 /**
@@ -1172,45 +1167,40 @@ re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
                                 int32_t index) /**< index of matching */
 {
   /* Set index property of the result array */
-  ecma_string_t *result_prop_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
-  {
-    ecma_builtin_helper_def_prop (array_obj_p,
-                                  result_prop_str_p,
-                                  ecma_make_int32_value (index),
-                                  true, /* Writable */
-                                  true, /* Enumerable */
-                                  true, /* Configurable */
-                                  true); /* Failure handling */
-  }
-  ecma_deref_ecma_string (result_prop_str_p);
-
-  /* Set input property of the result array */
-  result_prop_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INPUT);
+  ecma_string_t magic_string;
+  ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_INDEX);
 
   ecma_builtin_helper_def_prop (array_obj_p,
-                                result_prop_str_p,
+                                &magic_string,
+                                ecma_make_int32_value (index),
+                                true, /* Writable */
+                                true, /* Enumerable */
+                                true, /* Configurable */
+                                true); /* Failure handling */
+
+  /* Set input property of the result array */
+  ecma_init_ecma_magic_string (&magic_string, LIT_MAGIC_STRING_INPUT);
+
+  ecma_builtin_helper_def_prop (array_obj_p,
+                                &magic_string,
                                 ecma_make_string_value (input_str_p),
                                 true, /* Writable */
                                 true, /* Enumerable */
                                 true, /* Configurable */
                                 true); /* Failure handling */
 
-  ecma_deref_ecma_string (result_prop_str_p);
-
   /* Set length property of the result array */
-  result_prop_str_p = ecma_new_ecma_length_string ();
-  {
-    ecma_property_descriptor_t array_item_prop_desc = ecma_make_empty_property_descriptor ();
-    array_item_prop_desc.is_value_defined = true;
+  ecma_property_descriptor_t array_item_prop_desc = ecma_make_empty_property_descriptor ();
+  array_item_prop_desc.is_value_defined = true;
 
-    array_item_prop_desc.value = ecma_make_uint32_value (num_of_elements);
+  array_item_prop_desc.value = ecma_make_uint32_value (num_of_elements);
 
-    ecma_op_object_define_own_property (array_obj_p,
-                                        result_prop_str_p,
-                                        &array_item_prop_desc,
-                                        true);
-  }
-  ecma_deref_ecma_string (result_prop_str_p);
+  ecma_init_ecma_length_string (&magic_string);
+
+  ecma_op_object_define_own_property (array_obj_p,
+                                      &magic_string,
+                                      &array_item_prop_desc,
+                                      true);
 } /* re_set_result_array_properties */
 
 /**
@@ -1301,8 +1291,9 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
 
   if (input_buffer_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
-    ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
-    ecma_value_t lastindex_value = ecma_op_object_get_own_data_prop (regexp_object_p, magic_str_p);
+    ecma_string_t magic_string_last_index;
+    ecma_init_ecma_magic_string (&magic_string_last_index, LIT_MAGIC_STRING_LASTINDEX_UL);
+    ecma_value_t lastindex_value = ecma_op_object_get_own_data_prop (regexp_object_p, &magic_string_last_index);
 
     ECMA_OP_TO_NUMBER_TRY_CATCH (lastindex_num, lastindex_value, ret_value)
 
@@ -1321,8 +1312,6 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     ECMA_OP_TO_NUMBER_FINALIZE (lastindex_num);
 
     ecma_fast_free_value (lastindex_value);
-
-    ecma_deref_ecma_string (magic_str_p);
   }
 
   /* 2. Try to match */
@@ -1335,9 +1324,9 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     {
       if (re_ctx.flags & RE_FLAG_GLOBAL)
       {
-        ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
-        ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_integer_value (0), true);
-        ecma_deref_ecma_string (magic_str_p);
+        ecma_string_t magic_string_last_index;
+        ecma_init_ecma_magic_string (&magic_string_last_index, LIT_MAGIC_STRING_LASTINDEX_UL);
+        ecma_op_object_put (regexp_object_p, &magic_string_last_index, ecma_make_integer_value (0), true);
       }
 
       is_match = false;
@@ -1369,7 +1358,6 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
 
   if (input_curr_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
-    ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
     ecma_number_t lastindex_num;
 
     if (sub_str_p != NULL
@@ -1383,8 +1371,13 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
       lastindex_num = ECMA_NUMBER_ZERO;
     }
 
-    ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_number_value (lastindex_num), true);
-    ecma_deref_ecma_string (magic_str_p);
+    ecma_string_t magic_string_last_index;
+    ecma_init_ecma_magic_string (&magic_string_last_index, LIT_MAGIC_STRING_LASTINDEX_UL);
+
+    ecma_op_object_put (regexp_object_p,
+                        &magic_string_last_index,
+                        ecma_make_number_value (lastindex_num),
+                        true);
   }
 
   /* 3. Fill the result array or return with 'undefiend' */

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -50,7 +50,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   if (arguments_list_len == 0)
   {
-    prim_prop_str_value_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
+    prim_prop_str_value_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
   }
   else
   {


### PR DESCRIPTION
- Possible ecma_get_magic_string() calls are replaced by ecma_init_ecma_magic_string().
- Possible ecma_new_ecma_length_string() calls are replaced by ecma_init_ecma_magic_string().
- The ecma_new_ecma_string_from_magic_string_id() is replaced by ecma_get_magic_string().