### PR TITLE
Fix jerry-libc's srand function

### DIFF
--- a/jerry-libc/jerry-libc.c
+++ b/jerry-libc/jerry-libc.c
@@ -276,10 +276,14 @@ rand (void)
 void
 srand (unsigned int seed) /**< new seed */
 {
-  libc_random_gen_state[0] =
-  libc_random_gen_state[1] =
-  libc_random_gen_state[2] =
-  libc_random_gen_state[3] = seed;
+  libc_random_gen_state[0] = (uint32_t) ((seed * 14316555781)
+                                         + (seed * 1183186591)
+                                         + (seed * 622729787)
+                                         + (seed * 338294347));
+
+  libc_random_gen_state[1] = 842502087;
+  libc_random_gen_state[2] = 3579807591;
+  libc_random_gen_state[3] = 273326509;
 } /* srand */
 
 /**


### PR DESCRIPTION
The previous implementation of srand was wrong in jerry-libc.
It set all 4 values to the seed, not modifying anything in them, causing random values to be repeated pretty often.
This approach fixes the mentioned issue.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu

