### PR TITLE
Add 'jerry_job_queue_is_empty' function to the API.

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -870,49 +870,6 @@ jerry_eval (const jerry_char_t *source_p,
 - [jerry_create_external_function](#jerry_create_external_function)
 - [jerry_external_handler_t](#jerry_external_handler_t)
 
-## jerry_run_all_enqueued_jobs
-
-**Summary**
-
-Run enqueued Promise jobs until the first thrown error or until all get executed.
-
-**Prototype**
-
-```c
-jerry_value_t
-jerry_run_all_enqueued_jobs (void)
-```
-
-- return value - result of last executed job, may be error value.
-
-**Example**
-
-[doctest]: # ()
-
-```c
-#include <string.h>
-#include "jerryscript.h"
-
-int
-main (void)
-{
-  jerry_init (JERRY_INIT_EMPTY);
-
-  const jerry_char_t script[] = "new Promise(function(f,r) { f('Hello, World!'); }).then(function(x) { print(x); });";
-  size_t script_size = strlen ((const char *) script);
-
-  jerry_value_t parsed_code = jerry_parse (script, script_size, false);
-  jerry_value_t script_value = jerry_run (parsed_code);
-  jerry_value_t job_value = jerry_run_all_enqueued_jobs ();
-
-  jerry_release_value (job_value);
-  jerry_release_value (script_value);
-  jerry_release_value (parsed_code);
-
-  jerry_cleanup ();
-}
-```
-
 
 # Get the global context
 
@@ -2233,6 +2190,79 @@ jerry_resolve_or_reject_promise (jerry_value_t promise,
 
 - [jerry_release_value](#jerry_release_value)
 - [jerry_value_has_error_flag](#jerry_value_has_error_flag)
+
+
+## jerry_job_queue_is_empty
+
+**Summary**
+
+Checks whether the job queue is empty.
+
+**Prototype**
+
+```c
+bool
+jerry_job_queue_is_empty (void);
+```
+
+- return value
+  - true, if there is no enqueued job
+  - false, otherwise
+
+**See also**
+
+- [jerry_run_all_enqueued_jobs](#jerry_run_all_enqueued_jobs)
+
+
+## jerry_run_all_enqueued_jobs
+
+**Summary**
+
+Run enqueued Promise jobs until the first thrown error or until all get executed.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerry_run_all_enqueued_jobs (void)
+```
+
+- return value - result of last executed job, may be error value.
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include <string.h>
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  const jerry_char_t script[] = "new Promise(function(f,r) { f('Hello, World!'); }).then(function(x) { print(x); });";
+  size_t script_size = strlen ((const char *) script);
+
+  jerry_value_t parsed_code = jerry_parse (script, script_size, false);
+  jerry_value_t script_value = jerry_run (parsed_code);
+
+  if (!jerry_job_queue_is_empty ())
+  {
+    jerry_release_value (jerry_run_all_enqueued_jobs ());
+  }
+
+  jerry_release_value (script_value);
+  jerry_release_value (parsed_code);
+
+  jerry_cleanup ();
+}
+```
+
+**See also**
+
+- [jerry_job_queue_is_empty](#jerry_job_queue_is_empty)
 
 
 # Acquire and release API values

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -580,26 +580,6 @@ jerry_eval (const jerry_char_t *source_p, /**< source code */
 } /* jerry_eval */
 
 /**
- * Run enqueued Promise jobs until the first thrown error or until all get executed.
- *
- * Note:
- *      returned value must be freed with jerry_release_value, when it is no longer needed.
- *
- * @return result of last executed job, may be error value.
- */
-jerry_value_t
-jerry_run_all_enqueued_jobs (void)
-{
-  jerry_assert_api_available ();
-
-#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
-  return ecma_process_all_enqueued_jobs ();
-#else /* CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
-  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
-#endif /* CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
-} /* jerry_run_all_enqueued_jobs */
-
-/**
  * Get global object
  *
  * Note:
@@ -2490,6 +2470,42 @@ jerry_resolve_or_reject_promise (jerry_value_t promise, /**< the promise value *
   return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG ("Promise not supported.")));
 #endif /* !CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
 } /* jerry_resolve_or_reject_promise */
+
+/**
+ * Check whether job queue is empty.
+ *
+ * @return true - if there is no enqueued job
+ *         false - otherwise
+ */
+inline bool __attr_always_inline___
+jerry_job_queue_is_empty (void)
+{
+#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
+  return JERRY_CONTEXT (job_queue_head_p) == NULL;
+#else /* CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
+  return true;
+#endif /* !CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
+} /* jerry_job_queue_is_empty */
+
+/**
+ * Run enqueued Promise jobs until the first thrown error or until all get executed.
+ *
+ * Note:
+ *      returned value must be freed with jerry_release_value, when it is no longer needed.
+ *
+ * @return result of last executed job, may be error value.
+ */
+jerry_value_t
+jerry_run_all_enqueued_jobs (void)
+{
+  jerry_assert_api_available ();
+
+#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
+  return ecma_process_all_enqueued_jobs ();
+#else /* CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
+  return ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
+#endif /* CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
+} /* jerry_run_all_enqueued_jobs */
 
 /**
  * Validate UTF-8 string

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -263,8 +263,6 @@ jerry_value_t jerry_parse_function (const jerry_char_t *resource_name_p, size_t 
 jerry_value_t jerry_run (const jerry_value_t func_val);
 jerry_value_t jerry_eval (const jerry_char_t *source_p, size_t source_size, bool is_strict);
 
-jerry_value_t jerry_run_all_enqueued_jobs (void);
-
 /**
  * Get the global context.
  */
@@ -420,9 +418,11 @@ bool jerry_foreach_object_property (const jerry_value_t obj_val, jerry_object_pr
                                     void *user_data_p);
 
 /**
- * Promise resolve/reject functions.
+ * Functions for Promise object values.
  */
 jerry_value_t jerry_resolve_or_reject_promise (jerry_value_t promise, jerry_value_t argument, bool is_resolve);
+bool jerry_job_queue_is_empty (void);
+jerry_value_t jerry_run_all_enqueued_jobs (void);
 
 /**
  * Input validator functions.


### PR DESCRIPTION
This API function could be useful on systems which use eventloop and
real asyncron calls, like IoT.js.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com