### PR TITLE
Add extern "C" to module.h

### DIFF
--- a/jerry-ext/include/jerryscript-ext/module.h
+++ b/jerry-ext/include/jerryscript-ext/module.h
@@ -18,6 +18,11 @@
 
 #include "jerryscript.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
 /**
  * Declare the signature for the module initialization function.
  */
@@ -129,4 +134,7 @@ jerry_value_t jerryx_module_resolve (const jerry_value_t name,
                                      const jerryx_module_resolver_t **resolvers,
                                      size_t count);
 
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
 #endif /* !JERRYX_MODULE_H */


### PR DESCRIPTION
After a couple of hours hair pulling, I discovered this header file does not wrap definitions in `extern "c" {}` like others in the library :) 