### PR TITLE
Fixes pattern parsing in ecma_builtin_global_object_unescape ()

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -1316,6 +1316,12 @@ ecma_builtin_global_object_unescape (ecma_value_t this_arg, /**< this argument *
       hex_digits = (ecma_char_t) (hex_digits * 16 + (ecma_char_t) lit_char_hex_to_int (chr));
       status++;
     }
+    else
+    {
+      /* Previously found hexadecimal digit in escape sequence but it's not valid '%xy' pattern
+       * so essentially it was only a simple character. */
+      status = 0;
+    }
 
     /* 11-17. Found valid '%uwxyz' or '%xy' escape. */
     if (status == 8 || status == 3)

--- a/tests/jerry/regression-test-issue-1990.js
+++ b/tests/jerry/regression-test-issue-1990.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert(unescape("%f׊nd") === "%f׊nd")


### PR DESCRIPTION
Issue #1990 revealed an unhandled corner case while parsing pattern. This patch fixes it and also adds a test case.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu