### PR TITLE
Add fast path to ecma_op_object_get with magic string.

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -1345,14 +1345,10 @@ jerry_get_array_length (const jerry_value_t value)
     return 0;
   }
 
-  jerry_length_t length = 0;
-  ecma_string_t magic_string_length;
-  ecma_init_ecma_length_string (&magic_string_length);
+  ecma_value_t len_value = ecma_op_object_get_by_magic_id (ecma_get_object_from_value (array),
+                                                           LIT_MAGIC_STRING_LENGTH);
 
-  ecma_value_t len_value = ecma_op_object_get (ecma_get_object_from_value (array),
-                                               &magic_string_length);
-
-  length = ecma_number_to_uint32 (ecma_get_number_from_value (len_value));
+  jerry_length_t length = ecma_number_to_uint32 (ecma_get_number_from_value (len_value));
   ecma_free_value (len_value);
 
   return length;
@@ -2461,18 +2457,10 @@ jerry_resolve_or_reject_promise (jerry_value_t promise, /**< the promise value *
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (wrong_args_msg_p)));
   }
 
-  ecma_string_t str;
+  lit_magic_string_id_t prop_name = (is_resolve ? LIT_INTERNAL_MAGIC_STRING_RESOLVE_FUNCTION
+                                                : LIT_INTERNAL_MAGIC_STRING_REJECT_FUNCTION);
 
-  if (is_resolve)
-  {
-    ecma_init_ecma_magic_string (&str, LIT_INTERNAL_MAGIC_STRING_RESOLVE_FUNCTION);
-  }
-  else
-  {
-    ecma_init_ecma_magic_string (&str, LIT_INTERNAL_MAGIC_STRING_REJECT_FUNCTION);
-  }
-
-  ecma_value_t function = ecma_op_object_get (ecma_get_object_from_value (promise), &str);
+  ecma_value_t function = ecma_op_object_get_by_magic_id (ecma_get_object_from_value (promise), prop_name);
 
   ecma_value_t ret = ecma_op_function_call (ecma_get_object_from_value (function),
                                             ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -372,15 +372,6 @@ ecma_init_ecma_magic_string (ecma_string_t *string_desc_p, /**< ecma-string */
 } /* ecma_init_ecma_magic_string */
 
 /**
- * Initialize a length ecma-string
- */
-inline void __attr_always_inline___
-ecma_init_ecma_length_string (ecma_string_t *string_desc_p) /**< ecma-string */
-{
-  ecma_init_ecma_magic_string (string_desc_p, LIT_MAGIC_STRING_LENGTH);
-} /* ecma_init_ecma_length_string */
-
-/**
  * Allocate new ecma-string and fill it with ecma-number
  *
  * @return pointer to ecma-string descriptor
@@ -483,7 +474,7 @@ ecma_string_t *
 ecma_new_ecma_length_string (void)
 {
   ecma_string_t *string_desc_p = ecma_alloc_string ();
-  ecma_init_ecma_length_string (string_desc_p);
+  ecma_init_ecma_magic_string (string_desc_p, LIT_MAGIC_STRING_LENGTH);
 
   return string_desc_p;
 } /* ecma_new_ecma_length_string */

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -199,7 +199,6 @@ void ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, lit_utf8_byt
                                 lit_utf8_size_t buffer_size);
 const lit_utf8_byte_t *ecma_string_raw_chars (const ecma_string_t *string_p, lit_utf8_size_t *size_p, bool *is_ascii_p);
 void ecma_init_ecma_string_from_uint32 (ecma_string_t *string_desc_p, uint32_t uint32_number);
-void ecma_init_ecma_length_string (ecma_string_t *string_desc_p);
 void ecma_init_ecma_magic_string (ecma_string_t *string_desc_p, lit_magic_string_id_t id);
 bool ecma_compare_ecma_string_to_magic_id (const ecma_string_t *string_p, lit_magic_string_id_t id);
 bool ecma_string_is_empty (const ecma_string_t *string_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -94,11 +94,9 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this_value);
 
-  ecma_string_t *join_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_JOIN);
-
   /* 2. */
   ECMA_TRY_CATCH (join_value,
-                  ecma_op_object_get (obj_p, join_magic_string_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_JOIN),
                   ret_value);
 
   if (!ecma_op_is_callable (join_value))
@@ -115,9 +113,6 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg) /**< this 
   }
 
   ECMA_FINALIZE (join_value);
-
-  ecma_deref_ecma_string (join_magic_string_p);
-
   ECMA_FINALIZE (obj_this_value);
 
   return ret_value;
@@ -144,11 +139,9 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_value);
 
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
-
   /* 2. */
   ECMA_TRY_CATCH (length_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   /* 3. */
@@ -214,9 +207,6 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
   ECMA_OP_TO_NUMBER_FINALIZE (length_number);
 
   ECMA_FINALIZE (length_value);
-
-  ecma_deref_ecma_string (length_magic_string_p);
-
   ECMA_FINALIZE (obj_value);
 
   return ret_value;
@@ -368,11 +358,9 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_value);
 
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
-
   /* 2. */
   ECMA_TRY_CATCH (length_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (length_number,
@@ -445,9 +433,6 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
   ECMA_OP_TO_NUMBER_FINALIZE (length_number);
 
   ECMA_FINALIZE (length_value);
-
-  ecma_deref_ecma_string (length_magic_string_p);
-
   ECMA_FINALIZE (obj_value);
 
   return ret_value;
@@ -473,11 +458,10 @@ ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argume
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -526,7 +510,6 @@ ecma_builtin_array_prototype_object_pop (ecma_value_t this_arg) /**< this argume
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -554,9 +537,9 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this_value);
 
   /* 2. */
-  ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
-
-  ECMA_TRY_CATCH (length_value, ecma_op_object_get (obj_p, length_str_p), ret_value);
+  ECMA_TRY_CATCH (length_value,
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
+                  ret_value);
 
   /* 3. */
   ECMA_OP_TO_NUMBER_TRY_CATCH (length_var, length_value, ret_value);
@@ -595,9 +578,6 @@ ecma_builtin_array_prototype_object_push (ecma_value_t this_arg, /**< this argum
   ECMA_OP_TO_NUMBER_FINALIZE (length_var);
 
   ECMA_FINALIZE (length_value);
-
-  ecma_deref_ecma_string (length_str_p);
-
   ECMA_FINALIZE (obj_this_value);
 
   return ret_value;
@@ -623,11 +603,10 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this ar
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   /* 3. */
@@ -693,7 +672,6 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg) /**< this ar
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -719,11 +697,10 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -806,7 +783,6 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -834,10 +810,9 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
 
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   /* 3. */
@@ -922,7 +897,6 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (length_magic_string_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1204,10 +1178,9 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1325,7 +1298,6 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1355,10 +1327,8 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
 
   /* 3. */
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
-
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, length_magic_string_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   /* 4. */
@@ -1610,7 +1580,6 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (length_magic_string_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1638,11 +1607,10 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1707,7 +1675,6 @@ ecma_builtin_array_prototype_object_unshift (ecma_value_t this_arg, /**< this ar
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1735,11 +1702,10 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1799,9 +1765,6 @@ ecma_builtin_array_prototype_object_index_of (ecma_value_t this_arg, /**< this a
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
 
   ECMA_FINALIZE (len_value);
-
-  ecma_deref_ecma_string (magic_string_length_p);
-
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1830,11 +1793,10 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -1946,7 +1908,6 @@ ecma_builtin_array_prototype_object_last_index_of (ecma_value_t this_arg, /**< t
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -1974,11 +1935,10 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2045,7 +2005,6 @@ ecma_builtin_array_prototype_object_every (ecma_value_t this_arg, /**< this argu
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2073,11 +2032,10 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2145,7 +2103,6 @@ ecma_builtin_array_prototype_object_some (ecma_value_t this_arg, /**< this argum
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2172,11 +2129,10 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2237,7 +2193,6 @@ ecma_builtin_array_prototype_object_for_each (ecma_value_t this_arg, /**< this a
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2265,11 +2220,10 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2349,7 +2303,6 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2377,11 +2330,10 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   /* 3. */
@@ -2469,7 +2421,6 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2499,11 +2450,10 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2624,7 +2574,6 @@ ecma_builtin_array_prototype_object_reduce (ecma_value_t this_arg, /**< this arg
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;
@@ -2654,11 +2603,10 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
                   ret_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   /* 2. */
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (obj_p, magic_string_length_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);
@@ -2780,7 +2728,6 @@ ecma_builtin_array_prototype_object_reduce_right (ecma_value_t this_arg, /**< th
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);
   ECMA_FINALIZE (len_value);
-  ecma_deref_ecma_string (magic_string_length_p);
   ECMA_FINALIZE (obj_this);
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -151,12 +151,11 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg) /**< this argument *
 
   if (ecma_is_value_empty (ret_value))
   {
-    ecma_string_t *to_iso_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_ISO_STRING_UL);
     ecma_object_t *value_obj_p = ecma_get_object_from_value (obj);
 
     /* 4. */
     ECMA_TRY_CATCH (to_iso,
-                    ecma_op_object_get (value_obj_p, to_iso_str_p),
+                    ecma_op_object_get_by_magic_id (value_obj_p, LIT_MAGIC_STRING_TO_ISO_STRING_UL),
                     ret_value);
 
     /* 5. */
@@ -172,8 +171,6 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg) /**< this argument *
     }
 
     ECMA_FINALIZE (to_iso);
-
-    ecma_deref_ecma_string (to_iso_str_p);
   }
 
   ECMA_FINALIZE (tv);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -65,10 +65,9 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
   else
   {
     ecma_object_t *obj_p = ecma_get_object_from_value (this_arg);
-    ecma_string_t *name_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAME);
 
     ECMA_TRY_CATCH (name_get_ret_value,
-                    ecma_op_object_get (obj_p, name_magic_string_p),
+                    ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_NAME),
                     ret_value);
 
     ecma_value_t name_to_str_completion;
@@ -90,10 +89,8 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
     }
     else
     {
-      ecma_string_t *message_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE);
-
       ECMA_TRY_CATCH (msg_get_ret_value,
-                      ecma_op_object_get (obj_p, message_magic_string_p),
+                      ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_MESSAGE),
                       ret_value);
 
       ecma_value_t msg_to_str_completion;
@@ -173,15 +170,11 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
       ecma_free_value (msg_to_str_completion);
 
       ECMA_FINALIZE (msg_get_ret_value);
-
-      ecma_deref_ecma_string (message_magic_string_p);
     }
 
     ecma_free_value (name_to_str_completion);
 
     ECMA_FINALIZE (name_get_ret_value);
-
-    ecma_deref_ecma_string (name_magic_string_p);
   }
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -109,11 +109,10 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
       else
       {
         ecma_object_t *obj_p = ecma_get_object_from_value (arg2);
-        ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
 
         /* 4. */
         ECMA_TRY_CATCH (length_value,
-                        ecma_op_object_get (obj_p, length_magic_string_p),
+                        ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                         ret_value);
 
         ECMA_OP_TO_NUMBER_TRY_CATCH (length_number,
@@ -163,7 +162,6 @@ ecma_builtin_function_prototype_object_apply (ecma_value_t this_arg, /**< this a
 
         ECMA_OP_TO_NUMBER_FINALIZE (length_number);
         ECMA_FINALIZE (length_value);
-        ecma_deref_ecma_string (length_magic_string_p);
       }
     }
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -141,10 +141,9 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
                     ret_value);
 
     ecma_object_t *index_obj_p = ecma_get_object_from_value (index_obj_value);
-    ecma_string_t *locale_string_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_LOCALE_STRING_UL);
 
     ECMA_TRY_CATCH (to_locale_value,
-                    ecma_op_object_get (index_obj_p, locale_string_magic_string_p),
+                    ecma_op_object_get_by_magic_id (index_obj_p, LIT_MAGIC_STRING_TO_LOCALE_STRING_UL),
                     ret_value);
 
     if (ecma_op_is_callable (to_locale_value))
@@ -166,9 +165,6 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
     }
 
     ECMA_FINALIZE (to_locale_value);
-
-    ecma_deref_ecma_string (locale_string_magic_string_p);
-
     ECMA_FINALIZE (index_obj_value);
   }
 
@@ -332,11 +328,10 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
   if (ecma_is_value_object (value)
       && (ecma_object_get_class_name (ecma_get_object_from_value (value)) == LIT_MAGIC_STRING_ARRAY_UL))
   {
-    ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
     /* 5.b.ii */
     ECMA_TRY_CATCH (arg_len_value,
-                    ecma_op_object_get (ecma_get_object_from_value (value),
-                                        magic_string_length_p),
+                    ecma_op_object_get_by_magic_id (ecma_get_object_from_value (value),
+                                                    LIT_MAGIC_STRING_LENGTH),
                     ret_value);
     ECMA_OP_TO_NUMBER_TRY_CATCH (arg_len_number, arg_len_value, ret_value);
 
@@ -383,7 +378,6 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
 
     ECMA_OP_TO_NUMBER_FINALIZE (arg_len_number);
     ECMA_FINALIZE (arg_len_value);
-    ecma_deref_ecma_string (magic_string_length_p);
   }
   else
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -924,10 +924,8 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
     /* 4.b */
     else if (ecma_object_get_class_name (obj_p) == LIT_MAGIC_STRING_ARRAY_UL)
     {
-      ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
-
       ECMA_TRY_CATCH (array_length,
-                      ecma_op_object_get (obj_p, length_str_p),
+                      ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                       ret_value);
 
       ECMA_OP_TO_NUMBER_TRY_CATCH (array_length_num,
@@ -1007,8 +1005,6 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
 
       ECMA_OP_TO_NUMBER_FINALIZE (array_length_num);
       ECMA_FINALIZE (array_length);
-
-      ecma_deref_ecma_string (length_str_p);
     }
   }
 
@@ -1328,11 +1324,10 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
   if (ecma_is_value_object (my_val))
   {
     ecma_object_t *value_obj_p = ecma_get_object_from_value (my_val);
-    ecma_string_t *to_json_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_JSON_UL);
 
     /* 2.a */
     ECMA_TRY_CATCH (toJSON,
-                    ecma_op_object_get (value_obj_p, to_json_str_p),
+                    ecma_op_object_get_by_magic_id (value_obj_p, LIT_MAGIC_STRING_TO_JSON_UL),
                     ret_value);
 
     /* 2.b */
@@ -1353,8 +1348,6 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
     }
 
     ECMA_FINALIZE (toJSON);
-
-    ecma_deref_ecma_string (to_json_str_p);
   }
 
   /* 3. */
@@ -1727,11 +1720,9 @@ ecma_builtin_json_array (ecma_object_t *obj_p, /**< the array object*/
   /* 5. */
   ecma_collection_header_t *partial_p = ecma_new_values_collection (NULL, 0, true);
 
-  ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
-
   /* 6. */
   ECMA_TRY_CATCH (array_length,
-                  ecma_op_object_get (obj_p, length_str_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (array_length_num,
@@ -1819,7 +1810,6 @@ ecma_builtin_json_array (ecma_object_t *obj_p, /**< the array object*/
   ECMA_OP_TO_NUMBER_FINALIZE (array_length_num);
   ECMA_FINALIZE (array_length);
 
-  ecma_deref_ecma_string (length_str_p);
   ecma_free_values_collection (partial_p, true);
 
   /* 11. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -93,11 +93,10 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /*
                   return_value);
 
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_val);
-  ecma_string_t *to_string_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_TO_STRING_UL);
 
   /* 2. */
   ECMA_TRY_CATCH (to_string_val,
-                  ecma_op_object_get (obj_p, to_string_magic_string_p),
+                  ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_TO_STRING_UL),
                   return_value);
 
   /* 3. */
@@ -111,10 +110,8 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /*
     ecma_object_t *to_string_func_obj_p = ecma_get_object_from_value (to_string_val);
     return_value = ecma_op_function_call (to_string_func_obj_p, this_arg, NULL, 0);
   }
+
   ECMA_FINALIZE (to_string_val);
-
-  ecma_deref_ecma_string (to_string_magic_string_p);
-
   ECMA_FINALIZE (obj_val);
 
   return return_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -205,10 +205,8 @@ ecma_builtin_promise_do_race (ecma_value_t array, /**< the array for race */
   JERRY_ASSERT (ecma_get_object_type (ecma_get_object_from_value (array)) == ECMA_OBJECT_TYPE_ARRAY);
 
   ecma_value_t ret = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
   ecma_object_t *array_p = ecma_get_object_from_value (array);
-  ecma_value_t len_value = ecma_op_object_get (array_p, magic_string_length_p);
-  ecma_deref_ecma_string (magic_string_length_p);
+  ecma_value_t len_value = ecma_op_object_get_by_magic_id (array_p, LIT_MAGIC_STRING_LENGTH);
   ecma_length_t len = (ecma_length_t) ecma_get_integer_from_value (len_value);
   ecma_fast_free_value (len_value);
 
@@ -416,10 +414,8 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
   JERRY_ASSERT (ecma_get_object_type (ecma_get_object_from_value (array)) == ECMA_OBJECT_TYPE_ARRAY);
 
   ecma_value_t ret = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
   ecma_object_t *array_p = ecma_get_object_from_value (array);
-  ecma_value_t len_value = ecma_op_object_get (array_p, magic_string_length_p);
-  ecma_deref_ecma_string (magic_string_length_p);
+  ecma_value_t len_value = ecma_op_object_get_by_magic_id (array_p, LIT_MAGIC_STRING_LENGTH);
   ecma_length_t len = (ecma_length_t) ecma_get_integer_from_value (len_value);
   ecma_fast_free_value (len_value);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -430,11 +430,10 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
   {
     JERRY_ASSERT (!ecma_is_value_empty (regexp_value));
     ecma_object_t *regexp_obj_p = ecma_get_object_from_value (regexp_value);
-    ecma_string_t *global_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
 
     /* 5. */
     ECMA_TRY_CATCH (global_value,
-                    ecma_op_object_get (regexp_obj_p, global_string_p),
+                    ecma_op_object_get_by_magic_id (regexp_obj_p, LIT_MAGIC_STRING_GLOBAL),
                     ret_value);
 
     JERRY_ASSERT (ecma_is_value_boolean (global_value));
@@ -489,7 +488,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
         {
           /* 8.f.iii. */
           ECMA_TRY_CATCH (this_index_value,
-                          ecma_op_object_get (regexp_obj_p, last_index_string_p),
+                          ecma_op_object_get_by_magic_id (regexp_obj_p, LIT_MAGIC_STRING_LASTINDEX_UL),
                           ret_value);
 
           ECMA_TRY_CATCH (this_index_number,
@@ -582,8 +581,6 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
     }
 
     ECMA_FINALIZE (global_value);
-
-    ecma_deref_ecma_string (global_string_p);
 
     ecma_free_value (regexp_value);
   }
@@ -691,11 +688,10 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
       JERRY_ASSERT (ecma_is_value_object (match_value));
 
       ecma_object_t *match_object_p = ecma_get_object_from_value (match_value);
-      ecma_string_t *index_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
       ecma_string_t *zero_string_p = ecma_new_ecma_string_from_uint32 (0);
 
       ECMA_TRY_CATCH (index_value,
-                      ecma_op_object_get (match_object_p, index_string_p),
+                      ecma_op_object_get_by_magic_id (match_object_p, LIT_MAGIC_STRING_INDEX),
                       ret_value);
 
       ECMA_TRY_CATCH (result_string_value,
@@ -722,7 +718,7 @@ ecma_builtin_string_prototype_object_replace_match (ecma_builtin_replace_search_
 
       ECMA_FINALIZE (result_string_value);
       ECMA_FINALIZE (index_value);
-      ecma_deref_ecma_string (index_string_p);
+
       ecma_deref_ecma_string (zero_string_p);
     }
     else
@@ -775,11 +771,10 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
                                                          ecma_value_t match_value) /**< returned match value */
 {
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
-  ecma_string_t *length_string_p = ecma_new_ecma_length_string ();
   ecma_object_t *match_object_p = ecma_get_object_from_value (match_value);
 
   ECMA_TRY_CATCH (match_length_value,
-                  ecma_op_object_get (match_object_p, length_string_p),
+                  ecma_op_object_get_by_magic_id (match_object_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   JERRY_ASSERT (ecma_is_value_number (match_length_value));
@@ -1049,7 +1044,6 @@ ecma_builtin_string_prototype_object_replace_get_string (ecma_builtin_replace_se
   }
 
   ECMA_FINALIZE (match_length_value);
-  ecma_deref_ecma_string (length_string_p);
 
   return ret_value;
 } /* ecma_builtin_string_prototype_object_replace_get_string */
@@ -1260,10 +1254,9 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this a
       && ecma_object_class_is (ecma_get_object_from_value (search_value), LIT_MAGIC_STRING_REGEXP_UL))
   {
     ecma_object_t *regexp_obj_p = ecma_get_object_from_value (search_value);
-    ecma_string_t *global_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
 
     ECMA_TRY_CATCH (global_value,
-                    ecma_op_object_get (regexp_obj_p, global_string_p),
+                    ecma_op_object_get_by_magic_id (regexp_obj_p, LIT_MAGIC_STRING_GLOBAL),
                     ret_value);
 
     JERRY_ASSERT (ecma_is_value_boolean (global_value));
@@ -1295,7 +1288,6 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_arg, /**< this a
     }
 
     ECMA_FINALIZE (global_value);
-    ecma_deref_ecma_string (global_string_p);
   }
   else
   {
@@ -1381,10 +1373,9 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this ar
       JERRY_ASSERT (ecma_is_value_object (match_result));
 
       ecma_object_t *match_object_p = ecma_get_object_from_value (match_result);
-      ecma_string_t *index_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
 
       ECMA_TRY_CATCH (index_value,
-                      ecma_op_object_get (match_object_p, index_string_p),
+                      ecma_op_object_get_by_magic_id (match_object_p, LIT_MAGIC_STRING_INDEX),
                       ret_value);
 
       JERRY_ASSERT (ecma_is_value_number (index_value));
@@ -1392,7 +1383,6 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_arg, /**< this ar
       offset = ecma_get_number_from_value (index_value);
 
       ECMA_FINALIZE (index_value);
-      ecma_deref_ecma_string (index_string_p);
     }
 
     if (ecma_is_value_empty (ret_value))
@@ -1698,7 +1688,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
           else
           {
             ecma_object_t *match_obj_p = ecma_get_object_from_value (match_result);
-            ecma_string_t *zero_str_p = ecma_new_ecma_string_from_number (ECMA_NUMBER_ZERO);
+            ecma_string_t *zero_str_p = ecma_new_ecma_string_from_uint32 (0);
             ecma_string_t *magic_index_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
             ecma_property_value_t *index_prop_value_p;
 
@@ -1786,10 +1776,9 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
 
             /* 13.c.iii.5 */
             start_pos = end_pos + match_str_length;
-            ecma_string_t *magic_length_str_p = ecma_new_ecma_length_string ();
 
             ECMA_TRY_CATCH (array_length_val,
-                            ecma_op_object_get (match_obj_p, magic_length_str_p),
+                            ecma_op_object_get_by_magic_id (match_obj_p, LIT_MAGIC_STRING_LENGTH),
                             ret_value);
 
             ECMA_OP_TO_NUMBER_TRY_CATCH (array_length_num, array_length_val, ret_value);
@@ -1842,7 +1831,6 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
 
             ECMA_OP_TO_NUMBER_FINALIZE (array_length_num);
             ECMA_FINALIZE (array_length_val);
-            ecma_deref_ecma_string (magic_length_str_p);
             ecma_deref_ecma_string (array_length_str_p);
             ecma_deref_ecma_string (substr_str_p);
           }

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -704,18 +704,21 @@ ecma_builtin_typedarray_prototype_set (ecma_value_t this_arg, /**< this argument
   ECMA_TRY_CATCH (source_obj, ecma_op_to_object (arr_val), ret_val);
 
   /* 18.~ 19. */
-  ecma_string_t length_str;
-  ecma_init_ecma_length_string (&length_str);
   ecma_object_t *source_obj_p = ecma_get_object_from_value (source_obj);
+
   ECMA_TRY_CATCH (source_length,
-                  ecma_op_object_get (source_obj_p, &length_str),
+                  ecma_op_object_get_by_magic_id (source_obj_p, LIT_MAGIC_STRING_LENGTH),
                   ret_val);
+
   ECMA_OP_TO_NUMBER_TRY_CATCH (source_length_num, source_length, ret_val);
+
   if (ecma_number_is_nan (source_length_num) || source_length_num <= 0)
   {
     source_length_num = 0;
   }
+
   uint32_t source_length_uint32 = ecma_number_to_uint32 (source_length_num);
+
   if ((ecma_number_t) source_length_uint32 != source_length_num)
   {
     return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid source length"));
@@ -730,17 +733,23 @@ ecma_builtin_typedarray_prototype_set (ecma_value_t this_arg, /**< this argument
   /* 21.~ 25. */
   uint32_t target_byte_index = target_offset_uint32 * element_size;
   uint32_t k = 0;
+
   while (k < source_length_uint32 && ecma_is_value_empty (ret_val))
   {
     ecma_string_t k_str;
     ecma_init_ecma_string_from_uint32 (&k_str, k);
+
     ECMA_TRY_CATCH (elem,
                     ecma_op_object_get (source_obj_p, &k_str),
                     ret_val);
+
     ECMA_OP_TO_NUMBER_TRY_CATCH (elem_num, elem, ret_val);
+
     ecma_set_typedarray_element (target_buffer_p + target_byte_index, elem_num, target_class_id);
+
     ECMA_OP_TO_NUMBER_FINALIZE (elem_num);
     ECMA_FINALIZE (elem);
+
     k++;
     target_byte_index += element_size;
   }

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -274,10 +274,8 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, /**< Function object *
 
   ecma_object_t *v_obj_p = ecma_get_object_from_value (value);
 
-  ecma_string_t prototype_magic_string;
-  ecma_init_ecma_magic_string (&prototype_magic_string, LIT_MAGIC_STRING_PROTOTYPE);
-
-  ecma_value_t prototype_obj_value = ecma_op_object_get (func_obj_p, &prototype_magic_string);
+  ecma_value_t prototype_obj_value = ecma_op_object_get_by_magic_id (func_obj_p,
+                                                                     LIT_MAGIC_STRING_PROTOTYPE);
 
   if (ECMA_IS_VALUE_ERROR (prototype_obj_value))
   {
@@ -558,12 +556,10 @@ ecma_op_function_construct_simple_or_external (ecma_object_t *func_obj_p, /**< F
 
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
-  ecma_string_t *prototype_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_PROTOTYPE);
-
   /* 5. */
   ECMA_TRY_CATCH (func_obj_prototype_prop_value,
-                  ecma_op_object_get (func_obj_p,
-                                      prototype_magic_string_p),
+                  ecma_op_object_get_by_magic_id (func_obj_p,
+                                                  LIT_MAGIC_STRING_PROTOTYPE),
                   ret_value);
 
   /* 1., 2., 4. */
@@ -619,8 +615,6 @@ ecma_op_function_construct_simple_or_external (ecma_object_t *func_obj_p, /**< F
   ecma_deref_object (obj_p);
 
   ECMA_FINALIZE (func_obj_prototype_prop_value);
-
-  ecma_deref_ecma_string (prototype_magic_string_p);
 
   return ret_value;
 } /* ecma_op_function_construct_simple_or_external */

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -214,34 +214,30 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
 
   for (uint32_t i = 1; i <= 2; i++)
   {
-    lit_magic_string_id_t function_name_magic_string_id;
+    lit_magic_string_id_t function_name_id;
 
     if ((i == 1 && hint == ECMA_PREFERRED_TYPE_STRING)
         || (i == 2 && hint == ECMA_PREFERRED_TYPE_NUMBER))
     {
-      function_name_magic_string_id = LIT_MAGIC_STRING_TO_STRING_UL;
+      function_name_id = LIT_MAGIC_STRING_TO_STRING_UL;
     }
     else
     {
-      function_name_magic_string_id = LIT_MAGIC_STRING_VALUE_OF_UL;
+      function_name_id = LIT_MAGIC_STRING_VALUE_OF_UL;
     }
 
-    ecma_string_t *function_name_p = ecma_get_magic_string (function_name_magic_string_id);
+    ecma_value_t function_value = ecma_op_object_get_by_magic_id (obj_p, function_name_id);
 
-    ecma_value_t function_value_get_completion = ecma_op_object_get (obj_p, function_name_p);
-
-    ecma_deref_ecma_string (function_name_p);
-
-    if (ECMA_IS_VALUE_ERROR (function_value_get_completion))
+    if (ECMA_IS_VALUE_ERROR (function_value))
     {
-      return function_value_get_completion;
+      return function_value;
     }
 
     ecma_value_t call_completion = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 
-    if (ecma_op_is_callable (function_value_get_completion))
+    if (ecma_op_is_callable (function_value))
     {
-      ecma_object_t *func_obj_p = ecma_get_object_from_value (function_value_get_completion);
+      ecma_object_t *func_obj_p = ecma_get_object_from_value (function_value);
 
       call_completion = ecma_op_function_call (func_obj_p,
                                                ecma_make_object_value (obj_p),
@@ -249,7 +245,7 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
                                                0);
     }
 
-    ecma_free_value (function_value_get_completion);
+    ecma_free_value (function_value);
 
     if (ECMA_IS_VALUE_ERROR (call_completion)
         || (!ecma_is_value_empty (call_completion)

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -36,6 +36,7 @@ ecma_value_t ecma_op_object_find_own (ecma_value_t base_value, ecma_object_t *ob
 ecma_value_t ecma_op_object_find (ecma_object_t *object_p, ecma_string_t *property_name_p);
 ecma_value_t ecma_op_object_get_own_data_prop (ecma_object_t *object_p, ecma_string_t *property_name_p);
 ecma_value_t ecma_op_object_get (ecma_object_t *object_p, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_object_get_by_magic_id (ecma_object_t *object_p, lit_magic_string_id_t property_id);
 ecma_value_t ecma_op_object_put (ecma_object_t *object_p, ecma_string_t *property_name_p, ecma_value_t value,
                                  bool is_throw);
 ecma_value_t ecma_op_object_delete (ecma_object_t *obj_p, ecma_string_t *property_name_p, bool is_throw);

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -311,8 +311,8 @@ ecma_promise_resolve_handler (const ecma_value_t function, /**< the function its
   }
 
   /* 8. */
-  ecma_string_t *str_then = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_THEN);
-  ecma_value_t then = ecma_op_object_get (ecma_get_object_from_value (argv[0]), str_then);
+  ecma_value_t then = ecma_op_object_get_by_magic_id (ecma_get_object_from_value (argv[0]),
+                                                                                  LIT_MAGIC_STRING_THEN);
 
   if (ECMA_IS_VALUE_ERROR (then))
   {
@@ -331,7 +331,6 @@ ecma_promise_resolve_handler (const ecma_value_t function, /**< the function its
     ecma_enqueue_promise_resolve_thenable_job (promise, argv[0], then);
   }
 
-  ecma_deref_ecma_string (str_then);
   ecma_free_value (then);
 
 end_of_resolve_function:

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -398,11 +398,8 @@ ecma_op_typedarray_from (ecma_value_t items_val, /**< the source array-like obje
   ecma_object_t *arraylike_object_p = ecma_get_object_from_value (arraylike_object_val);
 
   /* 12 */
-  ecma_string_t magic_string_length;
-  ecma_init_ecma_length_string (&magic_string_length);
-
   ECMA_TRY_CATCH (len_value,
-                  ecma_op_object_get (arraylike_object_p, &magic_string_length),
+                  ecma_op_object_get_by_magic_id (arraylike_object_p, LIT_MAGIC_STRING_LENGTH),
                   ret_value);
 
   ECMA_OP_TO_NUMBER_TRY_CATCH (len_number, len_value, ret_value);


### PR DESCRIPTION
This patch causes a similar effect than my other patch a while ago: binary 139880 -> 137532 and -13% RSS. This is the effect of code / data layout change in memory. No other major effect.