### PR TITLE
Move sleep calls to a port function

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -112,6 +112,22 @@ Allow user to provide external buffer for jerry instance (which includes an isol
 struct jerry_instance_t *jerry_port_get_current_instance (void);
 ```
 
+## Sleep
+
+Internally JerryScript uses a sleep function for the debugger (if enabled).
+This sleep function is used to wait for debugger client input data.
+
+```c
+/**
+ * Delay for the specified number of milliseconds.
+ *
+ *Note:
+ *   This port function us currently used only when the debugger framework is enabled.
+ *   Otherwise this function is not used.
+ */
+void jerry_port_sleep_ms (uint32_t msec);
+```
+
 # How to port JerryScript
 
 This section describes a basic port implementation which was created for Unix based systems.
@@ -230,4 +246,21 @@ jerry_port_get_current_instance (void)
 {
   return current_instance_p;
 } /* jerry_port_get_current_instance */
+```
+
+## Sleep
+
+If a system does not have any sleep functionality
+the port implementation could also be left empty.
+
+```c
+#include <unistd.h>
+
+/**
+ * Delay for the specified number of milliseconds.
+ */
+void jerry_port_sleep_ms (uint32_t msec)
+{
+  usleep (msec * 1000);
+}
 ```

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -183,16 +183,6 @@ if(FEATURE_DEBUGGER)
     message(FATAL_ERROR "This configuration is not supported. Please build against your system libc to enable the JerryScript debugger.")
   endif()
 
-  # Sleep function availability check
-  INCLUDE (CheckIncludeFiles)
-  CHECK_INCLUDE_FILES (time.h HAVE_TIME_H)
-  CHECK_INCLUDE_FILES (unistd.h HAVE_UNISTD_H)
-  if(HAVE_TIME_H)
-    set(DEFINES_JERRY ${DEFINES_JERRY} HAVE_TIME_H)
-  elseif(HAVE_UNISTD_H)
-    set(DEFINES_JERRY ${DEFINES_JERRY} HAVE_UNISTD_H)
-  endif()
-
   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_DEBUGGER)
 endif()
 

--- a/jerry-core/api/jerry-debugger.c
+++ b/jerry-core/api/jerry-debugger.c
@@ -175,7 +175,7 @@ jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t
         }
       }
 
-      jerry_debugger_sleep ();
+      jerry_port_sleep_ms (JERRY_DEBUGGER_TIMEOUT);
     }
 
     JERRY_ASSERT (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CLIENT_SOURCE_MODE)

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -338,8 +338,6 @@ typedef struct
 
 void jerry_debugger_free_unreferenced_byte_code (void);
 
-void jerry_debugger_sleep (void);
-
 bool jerry_debugger_process_message (uint8_t *recv_buffer_p, uint32_t message_size,
                                      bool *resume_exec_p, uint8_t *expected_message_p,
                                      jerry_debugger_uint8_data_t **message_data_p);

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -139,6 +139,15 @@ double jerry_port_get_current_time (void);
 struct jerry_instance_t *jerry_port_get_current_instance (void);
 
 /**
+ * Delay for the specified number of milliseconds.
+ *
+ *Note:
+ *   This port function us currently used only when the debugger framework is enabled.
+ *   Otherwise this function is not used.
+ */
+void jerry_port_sleep_ms (uint32_t msec);
+
+/**
  * @}
  */
 

--- a/jerry-port/default/CMakeLists.txt
+++ b/jerry-port/default/CMakeLists.txt
@@ -26,6 +26,16 @@ file(GLOB SOURCE_PORT_DEFAULT *.c)
 # (should only be necessary if we used compiler default libc but not checking that)
 set(DEFINES_PORT_DEFAULT _BSD_SOURCE _DEFAULT_SOURCE)
 
+# Sleep function availability check
+INCLUDE (CheckIncludeFiles)
+CHECK_INCLUDE_FILES (time.h HAVE_TIME_H)
+CHECK_INCLUDE_FILES (unistd.h HAVE_UNISTD_H)
+if(HAVE_TIME_H)
+  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_TIME_H)
+elseif(HAVE_UNISTD_H)
+  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_UNISTD_H)
+endif()
+
 # Default Jerry port implementation library variants:
 #   - default
 #   - default-minimal (no extra termination and log APIs)

--- a/jerry-port/default/default-sleep.c
+++ b/jerry-port/default/default-sleep.c
@@ -1,0 +1,43 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define _XOPEN_SOURCE 500 /* Required macro for sleep functions */
+
+#if defined (HAVE_TIME_H)
+#include <time.h>
+#elif defined (HAVE_UNISTD_H)
+#include <unistd.h>
+#endif
+
+#include "jerryscript-port.h"
+
+/**
+ * Default implementation of 'jerry_port_sleep_ms'.
+ * Uses nanosleep (if time.h is available) or usleep (unistd.h)
+ */
+void
+jerry_port_sleep_ms (uint32_t msecs)
+{
+#if defined (HAVE_TIME_H)
+  const struct timespec wait =
+  {
+    msecs / 1000,   /* seconds */
+    (msecs % 1000) * 1000000L /* nanoseconds */
+  };
+  nanosleep (&wait, NULL);
+#elif defined (HAVE_UNISTD_H)
+  usleep ((useconds_t) msecs * 1000);
+#endif
+} /* jerry_port_sleep_ms */

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
@@ -566,6 +567,15 @@ jerry_port_get_current_time (void)
 {
   return 0;
 } /* jerry_port_get_current_time */
+
+/**
+ * Delay for the specified number of milliseconds.
+ */
+void
+jerry_port_sleep_ms (uint32_t msecs)
+{
+  usleep (msecs * 1000);
+} /* jerry_port_sleep_ms */
 
 /**
  * Provide the implementation of jerryx_port_handler_print_char.

--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
@@ -17,6 +17,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <tinyara/fs/fs_utils.h>
+#include <unistd.h>
 
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
@@ -522,6 +523,15 @@ jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
 
   return true;
 } /* jerry_port_get_time_zone */
+
+/**
+ * Delay for the specified number of milliseconds.
+ */
+void
+jerry_port_sleep_ms (uint32_t msecs)
+{
+  usleep (msecs * 1000);
+} /* jerry_port_sleep_ms */
 
 /**
  * Dummy function to get the current time.


### PR DESCRIPTION
Usage of nanosleep or usleep in the debugger parts
is a platform dependent information.

Created a jerry_port_sleep_ms function to allow
port specific sleep calls.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com