### PR TITLE
Refactor CLI argument handling and test runner logic of run-tests.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script: tools/run-tests.py $OPTS
 # All the job definitions in the matrix.
 matrix:
   include:
-    - env: OPTS="--check-signed-off-travis --check-cppcheck --check-doxygen --check-vera --check-license --check-magic-strings"
+    - env: OPTS="--check-signed-off=travis --check-cppcheck --check-doxygen --check-vera --check-license --check-magic-strings"
     - env: OPTS="--jerry-debugger"
     - env: OPTS="--jerry-tests --jerry-test-suite"
     - env: OPTS="--jerry-tests --jerry-test-suite --toolchain=cmake/toolchain_linux_armv7l.cmake" TIMEOUT=300


### PR DESCRIPTION
On argument handling:
- Merged all signoff check options into one, option value chooses
  between strict/tolerant check variants.
- Added sensible metavars to options with arguments (consistent
  with metavars of build.py).
- Reordered options to match the order the checks are executed in.
- Added `--all` alias to `--precommit` check option.
- Beautified code (always placed `help` on separate line, removed
  unnecessary arguments of `add_argument` that just repeated their
  defaults).

On test runner logic:
There was too many code duplication on how checks were executed, it
got refactored. No change in semantics.

The only change was in Travis CI-related invocations,
`--check-signed-off-travis` had to be rewritten to
`--check-signed-off=travis`.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu