### PR TITLE
Add convenience macros for declaring C strings

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1536,7 +1536,7 @@ jerry_get_number_value (const jerry_value_t value);
 - [jerry_release_value](#jerry_release_value)
 
 
-# Functions for string values
+# Functions and macros for string values
 
 ## jerry_get_string_size
 
@@ -1905,6 +1905,73 @@ jerry_substring_to_utf8_char_buffer (const jerry_value_t value,
 - [jerry_get_utf8_string_length](#jerry_get_utf8_string_length)
 - [jerry_is_valid_utf8_string](#jerry_is_valid_utf8_string)
 
+## DECLARE_C_STRING_FROM_JERRY_STRING
+
+**Summary**
+
+Declares a variable holding the length in bytes of a CESU8 JavaScript string stored in a
+`jerry_value_t` and a second variable holding the contents of the JavaScript string in a
+stack-allocated `jerry_char_t` buffer. It then fills the buffer using
+`jerry_string_to_char_buffer()`.
+
+**Prototype**
+
+```c
+#define DECLARE_C_STRING_FROM_JERRY_STRING(prefix, value)
+```
+
+- `prefix` - prefix of name to assign to variables. The variable holding the length in bytes will
+be called `<prefix>_size` and the variable holding the buffer will be called `<prefix>_string`.
+- `value` - the `jerry_value_t` from which to retrieve the length in bytes and the contents of
+which to store in `<prefix>_string`.
+
+**Example**
+
+```c
+jerry_value_t js_token = get_token_from_somewhere ();
+DECLARE_C_STRING_FROM_JERRY_STRING(token, js_token);
+printf("token '%*s' has length %d\n", token_size, token_string, token_size);
+```
+
+**See also**
+
+- [jerry_create_string](#jerry_create_string)
+- [jerry_get_string_size](#jerry_get_string_size)
+- [jerry_string_to_char_buffer](#jerry_string_to_char_buffer)
+
+## DECLARE_C_STRING_FROM_UTF8_JERRY_STRING
+
+**Summary**
+
+Declares a variable holding the length in bytes of a UTF-8 JavaScript string stored in a
+`jerry_value_t` and a second variable holding the contents of the JavaScript string in a
+stack-allocated `jerry_char_t` buffer. It then fills the buffer using
+`jerry_string_to_utf8_char_buffer()`.
+
+**Prototype**
+
+```c
+#define DECLARE_C_STRING_FROM_UTF8_JERRY_STRING(prefix, value)
+```
+
+- `prefix` - prefix of name to assign to variables. The variable holding the length in bytes will
+be called `<prefix>_size` and the variable holding the buffer will be called `<prefix>_string`.
+- `value` - the `jerry_value_t` from which to retrieve the length in bytes and the contents of
+which to store in `<prefix>_string`.
+
+**Example**
+
+```c
+jerry_value_t js_token = get_utf8_token_from_somewhere ();
+DECLARE_C_STRING_FROM_UTF8_JERRY_STRING(token, js_token);
+printf("token '%*s' has length %d\n", token_size, token_string, token_size);
+```
+
+**See also**
+
+- [jerry_create_string_from_utf8](#jerry_create_string_from_utf8)
+- [jerry_get_utf8_string_size](#jerry_get_utf8_string_size)
+- [jerry_string_to_utf8_char_buffer](#jerry_string_to_utf8_char_buffer)
 
 # Functions for array object values
 

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -300,7 +300,7 @@ bool jerry_get_boolean_value (const jerry_value_t value);
 double jerry_get_number_value (const jerry_value_t value);
 
 /**
- * Functions for string values.
+ * Functions and macros for string values.
  */
 jerry_size_t jerry_get_string_size (const jerry_value_t value);
 jerry_size_t jerry_get_utf8_string_size (const jerry_value_t value);
@@ -320,6 +320,16 @@ jerry_size_t jerry_substring_to_utf8_char_buffer (const jerry_value_t value,
                                                   jerry_length_t end_pos,
                                                   jerry_char_t *buffer_p,
                                                   jerry_size_t buffer_size);
+
+#define DECLARE_C_STRING_FROM_JERRY_STRING(prefix, value)               \
+  jerry_size_t prefix##_size = jerry_get_string_size ((value));         \
+  jerry_char_t prefix##_string[prefix##_size];                          \
+  jerry_string_to_char_buffer ((value), prefix##_string, prefix##_size)
+
+#define DECLARE_C_STRING_FROM_UTF8_JERRY_STRING(prefix, value)               \
+  jerry_size_t prefix##_size = jerry_get_string_size ((value));              \
+  jerry_char_t prefix##_string[prefix##_size];                               \
+  jerry_string_to_utf8_char_buffer ((value), prefix##_string, prefix##_size)
 
 /**
  * Functions for array object values.


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Gabriel Schulhof <gabriel.schulhof@intel.com>

I found I was writing the steps in these macros over and over so I figured these might be common enough to warrant macros.