### PR TITLE
Limit maximum number of arguments for apply().

### DIFF
--- a/tests/jerry/regression-test-issue-2182.js
+++ b/tests/jerry/regression-test-issue-2182.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function test(len)
+{
+  function applyTest() { }
+  try {
+    applyTest.apply(null, { length : len });
+    assert(false);
+  } catch (e) {
+    assert(e instanceof RangeError);
+  }
+}
+
+test(65536);
+test(0x40000001);
+test(0xffffffff);


### PR DESCRIPTION
The length*sizeof(ecma_value_t) may overflow on 32 bit systems which
cause a memory corruption when the values are filled.

Fixes #2182.