### PR TITLE
Fix JSON.stringify, to allow TypedArray printing

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1516,7 +1516,8 @@ ecma_builtin_json_object (ecma_object_t *obj_p, /**< the object*/
 
       JERRY_ASSERT (ecma_is_property_enumerable (property));
 
-      if (ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_NAMEDDATA)
+      if (ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_NAMEDDATA
+          || ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_VIRTUAL)
       {
         ecma_append_to_values_collection (property_keys_p, *ecma_value_p, 0);
       }

--- a/tests/jerry/es2015/typedArray-stringify.js
+++ b/tests/jerry/es2015/typedArray-stringify.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var float_array = new Float32Array([1.125, 5.5, -1.25, -0.0]);
+var int_array = new Int8Array([3, 2, 1, 100, -30])
+var uint_array = new Uint8Array([3, 2, 1, 100, -30])
+var empty_array = new Uint32Array();
+
+assert((JSON.stringify(float_array)) === '{"0":1.125,"1":5.5,"2":-1.25,"3":0}');
+assert((JSON.stringify(int_array)) === '{"0":3,"1":2,"2":1,"3":100,"4":-30}');
+assert((JSON.stringify(uint_array)) === '{"0":3,"1":2,"2":1,"3":100,"4":226}');
+assert((JSON.stringify(empty_array)) === '{}');


### PR DESCRIPTION
TypedArrays returned string for an empty one, even if they had data in them. This is fixed in ecma_builtin_json_object, by looking for `ECMA_PROPERTY_TYPE_VIRTUAL` too, instead of only `ECMA_PROPERTY_TYPE_NAMEDDATA`. Added assert test for various types in the new `typedArray-stringify.js` file.

JerryScript-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu