### PR TITLE
Support static snapshots.

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -4736,6 +4736,77 @@ main (void)
 - [jerry_init](#jerry_init)
 - [jerry_cleanup](#jerry_cleanup)
 - [jerry_exec_snapshot](#jerry_exec_snapshot)
+- [jerry_parse_and_save_static_snapshot](#jerry_parse_and_save_static_snapshot)
+
+
+## jerry_parse_and_save_static_snapshot
+
+**Summary**
+
+Generate static snapshot from the specified source code.
+
+Unlike normal snaphots static snaphots are fully executed from ROM. Not
+even their header is loaded into the RAM. However they can only depend
+on magic strings and 28 bit integer numbers. Regular expression literals
+are not supported as well.
+
+**Prototype**
+
+```c
+size_t
+jerry_parse_and_save_static_snapshot (const jerry_char_t *source_p,
+                                      size_t source_size,
+                                      bool is_for_global,
+                                      bool is_strict,
+                                      uint32_t *buffer_p,
+                                      size_t buffer_size);
+```
+
+- `source_p` - script source, it must be a valid utf8 string.
+- `source_size` - script source size, in bytes.
+- `is_for_global` - snapshot would be executed as global (true) or eval (false).
+- `is_strict` - strict mode
+- `buffer_p` - buffer to save snapshot to.
+- `buffer_size` - the buffer's size.
+- return value
+  - the size of snapshot, if it was generated succesfully (i.e. there are no syntax errors in source
+    code, buffer size is sufficient, only magic strings are used by the snapshot, and snapshot support
+    is enabled in current configuration through JERRY_ENABLE_SNAPSHOT_SAVE)
+  - 0 otherwise.
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include <string.h>
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  static uint32_t global_mode_snapshot_buffer[256];
+  const jerry_char_t *code_to_snapshot_p = (const jerry_char_t *) "(function () { return 'string'; }) ();";
+
+  size_t global_mode_snapshot_size = jerry_parse_and_save_static_snapshot (code_to_snapshot_p,
+                                                                           strlen ((const char *) code_to_snapshot_p),
+                                                                           true,
+                                                                           false,
+                                                                           global_mode_snapshot_buffer,
+                                                                           sizeof (global_mode_snapshot_buffer) / sizeof (uint32_t));
+
+  jerry_cleanup ();
+}
+```
+
+**See also**
+
+- [jerry_init](#jerry_init)
+- [jerry_cleanup](#jerry_cleanup)
+- [jerry_exec_snapshot](#jerry_exec_snapshot)
+- [jerry_parse_and_save_snapshot](#jerry_parse_and_save_snapshot)
 
 
 ## jerry_parse_and_save_function_snapshot
@@ -4808,6 +4879,82 @@ main (void)
 - [jerry_init](#jerry_init)
 - [jerry_cleanup](#jerry_cleanup)
 - [jerry_load_function_snapshot_at](#jerry_load_function_snapshot_at)
+- [jerry_parse_and_save_static_function_snapshot](#jerry_parse_and_save_static_function_snapshot)
+
+
+## jerry_parse_and_save_static_function_snapshot
+
+**Summary**
+
+Generate static function snapshot from the specified source code
+with the given function body and arguments.
+
+Unlike normal snaphots static snaphots are fully executed from ROM. Not
+even their header is loaded into the RAM. However they can only depend
+on magic strings and 28 bit integer numbers. Regular expression literals
+are not supported as well.
+
+**Prototype**
+
+```c
+size_t
+jerry_parse_and_save_static_function_snapshot (const jerry_char_t *source_p,
+                                               size_t source_size,
+                                               const jerry_char_t *args_p,
+                                               size_t args_size,
+                                               bool is_strict,
+                                               uint32_t *buffer_p,
+                                               size_t buffer_size)
+```
+
+- `source_p` - script source, it must be a valid utf8 string.
+- `source_size` - script source size, in bytes.
+- `args_p` - function arguments, it must be a valid utf8 string.
+- `args_size` - function argument size, in bytes.
+- `is_strict` - strict mode
+- `buffer_p` - buffer to save snapshot to.
+- `buffer_size` - the buffer's size.
+- return value
+  - the size of snapshot, if it was generated succesfully (i.e. there are no syntax errors in source
+    code, buffer size is sufficient, only magic strings are used by the snapshot, and snapshot support
+    is enabled in current configuration through JERRY_ENABLE_SNAPSHOT_SAVE)
+  - 0 otherwise.
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include <string.h>
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  static uint32_t func_snapshot_buffer[256];
+  const jerry_char_t *args_p = (const jerry_char_t *) "string, bind";
+  const jerry_char_t *src_p = (const jerry_char_t *) "return bind(string)";
+
+  size_t func_snapshot_size = jerry_parse_and_save_static_function_snapshot (src_p,
+                                                                             strlen ((const char *) src_p),
+                                                                             args_p,
+                                                                             strlen ((const char *) args_p),
+                                                                             false,
+                                                                             func_snapshot_buffer,
+                                                                             sizeof (func_snapshot_buffer) / sizeof (uint32_t));
+
+  jerry_cleanup ();
+}
+```
+
+**See also**
+
+- [jerry_init](#jerry_init)
+- [jerry_cleanup](#jerry_cleanup)
+- [jerry_load_function_snapshot_at](#jerry_load_function_snapshot_at)
+- [jerry_parse_and_save_function_snapshot](#jerry_parse_and_save_function_snapshot)
 
 
 ## jerry_exec_snapshot

--- a/jerry-core/api/jerry-snapshot.h
+++ b/jerry-core/api/jerry-snapshot.h
@@ -46,7 +46,7 @@ typedef struct
 /**
  * Jerry snapshot format version.
  */
-#define JERRY_SNAPSHOT_VERSION (9u)
+#define JERRY_SNAPSHOT_VERSION (10u)
 
 /**
  * Snapshot configuration flags.

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -558,11 +558,7 @@ jerry_run (const jerry_value_t func_val) /**< function to run */
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (wrong_args_msg_p)));
   }
 
-  const ecma_compiled_code_t *bytecode_data_p;
-  bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                     ext_func_p->u.function.bytecode_cp);
-
-  return jerry_return (vm_run_global (bytecode_data_p));
+  return jerry_return (vm_run_global (ecma_op_function_get_compiled_code (ext_func_p)));
 } /* jerry_run */
 
 /**

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -797,6 +797,33 @@ typedef struct
   ecma_built_in_props_t built_in; /**< built-in object part */
 } ecma_extended_built_in_object_t;
 
+/**
+ * Compiled byte code data.
+ */
+typedef struct
+{
+  uint16_t size;                    /**< real size >> JMEM_ALIGNMENT_LOG */
+  uint16_t refs;                    /**< reference counter for the byte code */
+  uint16_t status_flags;            /**< various status flags:
+                                      *    CBC_CODE_FLAGS_FUNCTION flag tells whether
+                                      *    the byte code is function or regular expression.
+                                      *    If function, the other flags must be CBC_CODE_FLAGS...
+                                      *    If regexp, the other flags must be RE_FLAG... */
+} ecma_compiled_code_t;
+
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+
+/**
+ * Description of static function objects.
+ */
+typedef struct
+{
+  ecma_extended_object_t header;
+  const ecma_compiled_code_t *bytecode_p;
+} ecma_static_function_t;
+
+#endif /* JERRY_ENABLE_SNAPSHOT_EXEC */
+
 #ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
 
 /**
@@ -809,6 +836,19 @@ typedef struct
   jmem_cpointer_t scope_cp; /**< function scope */
   jmem_cpointer_t bytecode_cp; /**< function byte code */
 } ecma_arrow_function_t;
+
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+
+/**
+ * Description of static arrow function objects.
+ */
+typedef struct
+{
+  ecma_arrow_function_t header;
+  const ecma_compiled_code_t *bytecode_p;
+} ecma_static_arrow_function_t;
+
+#endif /* JERRY_ENABLE_SNAPSHOT_EXEC */
 
 #endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 
@@ -1275,20 +1315,6 @@ typedef struct
   uint32_t refs_and_flags; /**< reference counter */
   ecma_value_t value; /**< referenced value */
 } ecma_error_reference_t;
-
-/**
- * Compiled byte code data.
- */
-typedef struct
-{
-  uint16_t size;                    /**< real size >> JMEM_ALIGNMENT_LOG */
-  uint16_t refs;                    /**< reference counter for the byte code */
-  uint16_t status_flags;            /**< various status flags:
-                                      *    CBC_CODE_FLAGS_FUNCTION flag tells whether
-                                      *    the byte code is function or regular expression.
-                                      *    If function, the other flags must be CBC_CODE_FLAGS...
-                                      *    If regexp, the other flags must be RE_FLAG... */
-} ecma_compiled_code_t;
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
 

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -312,6 +312,18 @@ ecma_is_value_string (ecma_value_t value) /**< ecma value */
 } /* ecma_is_value_string */
 
 /**
+ * Check if the value is direct_ecma-string.
+ *
+ * @return true - if the value contains ecma-string value,
+ *         false - otherwise
+ */
+inline bool __attr_const___ __attr_always_inline___
+ecma_is_value_direct_string (ecma_value_t value) /**< ecma value */
+{
+  return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT_STRING);
+} /* ecma_is_value_direct_string */
+
+/**
  * Check if the value is object.
  *
  * @return true - if the value contains object value,

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1487,6 +1487,7 @@ void
 ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
 {
   JERRY_ASSERT (bytecode_p->refs > 0);
+  JERRY_ASSERT (!(bytecode_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION));
 
   bytecode_p->refs--;
 

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -154,6 +154,7 @@ bool ecma_are_values_integer_numbers (ecma_value_t first_value, ecma_value_t sec
 bool ecma_is_value_float_number (ecma_value_t value) __attr_const___;
 bool ecma_is_value_number (ecma_value_t value) __attr_const___;
 bool ecma_is_value_string (ecma_value_t value) __attr_const___;
+bool ecma_is_value_direct_string (ecma_value_t value) __attr_const___;
 bool ecma_is_value_object (ecma_value_t value) __attr_const___;
 bool ecma_is_value_error_reference (ecma_value_t value) __attr_const___;
 bool ecma_is_value_collection_chunk (ecma_value_t value) __attr_const___;

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -124,8 +124,17 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
   /* 1., 4., 13. */
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_FUNCTION_PROTOTYPE);
 
+  size_t function_object_size = sizeof (ecma_extended_object_t);
+
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+  if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION)
+  {
+    function_object_size = sizeof (ecma_static_function_t);
+  }
+#endif
+
   ecma_object_t *func_p = ecma_create_object (prototype_obj_p,
-                                              sizeof (ecma_extended_object_t),
+                                              function_object_size,
                                               ECMA_OBJECT_TYPE_FUNCTION);
 
   ecma_deref_object (prototype_obj_p);
@@ -150,8 +159,22 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
   ECMA_SET_INTERNAL_VALUE_POINTER (ext_func_p->u.function.scope_cp, scope_p);
 
   /* 10., 11., 12. */
+
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+  if (!(bytecode_data_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION))
+  {
+    ECMA_SET_INTERNAL_VALUE_POINTER (ext_func_p->u.function.bytecode_cp, bytecode_data_p);
+    ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_data_p);
+  }
+  else
+  {
+    ext_func_p->u.function.bytecode_cp = ECMA_NULL_POINTER;
+    ((ecma_static_function_t *) func_p)->bytecode_p = bytecode_data_p;
+  }
+#else /* !JERRY_ENABLE_SNAPSHOT_EXEC */
   ECMA_SET_INTERNAL_VALUE_POINTER (ext_func_p->u.function.bytecode_cp, bytecode_data_p);
   ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_data_p);
+#endif
 
   /* 14., 15., 16., 17., 18. */
   /*
@@ -179,8 +202,17 @@ ecma_op_create_arrow_function_object (ecma_object_t *scope_p, /**< function's sc
 {
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_FUNCTION_PROTOTYPE);
 
+  size_t arrow_function_object_size = sizeof (ecma_arrow_function_t);
+
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+  if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION)
+  {
+    arrow_function_object_size = sizeof (ecma_static_arrow_function_t);
+  }
+#endif
+
   ecma_object_t *func_p = ecma_create_object (prototype_obj_p,
-                                              sizeof (ecma_arrow_function_t),
+                                              arrow_function_object_size,
                                               ECMA_OBJECT_TYPE_ARROW_FUNCTION);
 
   ecma_deref_object (prototype_obj_p);
@@ -190,8 +222,21 @@ ecma_op_create_arrow_function_object (ecma_object_t *scope_p, /**< function's sc
 
   ECMA_SET_NON_NULL_POINTER (arrow_func_p->scope_cp, scope_p);
 
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+  if (!(bytecode_data_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION))
+  {
+    ECMA_SET_NON_NULL_POINTER (arrow_func_p->bytecode_cp, bytecode_data_p);
+    ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_data_p);
+  }
+  else
+  {
+    arrow_func_p->bytecode_cp = ECMA_NULL_POINTER;
+    ((ecma_static_arrow_function_t *) func_p)->bytecode_p = bytecode_data_p;
+  }
+#else /* !JERRY_ENABLE_SNAPSHOT_EXEC */
   ECMA_SET_NON_NULL_POINTER (arrow_func_p->bytecode_cp, bytecode_data_p);
   ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_data_p);
+#endif
 
   arrow_func_p->this_binding = ecma_copy_value_if_not_object (this_binding);
   return func_p;
@@ -231,6 +276,58 @@ ecma_op_create_external_function_object (ecma_external_handler_t handler_cb) /**
 
   return function_obj_p;
 } /* ecma_op_create_external_function_object */
+
+/**
+ * Get compiled code of a function object.
+ *
+ * @return compiled code
+ */
+inline const ecma_compiled_code_t * __attr_always_inline___
+ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p) /**< function pointer */
+{
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+  if (function_p->u.function.bytecode_cp != ECMA_NULL_POINTER)
+  {
+    return ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
+                                            function_p->u.function.bytecode_cp);
+  }
+  else
+  {
+    return ((ecma_static_function_t *) function_p)->bytecode_p;
+  }
+#else /* !JERRY_ENABLE_SNAPSHOT_EXEC */
+  return ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
+                                          function_p->u.function.bytecode_cp);
+#endif /* JERRY_ENABLE_SNAPSHOT_EXEC */
+} /* ecma_op_function_get_compiled_code */
+
+#ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
+
+/**
+ * Get compiled code of an arrow function object.
+ *
+ * @return compiled code
+ */
+inline const ecma_compiled_code_t * __attr_always_inline___
+ecma_op_arrow_function_get_compiled_code (ecma_arrow_function_t *arrow_function_p) /**< arrow function pointer */
+{
+#ifdef JERRY_ENABLE_SNAPSHOT_EXEC
+  if (arrow_function_p->bytecode_cp != ECMA_NULL_POINTER)
+  {
+    return ECMA_GET_NON_NULL_POINTER (const ecma_compiled_code_t,
+                                      arrow_function_p->bytecode_cp);
+  }
+  else
+  {
+    return ((ecma_static_arrow_function_t *) arrow_function_p)->bytecode_p;
+  }
+#else /* !JERRY_ENABLE_SNAPSHOT_EXEC */
+  return ECMA_GET_NON_NULL_POINTER (const ecma_compiled_code_t,
+                                    arrow_function_p->bytecode_cp);
+#endif /* JERRY_ENABLE_SNAPSHOT_EXEC */
+} /* ecma_op_arrow_function_get_compiled_code */
+
+#endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 
 /**
  * [[Call]] implementation for Function objects,
@@ -357,9 +454,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       bool is_strict;
       bool is_no_lex_env;
 
-      const ecma_compiled_code_t *bytecode_data_p;
-      bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                         ext_func_p->u.function.bytecode_cp);
+      const ecma_compiled_code_t *bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
 
       is_strict = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE) ? true : false;
       is_no_lex_env = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED) ? true : false;
@@ -428,9 +523,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
 
     bool is_no_lex_env;
 
-    const ecma_compiled_code_t *bytecode_data_p;
-    bytecode_data_p = ECMA_GET_NON_NULL_POINTER (const ecma_compiled_code_t,
-                                                 arrow_func_p->bytecode_cp);
+    const ecma_compiled_code_t *bytecode_data_p = ecma_op_arrow_function_get_compiled_code (arrow_func_p);
 
     is_no_lex_env = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED) ? true : false;
 
@@ -782,15 +875,13 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
     if (ecma_get_object_type (object_p) == ECMA_OBJECT_TYPE_ARROW_FUNCTION)
     {
       ecma_arrow_function_t *arrow_func_p = (ecma_arrow_function_t *) object_p;
-      bytecode_data_p = ECMA_GET_NON_NULL_POINTER (const ecma_compiled_code_t,
-                                                   arrow_func_p->bytecode_cp);
+      bytecode_data_p = ecma_op_arrow_function_get_compiled_code (arrow_func_p);
     }
     else
     {
 #endif /* CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
       ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-      bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                         ext_func_p->u.function.bytecode_cp);
+      bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
 #ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
     }
 #endif /* CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
@@ -961,11 +1052,8 @@ ecma_op_function_list_lazy_property_names (ecma_object_t *object_p, /**< functio
                                     ecma_make_magic_string_value (LIT_MAGIC_STRING_PROTOTYPE),
                                     0);
 
-  ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-
   const ecma_compiled_code_t *bytecode_data_p;
-  bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                     ext_func_p->u.function.bytecode_cp);
+  bytecode_data_p = ecma_op_function_get_compiled_code ((ecma_extended_object_t *) object_p);
 
   if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE)
   {

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -43,6 +43,17 @@ ecma_op_create_arrow_function_object (ecma_object_t *scope_p, const ecma_compile
 ecma_object_t *
 ecma_op_create_external_function_object (ecma_external_handler_t handler_cb);
 
+const ecma_compiled_code_t *
+ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p);
+
+#ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
+const ecma_compiled_code_t *
+ecma_op_arrow_function_get_compiled_code (ecma_arrow_function_t *arrow_function_p);
+#endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
+
+ecma_value_t
+ecma_op_function_has_instance (ecma_object_t *func_obj_p, ecma_value_t value);
+
 ecma_value_t
 ecma_op_function_call (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
                        const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
@@ -50,9 +61,6 @@ ecma_op_function_call (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
 ecma_value_t
 ecma_op_function_construct (ecma_object_t *func_obj_p, const ecma_value_t *arguments_list_p,
                             ecma_length_t arguments_list_len);
-
-ecma_value_t
-ecma_op_function_has_instance (ecma_object_t *func_obj_p, ecma_value_t value);
 
 ecma_property_t *
 ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -208,19 +208,16 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
           if (type != ECMA_OBJECT_TYPE_ARROW_FUNCTION)
           {
             ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-            bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                               ext_func_p->u.function.bytecode_cp);
+            bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
           }
           else
           {
             ecma_arrow_function_t *arrow_func_p = (ecma_arrow_function_t *) object_p;
-            bytecode_data_p = ECMA_GET_NON_NULL_POINTER (const ecma_compiled_code_t,
-                                                         arrow_func_p->bytecode_cp);
+            bytecode_data_p = ecma_op_arrow_function_get_compiled_code (arrow_func_p);
           }
 #else /* CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
           ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-          bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                             ext_func_p->u.function.bytecode_cp);
+          bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
 #endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 
           uint32_t len;
@@ -532,19 +529,16 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
         if (type != ECMA_OBJECT_TYPE_ARROW_FUNCTION)
         {
           ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-          bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                             ext_func_p->u.function.bytecode_cp);
+          bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
         }
         else
         {
           ecma_arrow_function_t *arrow_func_p = (ecma_arrow_function_t *) object_p;
-          bytecode_data_p = ECMA_GET_NON_NULL_POINTER (const ecma_compiled_code_t,
-                                                       arrow_func_p->bytecode_cp);
+          bytecode_data_p = ecma_op_arrow_function_get_compiled_code (arrow_func_p);
         }
 #else /* CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
         ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-        bytecode_data_p = ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
-                                                           ext_func_p->u.function.bytecode_cp);
+        bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
 #endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 
         uint32_t len;

--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -32,6 +32,8 @@ extern "C"
  */
 size_t jerry_parse_and_save_snapshot (const jerry_char_t *source_p, size_t source_size, bool is_for_global,
                                       bool is_strict, uint32_t *buffer_p, size_t buffer_size);
+size_t jerry_parse_and_save_static_snapshot (const jerry_char_t *source_p, size_t source_size, bool is_for_global,
+                                             bool is_strict, uint32_t *buffer_p, size_t buffer_size);
 jerry_value_t jerry_exec_snapshot (const uint32_t *snapshot_p, size_t snapshot_size, bool copy_bytecode);
 jerry_value_t jerry_exec_snapshot_at (const uint32_t *snapshot_p, size_t snapshot_size,
                                       size_t func_index, bool copy_bytecode);
@@ -43,6 +45,9 @@ size_t jerry_parse_and_save_literals (const jerry_char_t *source_p, size_t sourc
 size_t jerry_parse_and_save_function_snapshot (const jerry_char_t *source_p, size_t source_size,
                                                const jerry_char_t *args_p, size_t args_size,
                                                bool is_strict, uint32_t *buffer_p, size_t buffer_size);
+size_t jerry_parse_and_save_static_function_snapshot (const jerry_char_t *source_p, size_t source_size,
+                                                      const jerry_char_t *args_p, size_t args_size,
+                                                      bool is_strict, uint32_t *buffer_p, size_t buffer_size);
 jerry_value_t jerry_load_function_snapshot_at (const uint32_t *function_snapshot_p,
                                                const size_t function_snapshot_size,
                                                size_t func_index,

--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -653,7 +653,8 @@ typedef enum
   CBC_CODE_FLAGS_NON_STRICT_ARGUMENTS_NEEDED = (1u << 5), /**< non-strict arguments object must be constructed */
   CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED = (1u << 6), /**< no need to create a lexical environment */
   CBC_CODE_FLAGS_ARROW_FUNCTION = (1u << 7), /**< this function is an arrow function */
-  CBC_CODE_FLAGS_DEBUGGER_IGNORE = (1u << 8), /**< this function should be ignored by debugger */
+  CBC_CODE_FLAGS_STATIC_FUNCTION = (1u << 8), /**< this function is a static snapshot function */
+  CBC_CODE_FLAGS_DEBUGGER_IGNORE = (1u << 9), /**< this function should be ignored by debugger */
 } cbc_code_flags;
 
 #define CBC_OPCODE(arg1, arg2, arg3, arg4) arg1,

--- a/tests/unit-core/test-snapshot.c
+++ b/tests/unit-core/test-snapshot.c
@@ -23,6 +23,29 @@
  */
 #define SNAPSHOT_BUFFER_SIZE (256)
 
+/**
+ * Magic strings
+ */
+static const jerry_char_ptr_t magic_strings[] =
+{
+  (const jerry_char_ptr_t) " ",
+  (const jerry_char_ptr_t) "a",
+  (const jerry_char_ptr_t) "b",
+  (const jerry_char_ptr_t) "c",
+  (const jerry_char_ptr_t) "from",
+  (const jerry_char_ptr_t) "func",
+  (const jerry_char_ptr_t) "string",
+  (const jerry_char_ptr_t) "snapshot"
+};
+
+/**
+ * Magic string lengths
+ */
+static const jerry_length_t magic_string_lengths[] =
+{
+  1, 1, 1, 1, 4, 4, 6, 8
+};
+
 static void test_function_snapshot (void)
 {
   /* function to snapshot */
@@ -85,6 +108,10 @@ static void test_exec_snapshot (uint32_t *snapshot_p, size_t snapshot_size, bool
 
   jerry_init (JERRY_INIT_EMPTY);
 
+  jerry_register_magic_strings (magic_strings,
+                                sizeof (magic_string_lengths) / sizeof (jerry_length_t),
+                                magic_string_lengths);
+
   jerry_value_t res = jerry_exec_snapshot (snapshot_p,
                                            snapshot_size,
                                            copy_bytecode);
@@ -104,15 +131,15 @@ static void test_exec_snapshot (uint32_t *snapshot_p, size_t snapshot_size, bool
 int
 main (void)
 {
+  static uint32_t global_mode_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
+  static uint32_t eval_mode_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
+
   TEST_INIT ();
 
   /* Dump / execute snapshot */
   if (jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_SAVE)
       && jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_EXEC))
   {
-    static uint32_t global_mode_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
-    static uint32_t eval_mode_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
-
     const char *code_to_snapshot_p = "(function () { return 'string from snapshot'; }) ();";
 
     jerry_init (JERRY_INIT_EMPTY);
@@ -127,11 +154,11 @@ main (void)
     /* Check the snapshot data. Unused bytes should be filled with zeroes */
     const uint8_t expected_data[] =
     {
-      0x4A, 0x52, 0x52, 0x59, 0x09, 0x00, 0x00, 0x00,
+      0x4A, 0x52, 0x52, 0x59, 0x0A, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00,
       0x01, 0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00,
       0x03, 0x00, 0x01, 0x00, 0x01, 0x00, 0x01, 0x00,
-      0x00, 0x00, 0x00, 0x01, 0x03, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x01, 0x18, 0x00, 0x00, 0x00,
       0x28, 0x00, 0xB7, 0x46, 0x00, 0x00, 0x00, 0x00,
       0x03, 0x00, 0x01, 0x00, 0x41, 0x00, 0x00, 0x00,
       0x00, 0x00, 0x01, 0x01, 0x07, 0x00, 0x00, 0x00,
@@ -170,6 +197,36 @@ main (void)
     test_exec_snapshot (eval_mode_snapshot_buffer,
                         eval_mode_snapshot_size,
                         true);
+  }
+
+  /* Static snapshot */
+  if (jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_SAVE)
+      && jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_EXEC))
+  {
+    const char *code_to_snapshot_p = ("function func(a, b, c) {"
+                                      "  c = 'snapshot';"
+                                      "  return arguments[0] + ' ' + b + ' ' + arguments[2];"
+                                      "};"
+                                      "func('string', 'from');");
+
+    jerry_init (JERRY_INIT_EMPTY);
+    jerry_register_magic_strings (magic_strings,
+                                  sizeof (magic_string_lengths) / sizeof (jerry_length_t),
+                                  magic_string_lengths);
+
+    size_t global_mode_snapshot_size = jerry_parse_and_save_static_snapshot ((jerry_char_t *) code_to_snapshot_p,
+                                                                             strlen (code_to_snapshot_p),
+                                                                             true,
+                                                                             false,
+                                                                             global_mode_snapshot_buffer,
+                                                                             SNAPSHOT_BUFFER_SIZE);
+    TEST_ASSERT (global_mode_snapshot_size != 0);
+
+    jerry_cleanup ();
+
+    test_exec_snapshot (global_mode_snapshot_buffer,
+                        global_mode_snapshot_size,
+                        false);
   }
 
   /* Merge snapshot */


### PR DESCRIPTION
Unlike normal snapshots, no part of a static snapshot is loaded into the RAM when executed from ROM. Static snapshots rely heavily on external magic strings.