### PR TITLE
Add regression test from issue #2008

### DIFF
--- a/tests/jerry/regression-test-issue-2008.js
+++ b/tests/jerry/regression-test-issue-2008.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'\
+'+'056';


### PR DESCRIPTION
The issue was reported against v1.0 and isn't reproducible anymore.
Still, adding the then-faulty input to the regression test suite to
prevent it occuring again.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu