### PR TITLE
Fix clearing of error reference

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1403,17 +1403,14 @@ ecma_clear_error_reference (ecma_value_t value)
 
   JERRY_ASSERT (error_ref_p->refs > 0);
 
-  ecma_value_t referenced_value = error_ref_p->value;
-
   if (error_ref_p->refs > 1)
   {
     error_ref_p->refs--;
-  }
-  else
-  {
-    jmem_pools_free (error_ref_p, sizeof (ecma_error_reference_t));
+    return ecma_copy_value (error_ref_p->value);
   }
 
+  ecma_value_t referenced_value = error_ref_p->value;
+  jmem_pools_free (error_ref_p, sizeof (ecma_error_reference_t));
   return referenced_value;
 } /* ecma_clear_error_reference */
 

--- a/tests/unit-core/test-api-set-and-clear-error-flag.c
+++ b/tests/unit-core/test-api-set-and-clear-error-flag.c
@@ -1,0 +1,36 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "test-common.h"
+
+int
+main (void)
+{
+  TEST_INIT ();
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t obj_val = jerry_create_object ();
+  jerry_value_set_error_flag (&obj_val);
+  jerry_value_t err_val = jerry_acquire_value (obj_val);
+
+  jerry_value_clear_error_flag (&obj_val);
+  jerry_release_value (obj_val);
+
+  jerry_release_value (err_val);
+
+  jerry_cleanup ();
+} /* main */


### PR DESCRIPTION
'ecma_clear_error_reference' must increase the reference of the returned
ecma value referenced by the error if there are more than one reference.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com