### PR TITLE
Check _XOPEN_SOURCE macro before defining

### DIFF
--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -16,8 +16,11 @@
 #ifndef JRT_H
 #define JRT_H
 
+#if !defined (_XOPEN_SOURCE) || _XOPEN_SOURCE < 500
+#undef _XOPEN_SOURCE
 /* Required macro for sleep functions (nanosleep or usleep) */
 #define _XOPEN_SOURCE 500
+#endif
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
In jrt.h the _XOPEN_SOURCE macro is defined.
However if the compiler already specifies this as
a default define, it can lead to compiler warnings
or errors.

By adding a macro check the warnings/errors can be
avoided.