### PR TITLE
Add job that tests with FEATURE_INIT_FINI turned ON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - OPTS="--buildoption-test"
     - OPTS="--jerry-tests --jerry-test-suite --buildoptions=--jerry-libc=off,--compile-flag=-m32,--cpointer-32bit=on"
     - OPTS="--unittests"
+    - OPTS="--unittests --buildoptions=--cmake-param=-DFEATURE_INIT_FINI=ON"
     - OPTS="--test262"
     - OPTS="--check-pylint"
   global:


### PR DESCRIPTION
Since modules behave differently depending on whether this feature is on or off
we should have a job that runs with the feature turned on.

JerryScript-DCO-1.0-Signed-off-by: Gabriel Schulhof gabriel.schulhof@intel.com