### PR TITLE
Fix bug in promise resolve handler

### DIFF
--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -317,6 +317,7 @@ ecma_promise_resolve_handler (const ecma_value_t function, /**< the function its
   if (ECMA_IS_VALUE_ERROR (then))
   {
     /* 9. */
+    then = JERRY_CONTEXT (error_value);
     ecma_reject_promise (promise, then);
   }
   else if (!ecma_op_is_callable (then))

--- a/tests/jerry/es2015/regression-test-issue-2111.js
+++ b/tests/jerry/es2015/regression-test-issue-2111.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var value = {};
+var poisonedThen = Object.defineProperty({}, 'then', {
+  get: function() {
+    throw value;
+  }
+});
+var promise = new Promise(function(resolve) {
+  resolve(poisonedThen);
+});


### PR DESCRIPTION
Should get the error_value if `then` prop is an error.

Fix issue: #2111

JerryScript-DCO-1.0-Signed-off-by: Zidong Jiang zidong.jiang@intel.com