### PR TITLE
Fix pending breakpoints in python debugger client

### DIFF
--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -226,8 +226,17 @@ class DebuggerPrompt(Cmd):
         """ Insert breakpoints on the given lines or functions """
         if args == "":
             print("Error: Breakpoint index expected")
+        elif ':' in args:
+            try:
+                args_second = int(args.split(':', 1)[1])
+                if args_second < 0:
+                    print("Error: Positive breakpoint index expected")
+                else:
+                    set_breakpoint(self.debugger, args, False)
+            except ValueError as val_errno:
+                print("Error: Positive breakpoint index expected: %s" % val_errno)
         else:
-            set_breakpoint(self.debugger, args)
+            set_breakpoint(self.debugger, args, False)
 
     do_b = do_break
 
@@ -826,14 +835,28 @@ def parse_source(debugger, data):
     # Try to set the pending breakpoints
     if len(debugger.pending_breakpoint_list) != 0:
         logging.debug("Pending breakpoints list: %s", debugger.pending_breakpoint_list)
+        bp_list = debugger.pending_breakpoint_list
 
-        for breakpoint in debugger.pending_breakpoint_list:
-            if debugger.pending_breakpoint_list[breakpoint].line:
-                breakpoint = debugger.pending_breakpoint_list[breakpoint].source_name + ":" \
-                             + str(debugger.pending_breakpoint_list[breakpoint].line)
-            else:
-                breakpoint = debugger.pending_breakpoint_list[breakpoint].function
-            set_breakpoint(debugger, breakpoint)
+        for breakpoint in bp_list:
+            for src in debugger.function_list.values():
+                if src.source_name == bp_list[breakpoint].source_name:
+                    source_lines = len(src.source)
+                else:
+                    source_lines = 0
+
+            if bp_list[breakpoint].line:
+                if bp_list[breakpoint].line <= source_lines:
+                    tmp_bp = breakpoint
+                    breakpoint = bp_list[breakpoint].source_name + ":" + str(bp_list[breakpoint].line)
+                    if set_breakpoint(debugger, breakpoint, True):
+                        del tmp_bp
+            elif bp_list[breakpoint].function:
+                tmp_bp = breakpoint
+                breakpoint = bp_list[breakpoint].function
+                if set_breakpoint(debugger, breakpoint, True):
+                    del tmp_bp
+
+
     else:
         logging.debug("No pending breakpoints")
 
@@ -913,7 +936,7 @@ def enable_breakpoint(debugger, breakpoint):
         print("%sBreakpoint %d %sat %s" % (debugger.green, breakpoint.active_index, debugger.nocolor, breakpoint))
 
 
-def set_breakpoint(debugger, string):
+def set_breakpoint(debugger, string, pending):
     line = re.match("(.*):(\\d+)$", string)
     found = False
 
@@ -936,7 +959,7 @@ def set_breakpoint(debugger, string):
                 enable_breakpoint(debugger, function.lines[function.first_breakpoint_line])
                 found = True
 
-    if not found:
+    if not found and not pending:
         print("No breakpoint found, do you want to add a %spending breakpoint%s? (y or [n])" % \
              (debugger.yellow, debugger.nocolor))
         ans = sys.stdin.readline()
@@ -946,8 +969,10 @@ def set_breakpoint(debugger, string):
             else:
                 breakpoint = JerryPendingBreakpoint(function=string)
             enable_breakpoint(debugger, breakpoint)
+    elif not found and pending:
+        return False
 
-    return
+    return True
 
 
 def get_breakpoint(debugger, breakpoint_data):


### PR DESCRIPTION
There was an issue where pending breakpoints were incorrectly tried to be assigned to invalid files, since they missed the source name check. It's also worth mentioning that pending breakpoints were not "moved" correctly to active status, just got copied there instead, making them appear in the pending list still.
This patch fixes both of these issues.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu