### PR TITLE
[ecma-collection] Check whether the header's first chunk is NULL

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-values-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-values-collection.c
@@ -318,7 +318,8 @@ bool
 ecma_collection_iterator_next (ecma_collection_iterator_t *iterator_p) /**< context of iterator */
 {
   if (iterator_p->header_p == NULL
-      || unlikely (iterator_p->header_p->unit_number == 0))
+      || unlikely (iterator_p->header_p->unit_number == 0)
+      || unlikely (iterator_p->header_p->first_chunk_cp == JMEM_CP_NULL))
   {
     return false;
   }

--- a/tests/jerry/es2015/regression-test-issue-1997.js
+++ b/tests/jerry/es2015/regression-test-issue-1997.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = Promise.resolve();
+for (var i = 0; i < 200; i++)
+{
+    Promise.race([a]).then();
+}


### PR DESCRIPTION
Fix Issue: #1997

the reason of the error in #1997 

1, in `ecma_append_to_values_collection`, the collection may be empty at first, and the header->first_chunk is NULL. then it will alloc the chunk, then it will set header's first_chunk. But during the **alloc**,  the alloc may cause GC .
2. GC will traverse the collection item by `ecma_collection_iterator_next` (the Promise needs it), but the original `ecma_collection_iterator_next` will cause error when the header's first chunk is NULL

So we should check whether header's first chunk is NULL in the `ecma_collection_iterator_next`.

The codes in #1997 is 
```
var a = Promise.resolve();
for (;;)
    Promise.race([a]).then()
$
```
Even I fixed the issue, the code will still cause OOM. 
How can I handle it in the test case?