### PR TITLE
Fix Date.parse() in ecma-builtin-date.c

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -263,40 +263,44 @@ ecma_builtin_date_parse (ecma_value_t this_arg, /**< this argument */
           hours = ECMA_NUMBER_ZERO;
         }
 
-        /* eat up ':' */
-        date_str_curr_p++;
-
-        minutes = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
-
-        if (minutes < 0 || minutes > 59)
-        {
-          minutes = ecma_number_make_nan ();
-        }
-
-        /* 4.2 read seconds if any */
         if (date_str_curr_p < date_str_end_p
             && *date_str_curr_p == ':')
         {
           /* eat up ':' */
           date_str_curr_p++;
-          seconds = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
-          if (seconds < 0 || seconds > 59)
+          minutes = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
+
+          if (minutes < 0 || minutes > 59)
           {
-            seconds = ecma_number_make_nan ();
+            minutes = ecma_number_make_nan ();
           }
 
-          /* 4.3 read milliseconds if any */
+          /* 4.2 read seconds if any */
           if (date_str_curr_p < date_str_end_p
-              && *date_str_curr_p == '.')
+              && *date_str_curr_p == ':')
           {
-            /* eat up '.' */
+            /* eat up ':' */
             date_str_curr_p++;
-            milliseconds = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 3);
+            seconds = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2);
 
-            if (milliseconds < 0)
+            if (seconds < 0 || seconds > 59)
             {
-              milliseconds = ecma_number_make_nan ();
+              seconds = ecma_number_make_nan ();
+            }
+
+            /* 4.3 read milliseconds if any */
+            if (date_str_curr_p < date_str_end_p
+                && *date_str_curr_p == '.')
+            {
+              /* eat up '.' */
+              date_str_curr_p++;
+              milliseconds = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 3);
+
+              if (milliseconds < 0)
+              {
+                milliseconds = ecma_number_make_nan ();
+              }
             }
           }
         }

--- a/tests/jerry/regression-test-issue-2073.js
+++ b/tests/jerry/regression-test-issue-2073.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Date.parse("2015-01-01T01߄'a': 1}:01F");


### PR DESCRIPTION
Fixes issue #2073, which introduced an error caused by Date.parse().
The problem was that the function didn't properly check if there was a ':' after the hours.
If any UTF8 character was inserted there which got decoded into multiple characters, it caused the pointer to point at a wrong character.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu