### PR TITLE
Bugfix: add missing stdlib.h include for rand() usage in ecma-builtin-math.c

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -14,6 +14,7 @@
  */
 
 #include <math.h>
+#include <stdlib.h>
 
 #include "ecma-alloc.h"
 #include "ecma-builtins.h"


### PR DESCRIPTION
`rand ()` is being used in `ecma-builtin-math.c`, but the `stdlib.h` header is not being included.