### PR TITLE
Fix toString method

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -290,10 +290,10 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
       }
 
       int buff_size = 1;
-      if (is_scale_negative)
+      if (is_scale_negative || scale == 0)
       {
         double counter = this_arg_number;
-        while (counter > radix)
+        while (counter >= radix)
         {
           counter /= radix;
           buff_size++;

--- a/tests/jerry/regression-test-issue-1974.js
+++ b/tests/jerry/regression-test-issue-1974.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert((39000000000000700).toString(2) == "10001010100011100100101100011010001111011000001011000000");


### PR DESCRIPTION
The buffer size was previously badly computed since scale == 0 case was not checked, therefore the buffer size was smaller than intended.
This patch fixes #1974.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu