### PR TITLE
Move the sleep function to jerry-port

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -112,6 +112,15 @@ Allow user to provide external buffer for jerry instance (which includes an isol
 struct jerry_instance_t *jerry_port_get_current_instance (void);
 ```
 
+## Sleep
+
+```c
+/**
+ * Makes the process sleep for a given time.
+ */
+void jerry_port_sleep (uint32_t sleep_time);
+```
+
 # How to port JerryScript
 
 This section describes a basic port implementation which was created for Unix based systems.
@@ -230,4 +239,33 @@ jerry_port_get_current_instance (void)
 {
   return current_instance_p;
 } /* jerry_port_get_current_instance */
+```
+
+## Sleep
+
+```c
+#include "jerryscript-port.h"
+#include "jerryscript-port-default.h"
+
+#ifdef HAVE_TIME_H
+#include <time.h>
+#elif defined (HAVE_UNISTD_H)
+#include <unistd.h>
+#endif /* HAVE_TIME_H */
+
+#ifdef JERRY_DEBUGGER
+void jerry_port_sleep (uint32_t sleep_time)
+{
+#ifdef HAVE_TIME_H
+  nanosleep (&(const struct timespec)
+  {
+    sleep_time / 1000, (sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
+  }
+  , NULL);
+#elif defined (HAVE_UNISTD_H)
+  usleep ((useconds_t) sleep_time * 1000);
+#endif /* HAVE_TIME_H */
+  (void) sleep_time;
+} /* jerry_port_sleep */
+#endif /* JERRY_DEBUGGER */
 ```

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -24,12 +24,6 @@
 
 #ifdef JERRY_DEBUGGER
 
-#ifdef HAVE_TIME_H
-#include <time.h>
-#elif defined (HAVE_UNISTD_H)
-#include <unistd.h>
-#endif /* HAVE_TIME_H */
-
 /**
  * The number of message types in the debugger should reflect the
  * debugger versioning.
@@ -220,15 +214,7 @@ jerry_debugger_send_eval (const lit_utf8_byte_t *eval_string_p, /**< evaluated s
 void
 jerry_debugger_sleep (void)
 {
-#ifdef HAVE_TIME_H
-  nanosleep (&(const struct timespec)
-  {
-    JERRY_DEBUGGER_TIMEOUT / 1000, (JERRY_DEBUGGER_TIMEOUT % 1000) * 1000000L /* Seconds, nanoseconds */
-  }
-  , NULL);
-#elif defined (HAVE_UNISTD_H)
-  usleep ((useconds_t) JERRY_DEBUGGER_TIMEOUT * 1000);
-#endif /* HAVE_TIME_H */
+  jerry_port_sleep (JERRY_DEBUGGER_TIMEOUT);
 } /* jerry_debugger_sleep */
 
 /**

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -139,6 +139,13 @@ double jerry_port_get_current_time (void);
 struct jerry_instance_t *jerry_port_get_current_instance (void);
 
 /**
+ * Makes the process sleep for a given time.
+ */
+#ifdef JERRY_DEBUGGER
+void jerry_port_sleep (uint32_t sleep_time);
+#endif /* JERRY_DEBUGGER */
+
+/**
  * @}
  */
 

--- a/jerry-port/default/default-debugger.c
+++ b/jerry-port/default/default-debugger.c
@@ -1,0 +1,39 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript-port.h"
+#include "jerryscript-port-default.h"
+
+#ifdef HAVE_TIME_H
+#include <time.h>
+#elif defined (HAVE_UNISTD_H)
+#include <unistd.h>
+#endif /* HAVE_TIME_H */
+
+#ifdef JERRY_DEBUGGER
+void jerry_port_sleep (uint32_t sleep_time)
+{
+#ifdef HAVE_TIME_H
+  nanosleep (&(const struct timespec)
+  {
+    sleep_time / 1000, (sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
+  }
+  , NULL);
+#elif defined (HAVE_UNISTD_H)
+  usleep ((useconds_t) sleep_time * 1000);
+#endif /* HAVE_TIME_H */
+  (void) sleep_time;
+} /* jerry_port_sleep */
+#endif /* JERRY_DEBUGGER */


### PR DESCRIPTION
Now the jerry-debugger uses the jerry-port's sleep, therefore if there are systems that don't support
usleep or nanosleep they can now define their own function.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu