### PR TITLE
Rename the jerry_value_has_abort_flag function.

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1089,6 +1089,45 @@ jerry_get_global_object (void);
 
 Functions to check the type of an API value ([jerry_value_t](#jerry_value_t)).
 
+## jerry_value_is_abort
+
+**Summary**
+
+Returns whether the given `jerry_value_t` has the error and abort value set.
+
+**Prototype**
+
+```c
+bool
+jerry_value_is_abort (const jerry_value_t value);
+```
+
+- `value` - api value
+- return value
+  - true, if the given `jerry_value_t` has the error and abort value set
+  - false, otherwise
+
+**Example**
+
+```c
+{
+  jerry_value_t value;
+  ... // create or acquire value
+
+  if (jerry_value_is_abort (value))
+  {
+    ...
+  }
+
+  jerry_release_value (value);
+}
+```
+
+**See also**
+
+- [jerry_value_t](#jerry_value_t)
+- [jerry_value_is_error](#jerry_value_is_error)
+
 ## jerry_value_is_array
 
 **Summary**
@@ -1281,7 +1320,7 @@ jerry_value_is_error (const jerry_value_t value);
 **See also**
 
 - [jerry_value_t](#jerry_value_t)
-- [jerry_value_has_abort_flag](#jerry_value_has_abort_flag)
+- [jerry_value_is_abort](#jerry_value_is_abort)
 
 ## jerry_value_is_function
 
@@ -1711,46 +1750,6 @@ jerry_get_error_type (const jerry_value_t value);
 
 - [jerry_create_error](#jerry_create_error)
 - [jerry_value_is_error](#jerry_value_is_error)
-
-## jerry_value_has_abort_flag
-
-**Summary**
-
-Returns whether the given `jerry_value_t` has the error and abort flags set.
-
-**Prototype**
-
-```c
-bool
-jerry_value_has_abort_flag (const jerry_value_t value);
-```
-
-- `value` - api value
-- return value
-  - true, if the given `jerry_value_t` has the error and abort flags set
-  - false, otherwise
-
-**Example**
-
-```c
-{
-  jerry_value_t value;
-  ... // create or acquire value
-
-  if (jerry_value_has_abort_flag (value))
-  {
-    ...
-  }
-
-  jerry_release_value (value);
-}
-```
-
-**See also**
-
-- [jerry_value_t](#jerry_value_t)
-- [jerry_value_is_error](#jerry_value_is_error)
-
 
 ## jerry_value_clear_error_flag
 

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -627,6 +627,27 @@ jerry_get_global_object (void)
 } /* jerry_get_global_object */
 
 /**
+ * Check if the specified value is an abort value.
+ *
+ * @return true  - if both the error and abort values are set,
+ *         false - otherwise
+ */
+bool
+jerry_value_is_abort (const jerry_value_t value) /**< api value */
+{
+  jerry_assert_api_available ();
+
+  if (!ecma_is_value_error_reference (value))
+  {
+    return false;
+  }
+
+  ecma_error_reference_t *error_ref_p = ecma_get_error_reference_from_value (value);
+
+  return (error_ref_p->refs_and_flags & ECMA_ERROR_REF_ABORT) != 0;
+} /* jerry_value_is_abort */
+
+/**
  * Check if the specified value is an array object value.
  *
  * @return true  - if the specified value is an array object,
@@ -905,27 +926,6 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature)
 } /* jerry_is_feature_enabled */
 
 /**
- * Check if the specified value is an abort value.
- *
- * @return true  - if both the error and abort flags of the specified value are true,
- *         false - otherwise
- */
-bool
-jerry_value_has_abort_flag (const jerry_value_t value) /**< api value */
-{
-  jerry_assert_api_available ();
-
-  if (!ecma_is_value_error_reference (value))
-  {
-    return false;
-  }
-
-  ecma_error_reference_t *error_ref_p = ecma_get_error_reference_from_value (value);
-
-  return (error_ref_p->refs_and_flags & ECMA_ERROR_REF_ABORT) != 0;
-} /* jerry_value_has_abort_flag */
-
-/**
  * Clear the error flag
  */
 void
@@ -951,7 +951,7 @@ jerry_value_set_error_flag (jerry_value_t *value_p)
   {
     /* This is a rare case so it is optimized for
      * binary size rather than performance. */
-    if (!jerry_value_has_abort_flag (*value_p))
+    if (!jerry_value_is_abort (*value_p))
     {
       return;
     }
@@ -974,7 +974,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p)
   {
     /* This is a rare case so it is optimized for
      * binary size rather than performance. */
-    if (jerry_value_has_abort_flag (*value_p))
+    if (jerry_value_is_abort (*value_p))
     {
       return;
     }

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -336,6 +336,7 @@ jerry_value_t jerry_get_global_object (void);
 /**
  * Checker functions of 'jerry_value_t'.
  */
+bool jerry_value_is_abort (const jerry_value_t value);
 bool jerry_value_is_array (const jerry_value_t value);
 bool jerry_value_is_boolean (const jerry_value_t value);
 bool jerry_value_is_constructor (const jerry_value_t value);
@@ -373,7 +374,6 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature);
 /**
  * Error manipulation functions.
  */
-bool jerry_value_has_abort_flag (const jerry_value_t value);
 void jerry_value_clear_error_flag (jerry_value_t *value_p);
 void jerry_value_set_error_flag (jerry_value_t *value_p);
 void jerry_value_set_abort_flag (jerry_value_t *value_p);

--- a/tests/unit-core/test-abort.c
+++ b/tests/unit-core/test-abort.c
@@ -71,7 +71,7 @@ main (void)
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
   res = jerry_run (parsed_code_val);
 
-  TEST_ASSERT (jerry_value_has_abort_flag (res));
+  TEST_ASSERT (jerry_value_is_abort (res));
 
   jerry_release_value (res);
   jerry_release_value (parsed_code_val);
@@ -104,26 +104,26 @@ main (void)
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
   res = jerry_run (parsed_code_val);
 
-  TEST_ASSERT (jerry_value_has_abort_flag (res));
+  TEST_ASSERT (jerry_value_is_abort (res));
 
   jerry_release_value (res);
   jerry_release_value (parsed_code_val);
 
   /* Test flag overwrites. */
   jerry_value_t value = jerry_create_string ((jerry_char_t *) "Error description");
-  TEST_ASSERT (!jerry_value_has_abort_flag (value));
+  TEST_ASSERT (!jerry_value_is_abort (value));
   TEST_ASSERT (!jerry_value_is_error (value));
 
   jerry_value_set_abort_flag (&value);
-  TEST_ASSERT (jerry_value_has_abort_flag (value));
+  TEST_ASSERT (jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 
   jerry_value_set_error_flag (&value);
-  TEST_ASSERT (!jerry_value_has_abort_flag (value));
+  TEST_ASSERT (!jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 
   jerry_value_set_abort_flag (&value);
-  TEST_ASSERT (jerry_value_has_abort_flag (value));
+  TEST_ASSERT (jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 
   jerry_release_value (value);


### PR DESCRIPTION
Rename the function to represent it's real functionality.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu