### PR TITLE
Improve magic string handling.

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -175,12 +175,8 @@ jerry_debugger_send_eval (const lit_utf8_byte_t *eval_string_p, /**< evaluated s
 
     if (ecma_is_value_object (result))
     {
-      ecma_string_t *message_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE);
-
       message = ecma_op_object_find (ecma_get_object_from_value (result),
-                                     message_string_p);
-
-      ecma_deref_ecma_string (message_string_p);
+                                     ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE));
 
       if (!ecma_is_value_string (message)
           || ecma_string_is_empty (ecma_get_string_from_value (message)))
@@ -978,11 +974,9 @@ jerry_debugger_exception_object_to_string (ecma_value_t exception_obj_value) /**
   lit_utf8_byte_t data[16];
   memcpy (data, lit_get_magic_string_utf8 (string_id), size);
 
-  ecma_string_t *message_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE);
-
   ecma_property_t *property_p;
   property_p = ecma_find_named_property (ecma_get_object_from_value (exception_obj_value),
-                                         message_string_p);
+                                         ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE));
 
   if (property_p == NULL
       || ECMA_PROPERTY_GET_TYPE (*property_p) != ECMA_PROPERTY_TYPE_NAMEDDATA)

--- a/jerry-core/ecma/base/ecma-helpers-external-pointers.c
+++ b/jerry-core/ecma/base/ecma-helpers-external-pointers.c
@@ -127,8 +127,7 @@ ecma_get_native_pointer_value (ecma_object_t *obj_p, /**< object to get property
   JERRY_ASSERT (id == LIT_INTERNAL_MAGIC_STRING_NATIVE_HANDLE
                 || id == LIT_INTERNAL_MAGIC_STRING_NATIVE_POINTER);
 
-  ecma_string_t *name_p = ecma_get_magic_string (id);
-  ecma_property_t *property_p = ecma_find_named_property (obj_p, name_p);
+  ecma_property_t *property_p = ecma_find_named_property (obj_p, ecma_get_magic_string (id));
 
   if (property_p == NULL)
   {

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -220,7 +220,7 @@ ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *string_p, /**< utf-8 stri
 
     if (magic_string_ex_id < lit_get_magic_string_ex_count ())
     {
-      return ecma_get_magic_string_ex (magic_string_ex_id);
+      return ecma_new_ecma_string_from_magic_string_ex_id (magic_string_ex_id);
     }
   }
 
@@ -410,6 +410,22 @@ ecma_new_ecma_string_from_uint32 (uint32_t uint32_number) /**< uint32 value of t
 } /* ecma_new_ecma_string_from_uint32 */
 
 /**
+ * Returns the constant assigned to the uint32 number.
+ *
+ * Note:
+ *   Calling ecma_deref_ecma_string on the returned pointer is optional.
+ *
+ * @return pointer to ecma-string descriptor
+ */
+ecma_string_t *
+ecma_get_ecma_string_from_uint32 (uint32_t uint32_number)
+{
+  JERRY_ASSERT (uint32_number <= ECMA_DIRECT_STRING_MAX_IMM);
+
+  return (ecma_string_t *) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_UINT, (uintptr_t) uint32_number);
+} /* ecma_get_ecma_string_from_uint32 */
+
+/**
  * Allocate new ecma-string and fill it with ecma-number
  *
  * @return pointer to ecma-string descriptor
@@ -458,16 +474,19 @@ ecma_new_ecma_string_from_number (ecma_number_t num) /**< ecma-number */
 } /* ecma_new_ecma_string_from_number */
 
 /**
- * Allocate new ecma-string and fill it with reference to ECMA magic string
+ * Returns the constant assigned to the magic string id.
+ *
+ * Note:
+ *   Calling ecma_deref_ecma_string on the returned pointer is optional.
  *
  * @return pointer to ecma-string descriptor
  */
 inline ecma_string_t * __attr_always_inline___
-ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t id) /**< identifier of magic string */
+ecma_get_magic_string (lit_magic_string_id_t id) /**< identifier of magic string */
 {
   JERRY_ASSERT (id < LIT_MAGIC_STRING__COUNT);
   return (ecma_string_t *) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC, (uintptr_t) id);
-} /* ecma_new_ecma_string_from_magic_string_id */
+} /* ecma_get_magic_string */
 
 /**
  * Allocate new ecma-string and fill it with reference to ECMA magic string
@@ -494,15 +513,18 @@ ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id) /**< 
 } /* ecma_new_ecma_string_from_magic_string_ex_id */
 
 /**
- * Allocate new ecma-string and fill it with reference to length magic string
+ * Returns the constant assigned to the length magic string.
+ *
+ * Note:
+ *   Calling ecma_deref_ecma_string on the returned pointer is optional.
  *
  * @return pointer to ecma-string descriptor
  */
 ecma_string_t *
-ecma_new_ecma_length_string (void)
+ecma_get_length_string (void)
 {
-  return ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING_LENGTH);
-} /* ecma_new_ecma_length_string */
+  return ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
+} /* ecma_get_length_string */
 
 /**
  * Append a cesu8 string after an ecma-string
@@ -666,7 +688,7 @@ ecma_append_chars_to_string (ecma_string_t *string1_p, /**< base ecma-string */
     if (magic_string_ex_id < lit_get_magic_string_ex_count ())
     {
       ecma_deref_ecma_string (string1_p);
-      return ecma_get_magic_string_ex (magic_string_ex_id);
+      return ecma_new_ecma_string_from_magic_string_ex_id (magic_string_ex_id);
     }
   }
 
@@ -844,7 +866,7 @@ ecma_append_magic_string_to_string (ecma_string_t *string1_p,
 {
   if (unlikely (ecma_string_is_empty (string1_p)))
   {
-    return ecma_new_ecma_string_from_magic_string_id (string2_id);
+    return ecma_get_magic_string (string2_id);
   }
 
   const lit_utf8_byte_t *cesu8_string2_p = lit_get_magic_string_utf8 (string2_id);
@@ -2154,28 +2176,6 @@ ecma_string_get_char_at_pos (const ecma_string_t *string_p, /**< ecma-string */
 
   return ch;
 } /* ecma_string_get_char_at_pos */
-
-/**
- * Get specified magic string
- *
- * @return ecma-string containing specified magic string
- */
-inline ecma_string_t * __attr_always_inline___
-ecma_get_magic_string (lit_magic_string_id_t id) /**< magic string id */
-{
-  return ecma_new_ecma_string_from_magic_string_id (id);
-} /* ecma_get_magic_string */
-
-/**
- * Get specified external magic string
- *
- * @return ecma-string containing specified external magic string
- */
-inline ecma_string_t * __attr_always_inline___
-ecma_get_magic_string_ex (lit_magic_string_ex_id_t id) /**< external magic string id */
-{
-  return ecma_new_ecma_string_from_magic_string_ex_id (id);
-} /* ecma_get_magic_string_ex */
 
 /**
  * Check if passed string equals to one of magic strings

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -515,6 +515,15 @@ ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to refer
 } /* ecma_make_string_value */
 
 /**
+ * String value constructor
+ */
+inline ecma_value_t __attr_pure___ __attr_always_inline___
+ecma_make_magic_string_value (lit_magic_string_id_t id) /**< magic string id */
+{
+  return (ecma_value_t) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC, (uintptr_t) id);
+} /* ecma_make_magic_string_value */
+
+/**
  * Object value constructor
  */
 inline ecma_value_t __attr_pure___ __attr_always_inline___

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -167,6 +167,7 @@ ecma_value_t ecma_make_number_value (ecma_number_t ecma_number);
 ecma_value_t ecma_make_int32_value (int32_t int32_number);
 ecma_value_t ecma_make_uint32_value (uint32_t uint32_number);
 ecma_value_t ecma_make_string_value (const ecma_string_t *ecma_string_p) __attr_pure___;
+ecma_value_t ecma_make_magic_string_value (lit_magic_string_id_t id) __attr_pure___;
 ecma_value_t ecma_make_object_value (const ecma_object_t *object_p) __attr_pure___;
 ecma_value_t ecma_make_error_reference_value (const ecma_error_reference_t *error_ref_p) __attr_pure___;
 ecma_value_t ecma_make_collection_chunk_value (const ecma_collection_chunk_t *collection_chunk_p) __attr_pure___;
@@ -195,10 +196,11 @@ ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8
                                                                   lit_utf8_size_t string_size);
 ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t code_unit);
 ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t uint32_number);
+ecma_string_t *ecma_get_ecma_string_from_uint32 (uint32_t uint32_number);
 ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t num);
-ecma_string_t *ecma_new_ecma_string_from_magic_string_id (lit_magic_string_id_t id);
+ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t id);
 ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id);
-ecma_string_t *ecma_new_ecma_length_string (void);
+ecma_string_t *ecma_get_length_string (void);
 ecma_string_t *ecma_append_chars_to_string (ecma_string_t *string1_p,
                                             const lit_utf8_byte_t *cesu8_string2_p,
                                             lit_utf8_size_t cesu8_string2_size,
@@ -252,8 +254,6 @@ lit_utf8_size_t ecma_string_get_size (const ecma_string_t *string_p);
 lit_utf8_size_t ecma_string_get_utf8_size (const ecma_string_t *string_p);
 ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *string_p, ecma_length_t index);
 
-ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t id);
-ecma_string_t *ecma_get_magic_string_ex (lit_magic_string_ex_id_t id);
 lit_magic_string_id_t ecma_get_string_magic (const ecma_string_t *string_p);
 
 lit_string_hash_t ecma_string_hash (const ecma_string_t *string_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -59,17 +59,14 @@ ecma_builtin_array_prototype_helper_set_length (ecma_object_t *object, /**< obje
                                                 ecma_number_t length) /**< new length */
 {
   ecma_value_t ret_value;
-  ecma_string_t *magic_string_length_p = ecma_new_ecma_length_string ();
 
   ecma_value_t length_value = ecma_make_number_value (length);
   ret_value = ecma_op_object_put (object,
-                                  magic_string_length_p,
+                                  ecma_get_length_string (),
                                   length_value,
                                   true),
 
   ecma_free_value (length_value);
-  ecma_deref_ecma_string (magic_string_length_p);
-
   return ret_value;
 } /* ecma_builtin_array_prototype_helper_set_length */
 
@@ -155,8 +152,7 @@ ecma_builtin_array_prototype_object_to_locale_string (const ecma_value_t this_ar
   /* 5. */
   if (length == 0)
   {
-    ecma_string_t *empty_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-    ret_value = ecma_make_string_value (empty_string_p);
+    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
   else
   {
@@ -282,13 +278,10 @@ ecma_op_array_get_separator_string (ecma_value_t separator) /**< possible separa
 {
   if (ecma_is_value_undefined (separator))
   {
-    ecma_string_t *comma_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_COMMA_CHAR);
-    return ecma_make_string_value (comma_string_p);
+    return ecma_make_magic_string_value (LIT_MAGIC_STRING_COMMA_CHAR);
   }
-  else
-  {
-    return ecma_op_to_string (separator);
-  }
+
+  return ecma_op_to_string (separator);
 } /* ecma_op_array_get_separator_string */
 
 /**
@@ -314,8 +307,7 @@ ecma_op_array_get_to_string_at_index (ecma_object_t *obj_p, /**< this object */
   if (ecma_is_value_undefined (index_value)
       || ecma_is_value_null (index_value))
   {
-    ecma_string_t *empty_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-    ret_value = ecma_make_string_value (empty_string_p);
+    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
   else
   {
@@ -371,8 +363,7 @@ ecma_builtin_array_prototype_join (const ecma_value_t this_arg, /**< this argume
   if (length == 0)
   {
     /* 6. */
-    ecma_string_t *empty_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-    ret_value = ecma_make_string_value (empty_string_p);
+    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
   else
   {
@@ -709,10 +700,10 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
   }
   else
   {
-    ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (0);
-
     /* 5. */
-    ECMA_TRY_CATCH (first_value, ecma_op_object_get (obj_p, index_str_p), ret_value);
+    ECMA_TRY_CATCH (first_value,
+                    ecma_op_object_get (obj_p, ecma_get_ecma_string_from_uint32 (0)),
+                    ret_value);
 
     /* 6. and 7. */
     for (uint32_t k = 1; k < len && ecma_is_value_empty (ret_value); k++)
@@ -766,7 +757,6 @@ ecma_builtin_array_prototype_object_shift (ecma_value_t this_arg) /**< this argu
     }
 
     ECMA_FINALIZE (first_value);
-    ecma_deref_ecma_string (index_str_p);
   }
 
   ECMA_OP_TO_NUMBER_FINALIZE (len_number);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
@@ -62,20 +62,16 @@ ecma_builtin_boolean_prototype_object_to_string (ecma_value_t this_arg) /**< thi
                   ecma_builtin_boolean_prototype_object_value_of (this_arg),
                   ret_value);
 
-  ecma_string_t *ret_str_p;
-
   if (ecma_is_value_true (value_of_ret))
   {
-    ret_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_TRUE);
+    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING_TRUE);
   }
   else
   {
     JERRY_ASSERT (ecma_is_value_boolean (value_of_ret));
 
-    ret_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_FALSE);
+    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING_FALSE);
   }
-
-  ret_value = ecma_make_string_value (ret_str_p);
 
   ECMA_FINALIZE (value_of_ret);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -192,8 +192,7 @@ ecma_builtin_date_prototype_dispatch_get (uint16_t builtin_routine_id, /**< buil
 {
   if (ecma_number_is_nan (date_num))
   {
-    ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-    return ecma_make_string_value (nan_str_p);
+    return ecma_make_magic_string_value (LIT_MAGIC_STRING_NAN);
   }
 
   switch (builtin_routine_id)
@@ -624,8 +623,7 @@ ecma_builtin_date_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< 
 
   if (ecma_number_is_nan (*prim_value_p))
   {
-    ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INVALID_DATE_UL);
-    return ecma_make_string_value (magic_str_p);
+    return ecma_make_magic_string_value (LIT_MAGIC_STRING_INVALID_DATE_UL);
   }
 
   switch (builtin_routine_id)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -74,9 +74,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
 
     if (ecma_is_value_undefined (name_get_ret_value))
     {
-      ecma_string_t *error_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ERROR_UL);
-
-      name_to_str_completion = ecma_make_string_value (error_magic_string_p);
+      name_to_str_completion = ecma_make_magic_string_value (LIT_MAGIC_STRING_ERROR_UL);
     }
     else
     {
@@ -97,9 +95,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
 
       if (ecma_is_value_undefined (msg_get_ret_value))
       {
-        ecma_string_t *empty_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-
-        msg_to_str_completion = ecma_make_string_value (empty_magic_string_p);
+        msg_to_str_completion = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
       }
       else
       {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -68,8 +68,7 @@ ecma_builtin_function_prototype_object_to_string (ecma_value_t this_arg) /**< th
   }
   else
   {
-    ecma_string_t *function_to_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__FUNCTION_TO_STRING);
-    ret_value = ecma_make_string_value (function_to_string_p);
+    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__FUNCTION_TO_STRING);
   }
   return ret_value;
 } /* ecma_builtin_function_prototype_object_to_string */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
@@ -72,7 +72,7 @@ ecma_builtin_function_helper_get_function_arguments (const ecma_value_t *argumen
 
   if (arguments_list_len <= 1)
   {
-    return ecma_make_string_value (ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY));
+    return ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
 
   ecma_value_t final_str = ecma_op_to_string (arguments_list_p[0]);
@@ -146,7 +146,7 @@ ecma_builtin_function_dispatch_construct (const ecma_value_t *arguments_list_p, 
   else
   {
     /* Very unlikely code path, not optimized. */
-    function_body_value = ecma_make_string_value (ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY));
+    function_body_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
 
   ecma_string_t *arguments_str_p = ecma_get_string_from_value (arguments_value);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -207,7 +207,6 @@ ecma_builtin_helper_json_create_non_formatted_json (lit_utf8_byte_t left_bracket
 
   /* 10.a.i */
   properties_str_p = ecma_builtin_helper_json_create_separated_properties (partial_p, comma_str_p);
-  ecma_deref_ecma_string (comma_str_p);
 
   /* 10.a.ii */
   ecma_string_t *result_str_p = ecma_new_ecma_string_from_code_unit (left_bracket);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -131,8 +131,7 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
 
   if (ecma_is_value_undefined (index_value) || ecma_is_value_null (index_value))
   {
-    ecma_string_t *return_string_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-    ret_value = ecma_make_string_value (return_string_p);
+    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
   else
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -856,11 +856,10 @@ ecma_builtin_json_parse (ecma_value_t this_arg, /**< 'this' argument */
     if (ecma_op_is_callable (arg2))
     {
       ecma_object_t *object_p = ecma_op_create_object_object_noarg ();
-      ecma_string_t *name_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
 
       ecma_property_value_t *prop_value_p;
       prop_value_p = ecma_create_named_data_property (object_p,
-                                                      name_p,
+                                                      ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY),
                                                       ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                                       NULL);
 
@@ -869,9 +868,8 @@ ecma_builtin_json_parse (ecma_value_t this_arg, /**< 'this' argument */
 
       ret_value = ecma_builtin_json_walk (ecma_get_object_from_value (arg2),
                                           object_p,
-                                          name_p);
+                                          ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY));
       ecma_deref_object (object_p);
-      ecma_deref_ecma_string (name_p);
     }
     else
     {
@@ -1143,7 +1141,6 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
       ECMA_FINALIZE (str_val);
 
       ecma_deref_object (obj_wrapper_p);
-      ecma_deref_ecma_string (empty_str_p);
     }
 
     ecma_deref_ecma_string (context.gap_str_p);
@@ -1413,8 +1410,7 @@ ecma_builtin_json_str (ecma_string_t *key_p, /**< property key*/
       else
       {
         /* 9.b */
-        ecma_string_t *null_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NULL);
-        ret_value = ecma_make_string_value (null_str_p);
+        ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING_NULL);
       }
     }
     /* 10. */
@@ -1695,9 +1691,7 @@ ecma_builtin_json_array (ecma_object_t *obj_p, /**< the array object*/
     /* 8.b */
     if (ecma_is_value_undefined (str_val))
     {
-      ecma_string_t *null_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NULL);
-      ecma_append_to_values_collection (partial_p, ecma_make_string_value (null_str_p), 0);
-      ecma_deref_ecma_string (null_str_p);
+      ecma_append_to_values_collection (partial_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_NULL), 0);
     }
     /* 8.c */
     else

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -590,8 +590,7 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
     /* 4. */
     if (ecma_number_is_nan (this_num))
     {
-      ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-      ret_value = ecma_make_string_value (nan_str_p);
+      ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING_NAN);
     }
     else
     {
@@ -609,7 +608,7 @@ ecma_builtin_number_prototype_object_to_fixed (ecma_value_t this_arg, /**< this 
         lit_magic_string_id_t id = (is_negative ? LIT_MAGIC_STRING_NEGATIVE_INFINITY_UL
                                                 : LIT_MAGIC_STRING_INFINITY_UL);
 
-        ret_value = ecma_make_string_value (ecma_get_magic_string (id));
+        ret_value = ecma_make_magic_string_value (id);
       }
       else
       {
@@ -721,8 +720,7 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
     /* 3. */
     if (ecma_number_is_nan (this_num))
     {
-      ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-      ret_value = ecma_make_string_value (nan_str_p);
+      ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING_NAN);
     }
     else
     {
@@ -740,7 +738,7 @@ ecma_builtin_number_prototype_object_to_exponential (ecma_value_t this_arg, /**<
         lit_magic_string_id_t id = (is_negative ? LIT_MAGIC_STRING_NEGATIVE_INFINITY_UL
                                                 : LIT_MAGIC_STRING_INFINITY_UL);
 
-        ret_value = ecma_make_string_value (ecma_get_magic_string (id));
+        ret_value = ecma_make_magic_string_value (id);
       }
       else
       {
@@ -858,8 +856,7 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
     /* 4. */
     if (ecma_number_is_nan (this_num))
     {
-      ecma_string_t *nan_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_NAN);
-      ret_value = ecma_make_string_value (nan_str_p);
+      ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING_NAN);
     }
     else
     {
@@ -877,7 +874,7 @@ ecma_builtin_number_prototype_object_to_precision (ecma_value_t this_arg, /**< t
         lit_magic_string_id_t id = (is_negative ? LIT_MAGIC_STRING_NEGATIVE_INFINITY_UL
                                                 : LIT_MAGIC_STRING_INFINITY_UL);
 
-        ret_value = ecma_make_string_value (ecma_get_magic_string (id));
+        ret_value = ecma_make_magic_string_value (id);
       }
       /* 8. */
       else if (arg_num < 1.0 || arg_num >= 22.0)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -79,19 +79,18 @@ ecma_builtin_promise_reject_or_resolve (ecma_value_t this_arg, /**< "this" argum
     return capability;
   }
 
-  ecma_string_t *str;
+  ecma_string_t *property_str_p;
 
   if (is_resolve)
   {
-    str = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
+    property_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
   }
   else
   {
-    str = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
+    property_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
   }
 
-  ecma_value_t func = ecma_op_object_get (ecma_get_object_from_value (capability), str);
-  ecma_deref_ecma_string (str);
+  ecma_value_t func = ecma_op_object_get (ecma_get_object_from_value (capability), property_str_p);
 
   ecma_value_t call_ret = ecma_op_function_call (ecma_get_object_from_value (func),
                                                  ECMA_VALUE_UNDEFINED,
@@ -107,9 +106,8 @@ ecma_builtin_promise_reject_or_resolve (ecma_value_t this_arg, /**< "this" argum
 
   ecma_free_value (call_ret);
 
-  ecma_string_t *str_promise = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
-  ecma_value_t promise_new = ecma_op_object_get (ecma_get_object_from_value (capability), str_promise);
-  ecma_deref_ecma_string (str_promise);
+  ecma_string_t *promise_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
+  ecma_value_t promise_new = ecma_op_object_get (ecma_get_object_from_value (capability), promise_str_p);
   ecma_free_value (capability);
 
   return promise_new;
@@ -128,9 +126,8 @@ inline static ecma_value_t
 ecma_builtin_promise_reject_abrupt (ecma_value_t capability) /**< reject description */
 {
   ecma_value_t reason = JERRY_CONTEXT (error_value);
-  ecma_string_t *str_reject = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
-  ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability), str_reject);
-  ecma_deref_ecma_string (str_reject);
+  ecma_string_t *reject_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
+  ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability), reject_str_p);
 
   ecma_value_t call_ret = ecma_op_function_call (ecma_get_object_from_value (reject),
                                                  ECMA_VALUE_UNDEFINED,
@@ -145,9 +142,8 @@ ecma_builtin_promise_reject_abrupt (ecma_value_t capability) /**< reject descrip
 
   ecma_free_value (call_ret);
 
-  ecma_string_t *str_promise = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
-  ecma_value_t promise_new = ecma_op_object_get (ecma_get_object_from_value (capability), str_promise);
-  ecma_deref_ecma_string (str_promise);
+  ecma_string_t *promise_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
+  ecma_value_t promise_new = ecma_op_object_get (ecma_get_object_from_value (capability), promise_str_p);
 
   return promise_new;
 } /* ecma_builtin_promise_reject_abrupt */
@@ -210,28 +206,28 @@ ecma_builtin_promise_do_race (ecma_value_t array, /**< the array for race */
   ecma_length_t len = (ecma_length_t) ecma_get_integer_from_value (len_value);
   ecma_fast_free_value (len_value);
 
-  ecma_string_t *str_promise = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
-  ecma_string_t *str_resolve = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
-  ecma_string_t *str_reject = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
+  ecma_string_t *promise_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
+  ecma_string_t *resolve_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
+  ecma_string_t *reject_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
 
   ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability),
-                                             str_resolve);
+                                             resolve_str_p);
   ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability),
-                                            str_reject);
+                                            reject_str_p);
 
   for (ecma_length_t index = 0; index <= len; index++)
   {
     /* b-d. */
     if (index == len)
     {
-      ret = ecma_op_object_get (ecma_get_object_from_value (capability), str_promise);
+      ret = ecma_op_object_get (ecma_get_object_from_value (capability), promise_str_p);
       break;
     }
 
     /* e. */
-    ecma_string_t *str_index = ecma_new_ecma_string_from_uint32 (index);
-    ecma_value_t array_item = ecma_op_object_get (array_p, str_index);
-    ecma_deref_ecma_string (str_index);
+    ecma_string_t *index_to_str_p = ecma_new_ecma_string_from_uint32 (index);
+    ecma_value_t array_item = ecma_op_object_get (array_p, index_to_str_p);
+    ecma_deref_ecma_string (index_to_str_p);
 
     /* h. */
     ecma_value_t next_promise = ecma_builtin_promise_resolve (ctor, array_item);
@@ -260,9 +256,6 @@ ecma_builtin_promise_do_race (ecma_value_t array, /**< the array for race */
 
   ecma_free_value (reject);
   ecma_free_value (resolve);
-  ecma_deref_ecma_string (str_promise);
-  ecma_deref_ecma_string (str_resolve);
-  ecma_deref_ecma_string (str_reject);
 
   JERRY_ASSERT (!ecma_is_value_empty (ret));
 
@@ -323,8 +316,8 @@ ecma_builtin_promise_all_handler (const ecma_value_t function, /**< the function
   ecma_value_t ret = ECMA_VALUE_UNDEFINED;
   /* 1. */
   ecma_object_t *function_p = ecma_get_object_from_value (function);
-  ecma_string_t *str_already_called = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_ALREADY_CALLED);
-  ecma_value_t already_called =  ecma_op_object_get (function_p, str_already_called);
+  ecma_string_t *already_called_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_ALREADY_CALLED);
+  ecma_value_t already_called = ecma_op_object_get (function_p, already_called_str_p);
 
   JERRY_ASSERT (ecma_is_value_boolean (already_called));
 
@@ -332,46 +325,43 @@ ecma_builtin_promise_all_handler (const ecma_value_t function, /**< the function
   if (ecma_is_value_true (already_called))
   {
     ecma_fast_free_value (already_called);
-    ecma_deref_ecma_string (str_already_called);
-
     return ret;
   }
 
   /* 3. */
   ecma_op_object_put (function_p,
-                      str_already_called,
+                      already_called_str_p,
                       ecma_make_boolean_value (true),
                       false);
 
-  ecma_string_t *str_index = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_INDEX);
-  ecma_string_t *str_value = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_VALUE);
-  ecma_string_t *str_capability = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
-  ecma_string_t *str_remaining = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REMAINING_ELEMENT);
+  ecma_string_t *str_index_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_INDEX);
+  ecma_string_t *str_value_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_VALUE);
+  ecma_string_t *str_capability_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
+  ecma_string_t *str_remaining_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REMAINING_ELEMENT);
 
   /* 4-7. */
-  ecma_value_t index_val = ecma_op_object_get (function_p, str_index);
-  ecma_value_t value_array = ecma_op_object_get (function_p, str_value);
-  ecma_value_t capability = ecma_op_object_get (function_p, str_capability);
-  ecma_value_t remaining = ecma_op_object_get (function_p, str_remaining);
+  ecma_value_t index_val = ecma_op_object_get (function_p, str_index_p);
+  ecma_value_t value_array = ecma_op_object_get (function_p, str_value_p);
+  ecma_value_t capability = ecma_op_object_get (function_p, str_capability_p);
+  ecma_value_t remaining = ecma_op_object_get (function_p, str_remaining_p);
 
   JERRY_ASSERT (ecma_is_value_integer_number (index_val));
 
   /* 8. */
-  ecma_string_t *index_str = ecma_new_ecma_string_from_uint32 ((uint32_t) ecma_get_integer_from_value (index_val));
+  ecma_string_t *index_to_str_p = ecma_new_ecma_string_from_uint32 ((uint32_t) ecma_get_integer_from_value (index_val));
 
   ecma_op_object_put (ecma_get_object_from_value (value_array),
-                      index_str,
+                      index_to_str_p,
                       argv[0],
                       false);
-  ecma_deref_ecma_string (index_str);
+  ecma_deref_ecma_string (index_to_str_p);
 
   /* 9-10. */
   if (ecma_builtin_promise_remaining_inc_or_dec (remaining, false) == 0)
   {
-    ecma_string_t *str_resolve = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
-    ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability),
-                                               str_resolve);
-    ecma_deref_ecma_string (str_resolve);
+    ecma_string_t *resolve_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
+    ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability), resolve_str_p);
+
     ret = ecma_op_function_call (ecma_get_object_from_value (resolve),
                                  ECMA_VALUE_UNDEFINED,
                                  &value_array,
@@ -384,11 +374,6 @@ ecma_builtin_promise_all_handler (const ecma_value_t function, /**< the function
   ecma_free_value (value_array);
   ecma_fast_free_value (index_val);
   ecma_fast_free_value (already_called);
-  ecma_deref_ecma_string (str_already_called);
-  ecma_deref_ecma_string (str_index);
-  ecma_deref_ecma_string (str_value);
-  ecma_deref_ecma_string (str_capability);
-  ecma_deref_ecma_string (str_remaining);
 
   return ret;
 } /* ecma_builtin_promise_all_handler */
@@ -419,21 +404,21 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
   ecma_length_t len = (ecma_length_t) ecma_get_integer_from_value (len_value);
   ecma_fast_free_value (len_value);
 
-  ecma_string_t *str_promise = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
-  ecma_string_t *str_resolve = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
-  ecma_string_t *str_reject = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
-  ecma_string_t *str_already_called = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_ALREADY_CALLED);
-  ecma_string_t *str_index = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_INDEX);
-  ecma_string_t *str_value = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_VALUE);
-  ecma_string_t *str_capability = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
-  ecma_string_t *str_remaining = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REMAINING_ELEMENT);
+  ecma_string_t *promise_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
+  ecma_string_t *resolve_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
+  ecma_string_t *reject_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
+  ecma_string_t *already_called_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_ALREADY_CALLED);
+  ecma_string_t *index_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_INDEX);
+  ecma_string_t *value_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_VALUE);
+  ecma_string_t *capability_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
+  ecma_string_t *remaining_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REMAINING_ELEMENT);
 
   ecma_value_t undefined_val = ECMA_VALUE_UNDEFINED;
   /* String '1' indicates [[Resolve]] and '2' indicates [[Reject]]. */
   ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability),
-                                             str_resolve);
+                                             resolve_str_p);
   ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability),
-                                            str_reject);
+                                            reject_str_p);
   /* 3. */
   ecma_value_t result_array_length_val = ecma_make_uint32_value (0);
   ecma_value_t value_array = ecma_op_create_array_object (&result_array_length_val, 1, true);
@@ -467,18 +452,18 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
       }
 
       /* iv. */
-      ret = ecma_op_object_get (ecma_get_object_from_value (capability), str_promise);
+      ret = ecma_op_object_get (ecma_get_object_from_value (capability), promise_str_p);
       break;
     }
 
     /* e. h. */
-    ecma_string_t *index_str = ecma_new_ecma_string_from_uint32 (index);
-    ecma_value_t array_item = ecma_op_object_get (array_p, index_str);
+    ecma_string_t *index_to_str_p = ecma_new_ecma_string_from_uint32 (index);
+    ecma_value_t array_item = ecma_op_object_get (array_p, index_to_str_p);
     ecma_op_object_put (ecma_get_object_from_value (value_array),
-                        index_str,
+                        index_to_str_p,
                         undefined_val,
                         false);
-    ecma_deref_ecma_string (index_str);
+    ecma_deref_ecma_string (index_to_str_p);
     /* i. */
     ecma_value_t next_promise = ecma_builtin_promise_resolve (ctor, array_item);
     ecma_free_value (array_item);
@@ -495,27 +480,27 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
     res_ele_p = ecma_op_create_external_function_object (ecma_builtin_promise_all_handler);
     /* l. */
     ecma_op_object_put (res_ele_p,
-                        str_already_called,
+                        already_called_str_p,
                         ecma_make_boolean_value (false),
                         false);
     /* m. */
     ecma_op_object_put (res_ele_p,
-                        str_index,
+                        index_str_p,
                         ecma_make_uint32_value (index),
                         false);
     /* n. */
     ecma_op_object_put (res_ele_p,
-                        str_value,
+                        value_str_p,
                         value_array,
                         false);
     /* o. */
     ecma_op_object_put (res_ele_p,
-                        str_capability,
+                        capability_str_p,
                         capability,
                         false);
     /* p. */
     ecma_op_object_put (res_ele_p,
-                        str_remaining,
+                        remaining_str_p,
                         remaining,
                         false);
 
@@ -543,14 +528,6 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
   ecma_free_value (resolve);
   ecma_free_value (remaining);
   ecma_free_value (value_array);
-  ecma_deref_ecma_string (str_already_called);
-  ecma_deref_ecma_string (str_index);
-  ecma_deref_ecma_string (str_value);
-  ecma_deref_ecma_string (str_capability);
-  ecma_deref_ecma_string (str_remaining);
-  ecma_deref_ecma_string (str_resolve);
-  ecma_deref_ecma_string (str_reject);
-  ecma_deref_ecma_string (str_promise);
 
   JERRY_ASSERT (!ecma_is_value_empty (ret));
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -89,13 +89,11 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
         /* Get source. */
         ecma_string_t *magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SOURCE);
         ecma_value_t source_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
         ecma_string_t *pattern_string_p = ecma_get_string_from_value (source_value);
 
         /* Get flags. */
         magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
         ecma_value_t global_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
 
         JERRY_ASSERT (ecma_is_value_boolean (global_value));
 
@@ -106,7 +104,6 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
 
         magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL);
         ecma_value_t ignore_case_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
 
         JERRY_ASSERT (ecma_is_value_boolean (ignore_case_value));
 
@@ -117,7 +114,6 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
 
         magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE);
         ecma_value_t multiline_value = ecma_op_object_get_own_data_prop (target_p, magic_string_p);
-        ecma_deref_ecma_string (magic_string_p);
 
         JERRY_ASSERT (ecma_is_value_boolean (multiline_value));
 
@@ -280,14 +276,10 @@ ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
     if (bytecode_p == NULL)
     {
       /* Missing bytecode means empty RegExp: '/(?:)/', so always return empty string. */
-      ecma_string_t *capture_str_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-
       ecma_value_t arguments_list[1];
-      arguments_list[0] = ecma_make_string_value (capture_str_p);
+      arguments_list[0] = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
 
       ret_value = ecma_op_create_array_object (arguments_list, 1, false);
-
-      ecma_deref_ecma_string (capture_str_p);
 
       re_set_result_array_properties (ecma_get_object_from_value (ret_value),
                                       ecma_get_string_from_value (input_str_value),
@@ -364,7 +356,6 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     /* Get RegExp source from the source property */
     ecma_string_t *magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SOURCE);
     ecma_value_t source_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
 
     ecma_string_t *output_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_SLASH_CHAR);
     ecma_string_t *source_str_p = ecma_get_string_from_value (source_value);
@@ -379,7 +370,6 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     /* Check the global flag */
     magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
     ecma_value_t global_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
 
     JERRY_ASSERT (ecma_is_value_boolean (global_value));
 
@@ -391,7 +381,6 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     /* Check the ignoreCase flag */
     magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL);
     ecma_value_t ignore_case_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
 
     JERRY_ASSERT (ecma_is_value_boolean (ignore_case_value));
 
@@ -403,7 +392,6 @@ ecma_builtin_regexp_prototype_to_string (ecma_value_t this_arg) /**< this argume
     /* Check the multiline flag */
     magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE);
     ecma_value_t multiline_value = ecma_op_object_get_own_data_prop (obj_p, magic_string_p);
-    ecma_deref_ecma_string (magic_string_p);
 
     JERRY_ASSERT (ecma_is_value_boolean (multiline_value));
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -223,8 +223,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
       ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_STRING_UL;
-      ecma_string_t *prim_prop_str_value_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
-      ext_object_p->u.class_prop.u.value = ecma_make_string_value (prim_prop_str_value_p);
+      ext_object_p->u.class_prop.u.value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
       break;
     }
 #endif /* !CONFIG_DISABLE_STRING_BUILTIN */
@@ -624,7 +623,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
     }
     case ECMA_BUILTIN_PROPERTY_STRING:
     {
-      value = ecma_make_string_value (ecma_get_magic_string (curr_property_p->value));
+      value = ecma_make_magic_string_value (curr_property_p->value);
       break;
     }
     case ECMA_BUILTIN_PROPERTY_OBJECT:
@@ -731,9 +730,9 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
     ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 
     /* 'length' property is non-enumerable (ECMA-262 v5, 15) */
-    ecma_string_t *name_p = ecma_new_ecma_length_string ();
-    ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-    ecma_deref_ecma_string (name_p);
+    ecma_append_to_values_collection (for_non_enumerable_p,
+                                      ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH),
+                                      0);
   }
   else
   {
@@ -776,7 +775,9 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
 
       if (!(*bitset_p & bit_for_index) || ecma_op_object_has_own_property (object_p, name_p))
       {
-        ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
+        ecma_append_to_values_collection (for_non_enumerable_p,
+                                          ecma_make_magic_string_value (curr_property_p->magic_string_id),
+                                          0);
       }
 
       ecma_deref_ecma_string (name_p);

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -353,9 +353,9 @@ ecma_op_array_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obje
 
   ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 
-  ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (length_str_p), 0);
-  ecma_deref_ecma_string (length_str_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH),
+                                    0);
 } /* ecma_op_array_list_lazy_property_names */
 
 /**

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -519,24 +519,20 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
     /* a. */
     prop_desc.value = src_prop_desc_p->value;
 
-    ecma_string_t *value_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_VALUE);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     value_magic_string_p,
+                                                     ecma_get_magic_string (LIT_MAGIC_STRING_VALUE),
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (value_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
 
     /* b. */
     const bool is_writable = (src_prop_desc_p->is_writable);
     prop_desc.value = ecma_make_boolean_value (is_writable);
 
-    ecma_string_t *writable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     writable_magic_string_p,
+                                                     ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE),
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (writable_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
   }
   else
@@ -555,12 +551,10 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
       prop_desc.value = ecma_make_object_value (src_prop_desc_p->get_p);
     }
 
-    ecma_string_t *get_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GET);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     get_magic_string_p,
+                                                     ecma_get_magic_string (LIT_MAGIC_STRING_GET),
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (get_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
 
     /* b. */
@@ -573,35 +567,29 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
       prop_desc.value = ecma_make_object_value (src_prop_desc_p->set_p);
     }
 
-    ecma_string_t *set_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SET);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     set_magic_string_p,
+                                                     ecma_get_magic_string (LIT_MAGIC_STRING_SET),
                                                      &prop_desc,
                                                      false);
-    ecma_deref_ecma_string (set_magic_string_p);
     JERRY_ASSERT (ecma_is_value_true (completion));
   }
 
   const bool is_enumerable = src_prop_desc_p->is_enumerable;
   prop_desc.value = ecma_make_boolean_value (is_enumerable);
 
-  ecma_string_t *enumerable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE);
   completion = ecma_op_object_define_own_property (obj_p,
-                                                   enumerable_magic_string_p,
+                                                   ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE),
                                                    &prop_desc,
                                                    false);
-  ecma_deref_ecma_string (enumerable_magic_string_p);
   JERRY_ASSERT (ecma_is_value_true (completion));
 
   const bool is_configurable = src_prop_desc_p->is_configurable;
   prop_desc.value = ecma_make_boolean_value (is_configurable);
 
-  ecma_string_t *configurable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE);
   completion = ecma_op_object_define_own_property (obj_p,
-                                                   configurable_magic_string_p,
+                                                   ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE),
                                                    &prop_desc,
                                                    false);
-  ecma_deref_ecma_string (configurable_magic_string_p);
   JERRY_ASSERT (ecma_is_value_true (completion));
 
   return obj_p;
@@ -637,10 +625,8 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
     ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
     /* 3. */
-    ecma_string_t *enumerable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE);
-
     ECMA_TRY_CATCH (enumerable_prop_value,
-                    ecma_op_object_find (obj_p, enumerable_magic_string_p),
+                    ecma_op_object_find (obj_p, ecma_get_magic_string (LIT_MAGIC_STRING_ENUMERABLE)),
                     ret_value);
 
     if (ecma_is_value_found (enumerable_prop_value))
@@ -651,17 +637,13 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
 
     ECMA_FINALIZE (enumerable_prop_value);
 
-    ecma_deref_ecma_string (enumerable_magic_string_p);
-
     if (!ECMA_IS_VALUE_ERROR (ret_value))
     {
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 4. */
-      ecma_string_t *configurable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE);
-
       ECMA_TRY_CATCH (configurable_prop_value,
-                      ecma_op_object_find (obj_p, configurable_magic_string_p),
+                      ecma_op_object_find (obj_p, ecma_get_magic_string (LIT_MAGIC_STRING_CONFIGURABLE)),
                       ret_value);
 
       if (ecma_is_value_found (configurable_prop_value))
@@ -671,8 +653,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (configurable_prop_value);
-
-      ecma_deref_ecma_string (configurable_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -680,10 +660,8 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 5. */
-      ecma_string_t *value_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_VALUE);
-
       ECMA_TRY_CATCH (value_prop_value,
-                      ecma_op_object_find (obj_p, value_magic_string_p),
+                      ecma_op_object_find (obj_p, ecma_get_magic_string (LIT_MAGIC_STRING_VALUE)),
                       ret_value);
 
       if (ecma_is_value_found (value_prop_value))
@@ -693,8 +671,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (value_prop_value);
-
-      ecma_deref_ecma_string (value_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -702,10 +678,8 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 6. */
-      ecma_string_t *writable_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE);
-
       ECMA_TRY_CATCH (writable_prop_value,
-                      ecma_op_object_find (obj_p, writable_magic_string_p),
+                      ecma_op_object_find (obj_p, ecma_get_magic_string (LIT_MAGIC_STRING_WRITABLE)),
                       ret_value);
 
       if (ecma_is_value_found (writable_prop_value))
@@ -715,8 +689,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (writable_prop_value);
-
-      ecma_deref_ecma_string (writable_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -724,10 +696,8 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 7. */
-      ecma_string_t *get_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GET);
-
       ECMA_TRY_CATCH (get_prop_value,
-                      ecma_op_object_find (obj_p, get_magic_string_p),
+                      ecma_op_object_find (obj_p, ecma_get_magic_string (LIT_MAGIC_STRING_GET)),
                       ret_value);
 
       if (ecma_is_value_found (get_prop_value))
@@ -758,8 +728,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (get_prop_value);
-
-      ecma_deref_ecma_string (get_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))
@@ -767,10 +735,8 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
       /* 8. */
-      ecma_string_t *set_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SET);
-
       ECMA_TRY_CATCH (set_prop_value,
-                      ecma_op_object_find (obj_p, set_magic_string_p),
+                      ecma_op_object_find (obj_p, ecma_get_magic_string (LIT_MAGIC_STRING_SET)),
                       ret_value);
 
       if (ecma_is_value_found (set_prop_value))
@@ -801,8 +767,6 @@ ecma_op_to_property_descriptor (ecma_value_t obj_value, /**< object value */
       }
 
       ECMA_FINALIZE (set_prop_value);
-
-      ecma_deref_ecma_string (set_magic_string_p);
     }
 
     if (!ECMA_IS_VALUE_ERROR (ret_value))

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -175,14 +175,11 @@ ecma_new_standard_error_with_message (ecma_standard_error_t error_type, /**< nat
 {
   ecma_object_t *new_error_obj_p = ecma_new_standard_error (error_type);
 
-  ecma_string_t *message_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE);
-
   ecma_property_value_t *prop_value_p;
   prop_value_p = ecma_create_named_data_property (new_error_obj_p,
-                                                  message_magic_string_p,
+                                                  ecma_get_magic_string (LIT_MAGIC_STRING_MESSAGE),
                                                   ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                   NULL);
-  ecma_deref_ecma_string (message_magic_string_p);
 
   ecma_ref_ecma_string (message_string_p);
   prop_value_p->value = ecma_make_string_value (message_string_p);
@@ -262,6 +259,7 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
       /* Convert an argument to string without side effects. */
       ecma_string_t *arg_string_p;
       const ecma_value_t arg_val = va_arg (args, ecma_value_t);
+
       if (unlikely (ecma_is_value_object (arg_val)))
       {
         ecma_object_t *arg_object_p = ecma_get_object_from_value (arg_val);

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -952,14 +952,14 @@ ecma_op_function_list_lazy_property_names (ecma_object_t *object_p, /**< functio
   ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 
   /* 'length' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-  ecma_string_t *name_p = ecma_new_ecma_length_string ();
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-  ecma_deref_ecma_string (name_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH),
+                                    0);
 
   /* 'prototype' property is non-enumerable (ECMA-262 v5, 13.2.18) */
-  name_p = ecma_get_magic_string (LIT_MAGIC_STRING_PROTOTYPE);
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-  ecma_deref_ecma_string (name_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_PROTOTYPE),
+                                    0);
 
   ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
 
@@ -970,14 +970,14 @@ ecma_op_function_list_lazy_property_names (ecma_object_t *object_p, /**< functio
   if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE)
   {
     /* 'caller' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-    name_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLER);
-    ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-    ecma_deref_ecma_string (name_p);
+    ecma_append_to_values_collection (for_non_enumerable_p,
+                                      ecma_make_magic_string_value (LIT_MAGIC_STRING_CALLER),
+                                      0);
 
     /* 'arguments' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-    name_p = ecma_get_magic_string (LIT_MAGIC_STRING_ARGUMENTS);
-    ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-    ecma_deref_ecma_string (name_p);
+    ecma_append_to_values_collection (for_non_enumerable_p,
+                                      ecma_make_magic_string_value (LIT_MAGIC_STRING_ARGUMENTS),
+                                      0);
   }
 } /* ecma_op_function_list_lazy_property_names */
 
@@ -1007,9 +1007,9 @@ ecma_op_external_function_list_lazy_property_names (bool separate_enumerable, /*
   ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 
   /* 'prototype' property is non-enumerable (ECMA-262 v5, 13.2.18) */
-  ecma_string_t *name_p = ecma_get_magic_string (LIT_MAGIC_STRING_PROTOTYPE);
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-  ecma_deref_ecma_string (name_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_PROTOTYPE),
+                                    0);
 } /* ecma_op_external_function_list_lazy_property_names */
 
 /**
@@ -1039,19 +1039,19 @@ ecma_op_bound_function_list_lazy_property_names (bool separate_enumerable, /**< 
   ecma_collection_header_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 
   /* 'length' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-  ecma_string_t *name_p = ecma_new_ecma_length_string ();
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-  ecma_deref_ecma_string (name_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH),
+                                    0);
 
   /* 'caller' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-  name_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLER);
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-  ecma_deref_ecma_string (name_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_CALLER),
+                                    0);
 
   /* 'arguments' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-  name_p = ecma_get_magic_string (LIT_MAGIC_STRING_ARGUMENTS);
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (name_p), 0);
-  ecma_deref_ecma_string (name_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_ARGUMENTS),
+                                    0);
 } /* ecma_op_bound_function_list_lazy_property_names */
 
 /**

--- a/jerry-core/ecma/operations/ecma-jobqueue.c
+++ b/jerry-core/ecma/operations/ecma-jobqueue.c
@@ -145,15 +145,15 @@ ecma_process_promise_reaction_job (void *obj_p) /**< the job to be operated */
   ecma_job_promise_reaction_t *job_p = (ecma_job_promise_reaction_t *) obj_p;
   ecma_object_t *reaction_p = ecma_get_object_from_value (job_p->reaction);
 
-  ecma_string_t *str_capability = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
-  ecma_string_t *str_handler = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_HANDLER);
-  ecma_string_t *str_resolve = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
-  ecma_string_t *str_reject = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
+  ecma_string_t *capability_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
+  ecma_string_t *handler_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_HANDLER);
+  ecma_string_t *resolve_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
+  ecma_string_t *reject_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
 
   /* 2. */
-  ecma_value_t capability = ecma_op_object_get (reaction_p, str_capability);
+  ecma_value_t capability = ecma_op_object_get (reaction_p, capability_str_p);
   /* 3. */
-  ecma_value_t handler = ecma_op_object_get (reaction_p, str_handler);
+  ecma_value_t handler = ecma_op_object_get (reaction_p, handler_str_p);
 
   JERRY_ASSERT (ecma_is_value_boolean (handler) || ecma_op_is_callable (handler));
 
@@ -183,7 +183,7 @@ ecma_process_promise_reaction_job (void *obj_p) /**< the job to be operated */
     }
 
     /* 7. */
-    ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability), str_reject);
+    ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability), reject_str_p);
 
     JERRY_ASSERT (ecma_op_is_callable (reject));
 
@@ -196,7 +196,7 @@ ecma_process_promise_reaction_job (void *obj_p) /**< the job to be operated */
   else
   {
     /* 8. */
-    ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability), str_resolve);
+    ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability), resolve_str_p);
 
     JERRY_ASSERT (ecma_op_is_callable (resolve));
 
@@ -210,10 +210,6 @@ ecma_process_promise_reaction_job (void *obj_p) /**< the job to be operated */
   ecma_free_value (handler_result);
   ecma_free_value (handler);
   ecma_free_value (capability);
-  ecma_deref_ecma_string (str_capability);
-  ecma_deref_ecma_string (str_handler);
-  ecma_deref_ecma_string (str_resolve);
-  ecma_deref_ecma_string (str_reject);
   ecma_free_promise_reaction_job (job_p);
 
   return status;

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -115,49 +115,41 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   ecma_property_value_t *prop_value_p;
 
   /* 11.a, 11.b */
-  for (ecma_length_t indx = 0;
-       indx < arguments_number;
-       indx++)
+  for (ecma_length_t index = 0;
+       index < arguments_number;
+       index++)
   {
-    ecma_string_t *indx_string_p = ecma_new_ecma_string_from_uint32 (indx);
+    ecma_string_t *index_string_p = ecma_new_ecma_string_from_uint32 (index);
 
     prop_value_p = ecma_create_named_data_property (obj_p,
-                                                    indx_string_p,
+                                                    index_string_p,
                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                                     NULL);
 
-    prop_value_p->value = ecma_copy_value_if_not_object (arguments_list_p[indx]);
+    prop_value_p->value = ecma_copy_value_if_not_object (arguments_list_p[index]);
 
-    ecma_deref_ecma_string (indx_string_p);
+    ecma_deref_ecma_string (index_string_p);
   }
 
   /* 7. */
-  ecma_string_t *length_magic_string_p = ecma_new_ecma_length_string ();
-
   prop_value_p = ecma_create_named_data_property (obj_p,
-                                                  length_magic_string_p,
+                                                  ecma_get_length_string (),
                                                   ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                   NULL);
 
   prop_value_p->value = ecma_make_uint32_value (arguments_number);
-
-  ecma_deref_ecma_string (length_magic_string_p);
 
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
   /* 13. */
   if (!is_strict)
   {
-    ecma_string_t *callee_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLEE);
-
     prop_value_p = ecma_create_named_data_property (obj_p,
-                                                    callee_magic_string_p,
+                                                    ecma_get_magic_string (LIT_MAGIC_STRING_CALLEE),
                                                     ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                     NULL);
 
     prop_value_p->value = ecma_make_object_value (func_obj_p);
-
-    ecma_deref_ecma_string (callee_magic_string_p);
   }
   else
   {
@@ -179,23 +171,18 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
       prop_desc.is_configurable = false;
     }
 
-    ecma_string_t *callee_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLEE);
-
     ecma_value_t completion = ecma_op_object_define_own_property (obj_p,
-                                                                  callee_magic_string_p,
+                                                                  ecma_get_magic_string (LIT_MAGIC_STRING_CALLEE),
                                                                   &prop_desc,
                                                                   false);
 
     JERRY_ASSERT (ecma_is_value_true (completion));
-    ecma_deref_ecma_string (callee_magic_string_p);
 
-    ecma_string_t *caller_magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_CALLER);
     completion = ecma_op_object_define_own_property (obj_p,
-                                                     caller_magic_string_p,
+                                                     ecma_get_magic_string (LIT_MAGIC_STRING_CALLER),
                                                      &prop_desc,
                                                      false);
     JERRY_ASSERT (ecma_is_value_true (completion));
-    ecma_deref_ecma_string (caller_magic_string_p);
 
     ecma_deref_object (thrower_p);
   }
@@ -223,7 +210,6 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
     JERRY_ASSERT (ecma_is_value_empty (completion));
   }
 
-  ecma_deref_ecma_string (arguments_string_p);
   ecma_deref_object (obj_p);
 } /* ecma_op_create_arguments_object */
 

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -362,55 +362,46 @@ ecma_call_builtin_executor (ecma_object_t *executor_p, /**< the executor object 
                             ecma_value_t resolve_func, /**< the resolve function */
                             ecma_value_t reject_func) /**< the reject function */
 {
-  ecma_string_t *str_capability = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
-  ecma_string_t *str_resolve = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
-  ecma_string_t *str_reject = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
+  ecma_string_t *capability_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
+  ecma_string_t *resolve_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
+  ecma_string_t *reject_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
 
   /* 2. */
-  ecma_value_t capability = ecma_op_object_get (executor_p, str_capability);
+  ecma_value_t capability = ecma_op_object_get (executor_p, capability_str_p);
   /* 3. */
-  ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability), str_resolve);
+  ecma_value_t resolve = ecma_op_object_get (ecma_get_object_from_value (capability), resolve_str_p);
 
   if (resolve != ECMA_VALUE_UNDEFINED)
   {
     ecma_free_value (resolve);
     ecma_free_value (capability);
-    ecma_deref_ecma_string (str_capability);
-    ecma_deref_ecma_string (str_resolve);
-    ecma_deref_ecma_string (str_reject);
 
     return ecma_raise_type_error (ECMA_ERR_MSG ("'resolve' function should be undefined."));
   }
 
   /* 4. */
-  ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability), str_reject);
+  ecma_value_t reject = ecma_op_object_get (ecma_get_object_from_value (capability), reject_str_p);
 
   if (reject != ECMA_VALUE_UNDEFINED)
   {
     ecma_free_value (reject);
     ecma_free_value (capability);
-    ecma_deref_ecma_string (str_capability);
-    ecma_deref_ecma_string (str_resolve);
-    ecma_deref_ecma_string (str_reject);
 
     return ecma_raise_type_error (ECMA_ERR_MSG ("'reject' function should be undefined."));
   }
 
   /* 5. */
   ecma_op_object_put (ecma_get_object_from_value (capability),
-                      str_resolve,
+                      resolve_str_p,
                       resolve_func,
                       false);
   /* 6. */
   ecma_op_object_put (ecma_get_object_from_value (capability),
-                      str_reject,
+                      reject_str_p,
                       reject_func,
                       false);
 
   ecma_free_value (capability);
-  ecma_deref_ecma_string (str_capability);
-  ecma_deref_ecma_string (str_resolve);
-  ecma_deref_ecma_string (str_reject);
 
   return ECMA_VALUE_UNDEFINED;
 } /* ecma_call_builtin_executor */
@@ -593,15 +584,16 @@ ecma_promise_new_capability (void)
 {
   /* 3. */
   ecma_object_t *capability_p = ecma_op_create_object_object_noarg ();
-  ecma_string_t *str_capability = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
-  ecma_string_t *str_promise = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
+
+  ecma_string_t *capability_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
+  ecma_string_t *promise_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
   /* 4. */
   ecma_object_t *executor_p;
   executor_p = ecma_op_create_object_object_noarg ();
   ecma_value_t executor = ecma_make_object_value (executor_p);
   /* 5. */
   ecma_op_object_put (executor_p,
-                      str_capability,
+                      capability_str_p,
                       ecma_make_object_value (capability_p),
                       false);
 
@@ -610,13 +602,12 @@ ecma_promise_new_capability (void)
 
   /* 10. */
   ecma_op_object_put (capability_p,
-                      str_promise,
+                      promise_str_p,
                       promise,
                       false);
 
   ecma_deref_object (executor_p);
-  ecma_deref_ecma_string (str_promise);
-  ecma_deref_ecma_string (str_capability);
+
   /* 7. */
   if (ECMA_IS_VALUE_ERROR (promise))
   {
@@ -627,9 +618,8 @@ ecma_promise_new_capability (void)
 
   ecma_free_value (promise);
   /* 8. */
-  ecma_string_t *str_resolve = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
-  ecma_value_t resolve = ecma_op_object_get (capability_p, str_resolve);
-  ecma_deref_ecma_string (str_resolve);
+  ecma_string_t *resolve_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_RESOLVE);
+  ecma_value_t resolve = ecma_op_object_get (capability_p, resolve_str_p);
 
   if (!ecma_op_is_callable (resolve))
   {
@@ -640,9 +630,8 @@ ecma_promise_new_capability (void)
 
   ecma_free_value (resolve);
   /* 9. */
-  ecma_string_t *str_reject = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
-  ecma_value_t reject = ecma_op_object_get (capability_p, str_reject);
-  ecma_deref_ecma_string (str_reject);
+  ecma_string_t *reject_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_REJECT);
+  ecma_value_t reject = ecma_op_object_get (capability_p, reject_str_p);
 
   if (!ecma_op_is_callable (reject))
   {
@@ -671,9 +660,9 @@ ecma_promise_do_then (ecma_value_t promise, /**< the promise which call 'then' *
                       ecma_value_t on_rejected, /**< on_rejected function */
                       ecma_value_t result_capability) /**< promise capability */
 {
-  ecma_string_t *str_capability = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
-  ecma_string_t *str_handler = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_HANDLER);
-  ecma_string_t *str_promise = ecma_new_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
+  ecma_string_t *capability_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_CAPABILITY);
+  ecma_string_t *handler_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_HANDLER);
+  ecma_string_t *promise_str_p = ecma_get_ecma_string_from_uint32 (ECMA_PROMISE_PROPERTY_PROMISE);
 
   /* 3. boolean true indicates "indentity" */
   if (!ecma_op_is_callable (on_fulfilled))
@@ -691,20 +680,20 @@ ecma_promise_do_then (ecma_value_t promise, /**< the promise which call 'then' *
   ecma_object_t *fulfill_reaction_p = ecma_op_create_object_object_noarg ();
   ecma_object_t *reject_reaction_p = ecma_op_create_object_object_noarg ();
   ecma_op_object_put (fulfill_reaction_p,
-                      str_capability,
+                      capability_str_p,
                       result_capability,
                       false);
   ecma_op_object_put (fulfill_reaction_p,
-                      str_handler,
+                      handler_str_p,
                       on_fulfilled,
                       false);
 
   ecma_op_object_put (reject_reaction_p,
-                      str_capability,
+                      capability_str_p,
                       result_capability,
                       false);
   ecma_op_object_put (reject_reaction_p,
-                      str_handler,
+                      handler_str_p,
                       on_rejected,
                       false);
 
@@ -738,13 +727,10 @@ ecma_promise_do_then (ecma_value_t promise, /**< the promise which call 'then' *
   }
 
   /* 10. */
-  ecma_value_t ret = ecma_op_object_get (ecma_get_object_from_value (result_capability), str_promise);
+  ecma_value_t ret = ecma_op_object_get (ecma_get_object_from_value (result_capability), promise_str_p);
 
   ecma_deref_object (fulfill_reaction_p);
   ecma_deref_object (reject_reaction_p);
-  ecma_deref_ecma_string (str_capability);
-  ecma_deref_ecma_string (str_handler);
-  ecma_deref_ecma_string (str_promise);
   return ret;
 } /* ecma_promise_do_then */
 

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -164,47 +164,35 @@ re_initialize_props (ecma_object_t *re_obj_p, /**< RegExp object */
                      ecma_string_t *source_p, /**< source string */
                      uint16_t flags) /**< flags */
 {
- /* Set source property. ECMA-262 v5, 15.10.7.1 */
-  ecma_string_t *magic_string_p;
-
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_SOURCE);
+  /* Set source property. ECMA-262 v5, 15.10.7.1 */
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        ecma_get_magic_string (LIT_MAGIC_STRING_SOURCE),
                         ECMA_PROPERTY_FIXED,
                         ecma_make_string_value (source_p));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set global property. ECMA-262 v5, 15.10.7.2 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        ecma_get_magic_string (LIT_MAGIC_STRING_GLOBAL),
                         ECMA_PROPERTY_FIXED,
                         ecma_make_boolean_value (flags & RE_FLAG_GLOBAL));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set ignoreCase property. ECMA-262 v5, 15.10.7.3 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        ecma_get_magic_string (LIT_MAGIC_STRING_IGNORECASE_UL),
                         ECMA_PROPERTY_FIXED,
                         ecma_make_boolean_value (flags & RE_FLAG_IGNORE_CASE));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set multiline property. ECMA-262 v5, 15.10.7.4 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        ecma_get_magic_string (LIT_MAGIC_STRING_MULTILINE),
                         ECMA_PROPERTY_FIXED,
                         ecma_make_boolean_value (flags & RE_FLAG_MULTILINE));
-  ecma_deref_ecma_string (magic_string_p);
 
   /* Set lastIndex property. ECMA-262 v5, 15.10.7.5 */
-  magic_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
   re_set_data_property (re_obj_p,
-                        magic_string_p,
+                        ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
                         ECMA_PROPERTY_FLAG_WRITABLE,
                         ecma_make_integer_value (0));
-  ecma_deref_ecma_string (magic_string_p);
 } /* re_initialize_props */
 
 /**
@@ -1172,33 +1160,24 @@ re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
                                 int32_t index) /**< index of matching */
 {
   /* Set index property of the result array */
-  ecma_string_t *result_prop_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INDEX);
-  {
-    ecma_builtin_helper_def_prop (array_obj_p,
-                                  result_prop_str_p,
-                                  ecma_make_int32_value (index),
-                                  true, /* Writable */
-                                  true, /* Enumerable */
-                                  true, /* Configurable */
-                                  true); /* Failure handling */
-  }
-  ecma_deref_ecma_string (result_prop_str_p);
+  ecma_builtin_helper_def_prop (array_obj_p,
+                                ecma_get_magic_string (LIT_MAGIC_STRING_INDEX),
+                                ecma_make_int32_value (index),
+                                true, /* Writable */
+                                true, /* Enumerable */
+                                true, /* Configurable */
+                                true); /* Failure handling */
 
   /* Set input property of the result array */
-  result_prop_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_INPUT);
-
   ecma_builtin_helper_def_prop (array_obj_p,
-                                result_prop_str_p,
+                                ecma_get_magic_string (LIT_MAGIC_STRING_INPUT),
                                 ecma_make_string_value (input_str_p),
                                 true, /* Writable */
                                 true, /* Enumerable */
                                 true, /* Configurable */
                                 true); /* Failure handling */
 
-  ecma_deref_ecma_string (result_prop_str_p);
-
   /* Set length property of the result array */
-  result_prop_str_p = ecma_new_ecma_length_string ();
   {
     ecma_property_descriptor_t array_item_prop_desc = ecma_make_empty_property_descriptor ();
     array_item_prop_desc.is_value_defined = true;
@@ -1206,11 +1185,10 @@ re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
     array_item_prop_desc.value = ecma_make_uint32_value (num_of_elements);
 
     ecma_op_object_define_own_property (array_obj_p,
-                                        result_prop_str_p,
+                                        ecma_get_length_string (),
                                         &array_item_prop_desc,
                                         true);
   }
-  ecma_deref_ecma_string (result_prop_str_p);
 } /* re_set_result_array_properties */
 
 /**
@@ -1321,8 +1299,6 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     ECMA_OP_TO_NUMBER_FINALIZE (lastindex_num);
 
     ecma_fast_free_value (lastindex_value);
-
-    ecma_deref_ecma_string (magic_str_p);
   }
 
   /* 2. Try to match */
@@ -1335,9 +1311,10 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
     {
       if (re_ctx.flags & RE_FLAG_GLOBAL)
       {
-        ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
-        ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_integer_value (0), true);
-        ecma_deref_ecma_string (magic_str_p);
+        ecma_op_object_put (regexp_object_p,
+                            ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
+                            ecma_make_integer_value (0),
+                            true);
       }
 
       is_match = false;
@@ -1369,7 +1346,6 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
 
   if (input_curr_p && (re_ctx.flags & RE_FLAG_GLOBAL))
   {
-    ecma_string_t *magic_str_p = ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL);
     ecma_number_t lastindex_num;
 
     if (sub_str_p != NULL
@@ -1383,8 +1359,10 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
       lastindex_num = ECMA_NUMBER_ZERO;
     }
 
-    ecma_op_object_put (regexp_object_p, magic_str_p, ecma_make_number_value (lastindex_num), true);
-    ecma_deref_ecma_string (magic_str_p);
+    ecma_op_object_put (regexp_object_p,
+                        ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
+                        ecma_make_number_value (lastindex_num),
+                        true);
   }
 
   /* 3. Fill the result array or return with 'undefiend' */

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -46,27 +46,18 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
   JERRY_ASSERT (arguments_list_len == 0
                 || arguments_list_p != NULL);
 
-  ecma_string_t *prim_prop_str_value_p;
+  ecma_value_t prim_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
 
-  if (arguments_list_len == 0)
+  if (arguments_list_len > 0)
   {
-    prim_prop_str_value_p = ecma_new_ecma_string_from_magic_string_id (LIT_MAGIC_STRING__EMPTY);
-  }
-  else
-  {
-    ecma_value_t to_str_arg_value = ecma_op_to_string (arguments_list_p[0]);
+    prim_value = ecma_op_to_string (arguments_list_p[0]);
 
-    if (ECMA_IS_VALUE_ERROR (to_str_arg_value))
+    if (ECMA_IS_VALUE_ERROR (prim_value))
     {
-      return to_str_arg_value;
+      return prim_value;
     }
-    else
-    {
-      JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (to_str_arg_value));
-      JERRY_ASSERT (ecma_is_value_string (to_str_arg_value));
 
-      prim_prop_str_value_p = ecma_get_string_from_value (to_str_arg_value);
-    }
+    JERRY_ASSERT (ecma_is_value_string (prim_value));
   }
 
 #ifndef CONFIG_DISABLE_STRING_BUILTIN
@@ -83,7 +74,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_STRING_UL;
-  ext_object_p->u.class_prop.u.value = ecma_make_string_value (prim_prop_str_value_p);
+  ext_object_p->u.class_prop.u.value = prim_value;
 
   return ecma_make_object_value (object_p);
 } /* ecma_op_create_string_object */
@@ -131,9 +122,9 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
     ecma_deref_ecma_string (name_p);
   }
 
-  ecma_string_t *length_str_p = ecma_new_ecma_length_string ();
-  ecma_append_to_values_collection (for_non_enumerable_p, ecma_make_string_value (length_str_p), 0);
-  ecma_deref_ecma_string (length_str_p);
+  ecma_append_to_values_collection (for_non_enumerable_p,
+                                    ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH),
+                                    0);
 } /* ecma_op_string_list_lazy_property_names */
 
 /**

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -92,8 +92,7 @@ opfunc_logical_not (ecma_value_t left_value) /**< left value */
 ecma_value_t
 opfunc_typeof (ecma_value_t left_value) /**< left value */
 {
-  ecma_string_t *type_str_p = ecma_get_magic_string (ecma_get_typeof_lit_id (left_value));
-  return ecma_make_string_value (type_str_p);
+  return ecma_make_magic_string_value (ecma_get_typeof_lit_id (left_value));
 } /* opfunc_typeof */
 
 /**


### PR DESCRIPTION
Remove unnecessary ref / deref calls when magic strings are used.