### PR TITLE
Fix conversion warnings

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -1084,7 +1084,6 @@ jerry_create_boolean (bool value) /**< bool value from which a jerry_value_t wil
 {
   jerry_assert_api_available ();
 
-  value = jerry_get_arg_value (value);
   return jerry_return (ecma_make_boolean_value (value));
 } /* jerry_create_boolean */
 
@@ -1889,14 +1888,16 @@ jerry_define_own_property (const jerry_value_t obj_val, /**< object value */
 
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
-  prop_desc.is_enumerable_defined = prop_desc_p->is_enumerable_defined;
-  prop_desc.is_enumerable = prop_desc_p->is_enumerable_defined ? prop_desc_p->is_enumerable : false;
+  prop_desc.is_enumerable_defined = ECMA_BOOL_TO_BITFIELD (prop_desc_p->is_enumerable_defined);
+  prop_desc.is_enumerable = ECMA_BOOL_TO_BITFIELD (prop_desc_p->is_enumerable_defined ? prop_desc_p->is_enumerable
+                                                                                      : false);
 
-  prop_desc.is_configurable_defined = prop_desc_p->is_configurable_defined;
-  prop_desc.is_configurable = prop_desc_p->is_configurable_defined ? prop_desc_p->is_configurable : false;
+  prop_desc.is_configurable_defined = ECMA_BOOL_TO_BITFIELD (prop_desc_p->is_configurable_defined);
+  prop_desc.is_configurable = ECMA_BOOL_TO_BITFIELD (prop_desc_p->is_configurable_defined ? prop_desc_p->is_configurable
+                                                                                          : false);
 
   /* Copy data property info. */
-  prop_desc.is_value_defined = prop_desc_p->is_value_defined;
+  prop_desc.is_value_defined = ECMA_BOOL_TO_BITFIELD (prop_desc_p->is_value_defined);
 
   if (prop_desc_p->is_value_defined)
   {
@@ -1908,8 +1909,9 @@ jerry_define_own_property (const jerry_value_t obj_val, /**< object value */
     prop_desc.value = prop_desc_p->value;
   }
 
-  prop_desc.is_writable_defined = prop_desc_p->is_writable_defined;
-  prop_desc.is_writable = prop_desc_p->is_writable_defined ? prop_desc_p->is_writable : false;
+  prop_desc.is_writable_defined = ECMA_BOOL_TO_BITFIELD (prop_desc_p->is_writable_defined);
+  prop_desc.is_writable = ECMA_BOOL_TO_BITFIELD (prop_desc_p->is_writable_defined ? prop_desc_p->is_writable
+                                                                                  : false);
 
   /* Copy accessor property info. */
   if (prop_desc_p->is_get_defined)

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -110,6 +110,11 @@
     jmem_heap_free_block ((void *) utf8_ptr, utf8_str_size); \
   }
 
+/**
+ * Convert boolean to bitfield value.
+ */
+#define ECMA_BOOL_TO_BITFIELD(x) ((x) ? 1 : 0)
+
 /* ecma-helpers-value.c */
 bool ecma_is_value_direct (ecma_value_t value) __attr_const___;
 bool ecma_is_value_simple (ecma_value_t value) __attr_const___;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -671,13 +671,13 @@ ecma_builtin_helper_def_prop (ecma_object_t *obj_p, /**< object */
   prop_desc.value = value;
 
   prop_desc.is_writable_defined = true;
-  prop_desc.is_writable = writable;
+  prop_desc.is_writable = ECMA_BOOL_TO_BITFIELD (writable);
 
   prop_desc.is_enumerable_defined = true;
-  prop_desc.is_enumerable = enumerable;
+  prop_desc.is_enumerable = ECMA_BOOL_TO_BITFIELD (enumerable);
 
   prop_desc.is_configurable_defined = true;
-  prop_desc.is_configurable = configurable;
+  prop_desc.is_configurable = ECMA_BOOL_TO_BITFIELD (configurable);
 
   return ecma_op_object_define_own_property (obj_p,
                                              index_p,

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -588,7 +588,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
     if (ecma_is_value_found (enumerable_prop_value))
     {
       prop_desc.is_enumerable_defined = true;
-      prop_desc.is_enumerable = ecma_op_to_boolean (enumerable_prop_value);
+      prop_desc.is_enumerable = ECMA_BOOL_TO_BITFIELD (ecma_op_to_boolean (enumerable_prop_value));
     }
 
     ECMA_FINALIZE (enumerable_prop_value);
@@ -609,7 +609,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       if (ecma_is_value_found (configurable_prop_value))
       {
         prop_desc.is_configurable_defined = true;
-        prop_desc.is_configurable = ecma_op_to_boolean (configurable_prop_value);
+        prop_desc.is_configurable = ECMA_BOOL_TO_BITFIELD (ecma_op_to_boolean (configurable_prop_value));
       }
 
       ECMA_FINALIZE (configurable_prop_value);
@@ -653,7 +653,7 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       if (ecma_is_value_found (writable_prop_value))
       {
         prop_desc.is_writable_defined = true;
-        prop_desc.is_writable = ecma_op_to_boolean (writable_prop_value);
+        prop_desc.is_writable = ECMA_BOOL_TO_BITFIELD (ecma_op_to_boolean (writable_prop_value));
       }
 
       ECMA_FINALIZE (writable_prop_value);

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1257,9 +1257,9 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
 
   *prop_desc_p = ecma_make_empty_property_descriptor ();
 
-  prop_desc_p->is_enumerable = ecma_is_property_enumerable (property);
+  prop_desc_p->is_enumerable = ECMA_BOOL_TO_BITFIELD (ecma_is_property_enumerable (property));
   prop_desc_p->is_enumerable_defined = true;
-  prop_desc_p->is_configurable = ecma_is_property_configurable (property);
+  prop_desc_p->is_configurable = ECMA_BOOL_TO_BITFIELD (ecma_is_property_configurable (property));
   prop_desc_p->is_configurable_defined = true;
 
   ecma_property_types_t type = ECMA_PROPERTY_GET_TYPE (property);
@@ -1277,7 +1277,7 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
     }
 
     prop_desc_p->is_value_defined = true;
-    prop_desc_p->is_writable = ecma_is_property_writable (property);
+    prop_desc_p->is_writable = ECMA_BOOL_TO_BITFIELD (ecma_is_property_writable (property));
     prop_desc_p->is_writable_defined = true;
   }
   else

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2035,7 +2035,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
                                           current_flags);
   ecma_deref_ecma_string (pattern_str_p);
 
-  bool is_throw = ECMA_IS_VALUE_ERROR (completion_value);
+  bool is_throw = ECMA_IS_VALUE_ERROR (completion_value) ? true : false;
 
   ecma_free_value (completion_value);
 


### PR DESCRIPTION
NuttX and artik053 build - compiling with strict Werror=conversion - fail when jerry-debugger option is enabled.
This patch based on #2007, because most of them are fixed earlier within that PR, but it was closed before the land.

Credit: Piotr Marcinkiewicz p.marcinkiew@samsung.com

JerryScript-DCO-1.0-Signed-off-by: Robert Sipka rsipka.uszeged@partner.samsung.com