### PR TITLE
Support abort in the debugger.

### DIFF
--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -26,7 +26,7 @@
 /**
  * JerryScript debugger protocol version.
  */
-#define JERRY_DEBUGGER_VERSION (2)
+#define JERRY_DEBUGGER_VERSION (3)
 
 /**
  * Frequency of calling jerry_debugger_receive() by the VM.
@@ -193,22 +193,30 @@ typedef enum
   JERRY_DEBUGGER_EVAL_PART = 18, /**< next message of evaluating a string */
 
   JERRY_DEBUGGER_MESSAGES_IN_MAX_COUNT, /**< number of different type of input messages */
-  JERRY_DEBUGGER_THROW = 19, /**< first message of the throw string */
-  JERRY_DEBUGGER_THROW_PART = 20, /**< next part of the throw message */
 } jerry_debugger_header_type_t;
 
 /**
-  * Subtypes of eval_result.
-  */
+ * Subtypes of eval.
+ */
+typedef enum
+{
+  JERRY_DEBUGGER_EVAL_EVAL = 0, /**< evaluate expression */
+  JERRY_DEBUGGER_EVAL_THROW = 1, /**< evaluate expression and throw the result */
+  JERRY_DEBUGGER_EVAL_ABORT = 2, /**< evaluate expression and abrot with the result */
+} jerry_debugger_eval_type_t;
+
+/**
+ * Subtypes of eval_result.
+ */
 typedef enum
 {
   JERRY_DEBUGGER_EVAL_OK = 1, /**< eval result, no error */
   JERRY_DEBUGGER_EVAL_ERROR = 2, /**< eval result when an error has occurred */
-} jerry_debugger_eval_subtype_t;
+} jerry_debugger_eval_result_type_t;
 
 /**
-  * Subtypes of output_result.
-  */
+ * Subtypes of output_result.
+ */
 typedef enum
 {
   JERRY_DEBUGGER_OUTPUT_OK = 1, /**< output result, no error */

--- a/jerry-debugger/jerry-client-ws.html
+++ b/jerry-debugger/jerry-client-ws.html
@@ -36,7 +36,7 @@ textarea {
 </div>
 <script>
 // Expected JerryScript debugger protocol version
-var JERRY_DEBUGGER_VERSION = 2;
+var JERRY_DEBUGGER_VERSION = 3;
 
 // Messages sent by the server to client.
 var JERRY_DEBUGGER_CONFIGURATION = 1;
@@ -67,6 +67,11 @@ var JERRY_DEBUGGER_OUTPUT_RESULT = 25;
 var JERRY_DEBUGGER_OUTPUT_RESULT_END = 26;
 
 // Subtypes of eval
+JERRY_DEBUGGER_EVAL_EVAL = "\0"
+JERRY_DEBUGGER_EVAL_THROW = "\1"
+JERRY_DEBUGGER_EVAL_ABORT = "\2"
+
+// Subtypes of eval result
 var JERRY_DEBUGGER_EVAL_OK = 1;
 var JERRY_DEBUGGER_EVAL_ERROR = 2;
 
@@ -1220,7 +1225,7 @@ function DebuggerClient(address)
       return;
     }
 
-    var array = stringToCesu8(str);
+    var array = stringToCesu8(JERRY_DEBUGGER_EVAL_EVAL + str);
     var byteLength = array.byteLength;
 
     if (byteLength <= maxMessageSize)

--- a/tests/debugger/do_abort.cmd
+++ b/tests/debugger/do_abort.cmd
@@ -1,0 +1,5 @@
+s
+s
+s
+s
+abort new Error('Fatal error :)')

--- a/tests/debugger/do_abort.expected
+++ b/tests/debugger/do_abort.expected
@@ -1,0 +1,12 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_abort.js:24
+(jerry-debugger) s
+Stopped at tests/debugger/do_abort.js:25
+(jerry-debugger) s
+Stopped at tests/debugger/do_abort.js:26
+(jerry-debugger) s
+Stopped at tests/debugger/do_abort.js:20 (in g() at line:19, col:1)
+(jerry-debugger) s
+Stopped at tests/debugger/do_abort.js:16 (in f() at line:15, col:1)
+(jerry-debugger) abort new Error('Fatal error :)')
+err: Script Error: Error: Fatal error :)

--- a/tests/debugger/do_abort.js
+++ b/tests/debugger/do_abort.js
@@ -20,16 +20,11 @@ function g() {
   f();
 }
 
-try {
+// In regular JS, it is not possible to escape from this loop
+while (true) {
   try {
-
-    while (true) {
-      g();
-    }
-
+    g();
   } catch (e) {
-    var s = "Stop here";
+    var s = "Don't stop here";
   }
-} catch (e) {
-  var s = "Stop here again";
 }

--- a/tests/debugger/do_help.expected
+++ b/tests/debugger/do_help.expected
@@ -4,8 +4,9 @@ Stopped at tests/debugger/do_help.js:15
 
 Documented commands (type help <topic>):
 ========================================
-b          bt        delete   e          f       list      n     s       src  
-backtrace  c         display  eval       finish  memstats  next  scroll  step 
-break      continue  dump     exception  help    ms        quit  source  throw
+abort      bt        display  exception  list      next    source
+b          c         dump     f          memstats  quit    src   
+backtrace  continue  e        finish     ms        s       step  
+break      delete    eval     help       n         scroll  throw 
 
 (jerry-debugger) quit

--- a/tests/debugger/do_throw.cmd
+++ b/tests/debugger/do_throw.cmd
@@ -1,1 +1,9 @@
+s
+s
+s
+s
+s
+throw new Error('Escape')
 throw new Error('Once upon a time there lived in a certain village a little country girl, the prettiest creature who was ever seen. Her mother was excessively fond of her; and her grandmother doted on her still more. This good woman had a little red riding hood made for her. It suited the girl so extremely well that everybody called her Little Red Riding Hood. One day her mother, having made some cakes, said to her, "Go, my dear, and see how your grandmother is doing, for I hear she has been very ill. Take her a cake, and this little pot of butter."')
+eval e.message.length
+throw new Error('Exit')

--- a/tests/debugger/do_throw.expected
+++ b/tests/debugger/do_throw.expected
@@ -1,3 +1,20 @@
 Connecting to: localhost:5001
-Stopped at tests/debugger/do_throw.js:19
+Stopped at tests/debugger/do_throw.js:23
+(jerry-debugger) s
+Stopped at tests/debugger/do_throw.js:24
+(jerry-debugger) s
+Stopped at tests/debugger/do_throw.js:26
+(jerry-debugger) s
+Stopped at tests/debugger/do_throw.js:27
+(jerry-debugger) s
+Stopped at tests/debugger/do_throw.js:20 (in g() at line:19, col:1)
+(jerry-debugger) s
+Stopped at tests/debugger/do_throw.js:16 (in f() at line:15, col:1)
+(jerry-debugger) throw new Error('Escape')
+Stopped at tests/debugger/do_throw.js:31
 (jerry-debugger) throw new Error('Once upon a time there lived in a certain village a little country girl, the prettiest creature who was ever seen. Her mother was excessively fond of her; and her grandmother doted on her still more. This good woman had a little red riding hood made for her. It suited the girl so extremely well that everybody called her Little Red Riding Hood. One day her mother, having made some cakes, said to her, "Go, my dear, and see how your grandmother is doing, for I hear she has been very ill. Take her a cake, and this little pot of butter."')
+Stopped at tests/debugger/do_throw.js:34
+(jerry-debugger) eval e.message.length
+538
+(jerry-debugger) throw new Error('Exit')
+err: Script Error: Error: Exit


### PR DESCRIPTION
Aborts are not caught by catch/finally blocks, so it is possible to stop a script using the debugger.