### PR TITLE
target: mbedos5: Added DigitalIn & Serial js bindings

### DIFF
--- a/targets/mbedos5/README.md
+++ b/targets/mbedos5/README.md
@@ -11,6 +11,7 @@ so far:
 - [Nordic Semiconductor NRF52 Development Kit](https://developer.mbed.org/platforms/Nordic-nRF52-DK/)
 - [NXP Freedom K64F](https://developer.mbed.org/platforms/FRDM-K64F/)
 - [STM NUCLEO F401RE](https://developer.mbed.org/platforms/ST-Nucleo-F401RE/)
+- [STM NUCLEO F411RE](https://developer.mbed.org/platforms/ST-Nucleo-F411RE/)
 - [Silicon Labs EFM32 Giant Gecko](https://developer.mbed.org/platforms/EFM32-Giant-Gecko/)
 
 ## Features

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/DigitalIn-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/DigitalIn-js.h
@@ -1,0 +1,22 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _JERRYSCRIPT_MBED_DRIVERS_DIGITALIN_H
+#define _JERRYSCRIPT_MBED_DRIVERS_DIGITALIN_H
+
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+DECLARE_CLASS_CONSTRUCTOR(DigitalIn);
+
+#endif  // _JERRYSCRIPT_MBED_DRIVERS_DIGITALIN_H

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/Serial-js.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/Serial-js.h
@@ -1,0 +1,22 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _JERRYSCRIPT_MBED_DRIVERS_SERIAL_H
+#define _JERRYSCRIPT_MBED_DRIVERS_SERIAL_H
+
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+DECLARE_CLASS_CONSTRUCTOR(Serial);
+
+#endif  // _JERRYSCRIPT_MBED_DRIVERS_SERIAL_H

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
@@ -17,6 +17,7 @@
 
 #include "jerryscript-ext/handler.h"
 #include "jerryscript-mbed-drivers/InterruptIn-js.h"
+#include "jerryscript-mbed-drivers/DigitalIn-js.h"
 #include "jerryscript-mbed-drivers/DigitalOut-js.h"
 #include "jerryscript-mbed-drivers/setInterval-js.h"
 #include "jerryscript-mbed-drivers/setTimeout-js.h"
@@ -32,11 +33,39 @@ DECLARE_JS_WRAPPER_REGISTRATION (base) {
     REGISTER_GLOBAL_FUNCTION(setTimeout);
     REGISTER_GLOBAL_FUNCTION(clearInterval);
     REGISTER_GLOBAL_FUNCTION(clearTimeout);
+    //REGISTER_CLASS_CONSTRUCTOR(AnalogOut);
+    //REGISTER_CLASS_CONSTRUCTOR(BusIn);
+    //REGISTER_CLASS_CONSTRUCTOR(BusInOut);
+    //REGISTER_CLASS_CONSTRUCTOR(BusOut);
+    //REGISTER_CLASS_CONSTRUCTOR(CAN);
+    REGISTER_CLASS_CONSTRUCTOR(DigitalIn);          //test
+    //REGISTER_CLASS_CONSTRUCTOR(DigitalInOut);
     REGISTER_CLASS_CONSTRUCTOR(DigitalOut);
+    //REGISTER_CLASS_CONSTRUCTOR(Ethernet);
+    //REGISTER_CLASS_CONSTRUCTOR(FlashIAP);
     REGISTER_CLASS_CONSTRUCTOR(I2C);
+    //REGISTER_CLASS_CONSTRUCTOR(I2CSlave);
     REGISTER_CLASS_CONSTRUCTOR(InterruptIn);
     REGISTER_CLASS_CONSTRUCTOR(AnalogIn);
+    //REGISTER_CLASS_CONSTRUCTOR(InterruptManager);
+    //REGISTER_CLASS_CONSTRUCTOR(LowPowerTicker);
+    //REGISTER_CLASS_CONSTRUCTOR(LowPowerTimeout);
+    //REGISTER_CLASS_CONSTRUCTOR(LowPowerTimer);
+    //REGISTER_CLASS_CONSTRUCTOR(PortIn);
+    //REGISTER_CLASS_CONSTRUCTOR(PortInOut);
+    //REGISTER_CLASS_CONSTRUCTOR(PortOut);
     REGISTER_CLASS_CONSTRUCTOR(PwmOut);
+    //REGISTER_CLASS_CONSTRUCTOR(RawSerial);
+    //REGISTER_CLASS_CONSTRUCTOR(SerialBase);
+    //REGISTER_CLASS_CONSTRUCTOR(Serial);
+    //REGISTER_CLASS_CONSTRUCTOR(SPI);
+    //REGISTER_CLASS_CONSTRUCTOR(SPISlave);
+    //REGISTER_CLASS_CONSTRUCTOR(Ticker);
+    //REGISTER_CLASS_CONSTRUCTOR(Timeout);
+    //REGISTER_CLASS_CONSTRUCTOR(Timer);
+    //REGISTER_CLASS_CONSTRUCTOR(TimerEvent);
+    //REGISTER_CLASS_CONSTRUCTOR(Timer);
+    //REGISTER_CLASS_CONSTRUCTOR(UARTSerial);
 }
 
 #endif  // _JERRYSCRIPT_MBED_DRIVERS_LIB_DRIVERS_H

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/lib_drivers.h
@@ -24,6 +24,7 @@
 #include "jerryscript-mbed-drivers/I2C-js.h"
 #include "jerryscript-mbed-drivers/AnalogIn-js.h"
 #include "jerryscript-mbed-drivers/PwmOut-js.h"
+#include "jerryscript-mbed-drivers/Serial-js.h"
 
 DECLARE_JS_WRAPPER_REGISTRATION (base) {
     REGISTER_GLOBAL_FUNCTION_WITH_HANDLER(assert, jerryx_handler_assert);
@@ -38,7 +39,7 @@ DECLARE_JS_WRAPPER_REGISTRATION (base) {
     //REGISTER_CLASS_CONSTRUCTOR(BusInOut);
     //REGISTER_CLASS_CONSTRUCTOR(BusOut);
     //REGISTER_CLASS_CONSTRUCTOR(CAN);
-    REGISTER_CLASS_CONSTRUCTOR(DigitalIn);          //test
+    REGISTER_CLASS_CONSTRUCTOR(DigitalIn);          //test     
     //REGISTER_CLASS_CONSTRUCTOR(DigitalInOut);
     REGISTER_CLASS_CONSTRUCTOR(DigitalOut);
     //REGISTER_CLASS_CONSTRUCTOR(Ethernet);
@@ -57,7 +58,7 @@ DECLARE_JS_WRAPPER_REGISTRATION (base) {
     REGISTER_CLASS_CONSTRUCTOR(PwmOut);
     //REGISTER_CLASS_CONSTRUCTOR(RawSerial);
     //REGISTER_CLASS_CONSTRUCTOR(SerialBase);
-    //REGISTER_CLASS_CONSTRUCTOR(Serial);
+    REGISTER_CLASS_CONSTRUCTOR(Serial);             //test
     //REGISTER_CLASS_CONSTRUCTOR(SPI);
     //REGISTER_CLASS_CONSTRUCTOR(SPISlave);
     //REGISTER_CLASS_CONSTRUCTOR(Ticker);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalIn-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalIn-js.cpp
@@ -1,0 +1,126 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ * Initial version by Rouan van der Ende @bitlabio / @fluentart
+ * usage: 
+ *  var a = new DigitalIn(BUTTON1); 
+ *  print(a.read());
+ * 
+ * known issues:
+ *  Does not support second argument for PULL setting because I don't
+ *  know how to code that yet :)
+ * 
+ */
+#include "jerryscript-mbed-util/logging.h"
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+#include "mbed.h"
+
+/**
+ * DigitalIn#destructor
+ *
+ * Called if/when the DigitalIn is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalIn)(void* void_ptr) {
+    delete static_cast<DigitalIn*>(void_ptr);
+}
+
+/**
+ * Type infomation of the native DigitalIn pointer
+ *
+ * Set DigitalIn#destructor as the free callback.
+ */
+static const jerry_object_native_info_t native_obj_type_info = {
+    .free_cb = NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalIn)
+};
+
+
+/**
+ * DigitalIn#read (native JavaScript method)
+ *
+ * Reads the current status of a DigitalIn
+ *
+ * @returns 1 if the pin is currently high, or 0 if the pin is currently low.
+ */
+DECLARE_CLASS_FUNCTION(DigitalIn, read) {
+    CHECK_ARGUMENT_COUNT(DigitalIn, read, (args_count == 0));
+
+    // Extract native DigitalIn pointer
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native DigitalIn pointer");
+    }
+
+    DigitalIn* native_ptr = static_cast<DigitalIn*>(void_ptr);
+
+    int result = native_ptr->read();
+    return jerry_create_number(result);
+}
+
+/**
+ * DigitalIn#is_connected (native JavaScript method)
+ *
+ * @returns 0 if the DigitalIn is set to NC, or 1 if it is connected to an
+ *  actual pin
+ */
+DECLARE_CLASS_FUNCTION(DigitalIn, is_connected) {
+    CHECK_ARGUMENT_COUNT(DigitalIn, is_connected, (args_count == 0));
+
+    // Extract native DigitalIn pointer
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native DigitalIn pointer");
+    }
+
+    DigitalIn* native_ptr = static_cast<DigitalIn*>(void_ptr);
+
+    int result = native_ptr->is_connected();
+    return jerry_create_number(result);
+}
+
+/**
+ * DigitalIn (native JavaScript constructor)
+ *
+ * @param pin_name mbed pin to connect the DigitalIn to.
+ * @returns a JavaScript object representing a DigitalIn.
+ */
+DECLARE_CLASS_CONSTRUCTOR(DigitalIn) {
+    CHECK_ARGUMENT_COUNT(DigitalIn, __constructor, args_count == 1);
+    CHECK_ARGUMENT_TYPE_ALWAYS(DigitalIn, __constructor, 0, number);
+
+    DigitalIn* native_ptr;
+
+    // Call correct overload of DigitalIn::DigitalIn depending on the
+    // arguments passed.
+    PinName pin_name = PinName(jerry_get_number_value(args[0]));
+    native_ptr = new DigitalIn(pin_name);
+
+    // create the jerryscript object
+    jerry_value_t js_object = jerry_create_object();
+    jerry_set_object_native_pointer(js_object, native_ptr, &native_obj_type_info);
+
+    // attach methods
+    ATTACH_CLASS_FUNCTION(js_object, DigitalIn, read);
+    ATTACH_CLASS_FUNCTION(js_object, DigitalIn, is_connected);
+
+    return js_object;
+}

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/Serial-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/Serial-js.cpp
@@ -1,0 +1,234 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "jerryscript-mbed-util/logging.h"
+#include "jerryscript-mbed-event-loop/EventLoop.h"
+#include "jerryscript-mbed-drivers/Serial-js.h"
+#include "jerryscript-mbed-library-registry/wrap_tools.h"
+
+#include "mbed.h"
+
+/**
+ * Serial#destructor
+ *
+ * Called if/when the Serial object is GC'ed.
+ */
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(Serial) (void *void_ptr) {
+    delete static_cast<Serial*>(void_ptr);
+}
+
+/**
+ * Type infomation of the native Serial pointer
+ *
+ * Set Serial#destructor as the free callback.
+ */
+static const jerry_object_native_info_t native_obj_type_info = {
+    .free_cb = NAME_FOR_CLASS_NATIVE_DESTRUCTOR(Serial)
+};
+
+/**
+ * Serial#baud (native JavaScript method)
+ * 
+ * Sets the baud rate
+ *
+ * @param integer byte value
+ * @returns undefined
+ */
+
+DECLARE_CLASS_FUNCTION(Serial, baud) {
+    CHECK_ARGUMENT_COUNT(Serial, baud, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(Serial, baud, 0, number);
+
+    // Extract native Serial pointer
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native Serial pointer");
+    }
+
+    
+
+    Serial* native_ptr = static_cast<Serial*>(void_ptr);
+
+    int arg0 = jerry_get_number_value(args[0]);
+    native_ptr->baud(arg0);
+
+    return jerry_create_undefined();
+}
+
+ /**
+ * Serial#putc (native JavaScript method)
+ * 
+ * Writes an integer value to a Serial connection.
+ *
+ * @param integer byte value or char
+ * @returns 1 on success, 0 on error
+ */
+
+DECLARE_CLASS_FUNCTION(Serial, putc) {
+    CHECK_ARGUMENT_COUNT(Serial, putc, (args_count == 1));
+    CHECK_ARGUMENT_TYPE_ALWAYS(Serial, putc, 0, number);
+
+    // Extract native Serial pointer
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                  (const jerry_char_t *) "Failed to get native Serial pointer");
+    }
+
+    Serial* native_ptr = static_cast<Serial*>(void_ptr);
+
+    int arg0 = jerry_get_number_value(args[0]);
+    native_ptr->putc(arg0);
+
+    return jerry_create_undefined();
+}
+
+
+
+/**
+ * Serial#getc (native JavaScript method)
+ * 
+ * Readed an integer value from a Serial connection.
+ *
+ * @returns byte read 
+ */
+
+DECLARE_CLASS_FUNCTION(Serial, getc) {
+    CHECK_ARGUMENT_COUNT(Serial, getc, (args_count == 0));
+    
+    // Extract native Serial pointer
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                    (const jerry_char_t *) "Failed to get native Serial pointer");
+    }
+
+    Serial* native_ptr = static_cast<Serial*>(void_ptr);
+
+    int result = native_ptr->getc();
+    return jerry_create_number(result);
+}
+
+
+
+/**
+ * Serial#writable (native JavaScript method)
+ * 
+ * Checks if a serialport is writable
+ *
+ * @returns true if writable, false if not writable
+ */
+
+DECLARE_CLASS_FUNCTION(Serial, writable) {
+    CHECK_ARGUMENT_COUNT(Serial, writable, (args_count == 0));
+    
+    // Extract native Serial pointer
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                    (const jerry_char_t *) "Failed to get native Serial pointer");
+    }
+
+    Serial* native_ptr = static_cast<Serial*>(void_ptr);
+
+    bool result = native_ptr->writable();
+    return jerry_create_number(result);
+}
+
+
+
+/**
+ * Serial#readable (native JavaScript method)
+ * 
+ * Checks if a serialport is readable
+ *
+ * @returns true if readable, false if not readable
+ */
+
+DECLARE_CLASS_FUNCTION(Serial, readable) {
+    CHECK_ARGUMENT_COUNT(Serial, readable, (args_count == 0));
+    
+    // Extract native Serial pointer
+    void* void_ptr;
+    const jerry_object_native_info_t* type_ptr;
+    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &type_ptr);
+
+    if (!has_ptr || type_ptr != &native_obj_type_info) {
+        return jerry_create_error(JERRY_ERROR_TYPE,
+                                    (const jerry_char_t *) "Failed to get native Serial pointer");
+    }
+
+    Serial* native_ptr = static_cast<Serial*>(void_ptr);
+
+    bool result = native_ptr->readable();
+    return jerry_create_number(result);
+}
+
+
+
+/**
+ * Serial (native JavaScript constructor)
+ * @param tx mbed pin for Serial tx
+ * @param rx mbed pin for Serial rx
+ * @returns a JavaScript object representing the Serial bus.
+ */
+
+DECLARE_CLASS_CONSTRUCTOR(Serial) {
+    CHECK_ARGUMENT_COUNT(Serial, __constructor, (args_count == 2 || args_count == 3));
+    CHECK_ARGUMENT_TYPE_ALWAYS(Serial, __constructor, 0, number);
+    CHECK_ARGUMENT_TYPE_ALWAYS(Serial, __constructor, 1, number);
+    CHECK_ARGUMENT_TYPE_ON_CONDITION(Serial, __constructor, 2, number, (args_count == 3));
+
+    Serial* native_ptr;
+
+    int tx = jerry_get_number_value(args[0]);
+    int rx = jerry_get_number_value(args[1]);
+
+    switch (args_count) {
+        case 2:
+            native_ptr = new Serial((PinName)tx, (PinName)rx);
+            break;
+        case 3:
+            int baud = static_cast<int>(jerry_get_number_value(args[2]));
+            native_ptr = new Serial((PinName)tx, (PinName)rx, baud);
+            break;
+    }
+
+
+    jerry_value_t js_object = jerry_create_object();
+    jerry_set_object_native_pointer(js_object, native_ptr, &native_obj_type_info);
+
+    //ATTACH_CLASS_FUNCTION(js_object, Serial, attach); //DISABLED, NON FUNCTIONAL
+    ATTACH_CLASS_FUNCTION(js_object, Serial, baud);
+    ATTACH_CLASS_FUNCTION(js_object, Serial, putc);
+    ATTACH_CLASS_FUNCTION(js_object, Serial, getc);
+    ATTACH_CLASS_FUNCTION(js_object, Serial, writable);
+    ATTACH_CLASS_FUNCTION(js_object, Serial, readable);
+    //ATTACH_CLASS_FUNCTION(js_object, Serial, write);
+
+    return js_object;
+}


### PR DESCRIPTION
This is now working:

```
var a = new DigitalIn(BUTTON1); 
print(a.read());
```

Also added the other missing class constructors to lib_drivers.h as commented out lines. Lets get them all done!

JerryScript-DCO-1.0-Signed-off-by: Rouan van der Ende rouan.vanderende@iotnxt.com