### PR TITLE
target: mbedos5: Update to mbed OS 5.5.5

### DIFF
--- a/targets/mbedos5/mbed-os.lib
+++ b/targets/mbedos5/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8d21974ba35e04c4854e5090c0f8283171664175
+https://github.com/ARMmbed/mbed-os/#db4be94693c3a873cfa0c025a5ad2e62b86a8474

--- a/targets/mbedos5/source/jerry_port_mbed.c
+++ b/targets/mbedos5/source/jerry_port_mbed.c
@@ -46,15 +46,6 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
 #endif /* JSMBED_OVERRIDE_JERRY_PORT_LOG */
 
 /**
- * Implementation of jerry_port_fatal.
- */
-void
-jerry_port_fatal (jerry_fatal_code_t code) /**< fatal code enum item */
-{
-  exit (code);
-} /* jerry_port_fatal */
-
-/**
  * Implementation of jerry_port_get_time_zone.
  *
  * @return true - if success

--- a/targets/mbedos5/template-mbedignore.txt
+++ b/targets/mbedos5/template-mbedignore.txt
@@ -3,7 +3,6 @@ docs/*
 jerry-libc/*
 jerry-main/*
 jerry-port/default/default-date.c
-jerry-port/default/default-fatal.c
 jerry-port/default/default-io.c
 targets/*
 tests/*


### PR DESCRIPTION
Switches fatal implementation to JerryScript default, updates to latest stable version of mbed OS. Tested on K64F.

JerryScript-DCO-1.0-Signed-off-by: Jan Jongboom janjongboom@gmail.com