### PR TITLE
Fix build failure of NuttX tools

### DIFF
--- a/targets/nuttx-stm32f4/Makefile.travis
+++ b/targets/nuttx-stm32f4/Makefile.travis
@@ -31,7 +31,9 @@ LOCAL_INSTALL:=$(CURDIR)/../local/
 install-kconfig:
 	git clone https://bitbucket.org/nuttx/tools.git ../tools
 	mkdir -p $(LOCAL_INSTALL)
-	cd ../tools/kconfig-frontends && ./configure --disable-mconf --disable-nconf --disable-gconf --disable-qconf --disable-utils --disable-shared --enable-static --prefix=$(LOCAL_INSTALL)
+	# FIXME: 'autoreconf --force --install' is a workaround after
+	#        https://bitbucket.org/nuttx/tools/commits/164450f982b404fdc2b3233db51dc3eaa1f08b7f
+	cd ../tools/kconfig-frontends && autoreconf --force --install && ./configure --disable-mconf --disable-nconf --disable-gconf --disable-qconf --disable-utils --disable-shared --enable-static --prefix=$(LOCAL_INSTALL)
 	$(MAKE) -C ../tools/kconfig-frontends
 	$(MAKE) -C ../tools/kconfig-frontends install
 


### PR DESCRIPTION
The CI is broken after 'https://bitbucket.org/nuttx/tools/commits/164450f982b404fdc2b3233db51dc3eaa1f08b7f',
because it cannot find 'aclocal-1.15'.

Fixes #2224 

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com