### PR TITLE
Introduce a way to directly save snapshot functions and load them back

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -4170,6 +4170,76 @@ main (void)
 - [jerry_exec_snapshot](#jerry_exec_snapshot)
 
 
+## jerry_parse_and_save_function_snapshot
+
+**Summary**
+
+Generate function snapshot from the specified source code
+with the given arguments.
+
+The function arguments and function body are
+passed as separated arguments.
+
+**Prototype**
+
+```c
+size_t
+jerry_parse_and_save_function_snapshot (const jerry_char_t *source_p,
+                                        size_t source_size,
+                                        const jerry_char_t *args_p,
+                                        size_t args_size,
+                                        bool is_strict,
+                                        uint32_t *buffer_p,
+                                        size_t buffer_size)
+- `source_p` - script source, it must be a valid utf8 string.
+- `source_size` - script source size, in bytes.
+- `args_p` - function arguments, it must be a valid utf8 string.
+- `args_size` - function argument size, in bytes.
+- `is_strict` - strict mode
+- `buffer_p` - buffer to save snapshot to.
+- `buffer_size` - the buffer's size.
+- return value
+  - the size of snapshot, if it was generated succesfully (i.e. there are no syntax errors in source
+    code, buffer size is sufficient, and snapshot support is enabled in current configuration through
+    JERRY_ENABLE_SNAPSHOT_SAVE)
+  - 0 otherwise.
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include <string.h>
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  static uint32_t func_snapshot_buffer[256];
+  const jerry_char_t *args_p = (const jerry_char_t *) "a, b";
+  const jerry_char_t *src_p = (const jerry_char_t *) "return a + b;";
+
+  size_t func_snapshot_size = jerry_parse_and_save_function_snapshot (src_p,
+                                                                      strlen ((const char *) src_p),
+                                                                      args_p,
+                                                                      strlen ((const char *) args_p),
+                                                                      false,
+                                                                      func_snapshot_buffer,
+                                                                      sizeof (func_snapshot_buffer) / sizeof (uint32_t));
+
+  jerry_cleanup ();
+}
+```
+
+**See also**
+
+- [jerry_init](#jerry_init)
+- [jerry_cleanup](#jerry_cleanup)
+- [jerry_load_function_snapshot_at](#jerry_load_function_snapshot_at)
+
+
 ## jerry_exec_snapshot
 
 **Summary**
@@ -4316,6 +4386,97 @@ main (void)
 - [jerry_cleanup](#jerry_cleanup)
 - [jerry_exec_snapshot](#jerry_exec_snapshot)
 - [jerry_parse_and_save_snapshot](#jerry_parse_and_save_snapshot)
+
+
+## jerry_load_function_snapshot_at
+
+**Summary**
+
+Load the selected snapshot function from the specified buffer as a function object.
+
+The lexical environment of the loaded function is always the global lexical environment.
+
+*Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+is no longer needed.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerry_load_function_snapshot_at (const uint32_t *snapshot_p,
+                                 size_t snapshot_size,
+                                 size_t func_index,
+                                 bool copy_bytecode);
+```
+
+- `snapshot_p` - pointer to snapshot
+- `snapshot_size` - size of snapshot
+- `func_index` - index of function to load
+- `copy_bytecode` - flag, indicating whether the passed snapshot buffer should be copied to the
+   engine's memory. If set the engine should not reference the buffer after the function returns
+   (in this case, the passed buffer could be freed after the call). Otherwise (if the flag is not
+   set) - the buffer could only be freed after the engine stops (i.e. after call to jerry_cleanup).
+- return value
+  - function object built from the snapshot
+  - thrown error, otherwise
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include <string.h>
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  static uint32_t snapshot_buffer[256];
+  const jerry_char_t *args_p = (const jerry_char_t *)"a, b";
+  const jerry_char_t *src_p = (const jerry_char_t *) "return a + b;";
+
+  jerry_init (JERRY_INIT_EMPTY);
+  size_t snapshot_size = jerry_parse_and_save_function_snapshot (src_p,
+                                                                 strlen ((const char *) src_p),
+                                                                 args_p,
+                                                                 strlen ((const char *) args_p),
+                                                                 false,
+                                                                 snapshot_buffer,
+                                                                 sizeof (snapshot_buffer) / sizeof (uint32_t));
+  jerry_cleanup ();
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t func = jerry_load_function_snapshot_at (snapshot_buffer,
+                                                        snapshot_size,
+                                                        0,
+                                                        false);
+  /* 'func' can be used now as a function object */
+
+  jerry_value_t this_value = jerry_create_undefined ();
+  jerry_value_t args[2];
+  args[0] = jerry_create_number (1.0);
+  args[1] = jerry_create_number (2.0);
+
+  jerry_value_t res = jerry_call_function (func, this_value, args, 2);
+
+  /* 'res' now contains the value 3 as a jerry_value_t */
+
+  jerry_release_value (args[0]);
+  jerry_release_value (args[1]);
+  jerry_release_value (this_value);
+  jerry_release_value (func);
+
+  jerry_cleanup ();
+  return 0;
+}
+```
+
+**See also**
+
+- [jerry_init](#jerry_init)
+- [jerry_cleanup](#jerry_cleanup)
+- [jerry_parse_and_save_function_snapshot](#jerry_parse_and_save_function_snapshot)
 
 
 ## jerry_parse_and_save_literals

--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -40,6 +40,13 @@ size_t jerry_merge_snapshots (const uint32_t **inp_buffers_p, size_t *inp_buffer
 size_t jerry_parse_and_save_literals (const jerry_char_t *source_p, size_t source_size, bool is_strict,
                                       uint32_t *buffer_p, size_t buffer_size, bool is_c_format);
 
+size_t jerry_parse_and_save_function_snapshot (const jerry_char_t *source_p, size_t source_size,
+                                               const jerry_char_t *args_p, size_t args_size,
+                                               bool is_strict, uint32_t *buffer_p, size_t buffer_size);
+jerry_value_t jerry_load_function_snapshot_at (const uint32_t *function_snapshot_p,
+                                               const size_t function_snapshot_size,
+                                               size_t func_index,
+                                               bool copy_bytecode);
 /**
  * @}
  */


### PR DESCRIPTION
Added two new api functions:
* jerry_parse_and_save_function_snapshot
* jerry_load_function_snapshot_at

The jerry_parse_and_save_function_snapshot function allows
creating snapshots from snapshot arguments and body source.

The jerry_load_function_snapshot_at function enables loading
back functions from a given snapshot as a JS function object.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com