### PR TITLE
Improve multiplication in vm

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -719,6 +719,31 @@ ecma_number_multiply (ecma_number_t left_num, /**< left operand */
 } /* ecma_number_multiply */
 
 /**
+ * ECMA-integer number multiplication.
+ *
+ * @return number - result of multiplication.
+ */
+inline ecma_value_t __attr_always_inline___
+ecma_integer_multiply (ecma_integer_value_t left_integer, /**< left operand */
+                       ecma_integer_value_t right_integer) /**< right operand */
+{
+#if defined (__GNUC__) || defined (__clang__)
+  /* Check if left_integer is power of 2 */
+  if (unlikely ((left_integer & (left_integer - 1)) == 0))
+  {
+    /* Right shift right_integer with log2 (left_integer) */
+    return ecma_make_integer_value (right_integer << (__builtin_ctz ((unsigned int) left_integer)));
+  }
+  else if (unlikely ((right_integer & (right_integer - 1)) == 0))
+  {
+    /* Right shift left_integer with log2 (right_integer) */
+    return ecma_make_integer_value (left_integer << (__builtin_ctz ((unsigned int) right_integer)));
+  }
+#endif /* defined (__GNUC__) || defined (__clang__) */
+  return ecma_make_integer_value (left_integer * right_integer);
+} /* ecma_integer_multiply */
+
+/**
  * ECMA-number division.
  *
  * @return number - result of division.

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -249,6 +249,7 @@ ecma_number_t ecma_number_calc_remainder (ecma_number_t left_num, ecma_number_t 
 ecma_number_t ecma_number_add (ecma_number_t left_num, ecma_number_t right_num);
 ecma_number_t ecma_number_substract (ecma_number_t left_num, ecma_number_t right_num);
 ecma_number_t ecma_number_multiply (ecma_number_t left_num, ecma_number_t right_num);
+ecma_value_t ecma_integer_multiply (ecma_integer_value_t left_integer, ecma_integer_value_t right_integer);
 ecma_number_t ecma_number_divide (ecma_number_t left_num, ecma_number_t right_num);
 lit_utf8_size_t ecma_number_to_decimal (ecma_number_t num, lit_utf8_byte_t *out_digits_p, int32_t *out_decimal_exp_p);
 lit_utf8_size_t ecma_number_to_binary_floating_point_number (ecma_number_t num,

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1793,7 +1793,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                 && left_value != 0
                 && right_value != 0)
             {
-              result = ecma_make_integer_value (left_integer * right_integer);
+              result = ecma_integer_multiply (left_integer, right_integer);
               break;
             }
 


### PR DESCRIPTION
This patch improves the ecma_integers_values multiplication by checking if the multiplier or multiplicand is power of 2.
If it is it uses right shift instead of multiplication.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

Benchmark | RSS (bytes) | Perf (sec) |
----: | ----: | ----: | 
3d-cube.js | 53248 -> 53248 : 0.000% | 0.824 -> 0.824 : +0.069% | 
3d-raytrace.js | 114102 -> 106496 : +6.666% | 1.063 -> 1.058 : +0.458% | 
access-binary-trees.js | 49152 -> 49152 : 0.000% | 0.565 -> 0.564 : +0.042% | 
access-fannkuch.js | 16384 -> 16384 : 0.000% | 2.134 -> 2.129 : +0.234% | 
access-nbody.js | 24576 -> 24576 : 0.000% | 1.131 -> 1.134 : -0.271% | 
bitops-3bit-bits-in-byte.js | 12288 -> 12288 : 0.000% | 0.592 -> 0.583 : +1.465% | 
bitops-bits-in-byte.js | 12288 -> 12288 : 0.000% | 0.789 -> 0.784 : +0.621% | 
bitops-bitwise-and.js | 12288 -> 12288 : 0.000% | 0.975 -> 0.971 : +0.370% | 
bitops-nsieve-bits.js | 110592 -> 110592 : 0.000% | 1.323 -> 1.319 : +0.339% | 
controlflow-recursive.js | 81920 -> 81920 : 0.000% | 0.387 -> 0.385 : +0.563% | 
crypto-aes.js | 61440 -> 61440 : 0.000% | 0.938 -> 0.938 : -0.034% | 
crypto-md5.js | 126976 -> 126976 : 0.000% | 0.644 -> 0.639 : +0.840% | 
crypto-sha1.js | 81920 -> 81920 : 0.000% | 0.643 -> 0.635 : +1.190% | 
date-format-tofte.js | 36864 -> 36864 : 0.000% | 0.726 -> 0.728 : -0.217% | 
date-format-xparb.js | 36864 -> 36864 : 0.000% | 0.410 -> 0.411 : -0.322% | 
math-cordic.js | 16384 -> 16384 : 0.000% | 1.255 -> 1.243 : +0.965% | 
math-partial-sums.js | 12288 -> 12288 : 0.000% | 0.761 -> 0.775 : -1.732% | 
math-spectral-norm.js | 20480 -> 20480 : 0.000% | 0.547 -> 0.563 : -2.984% | 
string-base64.js | 139264 -> 139264 : 0.000% | 1.627 -> 1.488 : +8.499% | 
string-fasta.js | 28672 -> 28672 : 0.000% | 1.253 -> 1.258 : -0.365% | 
Geometric mean: | +0.344% | +0.509% | 

Binary sizes (bytes)
1ed886b872:137620
ac44145d0f:137708