### PR TITLE
Add info to documentation about random numbers

### DIFF
--- a/docs/03.API-EXAMPLE.md
+++ b/docs/03.API-EXAMPLE.md
@@ -551,6 +551,50 @@ Value of x is 12
 Value of x is 17
 ```
 
+## Step 8. Changing the seed of pseudorandom generated numbers
+
+If you want to change the seed of `Math.random()` generated numbers, you have to initialize the seed value with `srand`.
+A recommended method is using `jerry_port_get_current_time()` or something based on a constantly changing value, therefore every run produces truly random numbers.
+
+[doctest]: # ()
+
+```c
+#include <string.h>
+#include <stdlib.h>
+#include "jerryscript.h"
+#include "jerryscript-port.h"
+#include "jerryscript-ext/handler.h"
+
+int
+main (void)
+{
+  /* Initialize srand value */
+  srand ((unsigned) jerry_port_get_current_time ());
+
+  /* Generate a random number, and print it */
+  const jerry_char_t script[] = "var a = Math.random (); print(a)";
+  size_t script_size = strlen ((const char *) script);
+
+  /* Initialize the engine */
+  jerry_init (JERRY_INIT_EMPTY);
+
+  /* Register the print function */
+  jerryx_handler_register_global ((const jerry_char_t *) "print",
+                                  jerryx_handler_print);
+
+  /* Evaluate the script */
+  jerry_value_t eval_ret = jerry_eval (script, script_size, false);
+
+  /* Free the JavaScript value returned by eval */
+  jerry_release_value (eval_ret);
+
+  /* Cleanup the engine */
+  jerry_cleanup ();
+
+  return 0;
+}
+```
+
 ## Further steps
 
 For further API description, please visit [API Reference page](https://jerryscript-project.github.io/jerryscript/api-reference/) on [JerryScript home page](https://jerryscript-project.github.io/jerryscript/).

--- a/jerry-main/main-unix-minimal.c
+++ b/jerry-main/main-unix-minimal.c
@@ -71,6 +71,7 @@ int
 main (int argc,
       char **argv)
 {
+  srand ((unsigned) jerry_port_get_current_time ());
   if (argc <= 1 || (argc == 2 && (!strcmp ("-h", argv[1]) || !strcmp ("--help", argv[1]))))
   {
     print_help (argv[0]);

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -424,6 +424,7 @@ int
 main (int argc,
       char **argv)
 {
+  srand ((unsigned) jerry_port_get_current_time ());
   const char *file_names[argc];
   int files_counter = 0;
 

--- a/targets/curie_bsp/jerry_app/quark/main.c
+++ b/targets/curie_bsp/jerry_app/quark/main.c
@@ -136,6 +136,7 @@ void eval_jerry_script (int argc, char *argv[], struct tcmd_handler_ctx *ctx)
 
 void jerry_start ()
 {
+  srand ((unsigned) jerry_port_get_current_time ());
   jerry_init (JERRY_INIT_EMPTY);
   jerry_value_t global_obj_val = jerry_get_global_object ();
   jerry_value_t print_func_name_val = jerry_create_string ((jerry_char_t *) "print");

--- a/targets/mbed/source/main.cpp
+++ b/targets/mbed/source/main.cpp
@@ -24,6 +24,7 @@ static Serial pc (USBTX, USBRX); //tx, rx
 
 static int jerry_task_init (void)
 {
+  srand ((unsigned) jerry_port_get_current_time ());
   int retcode;
 
   DECLARE_JS_CODES;

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
@@ -67,6 +67,7 @@ static int load_javascript() {
 }
 
 int jsmbed_js_init() {
+    srand ((unsigned) jerry_port_get_current_time());
     jerry_init_flag_t flags = JERRY_INIT_EMPTY;
     jerry_init(flags);
 

--- a/targets/riot-stm32f4/source/main-riotos.c
+++ b/targets/riot-stm32f4/source/main-riotos.c
@@ -97,6 +97,7 @@ const shell_command_t shell_commands[] = {
 
 int main (void)
 {
+  srand ((unsigned) jerry_port_get_current_time ());
   printf ("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
   printf ("This board features a(n) %s MCU.\n", RIOT_MCU);
 

--- a/targets/zephyr/src/main-zephyr.c
+++ b/targets/zephyr/src/main-zephyr.c
@@ -79,6 +79,7 @@ static int shell_cmd_handler (char *source_buffer)
 
 void main (void)
 {
+  srand ((unsigned) jerry_port_get_current_time ());
   uint32_t zephyr_ver = sys_kernel_version_get ();
   printf ("JerryScript build: " __DATE__ " " __TIME__ "\n");
   printf ("JerryScript API %d.%d\n", JERRY_API_MAJOR_VERSION, JERRY_API_MINOR_VERSION);

--- a/tests/unit-core/test-common.h
+++ b/tests/unit-core/test-common.h
@@ -47,25 +47,7 @@
 #define TEST_INIT() \
 do \
 { \
-  FILE *f_rnd = fopen ("/dev/urandom", "r"); \
- \
-  if (f_rnd == NULL) \
-  { \
-    return 1; \
-  } \
- \
-  uint32_t seed; \
- \
-  size_t bytes_read = fread (&seed, 1, sizeof (seed), f_rnd); \
- \
- fclose (f_rnd); \
- \
-  if (bytes_read != sizeof (seed)) \
-  { \
-    return 1; \
-  } \
- \
-  srand (seed); \
+  srand ((unsigned) jerry_port_get_current_time ()); \
 } while (0)
 
 #endif /* !TEST_COMMON_H */


### PR DESCRIPTION
Issue #2053 has highlighted the fact that random numbers are always generated with the same seed.
An example of generating different random numbers, other than the original seed, has been added to the documentation.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu