### PR TITLE
Fix misc. compiler warnings

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -313,7 +313,8 @@ jerry_get_memory_stats (jerry_heap_stats_t *out_stats_p) /**< [out] heap memory 
     return false;
   }
 
-  jmem_heap_stats_t jmem_heap_stats = {0};
+  jmem_heap_stats_t jmem_heap_stats;
+  memset (&jmem_heap_stats, 0, sizeof (jmem_heap_stats));
   jmem_heap_get_stats (&jmem_heap_stats);
 
   *out_stats_p = (jerry_heap_stats_t)
@@ -938,7 +939,7 @@ jerry_get_error_type (const jerry_value_t value) /**< api value */
   ecma_object_t *object_p = ecma_get_object_from_value (object);
   ecma_standard_error_t error_type = ecma_get_error_type (object_p);
 
-  return error_type;
+  return (jerry_error_t) error_type;
 } /* jerry_get_error_type */
 
 /**

--- a/tests/unit-core/test-mem-stats.c
+++ b/tests/unit-core/test-mem-stats.c
@@ -33,7 +33,8 @@ int main (void)
   jerry_value_t res = jerry_run (parsed_code_val);
   TEST_ASSERT (!jerry_value_has_error_flag (res));
 
-  jerry_heap_stats_t stats = {0};
+  jerry_heap_stats_t stats;
+  memset (&stats, 0, sizeof (stats));
   bool get_stats_ret = jerry_get_memory_stats (&stats);
   TEST_ASSERT (get_stats_ret);
   TEST_ASSERT (stats.version == 1);


### PR DESCRIPTION
Fixes these compiler warnings:
```
In file included from jerryscript/build/tests/unittests/jerry-all-in.c:3:
jerryscript/jerry-core/api/jerry.c:316:41: warning: missing field 'allocated_bytes' initializer [-Wmissing-field-initializers]
  jmem_heap_stats_t jmem_heap_stats = {0};
                                        ^
jerryscript/jerry-core/api/jerry.c:941:10: warning: implicit conversion from enumeration type 'ecma_standard_error_t' to different enumeration type 'jerry_error_t'
      [-Wenum-conversion]
  return error_type;
  ~~~~~~ ^~~~~~~~~~

jerryscript/tests/unit-core/api/test-mem-stats.c:36:32: warning: missing field 'size' initializer [-Wmissing-field-initializers]
  jerry_heap_stats_t stats = {0};
                               ^
```

... when using this version of clang:
```
$ clang -v
clang version 5.0.0 (tags/RELEASE_500/final)
Target: x86_64-apple-darwin16.7.0
Thread model: posix
InstalledDir: /usr/local/opt/llvm/bin
```

JerryScript-DCO-1.0-Signed-off-by: Martijn The martijn.the@intel.com