### PR TITLE
Modify the build method of TizenRT target

### DIFF
--- a/cmake/toolchain_mcu_artik053.cmake
+++ b/cmake/toolchain_mcu_artik053.cmake
@@ -12,27 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-JERRYHEAP	?= 16
-BUILD_DIR	?= build
+set(CMAKE_SYSTEM_NAME TizenRT)
+set(CMAKE_SYSTEM_PROCESSOR armv7l)
+set(CMAKE_SYSTEM_VERSION ARTIK053)
 
-EXT_CFLAGS += -I. -isystem ../TizenRT/os/include
+set(FLAGS_COMMON_ARCH -mcpu=cortex-r4 -mfpu=vfpv3 -fno-builtin -fno-strict-aliasing -fomit-frame-pointer -fno-strength-reduce -Wall -Werror -Wshadow -Wno-error=conversion)
 
-.PHONY: libjerry clean
-
-all: libjerry
-
-libjerry:
-	cmake -B$(BUILD_DIR) -H./ \
-	 -DENABLE_LTO=OFF \
-	 -DENABLE_ALL_IN_ONE=OFF \
-	 -DJERRY_LIBC=OFF \
-	 -DJERRY_CMDLINE=OFF \
-	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
-	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP) \
-	 -DCMAKE_BUILD_TYPE=Release \
-	 -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain_mcu_artik053.cmake
-
-	make -C$(BUILD_DIR) jerry-core jerry-libm jerry-ext
-
-clean:
-	rm -rf $(BUILD_DIR)
+set(CMAKE_C_COMPILER arm-none-eabi-gcc)
+set(CMAKE_C_COMPILER_WORKS TRUE)

--- a/targets/tizenrt-artik053/README.md
+++ b/targets/tizenrt-artik053/README.md
@@ -83,6 +83,22 @@ $ mkdir res
 
 ```
 # assuming you are in jerry-tizenrt folder
+jerryscript/tools/build.py \
+    --clean \
+    --lto=OFF \
+    --jerry-cmdline=OFF \
+    --jerry-libc=OFF \
+    --all-in-one=OFF \
+    --mem-heap=70 \
+    --profile=es2015-subset \
+    --compile-flag="--sysroot=${PWD}/TizenRT/os" \
+    --toolchain=${PWD}/jerryscript/cmake/toolchain_mcu_artik053.cmake
+```
+
+**Note**: there is a Makefile in the `targets/tizenrt-artik053/` folder that also helps to build JerryScript for TizenRT.
+
+```
+# assuming you are in jerry-tizenrt folder
 $ cd jerryscript
 $ make -f targets/tizenrt-artik053/Makefile.tizenrt
 ```

--- a/targets/tizenrt-artik053/apps/jerryscript/Kconfig
+++ b/targets/tizenrt-artik053/apps/jerryscript/Kconfig
@@ -27,23 +27,4 @@ config JERRYSCRIPT_STACKSIZE
 	int "Jerryscript stack size"
 	default 16384
 
-config JERRYSCRIPT_HEAPSIZE
-	int "Jerryscript heap size"
-	default 107520
-
-config JERRYSCRIPT_ERROR_MESSAGES
-	bool "Enable error messages for builtin error objects"
-	default n
-
-config JERRYSCRIPT_MEM_STATS
-	bool "Enable memory statistics"
-	default n
-
-config JERRYSCRIPT_SHOW_OPCODES
-	bool "Enable parser byte-code dumps"
-	default n
-
-config JERRYSCRIPT_DEBUGGER
-	bool "Jerryscript debugger"
-	default n
-endif
+endif # JERRYSCRIPT

--- a/targets/tizenrt-artik053/apps/jerryscript/Makefile
+++ b/targets/tizenrt-artik053/apps/jerryscript/Makefile
@@ -67,40 +67,28 @@
 -include $(TOPDIR)/Make.defs
 include $(APPDIR)/Make.defs
 
-# Jerryscript built-in application info
-
+# JerryScript built-in application information.
 CONFIG_JERRYSCRIPT_PRIORITY ?= SCHED_PRIORITY_DEFAULT
+CONFIG_JERRYSCRIPT_PROGNAME ?= jerry$(EXEEXT)
 CONFIG_JERRYSCRIPT_STACKSIZE ?= 32768
-CONFIG_JERRYSCRIPT_HEAPSIZE ?= 64000
 
-APPNAME = jerry
-# path to the project dir, "tizenrt-artik053" by default
-ROOT_DIR = ../../../..
 PRIORITY = $(CONFIG_JERRYSCRIPT_PRIORITY)
+PROGNAME = $(CONFIG_JERRYSCRIPT_PROGNAME)
 STACKSIZE = $(CONFIG_JERRYSCRIPT_STACKSIZE)
-CFLAGS += -std=c99 -DJERRY_NDEBUG '-DCONFIG_MEM_HEAP_AREA_SIZE=$(CONFIG_JERRYSCRIPT_HEAPSIZE)'
-CFLAGS += -I$(ROOT_DIR)/ $(shell find $(ROOT_DIR)/jerryscript/jerry-core -type d | sed -r -e 's/^/-I/g')
-CFLAGS += -I$(ROOT_DIR)/jerryscript/jerry-ext/include
 
-ifeq ($(CONFIG_JERRYSCRIPT_MEM_STATS),y)
-	CFLAGS += -DJMEM_STATS
-endif
+# Path to the JerryScript project. If not specified, it is supposed
+# that JerryScript is located next to the TizenRT folder.
+JERRYSCRIPT_ROOT_DIR ?= ../../../../jerryscript
 
-ifeq ($(CONFIG_JERRYSCRIPT_SHOW_OPCODES),y)
-	CFLAGS += -DPARSER_DUMP_BYTE_CODE
-endif
-
-ifeq ($(CONFIG_JERRYSCRIPT_DEBUGGER),y)
-	CFLAGS += -DJERRY_DEBUGGER
-endif
-
+CFLAGS += -std=c99
+CFLAGS += -I$(JERRYSCRIPT_ROOT_DIR)/jerry-core/include
+CFLAGS += -I$(JERRYSCRIPT_ROOT_DIR)/jerry-ext/include
 
 EXTRA_LIBS += libjerry-core.a libjerry-libm.a
 LINKLIBS=$(EXTRA_LIBS)
 
-
+APPNAME = jerry
 ASRCS = setjmp.S
-CSRCS =
 MAINSRC = jerry_main.c
 
 AOBJS = $(ASRCS:.S=$(OBJEXT))
@@ -130,8 +118,6 @@ else
   INSTALL_DIR = $(BIN_DIR)
 endif
 
-CONFIG_JERRYSCRIPT_PROGNAME ?= jerry$(EXEEXT)
-PROGNAME = $(CONFIG_JERRYSCRIPT_PROGNAME)
 
 ROOTDEPPATH	= --dep-path .
 
@@ -139,8 +125,9 @@ ROOTDEPPATH	= --dep-path .
 
 VPATH		=
 
-all:	.built
-.PHONY: context depend clean distclean
+
+all:	copylibs .built
+.PHONY: copylibs context depend clean distclean
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -151,6 +138,9 @@ $(COBJS) $(MAINOBJ): %$(OBJEXT): %.c
 .built: $(OBJS)
 	$(call ARCHIVE, $(BIN), $(OBJS))
 	$(Q) touch .built
+
+copylibs:
+	cp $(JERRYSCRIPT_ROOT_DIR)/build/lib/lib*.a $(TOPDIR)/../build/output/libraries/
 
 install:
 


### PR DESCRIPTION
Introduced a cmake/toolchain_mcu_artik053.cmake file that defines all the target specific compiler options.

Modified the Makefile.tizenrt to do not copy the created static libraries to the TizenRT folder. Instead, the application builder Makefile (tizenrt-artik053/apps/jerryscript/Makefile) copies the
required static libraries to TizenRT.

This modification helps to build JerryScript with the Python based build-script. In this case the user can use more build options.

```sh
tools/build.py \
    --clean \
    --lto=OFF \
    --jerry-cmdline=OFF \
    --all-in-one=OFF \
    --jerry-libc=OFF \
    --mem-heap=70 \
    --profile=es2015-subset \
    --toolchain=${PWD}/cmake/toolchain_mcu_artik053.cmake \
    --compile-flag="--sysroot=${PWD}/../TizenRT/os"
```
