### PR TITLE
Fixed toFixed method string conversion

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -128,7 +128,6 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits_p, /**< 
 static inline lit_utf8_size_t __attr_always_inline___
 ecma_builtin_binary_floating_number_to_string (lit_utf8_byte_t *digits_p, /**< number as string
                                                                            * in binary-floating point number */
-                                               lit_utf8_size_t num_digits, /**< length of the string representation */
                                                int32_t exponent, /**< decimal exponent */
                                                lit_utf8_byte_t *to_digits_p, /**< [out] buffer to write */
                                                lit_utf8_size_t to_num_digits) /**< requested number of digits */
@@ -149,10 +148,10 @@ ecma_builtin_binary_floating_number_to_string (lit_utf8_byte_t *digits_p, /**< n
 
   if (to_num_digits > 0)
   {
-    /* Add significant digits of the fraction part. */
+    /* Add significant digits of the fraction part and fill the remaining digits with zero */
     while (to_num_digits > 0)
     {
-      *p++ = num_digits == 1 ? '0' : *digits_p++;
+      *p++ = (*digits_p == 0 ? '0' : *digits_p++);
       to_num_digits--;
     }
   }
@@ -680,7 +679,6 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
           lit_utf8_size_t to_num_digits = ((exponent > 0) ? (lit_utf8_size_t) (exponent + frac_digits)
                                                           : (lit_utf8_size_t) (frac_digits + 1));
           p += ecma_builtin_binary_floating_number_to_string (digits,
-                                                              num_digits,
                                                               exponent,
                                                               p,
                                                               to_num_digits);

--- a/tests/jerry/regression-test-issue-2108.js
+++ b/tests/jerry/regression-test-issue-2108.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert((8e-9).toFixed(20) == "0.00000000800000000000");


### PR DESCRIPTION
This patch fixes #2108. The problem was if the convertible number had less significant fractions digits than the requested, the result was filled with memory junk instead of zeros.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu