### PR TITLE
Travis CI - Put the NuttX/STM32F4 job to the allowed failures section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,7 @@ matrix:
   allow_failures:
     - env: OPTS="--check-pylint"
     - env: JOBNAME="Mbed/K64F Build Test"
+    - env: JOBNAME="NuttX/STM32F4 Build Test"
   fast_finish: true
 
 # The channel name "chat.freenode.net#jerryscript"


### PR DESCRIPTION
Related issue: #2224

JerryScript-DCO-1.0-Signed-off-by: Zsolt Borbély zsborbely.u-szeged@partner.samsung.com