### PR TITLE
Refactor/simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,48 @@
 language: c
 
+# Default test platform: Ubuntu Trusty with sudo support.
 os: linux
 dist: trusty
 sudo: required
 
-env:
-  matrix:
-    - OPTS="--check-signed-off-travis --check-cppcheck --check-doxygen --check-vera --check-license --check-magic-strings"
-    - OPTS="--jerry-debugger"
-    - OPTS="--jerry-tests --jerry-test-suite"
-    - OPTS="--jerry-tests --jerry-test-suite --toolchain=cmake/toolchain_linux_armv7l.cmake" TIMEOUT=300 INSTALL_QEMU_ARM=yes
-    - OPTS="--buildoption-test"
-    - OPTS="--jerry-tests --jerry-test-suite --buildoptions=--jerry-libc=off,--compile-flag=-m32,--cpointer-32bit=on"
-    - OPTS="--unittests"
-    - OPTS="--unittests --buildoptions=--cmake-param=-DFEATURE_INIT_FINI=ON"
-    - OPTS="--test262"
-    - OPTS="--check-pylint"
-  global:
-    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-    #   via the "travis encrypt" command using the project repo's public key
-    - secure: "V7BdXv3FCVkFGEfKfWto6I+Sytou1zTCGyn49xurkBfKNsG/3vbkXfsbK1m6lCZxmY7W/1odpfjixpAPZgy2L4FgPZK6/UyVvC8pIFjDOubcEniN48haleSvm/ZFPLDifxDL2+VVFtK1oRYPtDBzzSoUCcfwovgk+Wy+tSBnhnyRLqO/WaI6PqFof7ECYMTRlJVjioZARVP4YmkBruIPmGDdR/3EvwowlxfuiFoPheix61ug4x3tpTBW2qWgvFjDyCZXFz4pJrBQPTAIbyKMxHcBykJjl9eR+dWAOsvE1Uw48tFOJxjKDfUttVQUPsyKFllmcCVS0fDYB5pzZOmRUPxJmox1jt8J1FY85Ri1PGY0THBPM2H7to4Yf2418Y3539epbN8p+79dwaM7e2OiJ2owukbWI7PoNqIz5DV5zxpIKsOQfeWuNLJOgsBePEIU7lz133Si/2d5W/7If46B1d+hZRBJfSYksgDqDU6G/voZkPf0K5bKe2O2BxiIW1DYk4yQ1ecZAkqGjZ8jG3zYGMG3mSF4VyuU4UGFG1Pg8fw7Ap5zuHxSVY1H9dtu4T6JQG3aj/x1omlzfw48DjgkwxVhf7Xvl3yfR7pzydYheLX3MZYtcVo7rWnglZFZoUjWDK1StbmzsvPftvwWtoDTWlzo4xeSXhahSJvJyc4U8Wc="
+# Default dependency installation step #1: install dependencies for linux.
+# Other platforms can change this by redefining the 'before_install' stage in
+# the matrix below.
+before_install: tools/apt-get-install-deps.sh
 
+# Default dependency installation step #2: nop intentionally.
+# Jobs can add their own dependencies on top of 'before_install' by redefinig
+# the 'install' stage in the matrix below.
+install: true
+
+# Default job task: run tests as defined in the $OPT environment variable.
+# Jobs can redefine the 'script' stage in the matrix below.
+script: tools/run-tests.py $OPTS
+
+# All the job definitions in the matrix.
 matrix:
   include:
+    - env: OPTS="--check-signed-off-travis --check-cppcheck --check-doxygen --check-vera --check-license --check-magic-strings"
+    - env: OPTS="--jerry-debugger"
+    - env: OPTS="--jerry-tests --jerry-test-suite"
+    - env: OPTS="--jerry-tests --jerry-test-suite --toolchain=cmake/toolchain_linux_armv7l.cmake" TIMEOUT=300
+      install: tools/apt-get-install-qemu-arm.sh
+    - env: OPTS="--buildoption-test"
+    - env: OPTS="--jerry-tests --jerry-test-suite --buildoptions=--jerry-libc=off,--compile-flag=-m32,--cpointer-32bit=on"
+    - env: OPTS="--unittests"
+    - env: OPTS="--unittests --buildoptions=--cmake-param=-DFEATURE_INIT_FINI=ON"
+    - env: OPTS="--test262"
+      install: sudo timedatectl set-timezone America/Los_Angeles
+    - env: OPTS="--check-pylint"
+      install: pip install --user pylint==1.6.5
     - os: osx
+      before_install: tools/brew-install-deps.sh
       env: OPTS="--jerry-tests --jerry-test-suite --unittests"
-    - os: linux
-      before_install:
-        - tools/apt-get-install-deps.sh
-        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+    - install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+      env:
+        # Declaration of the encrypted COVERITY_SCAN_TOKEN, created via the
+        # "travis encrypt" command using the project repo's public key.
+        - secure: "V7BdXv3FCVkFGEfKfWto6I+Sytou1zTCGyn49xurkBfKNsG/3vbkXfsbK1m6lCZxmY7W/1odpfjixpAPZgy2L4FgPZK6/UyVvC8pIFjDOubcEniN48haleSvm/ZFPLDifxDL2+VVFtK1oRYPtDBzzSoUCcfwovgk+Wy+tSBnhnyRLqO/WaI6PqFof7ECYMTRlJVjioZARVP4YmkBruIPmGDdR/3EvwowlxfuiFoPheix61ug4x3tpTBW2qWgvFjDyCZXFz4pJrBQPTAIbyKMxHcBykJjl9eR+dWAOsvE1Uw48tFOJxjKDfUttVQUPsyKFllmcCVS0fDYB5pzZOmRUPxJmox1jt8J1FY85Ri1PGY0THBPM2H7to4Yf2418Y3539epbN8p+79dwaM7e2OiJ2owukbWI7PoNqIz5DV5zxpIKsOQfeWuNLJOgsBePEIU7lz133Si/2d5W/7If46B1d+hZRBJfSYksgDqDU6G/voZkPf0K5bKe2O2BxiIW1DYk4yQ1ecZAkqGjZ8jG3zYGMG3mSF4VyuU4UGFG1Pg8fw7Ap5zuHxSVY1H9dtu4T6JQG3aj/x1omlzfw48DjgkwxVhf7Xvl3yfR7pzydYheLX3MZYtcVo7rWnglZFZoUjWDK1StbmzsvPftvwWtoDTWlzo4xeSXhahSJvJyc4U8Wc="
       addons:
         coverity_scan:
           project:
@@ -37,7 +51,7 @@ matrix:
           notification_email: rsipka.uszeged@partner.samsung.com
           build_command: "tools/build.py --clean"
           branch_pattern: master
-      env: OPTS=""
+      script: true # Changed to nop, Coverity Scan has already built the project by the time 'script' stage is reached.
     - compiler: gcc-5
       addons:
         apt:
@@ -60,20 +74,9 @@ matrix:
     - env: OPTS="--check-pylint"
   fast_finish: true
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then tools/apt-get-install-deps.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$INSTALL_QEMU_ARM" == "yes" ]]; then tools/apt-get-install-qemu-arm.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then tools/brew-install-deps.sh; fi
-  - if [[ "$OPTS" == "--test262" ]]; then sudo timedatectl set-timezone America/Los_Angeles; fi
-  - if [[ "$OPTS" == *"--check-pylint"* ]]; then pip install --user pylint==1.6.5; fi
-
-install:
-
-script: if [[ -n "$OPTS" ]]; then tools/run-tests.py $OPTS; fi
-
 # The channel name "chat.freenode.net#jerryscript"
 # is encrypted against Samsung/jerryscript
-# to prevent IRC spam of forks
+# to prevent IRC spam of forks.
 #
 # travis encrypt -r "Samsung/jerryscript" "chat.freenode.net#jerryscript"
 notifications:


### PR DESCRIPTION
Over time, `.travis.yml` grew somewhat organically and became quite
complex. With some rewrites, it can set up the Travis CI stages
better, and become simpler, more logical, and more maintainable.

The refactoring keeps all existing functionality.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu