### PR TITLE
Free the `error_value` of the global context before raise an error.

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -19,6 +19,7 @@
 #include "ecma-literal-storage.h"
 #include "js-parser-internal.h"
 #include "lit-char-helpers.h"
+#include "jcontext.h"
 
 #ifndef JERRY_DISABLE_JS_PARSER
 
@@ -2038,6 +2039,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
 
   if (is_throw)
   {
+    ecma_free_value (JERRY_CONTEXT (error_value));
     parser_raise_error (context_p, PARSER_ERR_INVALID_REGEXP);
   }
 

--- a/tests/jerry/fail/regression-test-issue-2058.js
+++ b/tests/jerry/fail/regression-test-issue-2058.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/?:/


### PR DESCRIPTION
This patch fixes #2058 .

JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu