### PR TITLE
Remove trivial ecma_number arithmetic functions

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -845,7 +845,7 @@ ecma_number_to_uint32 (ecma_number_t num) /**< ecma-number */
   }
 
   const bool sign = ecma_number_is_negative (num);
-  const ecma_number_t abs_num = sign ? ecma_number_negate (num) : num;
+  const ecma_number_t abs_num = sign ? -num : num;
 
   /* 2 ^ 32 */
   const uint64_t uint64_2_pow_32 = (1ull << 32);
@@ -1126,7 +1126,7 @@ ecma_number_to_utf8_string (ecma_number_t num, /**< ecma-number */
   {
     /* 3. */
     *dst_p++ = LIT_CHAR_MINUS;
-    num = ecma_number_negate (num);
+    num = -num;
   }
 
   if (ecma_number_is_infinity (num))

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -520,7 +520,7 @@ ecma_number_get_prev (ecma_number_t num) /**< ecma-number */
 
   if (ecma_number_is_negative (num))
   {
-    return ecma_number_negate (ecma_number_get_next (num));
+    return -ecma_number_get_next (num);
   }
 
   uint32_t biased_exp = ecma_number_get_biased_exponent_field (num);
@@ -555,7 +555,7 @@ ecma_number_get_next (ecma_number_t num) /**< ecma-number */
 
   if (ecma_number_is_negative (num))
   {
-    return ecma_number_negate (ecma_number_get_prev (num));
+    return -ecma_number_get_prev (num);
   }
 
   uint32_t biased_exp = ecma_number_get_biased_exponent_field (num);
@@ -580,35 +580,6 @@ ecma_number_get_next (ecma_number_t num) /**< ecma-number */
                            biased_exp,
                            fraction);
 } /* ecma_number_get_next */
-
-/**
- * Negate ecma-number
- *
- * @return negated number
- */
-ecma_number_t
-ecma_number_negate (ecma_number_t num) /**< ecma-number */
-{
-  ecma_number_t negated = -num;
-
-#ifndef JERRY_NDEBUG
-  bool sign;
-  uint32_t biased_exp;
-  uint64_t fraction;
-
-  ecma_number_unpack (num, &sign, &biased_exp, &fraction);
-
-  sign = !sign;
-
-  ecma_number_t negated_ieee754 = ecma_number_pack (sign, biased_exp, fraction);
-
-  JERRY_ASSERT (negated == negated_ieee754
-                || (ecma_number_is_nan (negated)
-                    && ecma_number_is_nan (negated_ieee754)));
-#endif /* !JERRY_NDEBUG */
-
-  return negated;
-} /* ecma_number_negate */
 
 /**
  * Truncate fractional part of the number
@@ -637,7 +608,7 @@ ecma_number_trunc (ecma_number_t num) /**< ecma-number */
                                                                                      exponent);
     if (sign)
     {
-      return ecma_number_negate (tmp);
+      return -tmp;
     }
     else
     {
@@ -670,65 +641,17 @@ ecma_number_calc_remainder (ecma_number_t left_num, /**< left operand */
                 && !ecma_number_is_zero (right_num)
                 && !ecma_number_is_infinity (right_num));
 
-  const ecma_number_t q = ecma_number_trunc (ecma_number_divide (left_num, right_num));
-  ecma_number_t r = ecma_number_substract (left_num, ecma_number_multiply (right_num, q));
+  const ecma_number_t q = ecma_number_trunc (left_num / right_num);
+  ecma_number_t r = left_num - right_num * q;
 
   if (ecma_number_is_zero (r)
       && ecma_number_is_negative (left_num))
   {
-    r = ecma_number_negate (r);
+    r = -r;
   }
 
   return r;
 } /* ecma_number_calc_remainder */
-
-/**
- * ECMA-number addition.
- *
- * @return number - result of addition.
- */
-ecma_number_t
-ecma_number_add (ecma_number_t left_num, /**< left operand */
-                 ecma_number_t right_num) /**< right operand */
-{
-  return left_num + right_num;
-} /* ecma_number_add */
-
-/**
- * ECMA-number substraction.
- *
- * @return number - result of substraction.
- */
-ecma_number_t
-ecma_number_substract (ecma_number_t left_num, /**< left operand */
-                       ecma_number_t right_num) /**< right operand */
-{
-  return ecma_number_add (left_num, ecma_number_negate (right_num));
-} /* ecma_number_substract */
-
-/**
- * ECMA-number multiplication.
- *
- * @return number - result of multiplication.
- */
-ecma_number_t
-ecma_number_multiply (ecma_number_t left_num, /**< left operand */
-                      ecma_number_t right_num) /**< right operand */
-{
-  return left_num * right_num;
-} /* ecma_number_multiply */
-
-/**
- * ECMA-number division.
- *
- * @return number - result of division.
- */
-ecma_number_t
-ecma_number_divide (ecma_number_t left_num, /**< left operand */
-                    ecma_number_t right_num) /**< right operand */
-{
-  return left_num / right_num;
-} /* ecma_number_divide */
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -1997,7 +1997,7 @@ ecma_get_string_magic (const ecma_string_t *string_p) /**< ecma-string */
  *
  * @return calculated hash
  */
-lit_string_hash_t
+inline lit_string_hash_t __attr_always_inline___
 ecma_string_hash (const ecma_string_t *string_p) /**< ecma-string to calculate hash for */
 {
   return (string_p->hash);

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -243,13 +243,8 @@ ecma_number_t
 ecma_number_make_from_sign_mantissa_and_exponent (bool sign, uint64_t mantissa, int32_t exponent);
 ecma_number_t ecma_number_get_prev (ecma_number_t num);
 ecma_number_t ecma_number_get_next (ecma_number_t num);
-ecma_number_t ecma_number_negate (ecma_number_t num);
 ecma_number_t ecma_number_trunc (ecma_number_t num);
 ecma_number_t ecma_number_calc_remainder (ecma_number_t left_num, ecma_number_t right_num);
-ecma_number_t ecma_number_add (ecma_number_t left_num, ecma_number_t right_num);
-ecma_number_t ecma_number_substract (ecma_number_t left_num, ecma_number_t right_num);
-ecma_number_t ecma_number_multiply (ecma_number_t left_num, ecma_number_t right_num);
-ecma_number_t ecma_number_divide (ecma_number_t left_num, ecma_number_t right_num);
 lit_utf8_size_t ecma_number_to_decimal (ecma_number_t num, lit_utf8_byte_t *out_digits_p, int32_t *out_decimal_exp_p);
 lit_utf8_size_t ecma_number_to_binary_floating_point_number (ecma_number_t num,
                                                              lit_utf8_byte_t *out_digits_p,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -277,7 +277,7 @@ ecma_builtin_helper_array_index_normalize (ecma_number_t index, /**< index */
     {
       if (ecma_number_is_negative (index))
       {
-        ecma_number_t index_neg = ecma_number_negate (index);
+        ecma_number_t index_neg = -index;
 
         if (index_neg > length)
         {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -295,7 +295,7 @@ ecma_builtin_math_dispatch_routine (uint16_t builtin_routine_id, /**< built-in w
         else if (ecma_number_is_negative (x)
                  && x >= -ECMA_NUMBER_HALF)
         {
-          x = ecma_number_negate (ECMA_NUMBER_ZERO);
+          x = -ECMA_NUMBER_ZERO;
         }
         else
         {

--- a/jerry-core/vm/opcodes-ecma-arithmetics.c
+++ b/jerry-core/vm/opcodes-ecma-arithmetics.c
@@ -56,17 +56,17 @@ do_number_arithmetic (number_arithmetic_op op, /**< number arithmetic operation 
   {
     case NUMBER_ARITHMETIC_SUBSTRACTION:
     {
-      result = ecma_number_substract (num_left, num_right);
+      result = num_left - num_right;
       break;
     }
     case NUMBER_ARITHMETIC_MULTIPLICATION:
     {
-      result = ecma_number_multiply (num_left, num_right);
+      result = num_left * num_right;
       break;
     }
     case NUMBER_ARITHMETIC_DIVISION:
     {
-      result = ecma_number_divide (num_left, num_right);
+      result = num_left / num_right;
       break;
     }
     case NUMBER_ARITHMETIC_REMAINDER:
@@ -150,7 +150,7 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
     ECMA_OP_TO_NUMBER_TRY_CATCH (num_left, left_value, ret_value);
     ECMA_OP_TO_NUMBER_TRY_CATCH (num_right, right_value, ret_value);
 
-    ret_value = ecma_make_number_value (ecma_number_add (num_left, num_right));
+    ret_value = ecma_make_number_value (num_left + num_right);
 
     ECMA_OP_TO_NUMBER_FINALIZE (num_right);
     ECMA_OP_TO_NUMBER_FINALIZE (num_left);
@@ -187,8 +187,7 @@ opfunc_unary_operation (ecma_value_t left_value, /**< left value */
                                left_value,
                                ret_value);
 
-  ret_value = ecma_make_number_value (is_plus ? num_var_value
-                                               : ecma_number_negate (num_var_value));
+  ret_value = ecma_make_number_value (is_plus ? num_var_value : -num_var_value);
 
   ECMA_OP_TO_NUMBER_FINALIZE (num_var_value);
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1696,8 +1696,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (ecma_is_value_float_number (left_value)
               && ecma_is_value_number (right_value))
           {
-            ecma_number_t new_value = ecma_number_add (ecma_get_float_from_value (left_value),
-                                                       ecma_get_number_from_value (right_value));
+            ecma_number_t new_value = (ecma_get_float_from_value (left_value) +
+                                       ecma_get_number_from_value (right_value));
 
             result = ecma_update_float_number (left_value, new_value);
             left_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -1707,8 +1707,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (ecma_is_value_float_number (right_value)
               && ecma_is_value_integer_number (left_value))
           {
-            ecma_number_t new_value = ecma_number_add ((ecma_number_t) ecma_get_integer_from_value (left_value),
-                                                       ecma_get_float_from_value (right_value));
+            ecma_number_t new_value = ((ecma_number_t) ecma_get_integer_from_value (left_value) +
+                                       ecma_get_float_from_value (right_value));
 
             result = ecma_update_float_number (right_value, new_value);
             right_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -1743,8 +1743,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (ecma_is_value_float_number (left_value)
               && ecma_is_value_number (right_value))
           {
-            ecma_number_t new_value = ecma_number_substract (ecma_get_float_from_value (left_value),
-                                                             ecma_get_number_from_value (right_value));
+            ecma_number_t new_value = (ecma_get_float_from_value (left_value) -
+                                       ecma_get_number_from_value (right_value));
 
             result = ecma_update_float_number (left_value, new_value);
             left_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -1754,8 +1754,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (ecma_is_value_float_number (right_value)
               && ecma_is_value_integer_number (left_value))
           {
-            ecma_number_t new_value = ecma_number_substract ((ecma_number_t) ecma_get_integer_from_value (left_value),
-                                                             ecma_get_float_from_value (right_value));
+            ecma_number_t new_value = ((ecma_number_t) ecma_get_integer_from_value (left_value) -
+                                       ecma_get_float_from_value (right_value));
 
             result = ecma_update_float_number (right_value, new_value);
             right_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -1797,8 +1797,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
               break;
             }
 
-            ecma_number_t multiply = ecma_number_multiply ((ecma_number_t) left_integer,
-                                                           (ecma_number_t) right_integer);
+            ecma_number_t multiply = (ecma_number_t) left_integer * (ecma_number_t) right_integer;
             result = ecma_make_number_value (multiply);
             break;
           }
@@ -1806,8 +1805,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (ecma_is_value_float_number (left_value)
               && ecma_is_value_number (right_value))
           {
-            ecma_number_t new_value = ecma_number_multiply (ecma_get_float_from_value (left_value),
-                                                            ecma_get_number_from_value (right_value));
+            ecma_number_t new_value = (ecma_get_float_from_value (left_value) *
+                                       ecma_get_number_from_value (right_value));
 
             result = ecma_update_float_number (left_value, new_value);
             left_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);
@@ -1817,8 +1816,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (ecma_is_value_float_number (right_value)
               && ecma_is_value_integer_number (left_value))
           {
-            ecma_number_t new_value = ecma_number_multiply ((ecma_number_t) ecma_get_integer_from_value (left_value),
-                                                            ecma_get_float_from_value (right_value));
+            ecma_number_t new_value = ((ecma_number_t) ecma_get_integer_from_value (left_value) *
+                                       ecma_get_float_from_value (right_value));
 
             result = ecma_update_float_number (right_value, new_value);
             right_value = ecma_make_simple_value (ECMA_SIMPLE_VALUE_UNDEFINED);

--- a/tests/unit-core/test-number-to-integer.c
+++ b/tests/unit-core/test-number-to-integer.c
@@ -43,7 +43,6 @@ main (void)
 #define TEST_CASE(num, uint32) { num, uint32 }
     TEST_CASE (1.0, 1),
     TEST_CASE (0.0, 0),
-    TEST_CASE (ecma_number_negate (0.0), 0),
     TEST_CASE (NAN, 0),
     TEST_CASE (-NAN, 0),
     TEST_CASE (INFINITY, 0),
@@ -73,7 +72,6 @@ main (void)
 #define TEST_CASE(num, int32) { num, int32 }
     TEST_CASE (1.0, 1),
     TEST_CASE (0.0, 0),
-    TEST_CASE (ecma_number_negate (0.0), 0),
     TEST_CASE (NAN, 0),
     TEST_CASE (-NAN, 0),
     TEST_CASE (INFINITY, 0),


### PR DESCRIPTION
The affected function calls have been replaced with the appropriate arithmetic operands.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu