### PR TITLE
Fixes uint16_t overflow in ecma_new_ecma_string_from_utf8_converted_to_cesu8 ()

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -273,7 +273,7 @@ ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *string
 
     lit_utf8_byte_t *data_p;
 
-    if (likely (string_size <= UINT16_MAX))
+    if (likely (converted_string_size <= UINT16_MAX))
     {
       string_desc_p = ecma_alloc_string_buffer (sizeof (ecma_string_t) + converted_string_size);
 

--- a/tests/unit-core/test-strings.c
+++ b/tests/unit-core/test-strings.c
@@ -26,7 +26,7 @@
 #define test_subiters (128)
 
 /* Max bytes in string. */
-#define max_bytes_in_string (16 * 1024)
+#define max_bytes_in_string (65 * 1024)
 #define max_code_units_in_string (max_bytes_in_string)
 
 typedef enum


### PR DESCRIPTION
This unreported test issue revealed an assertion in jmem_heap_finalize ().
During the conversion the lot of additional information what a cesu8 represented string needs caused overflow while setting the new ecma_string_t variable's length. This patch fixes this issue and the mentioned test case is available here:
https://gist.github.com/rerobika/3bd590fdcf664a3fcfcc98f11b14c74e

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu