### PR TITLE
[unix-main] call jerry_run_all_enqueued_jobs before cleanup

### DIFF
--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -817,17 +817,17 @@ main (int argc,
 
     ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
   }
-  else
-  {
-    jerry_release_value (ret_value);
-    ret_value = jerry_run_all_enqueued_jobs ();
 
-    if (jerry_value_has_error_flag (ret_value))
-    {
-      print_unhandled_exception (ret_value);
-      ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
-    }
+  jerry_release_value (ret_value);
+
+  ret_value = jerry_run_all_enqueued_jobs ();
+
+  if (jerry_value_has_error_flag (ret_value))
+  {
+    print_unhandled_exception (ret_value);
+    ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
   }
+
   jerry_release_value (ret_value);
 
   if (start_debug_server)

--- a/tests/jerry/es2015/regression-test-issue-1995.js
+++ b/tests/jerry/es2015/regression-test-issue-1995.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var name = "";
+
+try
+{
+    Promise.race([""]).$()
+}
+catch (e)
+{
+    name = e.name;
+}
+
+assert(name === "TypeError");


### PR DESCRIPTION
Related Issue: #1995

We should also call jerry_run_all_enqueued_jobs even though the script throws exception.

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com