### PR TITLE
Fix return value of 'Date.now'

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -22,6 +22,7 @@
 #include "ecma-helpers.h"
 #include "ecma-try-catch-macro.h"
 #include "lit-char-helpers.h"
+#include "math.h"
 
 #ifndef CONFIG_DISABLE_DATE_BUILTIN
 
@@ -437,7 +438,7 @@ static ecma_value_t
 ecma_builtin_date_now (ecma_value_t this_arg) /**< this argument */
 {
   JERRY_UNUSED (this_arg);
-  return ecma_make_number_value (DOUBLE_TO_ECMA_NUMBER_T (jerry_port_get_current_time ()));
+  return ecma_make_number_value (floor (DOUBLE_TO_ECMA_NUMBER_T (jerry_port_get_current_time ())));
 } /* ecma_builtin_date_now */
 
 /**

--- a/tests/jerry/regression-test-issue-2272.js
+++ b/tests/jerry/regression-test-issue-2272.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Number.isInteger = Number.isInteger || function (value) {
+  return typeof value === 'number' &&
+    isFinite (value) &&
+    Math.floor (value) === value;
+};
+
+var now = Date.now ();
+
+assert (Number.isInteger (now));
+
+var date = new Date(now); // Should not throw an error


### PR DESCRIPTION
'Date.now()' should return an integer value. Fixes #2272 