### PR TITLE
Add Travis CI jobs for build testing several targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,47 @@ matrix:
             - gcc-5
             - gcc-5-multilib
       env: OPTS="--jerry-tests --jerry-test-suite --skip-list=parser-oom.js --buildoptions=--compile-flag=-fsanitize=undefined,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--debug,--jerry-libc=off,--static-link=off,--system-allocator=on,--linker-flag=-fuse-ld=gold" UBSAN_OPTIONS=print_stacktrace=1 TIMEOUT=600
+
+    - env: JOBNAME="ESP8266 Build Test"
+      cache: ccache
+      install: make -f ./targets/esp8266/Makefile.travis install
+      script: make -f ./targets/esp8266/Makefile.travis script
+    - env: JOBNAME="Mbed/K64F Build Test"
+      addons:
+        apt:
+          sources:
+            - sourceline: ppa:team-gcc-arm-embedded/ppa
+          packages:
+            - gcc-arm-embedded
+      install: make -f ./targets/mbed/Makefile.travis install
+      script: make -f ./targets/mbed/Makefile.travis script
+    - env: JOBNAME="Mbed OS 5/K64F Build Test"
+      addons:
+        apt:
+          sources:
+            - sourceline: ppa:team-gcc-arm-embedded/ppa
+          packages:
+            - gcc-arm-embedded
+      install: make -f ./targets/mbedos5/Makefile.travis install
+      script: make -f ./targets/mbedos5/Makefile.travis script
+    - env: JOBNAME="NuttX/STM32F4 Build Test"
+      install: make -f targets/nuttx-stm32f4/Makefile.travis install
+      script: make -f targets/nuttx-stm32f4/Makefile.travis script
+    - env: JOBNAME="RIOT/STM32F4 Build Test"
+      install: make -f ./targets/riot-stm32f4/Makefile.travis install
+      script: make -f ./targets/riot-stm32f4/Makefile.travis script
+    - env: JOBNAME="Tizen RT/Artik053 Build Test"
+      addons:
+        apt:
+          sources:
+            - sourceline: ppa:team-gcc-arm-embedded/ppa
+          packages:
+            - gcc-arm-embedded
+      install: make -f ./targets/tizenrt-artik053/Makefile.travis install
+      script: make -f ./targets/tizenrt-artik053/Makefile.travis script
+    - env: JOBNAME="Zephyr/Arduino 101 Build Test"
+      install: make -f ./targets/zephyr/Makefile.travis install
+      script: make -f ./targets/zephyr/Makefile.travis script
   allow_failures:
     - env: OPTS="--check-pylint"
   fast_finish: true

--- a/targets/esp8266/Makefile.travis
+++ b/targets/esp8266/Makefile.travis
@@ -1,0 +1,51 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default target for running the build test outside the Travis CI environment.
+all:
+	$(MAKE) install
+	$(MAKE) script
+
+
+## Targets for installing build dependencies of the ESP8266 JerryScript target.
+
+# Install tools via apt.
+install-apt-get-deps:
+	sudo apt-get install -q -y gperf texinfo wget
+
+# Fetch and build crosstool-NG with support for Xtensa.
+install-xtensa-kx106-gcc:
+	git clone https://github.com/jcmvbkbc/crosstool-NG.git ../crosstool-NG -b lx106-g++-1.21.0
+	cd ../crosstool-NG && ./bootstrap
+	cd ../crosstool-NG && ./configure --enable-local
+	$(MAKE) -C ../crosstool-NG --no-print-directory -Rr # HACK: without the command line arguments, make bails out with recursion error
+	cd ../crosstool-NG && ./ct-ng xtensa-lx106-elf
+	cd ../crosstool-NG && ./ct-ng build
+
+# Fetch Espressif SDK and Xtensa libraries.
+install-espressif-sdk:
+	git clone https://github.com/espressif/ESP8266_RTOS_SDK.git ../ESP8266_SDK
+	cd ../ESP8266_SDK && git checkout 2fab9e23d779cdd6e5900b8ba2b588e30d9b08c4
+	wget https://github.com/esp8266/esp8266-wiki/raw/master/libs/libhal.a -O ../ESP8266_SDK/lib/libhal.a
+
+# Perform all the necessary (JerryScript-independent) installation steps.
+install: install-apt-get-deps install-xtensa-kx106-gcc install-espressif-sdk
+
+
+## Targets for building ESP8266 with JerryScript.
+
+# Build the firmware (ESP8266 with JerryScript).
+script:
+	PATH=$(CURDIR)/../crosstool-NG/builds/xtensa-lx106-elf/bin:$$PATH $(MAKE) -f ./targets/esp8266/Makefile.esp8266 BIN_PATH=build/obj-esp8266 SDK_PATH=$(CURDIR)/../ESP8266_SDK

--- a/targets/esp8266/include/jerry_run.h
+++ b/targets/esp8266/include/jerry_run.h
@@ -16,6 +16,8 @@
 #ifndef __JERRY_RUN_H__
 #define __JERRY_RUN_H__
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/targets/mbed/Makefile.travis
+++ b/targets/mbed/Makefile.travis
@@ -1,0 +1,40 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default target for running the build test outside the Travis CI environment.
+all:
+	$(MAKE) install
+	$(MAKE) script
+
+
+## Targets for installing build dependencies of the Mbed JerryScript target.
+
+# Install tools via apt.
+install-apt-get-deps:
+	sudo apt-get install -q -y ninja-build libffi-dev libssl-dev
+
+# Install yotta
+install-yotta:
+	pip install --user yotta
+
+# Perform all the necessary (JerryScript-independent) installation steps.
+install: install-apt-get-deps install-yotta
+
+
+## Targets for building Mbed with JerryScript.
+
+# Build the firmware (Mbed with JerryScript).
+script:
+	$(MAKE) -f targets/mbed/Makefile.mbed board=k64f

--- a/targets/mbedos5/Makefile.travis
+++ b/targets/mbedos5/Makefile.travis
@@ -1,0 +1,39 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default target for running the build test outside the Travis CI environment.
+all:
+	$(MAKE) install
+	$(MAKE) script
+
+
+## Targets for installing build dependencies of the Mbed OS 5 JerryScript target.
+
+# Deploy Mbed and install Mbed Python dependencies.
+install:
+	pip install --user mbed-cli
+	cd targets/mbedos5 && mbed deploy
+	pip install --user -r targets/mbedos5/mbed-os/requirements.txt
+
+
+## Targets for building Mbed OS 5 with JerryScript.
+
+# Build the firmware (Mbed OS 5 with JerryScript).
+script:
+	pip install --user -r targets/mbedos5/tools/requirements.txt
+	# HACK: `EXTRA_SRC[_MOD]` are abused to pass `--library` to `mbed compile` in the `all` make target that builds an app
+	# HACK: this is needed because the Mbed OS 5 target code does not contain any `main` function, so the `all` make target does not link
+	# HACK: but the `library` make target does not build either because the launcher sources require `jerry-targetjs.h` that are explicitly not generated for libraries
+	$(MAKE) -C targets/mbedos5 BOARD=K64F EXTRA_SRC=dummy EXTRA_SRC_MOD=--library

--- a/targets/nuttx-stm32f4/Makefile.travis
+++ b/targets/nuttx-stm32f4/Makefile.travis
@@ -1,0 +1,63 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default target for running the build test outside the Travis CI environment.
+all:
+	$(MAKE) install
+	$(MAKE) script
+
+
+## Targets for installing build dependencies of the NuttX JerryScript target.
+
+# Install cross-compiler and tools via apt.
+install-apt-get-deps:
+	sudo apt-get install -q -y gcc-arm-none-eabi gperf
+
+# Fetch and build kconfig-frontends (kconfig-conf) from nuttx/tools.
+LOCAL_INSTALL:=$(CURDIR)/../local/
+
+install-kconfig:
+	git clone https://bitbucket.org/nuttx/tools.git ../tools
+	mkdir -p $(LOCAL_INSTALL)
+	cd ../tools/kconfig-frontends && ./configure --disable-mconf --disable-nconf --disable-gconf --disable-qconf --disable-utils --disable-shared --enable-static --prefix=$(LOCAL_INSTALL)
+	$(MAKE) -C ../tools/kconfig-frontends
+	$(MAKE) -C ../tools/kconfig-frontends install
+
+# Fetch nuttx/{apps,nuttx} repositories.
+install-clone-nuttx:
+	git clone https://bitbucket.org/nuttx/apps.git ../apps -b nuttx-7.22
+	git clone https://bitbucket.org/nuttx/nuttx.git ../nuttx -b nuttx-7.22
+
+# Perform all the necessary (JerryScript-independent) installation steps.
+install: install-apt-get-deps install-kconfig install-clone-nuttx
+
+
+## Targets for building NuttX with JerryScript.
+
+# Link in the NuttX JerryScript target directory under the NuttX apps tree.
+script-add-jerryscript-app:
+	ln -s ../../jerryscript/targets/nuttx-stm32f4 ../apps/interpreters/jerryscript
+
+# Configure USB shell.
+script-configure-usbnsh:
+	cd ../nuttx/tools && PATH=$(LOCAL_INSTALL)/bin:$$PATH ./configure.sh stm32f4discovery/usbnsh
+
+# Configure and build the firmware (NuttX with JerryScript).
+script: script-add-jerryscript-app script-configure-usbnsh
+	echo 'CONFIG_HOST_LINUX=y' >> ../nuttx/.config
+	echo 'CONFIG_ARCH_FPU=y' >> ../nuttx/.config
+	echo 'CONFIG_JERRYSCRIPT=y'>> ../nuttx/.config
+	PATH=$(LOCAL_INSTALL)/bin:$$PATH $(MAKE) -C ../nuttx olddefconfig
+	PATH=$(LOCAL_INSTALL)/bin:$$PATH $(MAKE) -C ../nuttx

--- a/targets/riot-stm32f4/Makefile.travis
+++ b/targets/riot-stm32f4/Makefile.travis
@@ -1,0 +1,40 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default target for running the build test outside the Travis CI environment.
+all:
+	$(MAKE) install
+	$(MAKE) script
+
+
+## Targets for installing build dependencies of the RIOT JerryScript target.
+
+# Install cross-compiler via apt.
+install-apt-get-deps:
+	sudo apt-get install -q -y gcc-arm-none-eabi
+
+# Fetch RIOT OS repository.
+install-clone-riot:
+	git clone git://github.com/RIOT-OS/RIOT.git ../RIOT -b 2017.10
+
+# Perform all the necessary (JerryScript-independent) installation steps.
+install: install-apt-get-deps install-clone-riot
+
+
+## Targets for building RIOT with JerryScript.
+
+# Build the firmware (RIOT with JerryScript).
+script:
+	$(MAKE) -f ./targets/riot-stm32f4/Makefile.riot

--- a/targets/tizenrt-artik053/Makefile.travis
+++ b/targets/tizenrt-artik053/Makefile.travis
@@ -1,0 +1,46 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default target for running the build test outside the Travis CI environment.
+all:
+	$(MAKE) install
+	$(MAKE) script
+
+
+## Targets for installing build dependencies of the Tizen RT JerryScript target.
+
+# Fetch Tizen RT repository.
+install:
+	git clone https://github.com/Samsung/TizenRT.git ../TizenRT -b 1.1_Public_Release
+
+
+## Targets for building Tizen RT with JerryScript.
+
+# Link in files from the Tizen RT JerryScript target directory under the Tizen RT tree.
+script-add-jerryscript:
+	cp -R targets/tizenrt-artik053/apps/jerryscript/ ../TizenRT/apps/system/
+	cp -R targets/tizenrt-artik053/configs/jerryscript/ ../TizenRT/build/configs/artik053/
+	cp -R targets/tizenrt-artik053/romfs-1.1.patch ../TizenRT/
+
+# Build the JerryScript library.
+script-libjerry:
+	$(MAKE) -f targets/tizenrt-artik053/Makefile.tizenrt
+
+# Configure and build the firmware (Tizen RT with JerryScript).
+script: script-add-jerryscript script-libjerry
+	cd ../TizenRT/os/tools && ./configure.sh artik053/jerryscript
+	cd ../TizenRT && patch -p1 <romfs-1.1.patch
+	mkdir -p ../TizenRT/build/output/res
+	$(MAKE) -C ../TizenRT/os

--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
@@ -380,7 +380,8 @@ jerry_cmd_main (int argc, char *argv[])
     {
       if (++i < argc)
       {
-        debug_port = str_to_uint (argv[i]);
+        char *endptr;
+        debug_port = (uint16_t) strtol (argv[i], &endptr, 10);
       }
       else
       {

--- a/targets/tizenrt-artik053/romfs-1.1.patch
+++ b/targets/tizenrt-artik053/romfs-1.1.patch
@@ -1,0 +1,41 @@
+diff --git a/apps/system/init/init.c b/apps/system/init/init.c
+index 3aaa1860..815a9c11 100644
+--- a/apps/system/init/init.c
++++ b/apps/system/init/init.c
+@@ -139,6 +139,10 @@ int preapp_start(int argc, char *argv[])
+ 	}
+ #endif
+ 
++#ifdef CONFIG_FS_ROMFS
++	mount("/dev/smart4rom9", "/rom", "romfs", 0, NULL);
++#endif
++
+ #if defined(CONFIG_LIB_USRWORK) || defined(CONFIG_TASH)
+ error_out:
+ 	return pid;
+diff --git a/build/configs/artik053/artik053_download.sh b/build/configs/artik053/artik053_download.sh
+index 0fa4b9a3..a3178545 100755
+--- a/build/configs/artik053/artik053_download.sh
++++ b/build/configs/artik053/artik053_download.sh
+@@ -111,6 +111,7 @@ main()
+ 			flash_write sssfw ../../bin/sssfw.bin; 		\
+ 			flash_write wlanfw ../../bin/wlanfw.bin;	\
+ 			flash_write os ../../../../output/bin/tinyara_head.bin;	\
++			flash_write rom ../../../../output/bin/rom.img;	\
+ 			exit' || finish_download 1
+ 			popd
+ 
+diff --git a/build/configs/artik053/tools/openocd/partition_map.cfg b/build/configs/artik053/tools/openocd/partition_map.cfg
+index c3abdeff..8dca6666 100644
+--- a/build/configs/artik053/tools/openocd/partition_map.cfg
++++ b/build/configs/artik053/tools/openocd/partition_map.cfg
+@@ -18,7 +18,8 @@ set partition_list {
+ 	os	{ "OS"			0x040C8000	0x00258000	0 }
+ 	factory	{ "Factory Reset"	0x04320000	0x00180000	0 }
+ 	ota	{ "OTA download"	0x044A0000	0x00180000	0 }
+-	user	{ "USER R/W"		0x04620000	0x0015E000	0 }
++	user	{ "USER R/W"		0x04620000	0x000FA000	0 }
++	rom	{ "ROM FS"		0x0471A000	0x00064000	0 }
+ 	nvram	{ "WiFi NVRAM"		0x0477E000	0x00002000	1 }
+ 	sssrw	{ "SSS R/W Key"		0x04780000	0x00080000	1 }
+ }

--- a/targets/zephyr/Makefile.travis
+++ b/targets/zephyr/Makefile.travis
@@ -1,0 +1,51 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Default target for running the build test outside the Travis CI environment.
+all:
+	$(MAKE) install
+	$(MAKE) script
+
+
+## Targets for installing build dependencies of the Zephyr JerryScript target.
+
+# Install tools via apt.
+install-apt-get-deps:
+	sudo apt-get install -q -y gperf dfu-util device-tree-compiler python3-ply python3-pip
+
+# Install Zephyr SDK.
+install-zephyr-sdk:
+	wget https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/0.9.1/zephyr-sdk-0.9.1-setup.run -O ../zephyr-sdk-0.9.1-setup.run
+	sh ../zephyr-sdk-0.9.1-setup.run -- -y -d $(CURDIR)/../zephyr-sdk-0.9.1
+
+# Fetch Zephyr Project repository and install python dependencies.
+install-zephyr: install-apt-get-deps
+	git clone https://github.com/zephyrproject-rtos/zephyr.git ../zephyr -b zephyr-v1.9.1
+	pip3 install --user -r ../zephyr/scripts/requirements.txt
+
+# Perform all the necessary (JerryScript-independent) installation steps.
+install: install-zephyr-sdk install-zephyr
+
+
+## Targets for building Zephyr with JerryScript.
+
+# Build the firmware (Zephyr with JerryScript).
+SHELL=bash
+script:
+	export ZEPHYR_GCC_VARIANT=zephyr && \
+	export ZEPHYR_SDK_INSTALL_DIR=$(CURDIR)/../zephyr-sdk-0.9.1 && \
+	source ../zephyr/zephyr-env.sh && \
+	CC=$(CURDIR)/../zephyr-sdk-0.9.1/sysroots/x86_64-pokysdk-linux/usr/bin/i586-zephyr-elfiamcu/i586-zephyr-elfiamcu-gcc \
+	$(MAKE) -f ./targets/zephyr/Makefile.zephyr BOARD=arduino_101


### PR DESCRIPTION
Hitherto, code under the `targets` directory was not tested and so
its maintenance was sometimes speculative. This commit adds build
testing for several targets to prevent them from bit rotting.
Targets covered by this commit are: ESP8266, Mbed, Mbed OS 5,
NuttX, RIOT, Tizen RT, and Zephyr.

Some issues were revealed and fixed:
- ESP8266: added missing include for `uint32_t` typedef.
- Tizen RT: replaced missing `str_to_uint` with `strtol`.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu