### PR TITLE
Send every kind of output to the debugger client

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -48,10 +48,10 @@ typedef enum
 } jerry_log_level_t;
 
 /**
- * Display or log a debug/error message. The function should implement a printf-like
- * interface, where the first argument specifies the log level
- * and the second argument specifies a format string on how to stringify the rest
- * of the parameter list.
+ * Display or log a debug/error message, and sends it to the debugger client as well.
+ * The function should implement a printf-like interface, where the first argument
+ * specifies the log level and the second argument specifies a format string on how
+ * to stringify the rest of the parameter list.
  *
  * This function is only called with messages coming from the jerry engine as
  * the result of some abnormal operation or describing its internal operations

--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -246,7 +246,6 @@ jerry_debugger_wait_and_run_client_source (jerry_value_t *return_value)
 **Summary**
 
 Sends the program's output to the debugger client.
-At the moment only the JS print size is implemented.
 
 **Prototype**
 

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -162,8 +162,10 @@ typedef enum
 typedef enum
 {
   JERRY_DEBUGGER_OUTPUT_OK = 1, /**< output result, no error */
-  JERRY_DEBUGGER_OUTPUT_WARNING = 2, /**< output result, warning */
-  JERRY_DEBUGGER_OUTPUT_ERROR = 3, /**< output result, error */
+  JERRY_DEBUGGER_OUTPUT_ERROR = 2, /**< output result, error */
+  JERRY_DEBUGGER_OUTPUT_WARNING = 3, /**< output result, warning */
+  JERRY_DEBUGGER_OUTPUT_DEBUG = 4, /**< output result, debug */
+  JERRY_DEBUGGER_OUTPUT_TRACE = 5, /**< output result, trace */
 } jerry_debugger_output_subtype_t;
 
 /**

--- a/jerry-debugger/jerry-client-ws.html
+++ b/jerry-debugger/jerry-client-ws.html
@@ -68,8 +68,10 @@ var JERRY_DEBUGGER_EVAL_ERROR = 2;
 
 // Subtypes of output result
 var JERRY_DEBUGGER_OUTPUT_OK = 1;
-var JERRY_DEBUGGER_OUTPUT_WARNING = 2;
-var JERRY_DEBUGGER_OUTPUT_ERROR = 3;
+var JERRY_DEBUGGER_OUTPUT_ERROR = 2;
+var JERRY_DEBUGGER_OUTPUT_WARNING = 3;
+var JERRY_DEBUGGER_OUTPUT_DEBUG = 4;
+var JERRY_DEBUGGER_OUTPUT_TRACE = 5;
 
 // Messages sent by the client to server.
 var JERRY_DEBUGGER_FREE_BYTE_CODE_CP = 1;
@@ -944,6 +946,7 @@ function DebuggerClient(address)
           switch (subType)
           {
             case JERRY_DEBUGGER_OUTPUT_OK:
+            case JERRY_DEBUGGER_OUTPUT_DEBUG:
               outString = "out: " + cesu8ToString(outputResult);
               break;
             case JERRY_DEBUGGER_OUTPUT_WARNING:
@@ -952,12 +955,15 @@ function DebuggerClient(address)
             case JERRY_DEBUGGER_OUTPUT_ERROR:
               outString = "err: " + cesu8ToString(outputResult);
               break;
+            case JERRY_DEBUGGER_OUTPUT_TRACE:
+              outString = "trace: " + cesu8ToString(outputResult);
+              break;
           }
 
           appendLog(outString);
           outputResult = null;
         }
-        
+
         return;
       }
 

--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -58,8 +58,10 @@ JERRY_DEBUGGER_EVAL_ERROR = 2
 
 # Subtypes of output
 JERRY_DEBUGGER_OUTPUT_OK = 1
-JERRY_DEBUGGER_OUTPUT_WARNING = 2
-JERRY_DEBUGGER_OUTPUT_ERROR = 3
+JERRY_DEBUGGER_OUTPUT_ERROR = 2
+JERRY_DEBUGGER_OUTPUT_WARNING = 3
+JERRY_DEBUGGER_OUTPUT_DEBUG = 4
+JERRY_DEBUGGER_OUTPUT_TRACE = 5
 
 
 # Messages sent by the client to server.
@@ -1115,12 +1117,15 @@ def main():
 
             # Subtypes of output
             if buffer_type == JERRY_DEBUGGER_OUTPUT_RESULT_END:
-                if subtype == JERRY_DEBUGGER_OUTPUT_OK:
+                if subtype in [JERRY_DEBUGGER_OUTPUT_OK,
+                               JERRY_DEBUGGER_OUTPUT_DEBUG]:
                     print("%sout: %s%s" % (debugger.blue, debugger.nocolor, message))
                 elif subtype == JERRY_DEBUGGER_OUTPUT_WARNING:
                     print("%swarning: %s%s" % (debugger.yellow, debugger.nocolor, message))
                 elif subtype == JERRY_DEBUGGER_OUTPUT_ERROR:
                     print("%serr: %s%s" % (debugger.red, debugger.nocolor, message))
+                elif subtype == JERRY_DEBUGGER_OUTPUT_TRACE:
+                    print("%strace: %s%s" % (debugger.blue, debugger.nocolor, message))
 
             # Subtypes of eval
             elif buffer_type == JERRY_DEBUGGER_EVAL_RESULT_END:


### PR DESCRIPTION
Now correctly sending jerry_port_log output to the debugger client as well.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu