### PR TITLE
Fix undefined behaviour of global object freezing

### DIFF
--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -146,6 +146,11 @@ ecma_op_create_mutable_binding (ecma_object_t *lex_env_p, /**< lexical environme
     ecma_object_t *binding_obj_p = ecma_get_lex_env_binding_object (lex_env_p);
 
     ecma_value_t completion;
+    if (!ecma_get_object_extensible (binding_obj_p))
+    {
+      return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
+    }
+
     completion = ecma_builtin_helper_def_prop (binding_obj_p,
                                                name_p,
                                                ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED),

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -62,7 +62,7 @@ vm_var_decl (vm_frame_ctx_t *frame_ctx_p, /**< interpreter context */
      * and CreateMutableBinding sets the created binding's value to undefined */
     JERRY_ASSERT (ecma_is_value_undefined (ecma_op_get_binding_value (frame_ctx_p->lex_env_p,
                                                                       var_name_str_p,
-                                                                      true)));
+                                                                      vm_is_strict_mode ())));
   }
   return ecma_make_simple_value (ECMA_SIMPLE_VALUE_EMPTY);
 } /* vm_var_decl */

--- a/tests/jerry/regression-test-issue-2105.js
+++ b/tests/jerry/regression-test-issue-2105.js
@@ -1,0 +1,54 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* Adding property to a frozen object */
+var a = {one: "test"};
+a.two = 3;
+Object.freeze(a);
+a.three = 7;
+assert(a.three === undefined);
+
+/* Adding properties to frozen global object */
+Object.freeze(this);
+assert(eval ('function b() {};') === undefined);
+assert(eval('var test_var = 3') === undefined);
+
+/* Check strict mode TypeError */
+function fail() {
+  'use strict';
+  a.one = 'test'; // throws a TypeError
+  delete a.two; // throws a TypeError
+  a.three = 'test2'; // throws a TypeError
+}
+
+try {
+  fail();
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+function fail_two() {
+  'use strict';
+  this.a = 'test';
+}
+
+try {
+  fail_two();
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+/* Check properties of a */
+assert(Object.keys(a) == "one,two");
+/* Check properties of global object */
+assert(Object.keys(this) == "assert,gc,print,a,fail,fail_two");


### PR DESCRIPTION
Freezing the global object and later trying to add properties to it caused an assertion error (issue #2105).
This patch fixes the issue.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu