### PR TITLE
Add missing headers for srand() to jerry-minimal and riot-stm32f4

### DIFF
--- a/jerry-main/main-unix-minimal.c
+++ b/jerry-main/main-unix-minimal.c
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "jerryscript.h"

--- a/targets/riot-stm32f4/source/main-riotos.c
+++ b/targets/riot-stm32f4/source/main-riotos.c
@@ -14,10 +14,12 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "shell.h"
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
+#include "jerryscript-port.h"
 
 /**
  * Standalone Jerry exit codes

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -128,6 +128,8 @@ JERRY_BUILDOPTIONS = [
             ['--jerry-libc=off', '--compile-flag=-m32', '--cpointer-32bit=on', '--system-allocator=on']),
     Options('buildoption_test-external_context',
             ['--jerry-libc=off', '--external-context=on']),
+    Options('buildoption_test-cmdline_minimal',
+            ['--jerry-cmdline-minimal=on']),
     Options('buildoption_test-snapshot_tool',
             ['--jerry-cmdline-snapshot=on']),
 ]


### PR DESCRIPTION
A buildoption test is also added to test jerry-cmdline-minimal.

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com