### PR TITLE
Remove ineffective codes

### DIFF
--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -387,7 +387,6 @@ lit_char_to_utf8_bytes (uint8_t *dst_p, /**< destination buffer */
     return 2;
   }
 
-  JERRY_ASSERT (!(chr & ~LIT_UTF8_3_BYTE_CODE_POINT_MAX));
   /* zzzzyyyy yyxxxxxx -> 1110zzzz 10yyyyyy 10xxxxxx */
   *(dst_p++) = (uint8_t) (LIT_UTF8_3_BYTE_MARKER | ((chr >> 12) & LIT_UTF8_LAST_4_BITS_MASK));
   *(dst_p++) = (uint8_t) (LIT_UTF8_EXTRA_BYTE_MARKER | ((chr >> 6) & LIT_UTF8_LAST_6_BITS_MASK));
@@ -416,7 +415,6 @@ lit_char_get_utf8_length (ecma_char_t chr) /**< EcmaScript character */
   }
 
   /* zzzzyyyy yyxxxxxx */
-  JERRY_ASSERT (!(chr & ~LIT_UTF8_3_BYTE_CODE_POINT_MAX));
   return 3;
 } /* lit_char_get_utf8_length */
 


### PR DESCRIPTION
Results of assert statements are always true,
I think we don't need these assert statements anymore

JerryScript-DCO-1.0-Signed-off-by: Haesik Jun haesik.jun@samsung.com