### PR TITLE
Correctly enumerate function property members.

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -32,14 +32,6 @@ bool ecma_is_constructor (ecma_value_t value);
 ecma_object_t *
 ecma_op_create_function_object (ecma_object_t *scope_p, const ecma_compiled_code_t *bytecode_data_p);
 
-void
-ecma_op_function_list_lazy_property_names (bool separate_enumerable,
-                                           ecma_collection_header_t *main_collection_p,
-                                           ecma_collection_header_t *non_enum_collection_p);
-
-ecma_property_t *
-ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
-
 ecma_object_t *
 ecma_op_create_external_function_object (ecma_external_handler_t handler_cb);
 
@@ -55,7 +47,29 @@ ecma_value_t
 ecma_op_function_has_instance (ecma_object_t *func_obj_p, ecma_value_t value);
 
 ecma_property_t *
+ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
+
+ecma_property_t *
+ecma_op_external_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
+
+ecma_property_t *
 ecma_op_bound_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
+
+void
+ecma_op_function_list_lazy_property_names (ecma_object_t *object_p,
+                                           bool separate_enumerable,
+                                           ecma_collection_header_t *main_collection_p,
+                                           ecma_collection_header_t *non_enum_collection_p);
+
+void
+ecma_op_external_function_list_lazy_property_names (bool separate_enumerable,
+                                                    ecma_collection_header_t *main_collection_p,
+                                                    ecma_collection_header_t *non_enum_collection_p);
+
+void
+ecma_op_bound_function_list_lazy_property_names (bool separate_enumerable,
+                                                 ecma_collection_header_t *main_collection_p,
+                                                 ecma_collection_header_t *non_enum_collection_p);
 
 /**
  * @}

--- a/tests/jerry/es2015/function-properties.js
+++ b/tests/jerry/es2015/function-properties.js
@@ -1,0 +1,46 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function getProperties(obj)
+{
+  var str = "";
+  for (name in obj)
+  {
+    if (str)
+    {
+      str += " " + name;
+    }
+    else
+    {
+      str = name;
+    }
+  }
+  return str;
+}
+
+var prototype_obj = { dummy:1, length:1, caller:null,
+                      arguments:null, prototype:null };
+
+var func = function() {};
+
+Object.setPrototypeOf(func, prototype_obj);
+assert(getProperties(func) == "dummy caller arguments");
+
+var bound_func = (function() {}).bind(null);
+Object.setPrototypeOf(bound_func, prototype_obj);
+assert(getProperties(bound_func) == "dummy prototype");
+
+// 'print' is an external function
+Object.setPrototypeOf(print, prototype_obj);
+assert(getProperties(print) == "dummy length caller arguments");


### PR DESCRIPTION
Functions has several built-in non-enumerable properties, and
they are correctly ignored during enumeration after this patch.

External function prototype is also lazy enumerated.