### PR TITLE
Fix API docs

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -4191,6 +4191,8 @@ jerry_parse_and_save_function_snapshot (const jerry_char_t *source_p,
                                         bool is_strict,
                                         uint32_t *buffer_p,
                                         size_t buffer_size)
+```
+
 - `source_p` - script source, it must be a valid utf8 string.
 - `source_size` - script source size, in bytes.
 - `args_p` - function arguments, it must be a valid utf8 string.


### PR DESCRIPTION
The #2043 introduced a bit of error in the API
docs as there was missing backticks.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com