### PR TITLE
Improve bitwise operations in VM.

### DIFF
--- a/jerry-core/vm/opcodes-ecma-bitwise.c
+++ b/jerry-core/vm/opcodes-ecma-bitwise.c
@@ -42,54 +42,8 @@ do_number_bitwise_logic (number_bitwise_logic_op op, /**< number bitwise logic o
                          ecma_value_t left_value, /**< left value */
                          ecma_value_t right_value) /**< right value */
 {
-  JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_INTEGER_VALUE == 0,
-                       ecma_direct_type_integer_value_must_be_zero_for_bitwise_logic);
-  JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
-                       direct_type_mask_must_fill_all_bits_before_the_value_starts);
-
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (left_value)
                 && !ECMA_IS_VALUE_ERROR (right_value));
-
-  if (ecma_are_values_integer_numbers (left_value, right_value))
-  {
-    switch (op)
-    {
-      case NUMBER_BITWISE_LOGIC_AND:
-      {
-        return left_value & right_value;
-      }
-      case NUMBER_BITWISE_LOGIC_OR:
-      {
-        return left_value | right_value;
-      }
-      case NUMBER_BITWISE_LOGIC_XOR:
-      {
-        return (left_value ^ right_value) & (ecma_value_t) (~((1 << ECMA_DIRECT_SHIFT) - 1));
-      }
-      case NUMBER_BITWISE_SHIFT_LEFT:
-      {
-        ecma_integer_value_t left_integer = ecma_get_integer_from_value (left_value);
-        ecma_integer_value_t right_integer = ecma_get_integer_from_value (right_value);
-        return ecma_make_int32_value ((int32_t) (left_integer << (right_integer & 0x1f)));
-      }
-      case NUMBER_BITWISE_SHIFT_RIGHT:
-      {
-        ecma_integer_value_t left_integer = ecma_get_integer_from_value (left_value);
-        ecma_integer_value_t right_integer = ecma_get_integer_from_value (right_value);
-        return ecma_make_integer_value (left_integer >> (right_integer & 0x1f));
-      }
-      case NUMBER_BITWISE_SHIFT_URIGHT:
-      {
-        uint32_t left_uint32 = (uint32_t) ecma_get_integer_from_value (left_value);
-        ecma_integer_value_t right_integer = ecma_get_integer_from_value (right_value);
-        return ecma_make_uint32_value (left_uint32 >> (right_integer & 0x1f));
-      }
-      case NUMBER_BITWISE_NOT:
-      {
-        return (~right_value) & (ecma_value_t) (~((1 << ECMA_DIRECT_SHIFT) - 1));
-      }
-    }
-  }
 
   ecma_value_t ret_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1604,6 +1604,15 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_BIT_NOT:
         {
+          JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
+                               direct_type_mask_must_fill_all_bits_before_the_value_starts);
+
+          if (ecma_is_value_integer_number (left_value))
+          {
+            *stack_top_p++ = (~left_value) & (ecma_value_t) (~ECMA_DIRECT_TYPE_MASK);
+            goto free_left_value;
+          }
+
           result = do_number_bitwise_logic (NUMBER_BITWISE_NOT,
                                             left_value,
                                             left_value);
@@ -1917,6 +1926,15 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_BIT_OR:
         {
+          JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
+                               direct_type_mask_must_fill_all_bits_before_the_value_starts);
+
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            result = left_value | right_value;
+            break;
+          }
+
           result = do_number_bitwise_logic (NUMBER_BITWISE_LOGIC_OR,
                                             left_value,
                                             right_value);
@@ -1929,6 +1947,15 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_BIT_XOR:
         {
+          JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
+                               direct_type_mask_must_fill_all_bits_before_the_value_starts);
+
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            result = (left_value ^ right_value) & (ecma_value_t) (~ECMA_DIRECT_TYPE_MASK);
+            break;
+          }
+
           result = do_number_bitwise_logic (NUMBER_BITWISE_LOGIC_XOR,
                                             left_value,
                                             right_value);
@@ -1941,6 +1968,15 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_BIT_AND:
         {
+          JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
+                               direct_type_mask_must_fill_all_bits_before_the_value_starts);
+
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            result = left_value & right_value;
+            break;
+          }
+
           result = do_number_bitwise_logic (NUMBER_BITWISE_LOGIC_AND,
                                             left_value,
                                             right_value);
@@ -1953,6 +1989,17 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_LEFT_SHIFT:
         {
+          JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
+                               direct_type_mask_must_fill_all_bits_before_the_value_starts);
+
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            ecma_integer_value_t left_integer = ecma_get_integer_from_value (left_value);
+            ecma_integer_value_t right_integer = ecma_get_integer_from_value (right_value);
+            result = ecma_make_int32_value ((int32_t) (left_integer << (right_integer & 0x1f)));
+            break;
+          }
+
           result = do_number_bitwise_logic (NUMBER_BITWISE_SHIFT_LEFT,
                                             left_value,
                                             right_value);
@@ -1965,6 +2012,17 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_RIGHT_SHIFT:
         {
+          JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
+                               direct_type_mask_must_fill_all_bits_before_the_value_starts);
+
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            ecma_integer_value_t left_integer = ecma_get_integer_from_value (left_value);
+            ecma_integer_value_t right_integer = ecma_get_integer_from_value (right_value);
+            result = ecma_make_integer_value (left_integer >> (right_integer & 0x1f));
+            break;
+          }
+
           result = do_number_bitwise_logic (NUMBER_BITWISE_SHIFT_RIGHT,
                                             left_value,
                                             right_value);
@@ -1977,6 +2035,17 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_UNS_RIGHT_SHIFT:
         {
+          JERRY_STATIC_ASSERT (ECMA_DIRECT_TYPE_MASK == ((1 << ECMA_DIRECT_SHIFT) - 1),
+                               direct_type_mask_must_fill_all_bits_before_the_value_starts);
+
+          if (ecma_are_values_integer_numbers (left_value, right_value))
+          {
+            uint32_t left_uint32 = (uint32_t) ecma_get_integer_from_value (left_value);
+            ecma_integer_value_t right_integer = ecma_get_integer_from_value (right_value);
+            result = ecma_make_uint32_value (left_uint32 >> (right_integer & 0x1f));
+            break;
+          }
+
           result = do_number_bitwise_logic (NUMBER_BITWISE_SHIFT_URIGHT,
                                             left_value,
                                             right_value);


### PR DESCRIPTION
Now there is a shortcut in `do_number_bitwise_logic` function, if the two operands are integer numbers. It's faster if we check this condition in `vm_loop`.
( '+' means better)

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.825 -> 0.823 : +0.191% | 
3d-raytrace.js | 1.062 -> 1.059 : +0.215% | 
access-binary-trees.js | 0.564 -> 0.566 : -0.333% | 
access-fannkuch.js | 2.135 -> 2.131 : +0.192% | 
access-nbody.js | 1.131 -> 1.132 : -0.048% | 
bitops-3bit-bits-in-byte.js | 0.593 -> 0.533 : +10.021% | 
bitops-bits-in-byte.js | 0.793 -> 0.734 : +7.403% | 
bitops-bitwise-and.js | 0.970 -> 0.930 : +4.166% | 
bitops-nsieve-bits.js | 1.326 -> 1.234 : +6.904% | 
controlflow-recursive.js | 0.387 -> 0.391 : -1.230% | 
crypto-aes.js | 0.935 -> 0.929 : +0.584% | 
crypto-md5.js | 0.644 -> 0.634 : +1.532% | 
crypto-sha1.js | 0.643 -> 0.631 : +1.796% | 
date-format-tofte.js | 0.727 -> 0.730 : -0.421% | 
date-format-xparb.js | 0.410 -> 0.413 : -0.648% | 
math-cordic.js | 1.251 -> 1.250 : +0.121% | 
math-partial-sums.js | 0.756 -> 0.763 : -0.947% | 
math-spectral-norm.js | 0.544 -> 0.546 : -0.364% | 
string-base64.js | 1.630 -> 1.494 : +8.311% | 
string-fasta.js | 1.252 -> 1.257 : -0.404% | 
Geometric mean: | +1.913% | 

Binary sizes (bytes)
29056f9ab9:137620
2357205c18:137644


JerryScript-DCO-1.0-Signed-off-by: Marko Fabo mfabo@inf.u-szeged.hu