### PR TITLE
Modify the build method of NuttX target.

### DIFF
--- a/targets/nuttx-stm32f4/Kconfig
+++ b/targets/nuttx-stm32f4/Kconfig
@@ -27,23 +27,4 @@ config JERRYSCRIPT_STACKSIZE
 	int "Jerryscript stack size"
 	default 16384
 
-config JERRYSCRIPT_HEAPSIZE
-	int "Jerryscript heap size"
-	default 107520
-
-config JERRYSCRIPT_ERROR_MESSAGES
-	bool "Enable error messages for builtin error objects"
-	default n
-
-config JERRYSCRIPT_MEM_STATS
-	bool "Enable memory statistics"
-	default n
-
-config JERRYSCRIPT_SHOW_OPCODES
-	bool "Enable parser byte-code dumps"
-	default n
-
-config JERRYSCRIPT_DEBUGGER
-	bool "Jerryscript debugger"
-	default n
-endif
+endif # JERRYSCRIPT

--- a/targets/nuttx-stm32f4/Makefile
+++ b/targets/nuttx-stm32f4/Makefile
@@ -14,58 +14,48 @@
 
 -include $(TOPDIR)/Make.defs
 
-# Jerryscript built-in application info
-
+# Jerryscript built-in application information.
 CONFIG_JERRYSCRIPT_PRIORITY ?= SCHED_PRIORITY_DEFAULT
+CONFIG_JERRYSCRIPT_PROGNAME ?= jerry$(EXEEXT)
 CONFIG_JERRYSCRIPT_STACKSIZE ?= 16384
-CONFIG_JERRYSCRIPT_HEAPSIZE ?= 107520
 
-APPNAME = jerry
-# path to the project dir, "jerry-nuttx" by default
-ROOT_DIR = ../../..
+PROGNAME = $(CONFIG_JERRYSCRIPT_PROGNAME)
 PRIORITY = $(CONFIG_JERRYSCRIPT_PRIORITY)
 STACKSIZE = $(CONFIG_JERRYSCRIPT_STACKSIZE)
-CFLAGS += -std=c99 -DJERRY_NDEBUG '-DCONFIG_MEM_HEAP_AREA_SIZE=$(CONFIG_JERRYSCRIPT_HEAPSIZE)'
-CFLAGS += -I$(ROOT_DIR)/ $(shell find $(ROOT_DIR)/jerryscript/jerry-core -type d | sed -r -e 's/^/-I/g')
-CFLAGS += -I$(ROOT_DIR)/jerryscript/jerry-libm/include
-CFLAGS += -I$(ROOT_DIR)/jerryscript/jerry-ext/include
 
-# Fill error messages for builtin error objects
-ifeq ($(CONFIG_JERRYSCRIPT_ERROR_MESSAGES),y)
-	CFLAGS += -DJERRY_ENABLE_ERROR_MESSAGES
-endif
+# Path to the JerryScript project. If not specified, it is supposed
+# that JerryScript is located next to the nuttx-apps folder.
+JERRYSCRIPT_ROOT_DIR ?= ../../../jerryscript
 
-ifeq ($(CONFIG_JERRYSCRIPT_MEM_STATS),y)
-	CFLAGS += -DJMEM_STATS
-endif
+CFLAGS += -std=c99
+CFLAGS += -I$(JERRYSCRIPT_ROOT_DIR)/jerry-core/include
+CFLAGS += -I$(JERRYSCRIPT_ROOT_DIR)/jerry-ext/include
+CFLAGS += -I$(JERRYSCRIPT_ROOT_DIR)/jerry-libm/include
 
-ifeq ($(CONFIG_JERRYSCRIPT_SHOW_OPCODES),y)
-	CFLAGS += -DPARSER_DUMP_BYTE_CODE
-endif
+# These libs should be copied from the JerryScript project.
+LIBS = libjerry-core.a libjerry-ext.a libjerry-port-default.a libjerry-port-default-minimal.a libjerry-libm.a
 
-ifeq ($(CONFIG_JERRYSCRIPT_DEBUGGER),y)
-	CFLAGS += -DJERRY_DEBUGGER
-endif
-
-# Jerryscript
-
-.PHONY: jerry_core_allin.c
-jerry_core_allin.c:
-	find $(ROOT_DIR)/jerryscript/jerry-core -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' > jerry_core_allin.c
-
-.PHONY: jerry_libm_allin.c
-jerry_libm_allin.c:
-	find $(ROOT_DIR)/jerryscript/jerry-libm -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' > jerry_libm_allin.c
-
-.PHONY: jerry_ext_allin.c
-jerry_ext_allin.c:
-	find $(ROOT_DIR)/jerryscript/jerry-ext/handler -name "*.c" | sed -r -e 's/(\.\.\/)*(.+)/#include "\2"/g' > jerry_ext_allin.c
-
+APPNAME = jerry
 ASRCS = setjmp.S
-CSRCS = jerry_core_allin.c jerry_libm_allin.c jerry_ext_allin.c
 MAINSRC = jerry_main.c
 
-CONFIG_JERRYSCRIPT_PROGNAME ?= jerry$(EXEEXT)
-PROGNAME = $(CONFIG_JERRYSCRIPT_PROGNAME)
+.PHONY: copylibs
+copylibs:
+	cp $(JERRYSCRIPT_ROOT_DIR)/build/lib/lib*.a .
+
+$(LIBS): copylibs
+	$(firstword $(AR)) x $@
+
+.PHONY: updateobjs
+updateobjs:
+	$(eval OBJS += $(shell find . -name "*.obj"))
+
+.PHONY: cleanlibs
+cleanlibs: updateobjs
+	rm -f $(OBJS)
+
+clean: cleanlibs
+
+.built: $(LIBS) updateobjs
 
 include $(APPDIR)/Application.mk

--- a/targets/nuttx-stm32f4/Makefile.travis
+++ b/targets/nuttx-stm32f4/Makefile.travis
@@ -46,6 +46,10 @@ install: install-apt-get-deps install-kconfig install-clone-nuttx
 
 ## Targets for building NuttX with JerryScript.
 
+# Build JerryScript.
+script-build-jerryscript:
+	tools/build.py --clean --toolchain cmake/toolchain_mcu_stm32f4.cmake --profile=es2015-subset --jerry-cmdline OFF --jerry-libc OFF --lto OFF --jerry-libm ON --all-in-one ON --mem-heap 70 --compile-flag='--sysroot=../nuttx'
+
 # Link in the NuttX JerryScript target directory under the NuttX apps tree.
 script-add-jerryscript-app:
 	ln -s ../../jerryscript/targets/nuttx-stm32f4 ../apps/interpreters/jerryscript
@@ -55,7 +59,7 @@ script-configure-usbnsh:
 	cd ../nuttx/tools && PATH=$(LOCAL_INSTALL)/bin:$$PATH ./configure.sh stm32f4discovery/usbnsh
 
 # Configure and build the firmware (NuttX with JerryScript).
-script: script-add-jerryscript-app script-configure-usbnsh
+script: script-build-jerryscript script-add-jerryscript-app script-configure-usbnsh
 	echo 'CONFIG_HOST_LINUX=y' >> ../nuttx/.config
 	echo 'CONFIG_ARCH_FPU=y' >> ../nuttx/.config
 	echo 'CONFIG_JERRYSCRIPT=y'>> ../nuttx/.config

--- a/targets/nuttx-stm32f4/README.md
+++ b/targets/nuttx-stm32f4/README.md
@@ -5,20 +5,21 @@ This folder contains files to run JerryScript on
 
 ### How to build
 
-#### 1. Setting up the build environment for STM32F4-Discovery board
+#### 1. Setup the build environment for STM32F4-Discovery board
 
-Clone JerryScript and NuttX into jerry-nuttx directory
+Clone the necessary projects into a `jerry-nuttx` directory. The last tested working version of NuttX is 7.22.
 
-```
-mkdir jerry-nuttx
-cd jerry-nuttx
+```sh
+# Create a base folder for all the projects.
+mkdir jerry-nuttx && cd jerry-nuttx
+
 git clone https://github.com/jerryscript-project/jerryscript.git
-git clone https://bitbucket.org/nuttx/nuttx.git
-git clone https://bitbucket.org/nuttx/apps.git
+git clone https://bitbucket.org/nuttx/nuttx.git -b nuttx-7.22
+git clone https://bitbucket.org/nuttx/apps.git -b nuttx-7.22
 git clone https://github.com/texane/stlink.git
 ```
 
-The following directory structure is created after these commands
+The following directory structure is created after these commands:
 
 ```
 jerry-nuttx
@@ -30,66 +31,123 @@ jerry-nuttx
   + stlink
 ```
 
-#### 2. Adding JerryScript as an interpreter for NuttX
+#### 2. Build JerryScript for NuttX
 
-```
-cd apps/interpreters
-mkdir jerryscript
-cp ../../jerryscript/targets/nuttx-stm32f4/* ./jerryscript/
+Build JerryScript as a static library using the NuttX folder as sysroot. The created static libraries will be used later by NuttX.
+
+```sh
+# Assuming you are in jerry-nuttx folder.
+jerryscript/tools/build.py \
+    --clean \
+    --lto=OFF \
+    --jerry-cmdline=OFF \
+    --jerry-libc=OFF \
+    --jerry-libm=ON \
+    --all-in-one=ON \
+    --mem-heap=70 \
+    --profile=es2015-subset \
+    --compile-flag="--sysroot=${PWD}/nuttx" \
+    --toolchain=${PWD}/jerryscript/cmake/toolchain_mcu_stm32f4.cmake
 ```
 
-#### 3. Configure NuttX
+#### 3. Copy JerryScript's application files to NuttX
 
+After creating the static libs (see previous step), it is needed to move the JerryScript application files to the NuttX's interpreter path.
+
+```sh
+# Assuming you are in jerry-nuttx folder.
+mkdir -p apps/interpreters/jerryscript
+cp jerryscript/targets/nuttx-stm32f4/* apps/interpreters/jerryscript/
+
+# Or more simply:
+# ln -s jerryscript/targets/nuttx-stm32f4 apps/interpreters/jerryscript
 ```
-# assuming you are in jerry-nuttx folder
+
+#### 4. Configure NuttX
+
+NuttX requires configuration first. The configuration creates a `.config` file in the root folder of NuttX that has all the necessary options for the build.
+
+```sh
+# Assuming you are in jerry-nuttx folder.
 cd nuttx/tools
 
-# configure NuttX USB console shell
+# Configure NuttX to use USB console shell.
 ./configure.sh stm32f4discovery/usbnsh
-
-cd ..
-# might require to run "make menuconfig" twice
-make menuconfig
 ```
 
-We must set the following options:
+By default, JerryScript is not enabled, so it is needed to modify the configuration file.
 
-* Change `Build Setup -> Build Host Platform` from _Windows_ to _Linux_
-* Enable `System Type -> FPU support`
-* Enable `Application Configuration -> Interpreters -> JerryScript`
+##### 4.1 Enable JerryScript without user interaction
 
-If you get `kconfig-mconf: not found` error when you run `make menuconfig` you may have to install kconfig-frontends:
+```sh
+# Assuming you are in jerry-nuttx folder.
+sed --in-place "s/CONFIG_HOST_WINDOWS/# CONFIG_HOST_WINDOWS/g" nuttx/.config
+sed --in-place "s/CONFIG_WINDOWS_CYGWIN/# CONFIG_WINDOWS_CYGWIN/g" nuttx/.config
+sed --in-place "s/CONFIG_TOOLCHAIN_WINDOWS/# CONFIG_TOOLCHAIN_WINDOWS/g" nuttx/.config
 
+cat >> nuttx/.config << EOL
+CONFIG_HOST_LINUX=y
+CONFIG_ARCH_FPU=y
+CONFIG_JERRYSCRIPT=y
+CONFIG_JERRYSCRIPT_PRIORITY=100
+CONFIG_JERRYSCRIPT_STACKSIZE=16384
+EOL
 ```
-# assume you are in jerry-nuttx folder
-sudo apt-get install gperf flex bison libncurses-dev
-git clone https://github.com/jameswalmsley/kconfig-frontends.git
-cd kconfig-frontends
-./bootstrap
-./configure --enable-mconf
+
+##### 4.2 Enable JerryScript using kconfig-frontend
+
+`kconfig-frontend` could be useful if there are another options that should be enabled or disabled in NuttX.
+
+###### 4.2.1 Install kconfig-frontend
+
+```sh
+# Assuming you are in jerry-nuttx folder.
+git clone https://bitbucket.org/nuttx/tools.git nuttx-tools
+cd nuttx-tools/kconfig-frontends
+
+./configure \
+    --disable-nconf \
+    --disable-gconf \
+    --disable-qconf \
+    --disable-utils \
+    --disable-shared \
+    --enable-static \
+    --prefix=${PWD}/install
+
 make
 sudo make install
-sudo ldconfig
+
+# Add the install folder to PATH
+PATH=$PATH:${PWD}/install/bin
 ```
 
-#### 4. Build JerryScript for NuttX
-
+###### 4.2.2 Enable JerryScript
+```sh
+# Assuming you are in jerry-nuttx folder.
+# Might be required to run `make menuconfig` twice.
+make -C nuttx menuconfig
 ```
-# assuming you are in jerry-nuttx folder
-cd nuttx/
-make
+
+* Change `Build Setup -> Build Host Platform` to Linux
+* Enable `System Type -> FPU support`
+* Enable JerryScript `Application Configuration -> Interpreters -> JerryScript`
+
+#### 5. Build NuttX
+
+```sh
+# Assuming you are in jerry-nuttx folder.
+make -C nuttx
 ```
 
-#### 5. Flashing
+#### 6. Flash the device
 
 Connect Mini-USB for power supply and connect Micro-USB for `NSH` console.
 
-To configure `stlink` utility for flashing, follow the instructions in the official [Stlink repository](https://github.com/texane/stlink).
+```sh
+# Assuming you are in jerry-nuttx folder.
+make -C stlink release
 
-To flash,
-```
-# assuming you are in nuttx folder
-sudo ../stlink/build/Release/st-flash write nuttx.bin 0x8000000
+sudo stlink/build/Release/st-flash write nuttx/nuttx.bin 0x8000000
 ```
 
 ### Running JerryScript
@@ -97,7 +155,7 @@ sudo ../stlink/build/Release/st-flash write nuttx.bin 0x8000000
 You can use `minicom` for terminal program, or any other you may like, but set
 baud rate to `115200`.
 
-```
+```sh
 sudo minicom --device=/dev/ttyACM0 --baud=115200
 ```
 

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -20,7 +20,6 @@
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
 #include "jerryscript-port.h"
-#include "jmem.h"
 #include "setjmp.h"
 
 /**
@@ -94,7 +93,7 @@ read_file (const char *file_name, /**< source code */
 
   rewind (file);
 
-  uint8_t *buffer = jmem_heap_alloc_block_null_on_error (script_len);
+  uint8_t *buffer = (uint8_t *) malloc (script_len);
 
   if (buffer == NULL)
   {
@@ -108,7 +107,7 @@ read_file (const char *file_name, /**< source code */
   if (!bytes_read || bytes_read != script_len)
   {
     jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: failed to read file: %s\n", file_name);
-    jmem_heap_free_block ((void*) buffer, script_len);
+    free ((void*) buffer);
 
     fclose (file);
     return NULL;
@@ -482,12 +481,12 @@ int jerry_main (int argc, char *argv[])
       if (jerry_value_has_error_flag (ret_value))
       {
         print_unhandled_exception (ret_value, source_p);
-        jmem_heap_free_block ((void*) source_p, source_size);
+        free ((void*) source_p);
 
         break;
       }
 
-      jmem_heap_free_block ((void*) source_p, source_size);
+      free ((void*) source_p);
 
       jerry_release_value (ret_value);
       ret_value = jerry_create_undefined ();


### PR DESCRIPTION
Currently, NuttX compiles the whole JerryScript (with the target app) by the targets/nuttx-stm32f4/Makefile. I think, this is not the best because there are many compile/feature-options (in build.py) that are not supported neither in Makefile nor in KConfig.

This development helps to build JerryScript separately from NuttX. In this case it's simple enough just build the target app (targets/nuttx-stm32f4/jerry-main.c) by NuttX and use the JerryScript's static libraries.

The compile/feature-options maintenance could be better because it doesn't need to duplicate them in the Makefile and in the KConfig files.