### PR TITLE
Bitfields conversions fix for Nuttx build

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -1697,14 +1697,14 @@ jerry_define_own_property (const jerry_value_t obj_val, /**< object value */
 
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
-  prop_desc.is_enumerable_defined = prop_desc_p->is_enumerable_defined;
-  prop_desc.is_enumerable = prop_desc_p->is_enumerable_defined ? prop_desc_p->is_enumerable : false;
+  prop_desc.is_enumerable_defined = ECMA_CONVERT_BOOL_TO_FIELD(prop_desc_p->is_enumerable_defined);
+  prop_desc.is_enumerable = ECMA_CONVERT_BOOL_TO_FIELD(prop_desc_p->is_enumerable_defined ? prop_desc_p->is_enumerable : false);
 
-  prop_desc.is_configurable_defined = prop_desc_p->is_configurable_defined;
-  prop_desc.is_configurable = prop_desc_p->is_configurable_defined ? prop_desc_p->is_configurable : false;
+  prop_desc.is_configurable_defined = ECMA_CONVERT_BOOL_TO_FIELD(prop_desc_p->is_configurable_defined);
+  prop_desc.is_configurable = ECMA_CONVERT_BOOL_TO_FIELD(prop_desc_p->is_configurable_defined ? prop_desc_p->is_configurable : false);
 
   /* Copy data property info. */
-  prop_desc.is_value_defined = prop_desc_p->is_value_defined;
+  prop_desc.is_value_defined = ECMA_CONVERT_BOOL_TO_FIELD(prop_desc_p->is_value_defined);
 
   if (prop_desc_p->is_value_defined)
   {
@@ -1716,8 +1716,8 @@ jerry_define_own_property (const jerry_value_t obj_val, /**< object value */
     prop_desc.value = prop_desc_p->value;
   }
 
-  prop_desc.is_writable_defined = prop_desc_p->is_writable_defined;
-  prop_desc.is_writable = prop_desc_p->is_writable_defined ? prop_desc_p->is_writable : false;
+  prop_desc.is_writable_defined = ECMA_CONVERT_BOOL_TO_FIELD(prop_desc_p->is_writable_defined);
+  prop_desc.is_writable = ECMA_CONVERT_BOOL_TO_FIELD(prop_desc_p->is_writable_defined ? prop_desc_p->is_writable : false);
 
   /* Copy accessor property info. */
   if (prop_desc_p->is_get_defined)

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -109,6 +109,13 @@
     JERRY_ASSERT (utf8_ptr != NULL); \
     jmem_heap_free_block ((void *) utf8_ptr, utf8_str_size); \
   }
+/**
+ * This is very ugly macro but there is not better solution,
+ * which will work for bit fields in versions of GCC used in MCU-s
+ * See:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=39170
+ */
+#define ECMA_CONVERT_BOOL_TO_FIELD(x) ((x) ? 1 : 0)
 
 /* ecma-helpers-value.c */
 bool ecma_is_value_direct (ecma_value_t value) __attr_const___;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -674,16 +674,16 @@ ecma_builtin_helper_def_prop (ecma_object_t *obj_p, /**< object */
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
   prop_desc.is_value_defined = true;
-  prop_desc.value = value;
+  prop_desc.value = ECMA_CONVERT_BOOL_TO_FIELD(value);
 
   prop_desc.is_writable_defined = true;
-  prop_desc.is_writable = writable;
+  prop_desc.is_writable = ECMA_CONVERT_BOOL_TO_FIELD(writable);
 
   prop_desc.is_enumerable_defined = true;
-  prop_desc.is_enumerable = enumerable;
+  prop_desc.is_enumerable = ECMA_CONVERT_BOOL_TO_FIELD(enumerable);
 
   prop_desc.is_configurable_defined = true;
-  prop_desc.is_configurable = configurable;
+  prop_desc.is_configurable = ECMA_CONVERT_BOOL_TO_FIELD(configurable);
 
   return ecma_op_object_define_own_property (obj_p,
                                              index_p,

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -588,7 +588,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
     if (ecma_is_value_found (enumerable_prop_value))
     {
       prop_desc.is_enumerable_defined = true;
-      prop_desc.is_enumerable = ecma_op_to_boolean (enumerable_prop_value);
+      prop_desc.is_enumerable = ECMA_CONVERT_BOOL_TO_FIELD(ecma_op_to_boolean (enumerable_prop_value));
     }
 
     ECMA_FINALIZE (enumerable_prop_value);
@@ -609,7 +609,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       if (ecma_is_value_found (configurable_prop_value))
       {
         prop_desc.is_configurable_defined = true;
-        prop_desc.is_configurable = ecma_op_to_boolean (configurable_prop_value);
+        prop_desc.is_configurable = ECMA_CONVERT_BOOL_TO_FIELD(ecma_op_to_boolean (configurable_prop_value));
       }
 
       ECMA_FINALIZE (configurable_prop_value);
@@ -653,7 +653,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       if (ecma_is_value_found (writable_prop_value))
       {
         prop_desc.is_writable_defined = true;
-        prop_desc.is_writable = ecma_op_to_boolean (writable_prop_value);
+        prop_desc.is_writable = ECMA_CONVERT_BOOL_TO_FIELD(ecma_op_to_boolean (writable_prop_value));
       }
 
       ECMA_FINALIZE (writable_prop_value);

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1203,9 +1203,9 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
 
   *prop_desc_p = ecma_make_empty_property_descriptor ();
 
-  prop_desc_p->is_enumerable = ecma_is_property_enumerable (property);
+  prop_desc_p->is_enumerable = ECMA_CONVERT_BOOL_TO_FIELD(ecma_is_property_enumerable (property));
   prop_desc_p->is_enumerable_defined = true;
-  prop_desc_p->is_configurable = ecma_is_property_configurable (property);
+  prop_desc_p->is_configurable = ECMA_CONVERT_BOOL_TO_FIELD(ecma_is_property_configurable (property));
   prop_desc_p->is_configurable_defined = true;
 
   ecma_property_types_t type = ECMA_PROPERTY_GET_TYPE (property);
@@ -1223,7 +1223,7 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
     }
 
     prop_desc_p->is_value_defined = true;
-    prop_desc_p->is_writable = ecma_is_property_writable (property);
+    prop_desc_p->is_writable = ECMA_CONVERT_BOOL_TO_FIELD(ecma_is_property_writable (property));
     prop_desc_p->is_writable_defined = true;
   }
   else


### PR DESCRIPTION
A conversion from bool to bitfield causes "may alter its value" warnings
for some versions of GCC used for MCUs. It prevents enabling Nuttx
headers for JerryScript compilation with strict Werror mode.

ECMA_CONVERT_BOOL_TO_FIELD macro was introduced in ecma-helpers. It
provides conversion from boolean to 1/0 constant, which can be assigned
to bitfield without any warnings. It is very ugly solution for not very
smart compiler:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=39170

I enabled Nuttx headers for JerryScript with werrror active, which caused many warning for ECMA structures:
https://travis-ci.org/Samsung/iotjs/jobs/270446192

This commits provides ugly work around for GCC limitations and IoT.js strict warning policy but it will also benefit any project with similar configuration.

JerryScript-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com