### PR TITLE
Nuttx compilation fix for ECMA_IS_VALUE_ERROR

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -199,7 +199,7 @@ typedef int32_t ecma_integer_value_t;
  * Checks whether the error flag is set.
  */
 #define ECMA_IS_VALUE_ERROR(value) \
-  (unlikely ((value & ECMA_VALUE_ERROR_FLAG) != 0))
+  ((value) & ECMA_VALUE_ERROR_FLAG ? true : false)
 
 /**
  * Representation for native external pointer


### PR DESCRIPTION
The valid headers from Nuttx were introduced to JerryScript compilation
for IoT.js in PR 1163
https://github.com/Samsung/iotjs/pull/1163

This new setup for compilation detected type inconsistency in
ECMA_IS_VALUE_ERROR macro, which uses unlikely macro, which converts long int
to _Bool8.

To prevent such error tertiary operator was introduced.

JerryScript-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com