### PR TITLE
Simplify ECMA_OP_TO_NUMBER_TRY_CATCH macro.

### DIFF
--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -42,6 +42,7 @@ bool ecma_op_same_value (ecma_value_t x, ecma_value_t y);
 ecma_value_t ecma_op_to_primitive (ecma_value_t value, ecma_preferred_type_hint_t preferred_type);
 bool ecma_op_to_boolean (ecma_value_t value);
 ecma_value_t ecma_op_to_number (ecma_value_t value);
+ecma_value_t ecma_get_number (ecma_value_t value, ecma_number_t *number_p);
 ecma_value_t ecma_op_to_string (ecma_value_t value);
 ecma_value_t ecma_op_to_object (ecma_value_t value);
 

--- a/jerry-core/ecma/operations/ecma-try-catch-macro.h
+++ b/jerry-core/ecma/operations/ecma-try-catch-macro.h
@@ -66,23 +66,10 @@
  */
 #define ECMA_OP_TO_NUMBER_TRY_CATCH(num_var, value, return_value) \
   JERRY_ASSERT (return_value == ECMA_VALUE_EMPTY); \
-  ecma_number_t num_var = ecma_number_make_nan (); \
-  if (ecma_is_value_number (value)) \
-  { \
-    num_var = ecma_get_number_from_value (value); \
-  } \
-  else \
-  { \
-    ECMA_TRY_CATCH (to_number_value, \
-                    ecma_op_to_number (value), \
-                    return_value); \
-    \
-    num_var = ecma_get_number_from_value (to_number_value); \
-    \
-    ECMA_FINALIZE (to_number_value); \
-  } \
+  ecma_number_t num_var; \
+  return_value = ecma_get_number (value, &num_var); \
   \
-  if (ecma_is_value_empty (return_value)) \
+  if (likely (ecma_is_value_empty (return_value))) \
   {
 
 /**
@@ -92,10 +79,6 @@
  *      Each ECMA_OP_TO_NUMBER_TRY_CATCH should be followed by ECMA_OP_TO_NUMBER_FINALIZE
  *      with same argument as corresponding ECMA_OP_TO_NUMBER_TRY_CATCH's first argument.
  */
-#define ECMA_OP_TO_NUMBER_FINALIZE(num_var) } \
-  else \
-  { \
-    JERRY_ASSERT (ecma_number_is_nan (num_var)); \
-  }
+#define ECMA_OP_TO_NUMBER_FINALIZE(num_var) }
 
 #endif /* !ECMA_TRY_CATCH_MACRO_H */


### PR DESCRIPTION
Very interesting effects. The binary size is decreased by 3K, that is expected. The rest is unexpected. Large gain on RSS (while no effect on malloc), and perf improvement but stack is also increased a lot. I suspect the compiler inlined code that was no inlined before.

Benchmark | Heap (bytes) | Stack (bytes) | RSS (bytes) | Perf (sec) |
----: | ----: | ----: | ----: | ----: | 
3d-cube.js | 16376 -> 16376 : 0.000% | 15592 -> 19400 : -24.423% | 53248 -> 53248 : 0.000% | 0.835 -> 0.822 : +1.529% | 
3d-raytrace.js | 123768 -> 123768 : 0.000% | 2772 -> 3284 : -18.470% | 106496 -> 110592 : -3.846% | 1.076 -> 1.068 : +0.724% | 
access-binary-trees.js | 32760 -> 32760 : 0.000% | 3280 -> 4008 : -22.195% | 49152 -> 49152 : 0.000% | 0.566 -> 0.561 : +0.933% | 
access-fannkuch.js | 5344 -> 5344 : 0.000% | 1484 -> 1484 : 0.000% | 20480 -> 16384 : +20.000% | 2.145 -> 2.142 : +0.139% | 
access-nbody.js | 6456 -> 6456 : 0.000% | 1424 -> 1616 : -13.483% | 24576 -> 24576 : 0.000% | 1.132 -> 1.108 : +2.073% | 
bitops-3bit-bits-in-byte.js | 840 -> 840 : 0.000% | 1424 -> 1424 : 0.000% | 16384 -> 12288 : +25.000% | 0.534 -> 0.538 : -0.773% | 
bitops-bits-in-byte.js | 800 -> 800 : 0.000% | 1424 -> 1424 : 0.000% | 16384 -> 12288 : +25.000% | 0.735 -> 0.738 : -0.321% | 
bitops-bitwise-and.js | 488 -> 488 : 0.000% | 1200 -> 1200 : 0.000% | 16384 -> 12288 : +25.000% | 0.876 -> 0.875 : +0.099% | 
bitops-nsieve-bits.js | 98480 -> 98480 : 0.000% | 1424 -> 1424 : 0.000% | 110592 -> 110592 : 0.000% | 1.242 -> 1.234 : +0.631% | 
controlflow-recursive.js | 832 -> 832 : 0.000% | 69784 -> 88152 : -26.321% | 86016 -> 98304 : -14.286% | 0.388 -> 0.390 : -0.538% | 
crypto-aes.js | 34160 -> 34160 : 0.000% | 2052 -> 2188 : -6.628% | 65536 -> 61440 : +6.250% | 0.936 -> 0.924 : +1.348% | 
crypto-md5.js | 106488 -> 106488 : 0.000% | 1868 -> 2244 : -20.128% | 131072 -> 126976 : +3.125% | 0.642 -> 0.650 : -1.177% | 
crypto-sha1.js | 66456 -> 66456 : 0.000% | 1496 -> 1540 : -2.941% | 82505 -> 81920 : +0.709% | 0.637 -> 0.644 : -1.059% | 
date-format-tofte.js | 16368 -> 16368 : 0.000% | 2064 -> 2152 : -4.264% | 36864 -> 36864 : 0.000% | 0.739 -> 0.731 : +1.080% | 
date-format-xparb.js | 16376 -> 16376 : 0.000% | 2480 -> 2544 : -2.581% | 40960 -> 36864 : +10.000% | 0.420 -> 0.407 : +3.055% | 
math-cordic.js | 1968 -> 1968 : 0.000% | 1424 -> 1532 : -7.584% | 20480 -> 16384 : +20.000% | 1.263 -> 1.264 : -0.063% | 
math-partial-sums.js | 1368 -> 1368 : 0.000% | 1368 -> 1368 : 0.000% | 16384 -> 12288 : +25.000% | 0.773 -> 0.746 : +3.442% | 
math-spectral-norm.js | 6256 -> 6256 : 0.000% | 1532 -> 1860 : -21.410% | 20480 -> 20480 : 0.000% | 0.556 -> 0.562 : -1.056% | 
string-base64.js | 90936 -> 90936 : 0.000% | 1424 -> 1424 : 0.000% | 135168 -> 134582 : +0.434% | 1.539 -> 1.526 : +0.861% | 
string-fasta.js | 16320 -> 16320 : 0.000% | 1408 -> 1408 : 0.000% | 28672 -> 28672 : 0.000% | 1.323 -> 1.305 : +1.333% | 
Geometric mean: | 0.000% | -8.110% | +7.868% | +0.621% | 

Binary sizes (bytes)
918eb22a01:137124
aca87e099d:134476