### PR TITLE
Add ecma_free_all_enqueued_jobs function

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -222,6 +222,9 @@ jerry_cleanup (void)
     jmem_heap_free_block (this_p, sizeof (jerry_context_data_header_t) + this_p->manager_p->bytes_needed);
   }
 
+#ifndef CONFIG_DISABLE_ES2015_PROMISE_BUILTIN
+  ecma_free_all_enqueued_jobs ();
+#endif /* CONFIG_DISABLE_ES2015_PROMISE_BUILTIN */
   ecma_finalize ();
   jmem_finalize ();
   jerry_make_api_unavailable ();

--- a/jerry-core/ecma/operations/ecma-jobqueue.c
+++ b/jerry-core/ecma/operations/ecma-jobqueue.c
@@ -347,6 +347,23 @@ ecma_process_all_enqueued_jobs (void)
 } /* ecma_process_all_enqueued_jobs */
 
 /**
+ * Release enqueued Promise jobs.
+ */
+void
+ecma_free_all_enqueued_jobs (void)
+{
+  while (JERRY_CONTEXT (job_queue_head_p) != NULL)
+  {
+    ecma_job_queueitem_t *item_p = JERRY_CONTEXT (job_queue_head_p);
+    JERRY_CONTEXT (job_queue_head_p) = item_p->next_p;
+    void *job_p = item_p->job_p;
+    jmem_heap_free_block (item_p, sizeof (ecma_job_queueitem_t));
+
+    ecma_free_promise_reaction_job (job_p);
+  }
+} /* ecma_free_all_enqueued_jobs */
+
+/**
  * @}
  * @}
  */

--- a/jerry-core/ecma/operations/ecma-jobqueue.h
+++ b/jerry-core/ecma/operations/ecma-jobqueue.h
@@ -44,6 +44,7 @@ void ecma_job_queue_init (void);
 
 void ecma_enqueue_promise_reaction_job (ecma_value_t reaction, ecma_value_t argument);
 void ecma_enqueue_promise_resolve_thenable_job (ecma_value_t promise, ecma_value_t thenable, ecma_value_t then);
+void ecma_free_all_enqueued_jobs (void);
 
 ecma_value_t ecma_process_all_enqueued_jobs (void);
 


### PR DESCRIPTION
This function releases any remaining promise job that wasn't completed.
Also added this function to `jerry_cleanup ()`.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu