### PR TITLE
Add finish debugger command.

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -35,8 +35,8 @@
  * debugger versioning.
  */
 JERRY_STATIC_ASSERT (JERRY_DEBUGGER_MESSAGES_OUT_MAX_COUNT == 27
-                     && JERRY_DEBUGGER_MESSAGES_IN_MAX_COUNT == 18
-                     && JERRY_DEBUGGER_VERSION == 1,
+                     && JERRY_DEBUGGER_MESSAGES_IN_MAX_COUNT == 19
+                     && JERRY_DEBUGGER_VERSION == 2,
                      debugger_version_correlates_to_message_type_count);
 
 /**
@@ -434,6 +434,19 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
 
       JERRY_DEBUGGER_SET_FLAGS (JERRY_DEBUGGER_VM_STOP);
       JERRY_CONTEXT (debugger_stop_context) = JERRY_CONTEXT (vm_top_context_p);
+      *resume_exec_p = true;
+      return true;
+    }
+
+    case JERRY_DEBUGGER_FINISH:
+    {
+      JERRY_DEBUGGER_CHECK_PACKET_SIZE (jerry_debugger_receive_type_t);
+
+      JERRY_DEBUGGER_SET_FLAGS (JERRY_DEBUGGER_VM_STOP);
+
+      /* This will point to the current context's parent (where the function was called)
+       * and in case of NULL the result will the same as in case of STEP. */
+      JERRY_CONTEXT (debugger_stop_context) = JERRY_CONTEXT (vm_top_context_p->prev_context_p);
       *resume_exec_p = true;
       return true;
     }

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -26,7 +26,7 @@
 /**
  * JerryScript debugger protocol version.
  */
-#define JERRY_DEBUGGER_VERSION (1)
+#define JERRY_DEBUGGER_VERSION (2)
 
 /**
  * Frequency of calling jerry_debugger_receive() by the VM.
@@ -178,11 +178,12 @@ typedef enum
   JERRY_DEBUGGER_CONTINUE = 12, /**< continue execution */
   JERRY_DEBUGGER_STEP = 13, /**< next breakpoint, step into functions */
   JERRY_DEBUGGER_NEXT = 14, /**< next breakpoint in the same context */
+  JERRY_DEBUGGER_FINISH = 15, /**< Continue running just after the function in the current stack frame returns */
   /* The following messages are only available in breakpoint
    * mode and this mode is kept after the message is processed. */
-  JERRY_DEBUGGER_GET_BACKTRACE = 15, /**< get backtrace */
-  JERRY_DEBUGGER_EVAL = 16, /**< first message of evaluating a string */
-  JERRY_DEBUGGER_EVAL_PART = 17, /**< next message of evaluating a string */
+  JERRY_DEBUGGER_GET_BACKTRACE = 16, /**< get backtrace */
+  JERRY_DEBUGGER_EVAL = 17, /**< first message of evaluating a string */
+  JERRY_DEBUGGER_EVAL_PART = 18, /**< next message of evaluating a string */
 
   JERRY_DEBUGGER_MESSAGES_IN_MAX_COUNT, /**< number of different type of input messages */
 } jerry_debugger_header_type_t;

--- a/jerry-debugger/jerry-client-ws.html
+++ b/jerry-debugger/jerry-client-ws.html
@@ -36,7 +36,7 @@ textarea {
 </div>
 <script>
 // Expected JerryScript debugger protocol version
-var JERRY_DEBUGGER_VERSION = 1;
+var JERRY_DEBUGGER_VERSION = 2;
 
 // Messages sent by the server to client.
 var JERRY_DEBUGGER_CONFIGURATION = 1;
@@ -92,9 +92,10 @@ var JERRY_DEBUGGER_CONTEXT_RESET = 11;
 var JERRY_DEBUGGER_CONTINUE = 12;
 var JERRY_DEBUGGER_STEP = 13;
 var JERRY_DEBUGGER_NEXT = 14;
-var JERRY_DEBUGGER_GET_BACKTRACE = 15;
-var JERRY_DEBUGGER_EVAL = 16;
-var JERRY_DEBUGGER_EVAL_PART = 17;
+var JERRY_DEBUGGER_FINISH = 15;
+var JERRY_DEBUGGER_GET_BACKTRACE = 16;
+var JERRY_DEBUGGER_EVAL = 17;
+var JERRY_DEBUGGER_EVAL_PART = 18;
 
 var textBox = document.getElementById("log");
 var commandBox = document.getElementById("command");
@@ -1367,6 +1368,7 @@ function debuggerCommand(event)
               "  continue|c - continue execution\n" +
               "  step|s - step-in execution\n" +
               "  next|n - execution until the next breakpoint\n" +
+              "  finish|f - continue running until the current function returns\n" +
               "  eval|e - evaluate expression\n" +
               "  backtrace|bt <max-depth> - get backtrace\n" +
               "  src - print current source code\n" +
@@ -1459,6 +1461,11 @@ function debuggerCommand(event)
     case "n":
     case "next":
       debuggerObj.sendResumeExec(JERRY_DEBUGGER_NEXT);
+      break;
+
+    case "f":
+    case "finish":
+      debuggerObj.sendResumeExec(JERRY_DEBUGGER_FINISH);
       break;
 
     case "e":

--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -28,7 +28,7 @@ import math
 import time
 
 # Expected debugger protocol version.
-JERRY_DEBUGGER_VERSION = 1
+JERRY_DEBUGGER_VERSION = 2
 
 # Messages sent by the server to client.
 JERRY_DEBUGGER_CONFIGURATION = 1
@@ -85,9 +85,10 @@ JERRY_DEBUGGER_CONTEXT_RESET = 11
 JERRY_DEBUGGER_CONTINUE = 12
 JERRY_DEBUGGER_STEP = 13
 JERRY_DEBUGGER_NEXT = 14
-JERRY_DEBUGGER_GET_BACKTRACE = 15
-JERRY_DEBUGGER_EVAL = 16
-JERRY_DEBUGGER_EVAL_PART = 17
+JERRY_DEBUGGER_FINISH = 15
+JERRY_DEBUGGER_GET_BACKTRACE = 16
+JERRY_DEBUGGER_EVAL = 17
+JERRY_DEBUGGER_EVAL_PART = 18
 
 MAX_BUFFER_SIZE = 128
 WEBSOCKET_BINARY_FRAME = 2
@@ -285,6 +286,13 @@ class DebuggerPrompt(Cmd):
         self.cont = True
 
     do_n = do_next
+
+    def do_finish(self, args):
+        """ Continue running until the current function returns """
+        self._exec_command(args, JERRY_DEBUGGER_FINISH)
+        self.cont = True
+
+    do_f = do_finish
 
     def do_list(self, _):
         """ Lists the available breakpoints """

--- a/tests/debugger/do_finish.cmd
+++ b/tests/debugger/do_finish.cmd
@@ -1,0 +1,6 @@
+finish
+finish
+finish
+step
+finish
+continue

--- a/tests/debugger/do_finish.expected
+++ b/tests/debugger/do_finish.expected
@@ -1,0 +1,20 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_finish.js:15
+(jerry-debugger) finish
+out: finish-test
+Stopped at tests/debugger/do_finish.js:26
+(jerry-debugger) finish
+Stopped at tests/debugger/do_finish.js:18 (in foo() at line:17, col:1)
+(jerry-debugger) finish
+out: foo
+out: bar
+Stopped at tests/debugger/do_finish.js:42
+(jerry-debugger) step
+Stopped at tests/debugger/do_finish.js:29 (in dog() at line:28, col:1)
+(jerry-debugger) finish
+out: *bark*
+out: *sit*
+out: *bark*
+Stopped at tests/debugger/do_finish.js:44
+(jerry-debugger) continue
+out: END: finish-test

--- a/tests/debugger/do_finish.js
+++ b/tests/debugger/do_finish.js
@@ -1,0 +1,44 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+print("finish-test");
+
+function foo() {
+  print("foo");
+  return bar();
+}
+
+function bar() {
+  return "bar";
+}
+
+print(foo());
+
+function dog() {
+  bark();
+  sit();
+  bark();
+}
+
+function bark() {
+  print("*bark*");
+}
+
+function sit() {
+  print("*sit*");
+}
+
+dog();
+
+print("END: finish-test");

--- a/tests/debugger/do_help.expected
+++ b/tests/debugger/do_help.expected
@@ -4,8 +4,8 @@ Stopped at tests/debugger/do_help.js:15
 
 Documented commands (type help <topic>):
 ========================================
-b          bt        delete   e          help      ms    quit    source
-backtrace  c         display  eval       list      n     s       src   
-break      continue  dump     exception  memstats  next  scroll  step  
+b          bt        delete   e          f       list      n     s       src 
+backtrace  c         display  eval       finish  memstats  next  scroll  step
+break      continue  dump     exception  help    ms        quit  source
 
 (jerry-debugger) quit

--- a/tools/pylint/pylintrc
+++ b/tools/pylint/pylintrc
@@ -331,7 +331,7 @@ max-attributes=7
 min-public-methods=0
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=20
+max-public-methods=25
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5


### PR DESCRIPTION
With this command the engine continue running just after the function
in the current stack frame returns.

JerryScript-DCO-1.0-Signed-off-by: Imre Kiss kissi.szeged@partner.samsung.com