### PR TITLE
Fixed dynamic-stack-buffer-overflow in jerry_value_is_syntax_error

### DIFF
--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -109,6 +109,14 @@ jerry_value_is_syntax_error (jerry_value_t error_value) /**< error value */
   }
 
   jerry_size_t err_str_size = jerry_get_string_size (error_name);
+  const char syntax_error_str[] = "SyntaxError";
+
+  if (err_str_size != strlen (syntax_error_str) - 1)
+  {
+    jerry_release_value (error_name);
+    return false;
+  }
+
   jerry_char_t err_str_buf[err_str_size];
 
   jerry_size_t sz = jerry_string_to_char_buffer (error_name, err_str_buf, err_str_size);
@@ -119,7 +127,7 @@ jerry_value_is_syntax_error (jerry_value_t error_value) /**< error value */
     return false;
   }
 
-  if (!strcmp ((char *) err_str_buf, "SyntaxError"))
+  if (!strncmp ((char *) err_str_buf, syntax_error_str, sizeof (syntax_error_str) - 1))
   {
     return true;
   }

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -147,6 +147,14 @@ jerry_value_is_syntax_error (jerry_value_t error_value) /**< error value */
   }
 
   jerry_size_t err_str_size = jerry_get_string_size (error_name);
+  const char syntax_error_str[] = "SyntaxError";
+
+  if (err_str_size != strlen (syntax_error_str) - 1)
+  {
+    jerry_release_value (error_name);
+    return false;
+  }
+
   jerry_char_t err_str_buf[err_str_size];
 
   jerry_size_t sz = jerry_string_to_char_buffer (error_name, err_str_buf, err_str_size);
@@ -157,7 +165,7 @@ jerry_value_is_syntax_error (jerry_value_t error_value) /**< error value */
     return false;
   }
 
-  if (!strcmp ((char *) err_str_buf, "SyntaxError"))
+  if (!strncmp ((char *) err_str_buf, syntax_error_str, sizeof (syntax_error_str) - 1))
   {
     return true;
   }

--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
@@ -149,6 +149,14 @@ jerry_value_is_syntax_error (jerry_value_t error_value) /**< error value */
   }
 
   jerry_size_t err_str_size = jerry_get_string_size (error_name);
+  const char syntax_error_str[] = "SyntaxError";
+
+  if (err_str_size != strlen (syntax_error_str) - 1)
+  {
+    jerry_release_value (error_name);
+    return false;
+  }
+
   jerry_char_t err_str_buf[err_str_size];
 
   jerry_size_t sz = jerry_string_to_char_buffer (error_name, err_str_buf, err_str_size);
@@ -159,7 +167,7 @@ jerry_value_is_syntax_error (jerry_value_t error_value) /**< error value */
     return false;
   }
 
-  if (!strcmp ((char *) err_str_buf, "SyntaxError"))
+  if (!strncmp ((char *) err_str_buf, syntax_error_str, sizeof (syntax_error_str) - 1))
   {
     return true;
   }

--- a/tests/jerry/fail/regression-test-issue-2094.js
+++ b/tests/jerry/fail/regression-test-issue-2094.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function a() {

--- a/tests/jerry/fail/regression-test-issue-2095.js
+++ b/tests/jerry/fail/regression-test-issue-2095.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var e = new SyntaxError('dummy');
+e.name = 'Syntax';
+throw e;


### PR DESCRIPTION
Fixes issue #2094, which introduced an error caused by jerry_value_is_syntax_error.
The problem was that the function used strcmp instead of strncmp while checking if err_str_buf contains syntax error and it caused buffer overflow.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu