### PR TITLE
Fix ecma_op_array_object_set_length method

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -162,7 +162,7 @@ ecma_op_array_object_set_length (ecma_object_t *object_p, /**< the array object 
   {
     ecma_value_t compared_num_val = ecma_op_to_number (new_value);
 
-    if (ECMA_IS_VALUE_ERROR (completion))
+    if (ECMA_IS_VALUE_ERROR (compared_num_val))
     {
       return compared_num_val;
     }

--- a/tests/jerry/regression-test-issue-1972.js
+++ b/tests/jerry/regression-test-issue-1972.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  [].length = {
+    valueOf: function() {
+      return Array.prototype.push (1), Object.freeze (Array.prototype);
+    }
+  }
+  assert (false);
+}
+catch (e) {
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
So far a freed variable was tested during error flag inspection.
This patch fixes it and #1972 as well.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu