### PR TITLE
Fix typo in the debugger documentation

### DIFF
--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -335,9 +335,9 @@ int main ()
       jerry_value_t run_result;
       jerry_debugger_wait_for_source_status_t receive_status;
 
-      receive_status = jerry_debugger_wait_and_run_client_source (wait_for_source_callback,
-                                                                  NULL,
-                                                                  &run_result);
+      receive_status = jerry_debugger_wait_for_client_source (wait_for_source_callback,
+                                                              NULL,
+                                                              &run_result);
 
       jerry_release_value (run_result);
     }


### PR DESCRIPTION
The old function name was used in one occurrence.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu