### PR TITLE
Remove new line from output log in python client.

### DIFF
--- a/jerry-debugger/jerry-client-ws.py
+++ b/jerry-debugger/jerry-client-ws.py
@@ -1238,6 +1238,7 @@ def main():
 
             # Subtypes of output
             if buffer_type == JERRY_DEBUGGER_OUTPUT_RESULT_END:
+                message = message.rstrip('\n')
                 if subtype in [JERRY_DEBUGGER_OUTPUT_OK,
                                JERRY_DEBUGGER_OUTPUT_DEBUG]:
                     print("%sout: %s%s" % (debugger.blue, debugger.nocolor, message))


### PR DESCRIPTION
There was an unnecessary new line character in the python debugger client.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu