### PR TITLE
Fixed template literal parsing

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -716,6 +716,16 @@ lexer_parse_string (parser_context_t *context_p) /**< context */
         continue;
       }
     }
+#ifndef CONFIG_DISABLE_ES2015_TEMPLATE_STRINGS
+    else if (str_end_character == LIT_CHAR_GRAVE_ACCENT &&
+             source_p[0] == LIT_CHAR_DOLLAR_SIGN &&
+             source_p + 1 < source_end_p &&
+             source_p[1] == LIT_CHAR_LEFT_BRACE)
+    {
+      source_p++;
+      break;
+    }
+#endif /* !CONFIG_DISABLE_ES2015_TEMPLATE_STRINGS */
 
     if (*source_p >= LEXER_UTF8_4BYTE_START)
     {
@@ -737,14 +747,6 @@ lexer_parse_string (parser_context_t *context_p) /**< context */
 #ifndef CONFIG_DISABLE_ES2015_TEMPLATE_STRINGS
     else if (str_end_character == LIT_CHAR_GRAVE_ACCENT)
     {
-      if (source_p[0] == LIT_CHAR_LEFT_BRACE
-          && source_p[-1] == LIT_CHAR_DOLLAR_SIGN
-          && source_p[-2] != LIT_CHAR_BACKSLASH)
-      {
-        length--;
-        break;
-      }
-
       /* Newline (without backslash) is part of the string. */
       if (*source_p == LIT_CHAR_CR)
       {

--- a/tests/jerry/fail/regression-test-issue-2039.js
+++ b/tests/jerry/fail/regression-test-issue-2039.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+` ?N\7$D\\${D ?N@ ${Z ?11.1Z7$D\\${D ?N@ ${Z ?11.1 ?11.1.G.{Z %11.0.G.


### PR DESCRIPTION
Fixed an unhandled corner case while parsing slashes and template literals.
This patch fixes #2039 and adds a test case for it.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu