### PR TITLE
Add version fields for debugger configuration

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -31,6 +31,15 @@
 #endif /* HAVE_TIME_H */
 
 /**
+ * The number of message types in the debugger should reflect the
+ * debugger versioning.
+ */
+JERRY_STATIC_ASSERT (JERRY_DEBUGGER_MESSAGES_OUT_MAX_COUNT == 26
+                     && JERRY_DEBUGGER_MESSAGES_IN_MAX_COUNT == 16
+                     && JERRY_DEBUGGER_VERSION == 1,
+                     debugger_version_correlates_to_message_type_count);
+
+/**
  * Type cast the debugger send buffer into a specific type.
  */
 #define JERRY_DEBUGGER_SEND_BUFFER_AS(type, name_p) \
@@ -707,6 +716,7 @@ jerry_debugger_send_configuration (uint8_t max_message_size) /**< maximum messag
   configuration_p->max_message_size = max_message_size;
   configuration_p->cpointer_size = sizeof (jmem_cpointer_t);
   configuration_p->little_endian = (endian_data.uint8_value[0] == 1);
+  configuration_p->version = JERRY_DEBUGGER_VERSION;
 
   return jerry_debugger_send (sizeof (jerry_debugger_send_configuration_t));
 } /* jerry_debugger_send_configuration */

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -24,6 +24,11 @@
 /* JerryScript debugger protocol is a simplified version of RFC-6455 (WebSockets). */
 
 /**
+ * JerryScript debugger protocol version.
+ */
+#define JERRY_DEBUGGER_VERSION (1)
+
+/**
  * Frequency of calling jerry_debugger_receive() by the VM.
  */
 #define JERRY_DEBUGGER_MESSAGE_FREQUENCY 5
@@ -125,6 +130,8 @@ typedef enum
   JERRY_DEBUGGER_OUTPUT_RESULT = 24, /**< output sent by the program to the debugger */
   JERRY_DEBUGGER_OUTPUT_RESULT_END = 25, /**< last output result data */
 
+  JERRY_DEBUGGER_MESSAGES_OUT_MAX_COUNT, /**< number of different type of output messages by the debugger */
+
   /* Messages sent by the client to server. */
 
   /* The following messages are accepted in both run and breakpoint modes. */
@@ -147,6 +154,8 @@ typedef enum
   JERRY_DEBUGGER_GET_BACKTRACE = 13, /**< get backtrace */
   JERRY_DEBUGGER_EVAL = 14, /**< first message of evaluating a string */
   JERRY_DEBUGGER_EVAL_PART = 15, /**< next message of evaluating a string */
+
+  JERRY_DEBUGGER_MESSAGES_IN_MAX_COUNT, /**< number of different type of input messages */
 } jerry_debugger_header_type_t;
 
 /**
@@ -189,6 +198,7 @@ typedef struct
   uint8_t max_message_size; /**< maximum incoming message size */
   uint8_t cpointer_size; /**< size of compressed pointers */
   uint8_t little_endian; /**< little endian machine */
+  uint8_t version; /**< debugger version */
 } jerry_debugger_send_configuration_t;
 
 /**

--- a/jerry-debugger/jerry-client-ws.html
+++ b/jerry-debugger/jerry-client-ws.html
@@ -35,6 +35,9 @@ textarea {
   <div>
 </div>
 <script>
+// Expected JerryScript debugger protocol version
+var JERRY_DEBUGGER_VERSION = 1;
+
 // Messages sent by the server to client.
 var JERRY_DEBUGGER_CONFIGURATION = 1;
 var JERRY_DEBUGGER_PARSE_ERROR = 2;
@@ -136,6 +139,7 @@ function DebuggerClient(address)
   var outputResult = null;
   var exceptionData = null;
   var display = 0;
+  var version = 0;
 
   function assert(expr)
   {
@@ -783,7 +787,7 @@ function DebuggerClient(address)
     if (cpointerSize == 0)
     {
       if (message[0] != JERRY_DEBUGGER_CONFIGURATION
-          || message.byteLength != 4)
+          || message.byteLength != 5)
       {
         abortConnection("the first message must be configuration.");
       }
@@ -792,9 +796,17 @@ function DebuggerClient(address)
       cpointerSize = message[2]
       littleEndian = (message[3] != 0);
 
+      version = message[4];
+
       if (cpointerSize != 2 && cpointerSize != 4)
       {
         abortConnection("compressed pointer must be 2 or 4 byte long.");
+      }
+
+      if (version != JERRY_DEBUGGER_VERSION)
+      {
+        abortConnection("incorrect target debugger version detected: "
+                        + version + " expected: " + JERRY_DEBUGGER_VERSION);
       }
 
       config = false;


### PR DESCRIPTION
By adding version information to the debugger protocol
it is possible to report if the debugger client and server
have different expectations on debugger workings (opcodes, types, etc.).