### PR TITLE
Improved ecma_utf8_string_to_number function

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -324,6 +324,20 @@
 
 #define EPSILON 0.0000001
 
+#if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64
+/**
+ * Number.MAX_VALUE and Number.MIN_VALUE exponent parts while using 64 bit float representation
+ */
+# define NUMBER_MAX_DECIMAL_EXPONENT 308
+# define NUMBER_MIN_DECIMAL_EXPONENT -324
+#elif CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
+/**
+ * Number.MAX_VALUE and Number.MIN_VALUE exponent parts while using 32 bit float representation
+ */
+# define NUMBER_MAX_DECIMAL_EXPONENT 38
+# define NUMBER_MIN_DECIMAL_EXPONENT -45
+#endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
+
 /**
  * @}
  */
@@ -485,8 +499,7 @@ ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
         fraction_uint64 = fraction_uint64 * 10 + (uint32_t) digit_value;
         digits++;
       }
-      else if (e <= 100000) /* Limit the exponent, since large
-                             * exponent is rounded to infinity anyway. */
+      else
       {
         e++;
       }
@@ -581,6 +594,16 @@ ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
       }
 
       e_in_lit = e_in_lit * 10 + digit_value;
+      int32_t e_check = e + (int32_t) digits - 1  + (e_in_lit_sign ? -e_in_lit : e_in_lit);
+
+      if (e_check > NUMBER_MAX_DECIMAL_EXPONENT)
+      {
+        return ecma_number_make_infinity (sign);
+      }
+      else if (e_check < NUMBER_MIN_DECIMAL_EXPONENT)
+      {
+        return sign ? -ECMA_NUMBER_ZERO : ECMA_NUMBER_ZERO;
+      }
 
       begin_p++;
     }

--- a/tests/jerry/regression-test-issue-1973.js
+++ b/tests/jerry/regression-test-issue-1973.js
@@ -1,0 +1,46 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+print (777E7777777777 == Infinity)
+print (-777E7777777777 == -Infinity)
+print (777E-7777777777 == 0)
+print (-777E-7777777777 == -0)
+
+print (100E307 == Infinity)
+print (10E307 == 1E308)
+print (10E308 == Infinity)
+print (1E308 == 1E308)
+print (0.1E309 == 1E308)
+print (0.1E310 == Infinity)
+
+print (-100E307 == -Infinity)
+print (-10E307 == -1E308)
+print (-10E308 == -Infinity)
+print (-1E308 == -1E308)
+print (-0.1E309 == -1E308)
+print (-0.1E310 == -Infinity)
+
+print (5E-325 == 0)
+print (50E-325 == 5E-324)
+print (0.5E-324 == 0)
+print (5E-324 == 5E-324)
+print (0.05E-323 == 0)
+print (0.5E-323 == 5E-324)
+
+print (-5E-325 == -0)
+print (-50E-325 == -5E-324)
+print (-0.5E-324 == -0)
+print (-5E-324 == -5E-324)
+print (-0.05E-323 == -0)
+print (-0.5E-323 == -5E-324)


### PR DESCRIPTION
This patch extends the infinity and zero parsing of the convertible number by comparing it to Number.MAX_VALUE or Number.MIN_VALUE which makes it even faster than before.
In addition added a test case for it based on #1973.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu