### PR TITLE
Make source scrolling command in python debugger

### DIFF
--- a/tests/debugger/do_help.expected
+++ b/tests/debugger/do_help.expected
@@ -4,8 +4,8 @@ Stopped at tests/debugger/do_help.js:15
 
 Documented commands (type help <topic>):
 ========================================
-b          bt        delete   e          help      ms    quit    src 
-backtrace  c         display  eval       list      n     s       step
-break      continue  dump     exception  memstats  next  source
+b          bt        delete   e          help      ms    quit    source
+backtrace  c         display  eval       list      n     s       src   
+break      continue  dump     exception  memstats  next  scroll  step  
 
 (jerry-debugger) quit


### PR DESCRIPTION
Source is now scrollable after writing `scroll`.
Keys are `q` to quit, `w` to scroll up `s` to scroll down.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu