### PR TITLE
Move jerry_debugger_send_output to public API

### DIFF
--- a/jerry-core/api/jerry-debugger.c
+++ b/jerry-core/api/jerry-debugger.c
@@ -203,3 +203,24 @@ jerry_debugger_wait_and_run_client_source (jerry_value_t *return_value) /**< [ou
   return JERRY_DEBUGGER_SOURCE_RECEIVE_FAILED;
 #endif /* JERRY_DEBUGGER */
 } /* jerry_debugger_wait_and_run_client_source */
+
+/**
+ * Send the output of the program to the debugger client.
+ * Currently only sends print output.
+ */
+
+#ifdef JERRY_DEBUGGER
+void
+jerry_debugger_send_output (jerry_char_t buffer[], /**< buffer */
+                            jerry_size_t str_size, /**< string size */
+                            uint8_t type) /**< type of output */
+{
+  if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
+  {
+    jerry_debugger_send_string (JERRY_DEBUGGER_OUTPUT_RESULT,
+                                type,
+                                (const uint8_t *) buffer,
+                                sizeof (uint8_t) * str_size);
+  }
+} /* jerry_debugger_send_output */
+#endif /* JERRY_DEBUGGER */

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -22,7 +22,6 @@
 #include "ecma-eval.h"
 #include "ecma-objects.h"
 #include "jcontext.h"
-#include "jerryscript-port.h"
 #include "lit-char-helpers.h"
 
 #ifdef JERRY_DEBUGGER
@@ -813,24 +812,6 @@ jerry_debugger_send_parse_function (uint32_t line, /**< line */
 
   return jerry_debugger_send (sizeof (jerry_debugger_send_parse_function_t));
 } /* jerry_debugger_send_parse_function */
-
-/**
- * Send the output of the program to the debugger client.
- * Currently only sends print output.
- */
-void
-jerry_debugger_send_output (jerry_char_t buffer[], /**< buffer */
-                            jerry_size_t str_size, /**< string size */
-                            uint8_t type) /**< type of output */
-{
-  if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
-  {
-    jerry_debugger_send_string (JERRY_DEBUGGER_OUTPUT_RESULT,
-                                type,
-                                (const uint8_t *) buffer,
-                                sizeof (uint8_t) * str_size);
-  }
-} /* jerry_debugger_send_output */
 
 /**
  * Send memory statistics to the debugger client.

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -18,7 +18,6 @@
 
 #include "debugger-ws.h"
 #include "ecma-globals.h"
-#include "jerryscript-core.h"
 
 #ifdef JERRY_DEBUGGER
 
@@ -350,7 +349,6 @@ bool jerry_debugger_send_function_cp (jerry_debugger_header_type_t type, ecma_co
 bool jerry_debugger_send_parse_function (uint32_t line, uint32_t column);
 void jerry_debugger_send_memstats (void);
 bool jerry_debugger_send_exception_string (ecma_value_t exception_value);
-void jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t str_size, uint8_t type);
 
 #endif /* JERRY_DEBUGGER */
 

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -45,6 +45,7 @@ void jerry_debugger_stop (void);
 void jerry_debugger_continue (void);
 void jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint);
 jerry_debugger_wait_and_run_type_t jerry_debugger_wait_and_run_client_source (jerry_value_t *return_value);
+void jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t str_size, uint8_t type);
 
 void jerry_debugger_init (uint16_t port);
 void jerry_debugger_cleanup (void);


### PR DESCRIPTION
The function jerry_debugger_send_output wasn't placed correctly in the public API.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu