### PR TITLE
Fix random number generation on ESP8266

### DIFF
--- a/targets/esp8266/js/main.js
+++ b/targets/esp8266/js/main.js
@@ -1,4 +1,5 @@
 function sysloop(ticknow) {
   blink();
 };
+print("Random generated number: ", Math.random());
 print("main js OK");

--- a/targets/esp8266/ld/eagle.app.v6.ld
+++ b/targets/esp8266/ld/eagle.app.v6.ld
@@ -26,7 +26,7 @@ MEMORY
   dport0_0_seg :                      	org = 0x3FF00000, len = 0x10
   dram0_0_seg :                       	org = 0x3FFE8000, len = 0x18000
   iram1_0_seg :                       	org = 0x40100000, len = 0x8000
-  irom0_0_seg :                       	org = 0x40220000, len = 0x6C000
+  irom0_0_seg :                       	org = 0x40220000, len = 0x7C000
 }
 
 INCLUDE ../ld/eagle.app.v6.common.ld

--- a/targets/esp8266/user/jerry_extapi.c
+++ b/targets/esp8266/user/jerry_extapi.c
@@ -73,9 +73,20 @@ DELCARE_HANDLER(print) {
         printf("%s ", buffer);
         free (buffer);
       }
-      else
+      else if (jerry_value_is_number (args_p[cc]))
       {
-        printf ("(%d) ", args_p[cc]);
+        double number = jerry_get_number_value (args_p[cc]);
+        if ((int) number == number)
+        {
+          printf ("%d", (int) number);
+        }
+        else
+        {
+          char buff[50];
+          sprintf(buff, "%.10f", number);
+          printf("%s", buff);
+        }
+
       }
     }
     printf ("\r\n");

--- a/targets/esp8266/user/jerry_port.c
+++ b/targets/esp8266/user/jerry_port.c
@@ -56,14 +56,8 @@ jerry_port_fatal (jerry_fatal_code_t code)
 double
 jerry_port_get_current_time (void)
 {
-  struct timeval tv;
-
-  if (gettimeofday (&tv, NULL) != 0)
-  {
-    return 0;
-  }
-
-  return ((double) tv.tv_sec) * 1000.0 + ((double) tv.tv_usec) / 1000.0;
+  uint32_t rtc_time = system_rtc_clock_cali_proc();
+  return (double) rtc_time;
 } /* jerry_port_get_current_time */
 
 /**


### PR DESCRIPTION
This patch uses the onboard RTC for generating random seed. It also improves the print handler to support float values.
The rom segment is slightly increased to fit to the latest master.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu