### PR TITLE
Fix the mbed Travis build

### DIFF
--- a/targets/mbed/Makefile.travis
+++ b/targets/mbed/Makefile.travis
@@ -27,6 +27,8 @@ install-apt-get-deps:
 
 # Install yotta
 install-yotta:
+	pyenv global 2.7.13 # force the python version to a newer one
+	pip install --user "pyOpenSSL<17.5" # fix for failures with pyOpenSSL 17.5
 	pip install --user yotta
 
 # Perform all the necessary (JerryScript-independent) installation steps.


### PR DESCRIPTION
On Travis the Python (by default) is a bit old
and causes problems when the yotta is being used.

Switching to Python 2.7.13 solves half of the problem.

The other problem is the pyOpenSSL 17.5 and Linux
library incompatibilities. Thus we force the pyOpenSSL
to a pre-17.5 version.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com