### PR TITLE
Fix #1947

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -164,6 +164,13 @@ parser_compute_indicies (parser_context_t *context_p, /**< context */
   {
     if (literal_p->status_flags & LEXER_FLAG_UNUSED_IDENT)
     {
+#ifndef PARSER_DUMP_BYTE_CODE
+      if (!(literal_p->status_flags & LEXER_FLAG_SOURCE_PTR))
+      {
+        jmem_heap_free_block ((void *) literal_p->u.char_p, literal_p->prop.length);
+      }
+#endif /* !PARSER_DUMP_BYTE_CODE */
+
       context_p->literal_count--;
       continue;
     }

--- a/tests/jerry/regression-test-issue-1947.js
+++ b/tests/jerry/regression-test-issue-1947.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function a () {
+ function b () {
+   // Can be any unicode escape character, ie: A
+   \u0041
+ }
+}


### PR DESCRIPTION
If a literal was assigned the unused flag it wasn't freed, however it could have been not empty, therefore should've been freed.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu