### PR TITLE
Add object type checking to instantiation

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -730,7 +730,7 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
 } /* ecma_op_function_construct */
 
 /**
- * Lazy instantation of non-builtin ecma function object's properties
+ * Lazy instantiation of non-builtin ecma function object's properties
  *
  * Warning:
  *         Only non-configurable properties could be instantiated lazily in this function,
@@ -783,11 +783,23 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
   if (ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_CALLER)
       || ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_ARGUMENTS))
   {
-    ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-
     const ecma_compiled_code_t *bytecode_data_p;
-    bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                       ext_func_p->u.function.bytecode_cp);
+#ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
+    if (ecma_get_object_type (object_p) == ECMA_OBJECT_TYPE_ARROW_FUNCTION)
+    {
+      ecma_arrow_function_t *arrow_func_p = (ecma_arrow_function_t *) object_p;
+      bytecode_data_p = ECMA_GET_NON_NULL_POINTER (const ecma_compiled_code_t,
+                                                   arrow_func_p->bytecode_cp);
+    }
+    else
+    {
+#endif /* CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
+      ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
+      bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
+                                                         ext_func_p->u.function.bytecode_cp);
+#ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
+    }
+#endif /* CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 
     if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE)
     {

--- a/tests/jerry/es2015/regression-test-issue-2110.js
+++ b/tests/jerry/es2015/regression-test-issue-2110.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arrowFn = () => {};
+arrowFn.hasOwnProperty('caller');


### PR DESCRIPTION
It wasn't properly checked if the given object was an arrow function, therefore it always got wrongly casted into `ecma_extended_object_t`.
Fixes issue #2110
*plus fixing a typo in the comments

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu