### PR TITLE
Move _XOPEN_SOURCE macro to a more generic place

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-#define _XOPEN_SOURCE 500 /* Required macro for sleep functions */
-
 #include "byte-code.h"
 #include "debugger.h"
 #include "ecma-builtin-helpers.h"

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -16,6 +16,9 @@
 #ifndef JRT_H
 #define JRT_H
 
+/* Required macro for sleep functions (nanosleep or usleep) */
+#define _XOPEN_SOURCE 500
+
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
Building with all-in-one and enabled debugger caused
errors as the sleep functions were not defined.

By moving the _XOPEN_SOURCE macro to a generic place
we make sure that the required sleep functions are
present in every case.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com