### PR TITLE
Add support for aborts.

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1457,13 +1457,54 @@ jerry_value_has_error_flag (const jerry_value_t value);
 **See also**
 
 - [jerry_value_t](#jerry_value_t)
+- [jerry_value_has_abort_flag](#jerry_value_has_abort_flag)
+
+
+## jerry_value_has_abort_flag
+
+**Summary**
+
+Returns whether the given `jerry_value_t` has the error and abort flags set.
+
+**Prototype**
+
+```c
+bool
+jerry_value_has_abort_flag (const jerry_value_t value);
+```
+
+- `value` - api value
+- return value
+  - true, if the given `jerry_value_t` has the error and abort flags set
+  - false, otherwise
+
+**Example**
+
+```c
+{
+  jerry_value_t value;
+  ... // create or acquire value
+
+  if (jerry_value_has_abort_flag (value))
+  {
+    ...
+  }
+
+  jerry_release_value (value);
+}
+```
+
+**See also**
+
+- [jerry_value_t](#jerry_value_t)
+- [jerry_value_has_error_flag](#jerry_value_has_error_flag)
 
 
 ## jerry_value_clear_error_flag
 
 **Summary**
 
-Clear the error flag.
+Clear both the error and abort flags.
 
 **Prototype**
 
@@ -1490,6 +1531,8 @@ jerry_value_clear_error_flag (jerry_value_t *value_p);
 **See also**
 
 - [jerry_value_t](#jerry_value_t)
+- [jerry_value_set_error_flag](#jerry_value_set_error_flag)
+- [jerry_value_set_abort_flag](#jerry_value_set_abort_flag)
 
 
 ## jerry_value_set_error_flag
@@ -1523,6 +1566,43 @@ jerry_value_set_error_flag (jerry_value_t *value_p);
 **See also**
 
 - [jerry_value_t](#jerry_value_t)
+- [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
+- [jerry_value_set_abort_flag](#jerry_value_set_abort_flag)
+
+
+## jerry_value_set_abort_flag
+
+**Summary**
+
+Set both the error and abort flags.
+
+**Prototype**
+
+```c
+void
+jerry_value_set_abort_flag (jerry_value_t *value_p);
+```
+
+- `value_p` - pointer to an api value
+
+**Example**
+
+```c
+{
+  jerry_value_t value;
+  ... // create or acquire value
+
+  jerry_value_set_abort_flag (&value);
+
+  jerry_release_value (value);
+}
+```
+
+**See also**
+
+- [jerry_value_t](#jerry_value_t)
+- [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
+- [jerry_value_set_error_flag](#jerry_value_set_error_flag)
 
 
 ## jerry_get_value_without_error_flag

--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -730,7 +730,7 @@ jerry_snapshot_result_at (const uint32_t *snapshot_p, /**< snapshot */
 
   if (ECMA_IS_VALUE_ERROR (ret_val))
   {
-    return ecma_create_error_reference (JERRY_CONTEXT (error_value));
+    return ecma_create_error_reference_from_context ();
   }
 
   return ret_val;

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -902,7 +902,7 @@ ecma_free_unused_memory (jmem_free_unused_memory_severity_t severity) /**< sever
     {
       --JERRY_CONTEXT (ecma_prop_hashmap_alloc_state);
     }
-    JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc) = false;
+    JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_HIGH_SEV_GC;
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 
     /*
@@ -921,14 +921,14 @@ ecma_free_unused_memory (jmem_free_unused_memory_severity_t severity) /**< sever
     JERRY_ASSERT (severity == JMEM_FREE_UNUSED_MEMORY_SEVERITY_HIGH);
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
-    if (JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc))
+    if (JERRY_CONTEXT (status_flags) & ECMA_STATUS_HIGH_SEV_GC)
     {
       JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) = ECMA_PROP_HASHMAP_ALLOC_MAX;
     }
     else if (JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) < ECMA_PROP_HASHMAP_ALLOC_MAX)
     {
       ++JERRY_CONTEXT (ecma_prop_hashmap_alloc_state);
-      JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc) = true;
+      JERRY_CONTEXT (status_flags) |= ECMA_STATUS_HIGH_SEV_GC;
     }
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -65,6 +65,19 @@ typedef enum
 } ecma_init_flag_t;
 
 /**
+ * JerryScript status flags.
+ */
+typedef enum
+{
+  ECMA_STATUS_API_AVAILABLE     = (1u << 0), /**< api available */
+  ECMA_STATUS_DIRECT_EVAL       = (1u << 1), /**< eval is called directly */
+#ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+  ECMA_STATUS_HIGH_SEV_GC       = (1u << 2), /**< last gc run was a high severity run */
+#endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
+  ECMA_STATUS_EXCEPTION         = (1u << 3), /**< last exception is a normal exception */
+} ecma_status_flag_t;
+
+/**
  * Type of ecma value
  */
 typedef enum
@@ -1162,11 +1175,26 @@ typedef struct
 } ecma_long_string_t;
 
 /**
+ * Abort flag for error reference.
+ */
+#define ECMA_ERROR_REF_ABORT 0x1
+
+/**
+ * Value for increasing or decreasing the reference counter.
+ */
+#define ECMA_ERROR_REF_ONE (1u << 1)
+
+/**
+ * Maximum value of the reference counter.
+ */
+#define ECMA_ERROR_MAX_REF (UINT32_MAX - 1u)
+
+/**
  * Representation of a thrown value on API level.
  */
 typedef struct
 {
-  uint32_t refs; /**< reference counter */
+  uint32_t refs_and_flags; /**< reference counter */
   ecma_value_t value; /**< referenced value */
 } ecma_error_reference_t;
 

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -352,11 +352,12 @@ void ecma_set_property_lcached (ecma_property_t *property_p, bool is_lcached);
 ecma_property_descriptor_t ecma_make_empty_property_descriptor (void);
 void ecma_free_property_descriptor (ecma_property_descriptor_t *prop_desc_p);
 
-ecma_value_t ecma_create_error_reference (ecma_value_t value);
+ecma_value_t ecma_create_error_reference (ecma_value_t value, bool is_exception);
+ecma_value_t ecma_create_error_reference_from_context (void);
 ecma_value_t ecma_create_error_object_reference (ecma_object_t *object_p);
 void ecma_ref_error_reference (ecma_error_reference_t *error_ref_p);
 void ecma_deref_error_reference (ecma_error_reference_t *error_ref_p);
-ecma_value_t ecma_clear_error_reference (ecma_value_t value);
+ecma_value_t ecma_clear_error_reference (ecma_value_t value, bool set_abort_flag);
 
 void ecma_bytecode_ref (ecma_compiled_code_t *bytecode_p);
 void ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p);

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -43,7 +43,7 @@ ecma_init (void)
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
   JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) = ECMA_PROP_HASHMAP_ALLOC_ON;
-  JERRY_CONTEXT (ecma_prop_hashmap_alloc_last_is_hs_gc) = false;
+  JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_HIGH_SEV_GC;
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 
 #ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -157,6 +157,7 @@ ecma_raise_standard_error (ecma_standard_error_t error_type, /**< error type */
   }
 
   JERRY_CONTEXT (error_value) = ecma_make_object_value (error_obj_p);
+  JERRY_CONTEXT (status_flags) |= ECMA_STATUS_EXCEPTION;
   return ECMA_VALUE_ERROR;
 } /* ecma_raise_standard_error */
 
@@ -243,6 +244,7 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
   ecma_deref_ecma_string (error_msg_p);
 
   JERRY_CONTEXT (error_value) = ecma_make_object_value (error_obj_p);
+  JERRY_CONTEXT (status_flags) |= ECMA_STATUS_EXCEPTION;
   return ECMA_VALUE_ERROR;
 } /* ecma_raise_standard_error_with_format */
 

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -470,14 +470,14 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
 
     if (unlikely (ecma_is_value_error_reference (ret_value)))
     {
-      JERRY_CONTEXT (error_value) = ecma_clear_error_reference (ret_value);
+      JERRY_CONTEXT (error_value) = ecma_clear_error_reference (ret_value, true);
       ret_value = ECMA_VALUE_ERROR;
     }
   }
   else
   {
     JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
-    JERRY_CONTEXT (is_direct_eval_form_call) = false;
+    JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_DIRECT_EVAL;
 
     /* 2-3. */
     ecma_extended_object_t *ext_function_p = (ecma_extended_object_t *) func_obj_p;

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -293,8 +293,10 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature);
  * Error flag manipulation functions.
  */
 bool jerry_value_has_error_flag (const jerry_value_t value);
+bool jerry_value_has_abort_flag (const jerry_value_t value);
 void jerry_value_clear_error_flag (jerry_value_t *value_p);
 void jerry_value_set_error_flag (jerry_value_t *value_p);
+void jerry_value_set_abort_flag (jerry_value_t *value_p);
 jerry_value_t jerry_get_value_without_error_flag (jerry_value_t value);
 
 /**

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -84,13 +84,11 @@ typedef struct
   ecma_value_t error_value; /**< currently thrown error value */
   uint32_t lit_magic_string_ex_count; /**< external magic strings count */
   uint32_t jerry_init_flags; /**< run-time configuration flags */
-  uint8_t is_direct_eval_form_call; /**< direct call from eval */
-  uint8_t jerry_api_available; /**< API availability flag */
+  uint32_t status_flags; /**< run-time flags */
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
   uint8_t ecma_prop_hashmap_alloc_state; /**< property hashmap allocation state: 0-4,
                                           *   if !0 property hashmap allocation is disabled */
-  bool ecma_prop_hashmap_alloc_last_is_hs_gc; /**< true, if and only if the last gc action was a high severity gc */
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */
 
 #ifndef CONFIG_DISABLE_REGEXP_BUILTIN

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2744,6 +2744,7 @@ parser_parse_script (const uint8_t *arg_list_p, /**< function argument list */
       /* It is unlikely that memory can be allocated in an out-of-memory
        * situation. However, a simple value can still be thrown. */
       JERRY_CONTEXT (error_value) = ECMA_VALUE_NULL;
+      JERRY_CONTEXT (status_flags) |= ECMA_STATUS_EXCEPTION;
       return ECMA_VALUE_ERROR;
     }
 #ifdef JERRY_ENABLE_ERROR_MESSAGES

--- a/tests/unit-core/test-abort.c
+++ b/tests/unit-core/test-abort.c
@@ -1,0 +1,129 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "jerryscript.h"
+
+#include "test-common.h"
+
+static jerry_value_t
+callback_func (const jerry_value_t function_obj,
+               const jerry_value_t this_val,
+               const jerry_value_t args_p[],
+               const jerry_length_t args_count)
+{
+  JERRY_UNUSED (function_obj);
+  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (args_p);
+  JERRY_UNUSED (args_count);
+
+  jerry_value_t value = jerry_create_string ((jerry_char_t *) "Abort run!");
+  jerry_value_set_abort_flag (&value);
+  return value;
+} /* callback_func */
+
+int
+main (void)
+{
+  TEST_INIT ();
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t global = jerry_get_global_object ();
+  jerry_value_t callback_name = jerry_create_string ((jerry_char_t *) "callback");
+  jerry_value_t func = jerry_create_external_function (callback_func);
+  jerry_value_t res = jerry_set_property (global, callback_name, func);
+  TEST_ASSERT (!jerry_value_has_error_flag (res));
+
+  jerry_release_value (res);
+  jerry_release_value (func);
+  jerry_release_value (callback_name);
+  jerry_release_value (global);
+
+  const char *inf_loop_code_src_p = ("while(true) {\n"
+                                     "  with ({}) {\n"
+                                     "    try {\n"
+                                     "      callback();\n"
+                                     "    } catch (e) {\n"
+                                     "    } finally {\n"
+                                     "    }\n"
+                                     "  }\n"
+                                     "}");
+
+  jerry_value_t parsed_code_val = jerry_parse ((jerry_char_t *) inf_loop_code_src_p,
+                                               strlen (inf_loop_code_src_p),
+                                               false);
+
+  TEST_ASSERT (!jerry_value_has_error_flag (parsed_code_val));
+  res = jerry_run (parsed_code_val);
+
+  TEST_ASSERT (jerry_value_has_abort_flag (res));
+
+  jerry_release_value (res);
+  jerry_release_value (parsed_code_val);
+
+  inf_loop_code_src_p = ("function f() {"
+                         "  while(true) {\n"
+                         "    with ({}) {\n"
+                         "      try {\n"
+                         "        callback();\n"
+                         "      } catch (e) {\n"
+                         "      } finally {\n"
+                         "      }\n"
+                         "    }\n"
+                         "  }"
+                         "}\n"
+                         "function g() {\n"
+                         "  for (a in { x:5 })\n"
+                         "    f();\n"
+                         "}\n"
+                          "\n"
+                         "with({})\n"
+                         " f();\n");
+
+  parsed_code_val = jerry_parse ((jerry_char_t *) inf_loop_code_src_p,
+                                 strlen (inf_loop_code_src_p),
+                                 false);
+
+  TEST_ASSERT (!jerry_value_has_error_flag (parsed_code_val));
+  res = jerry_run (parsed_code_val);
+
+  TEST_ASSERT (jerry_value_has_abort_flag (res));
+
+  jerry_release_value (res);
+  jerry_release_value (parsed_code_val);
+
+  /* Test flag overwrites. */
+  jerry_value_t value = jerry_create_string ((jerry_char_t *) "Error description");
+  TEST_ASSERT (!jerry_value_has_abort_flag (value));
+  TEST_ASSERT (!jerry_value_has_error_flag (value));
+
+  jerry_value_set_abort_flag (&value);
+  TEST_ASSERT (jerry_value_has_abort_flag (value));
+  TEST_ASSERT (jerry_value_has_error_flag (value));
+
+  jerry_value_set_error_flag (&value);
+  TEST_ASSERT (!jerry_value_has_abort_flag (value));
+  TEST_ASSERT (jerry_value_has_error_flag (value));
+
+  jerry_value_set_abort_flag (&value);
+  TEST_ASSERT (jerry_value_has_abort_flag (value));
+  TEST_ASSERT (jerry_value_has_error_flag (value));
+
+  jerry_release_value (value);
+
+  jerry_cleanup ();
+  return 0;
+} /* main */

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -166,21 +166,6 @@ handler_construct (const jerry_value_t func_obj_val, /**< function object */
   return jerry_create_boolean (true);
 } /* handler_construct */
 
-static jerry_value_t
-vm_exec_stop_callback (void *user_p)
-{
-  int *int_p = (int *) user_p;
-
-  if (*int_p > 0)
-  {
-    (*int_p)--;
-
-    return jerry_create_undefined ();
-  }
-
-  return jerry_create_string ((const jerry_char_t *) "Abort script");
-} /* vm_exec_stop_callback */
-
 /**
  * Extended Magic Strings
  */
@@ -1096,50 +1081,6 @@ main (void)
     jerry_release_value (parsed_code_val);
     TEST_ASSERT (!strcmp ((char *) err_str_buf,
                           "SyntaxError: Primary expression expected. [line: 2, column: 10]"));
-
-    jerry_cleanup ();
-  }
-
-  /* Test stopping an infinite loop. */
-  if (jerry_is_feature_enabled (JERRY_FEATURE_VM_EXEC_STOP))
-  {
-    jerry_init (JERRY_INIT_EMPTY);
-
-    int countdown = 6;
-    jerry_set_vm_exec_stop_callback (vm_exec_stop_callback, &countdown, 16);
-
-    const char *inf_loop_code_src_p = "while(true) {}";
-    parsed_code_val = jerry_parse ((jerry_char_t *) inf_loop_code_src_p, strlen (inf_loop_code_src_p), false);
-    TEST_ASSERT (!jerry_value_has_error_flag (parsed_code_val));
-    res = jerry_run (parsed_code_val);
-    TEST_ASSERT (countdown == 0);
-
-    TEST_ASSERT (jerry_value_has_error_flag (res));
-
-    jerry_release_value (res);
-    jerry_release_value (parsed_code_val);
-
-    /* A more complex example. Although the callback error is captured
-     * by the catch block, it is automatically thrown again. */
-
-    /* We keep the callback function, only the countdown is reset. */
-    countdown = 6;
-
-    inf_loop_code_src_p = ("function f() { while (true) ; }\n"
-                           "try { f(); } catch(e) {}");
-
-    parsed_code_val = jerry_parse ((jerry_char_t *) inf_loop_code_src_p, strlen (inf_loop_code_src_p), false);
-
-    TEST_ASSERT (!jerry_value_has_error_flag (parsed_code_val));
-    res = jerry_run (parsed_code_val);
-    TEST_ASSERT (countdown == 0);
-
-    /* The result must have an error flag which proves that
-     * the error is thrown again inside the catch block. */
-    TEST_ASSERT (jerry_value_has_error_flag (res));
-
-    jerry_release_value (res);
-    jerry_release_value (parsed_code_val);
 
     jerry_cleanup ();
   }

--- a/tests/unit-core/test-exec-stop.c
+++ b/tests/unit-core/test-exec-stop.c
@@ -1,0 +1,92 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "jerryscript.h"
+
+#include "test-common.h"
+
+static jerry_value_t
+vm_exec_stop_callback (void *user_p)
+{
+  int *int_p = (int *) user_p;
+
+  if (*int_p > 0)
+  {
+    (*int_p)--;
+
+    return jerry_create_undefined ();
+  }
+
+  return jerry_create_string ((const jerry_char_t *) "Abort script");
+} /* vm_exec_stop_callback */
+
+int
+main (void)
+{
+  TEST_INIT ();
+
+  /* Test stopping an infinite loop. */
+  if (!jerry_is_feature_enabled (JERRY_FEATURE_VM_EXEC_STOP))
+  {
+    return 0;
+  }
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  int countdown = 6;
+  jerry_set_vm_exec_stop_callback (vm_exec_stop_callback, &countdown, 16);
+
+  const char *inf_loop_code_src_p = "while(true) {}";
+  jerry_value_t parsed_code_val = jerry_parse ((jerry_char_t *) inf_loop_code_src_p,
+                                               strlen (inf_loop_code_src_p),
+                                               false);
+
+  TEST_ASSERT (!jerry_value_has_error_flag (parsed_code_val));
+  jerry_value_t res = jerry_run (parsed_code_val);
+  TEST_ASSERT (countdown == 0);
+
+  TEST_ASSERT (jerry_value_has_error_flag (res));
+
+  jerry_release_value (res);
+  jerry_release_value (parsed_code_val);
+
+  /* A more complex example. Although the callback error is captured
+   * by the catch block, it is automatically thrown again. */
+
+  /* We keep the callback function, only the countdown is reset. */
+  countdown = 6;
+
+  inf_loop_code_src_p = ("function f() { while (true) ; }\n"
+                         "try { f(); } catch(e) {}");
+
+  parsed_code_val = jerry_parse ((jerry_char_t *) inf_loop_code_src_p,
+                                 strlen (inf_loop_code_src_p),
+                                 false);
+
+  TEST_ASSERT (!jerry_value_has_error_flag (parsed_code_val));
+  res = jerry_run (parsed_code_val);
+  TEST_ASSERT (countdown == 0);
+
+  /* The result must have an error flag which proves that
+   * the error is thrown again inside the catch block. */
+  TEST_ASSERT (jerry_value_has_error_flag (res));
+
+  jerry_release_value (res);
+  jerry_release_value (parsed_code_val);
+
+  jerry_cleanup ();
+  return 0;
+} /* main */


### PR DESCRIPTION
Aborts are similar to exceptions except they are not caught by catch
and finally blocks. Callbacks should honor aborts as well and return
them without processing them. Aborts are never thrown by JavaScript
code.

In the future certain events such as out-of-memory condition may
also throw aborts.