### PR TITLE
Rename the jerry_value_clear_error_flag function

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1752,17 +1752,17 @@ jerry_value_has_abort_flag (const jerry_value_t value);
 - [jerry_value_is_error](#jerry_value_is_error)
 
 
-## jerry_value_clear_error_flag
+## jerry_value_clear_error
 
 **Summary**
 
-Clear both the error and abort flags.
+Clear both the error and abort value.
 
 **Prototype**
 
 ```c
 void
-jerry_value_clear_error_flag (jerry_value_t *value_p);
+jerry_value_clear_error (jerry_value_t *value_p);
 ```
 
 - `value_p` - pointer to an api value
@@ -1774,7 +1774,7 @@ jerry_value_clear_error_flag (jerry_value_t *value_p);
   jerry_value_t value;
   ... // create or acquire value
 
-  jerry_value_clear_error_flag (&value);
+  jerry_value_clear_error (&value);
 
   jerry_release_value (value);
 }
@@ -1818,7 +1818,7 @@ jerry_value_set_error_flag (jerry_value_t *value_p);
 **See also**
 
 - [jerry_value_t](#jerry_value_t)
-- [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
+- [jerry_value_clear_error](#jerry_value_clear_error)
 - [jerry_value_set_abort_flag](#jerry_value_set_abort_flag)
 
 
@@ -1853,7 +1853,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p);
 **See also**
 
 - [jerry_value_t](#jerry_value_t)
-- [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
+- [jerry_value_clear_error](#jerry_value_clear_error)
 - [jerry_value_set_error_flag](#jerry_value_set_error_flag)
 
 
@@ -1886,7 +1886,7 @@ jerry_get_value_without_error_flag (jerry_value_t value)
   jerry_value_set_error_flag (&value);
 
   jerry_value_t real_value = jerry_get_value_without_error_flag (value);
-  ... // process the real_value. Different from `jerry_value_clear_error_flag`,
+  ... // process the real_value. Different from `jerry_value_clear_error`,
       // the error `value` will not be automatically released after calling
       // `jerry_get_value_without_error_flag`.
 
@@ -1898,7 +1898,7 @@ jerry_get_value_without_error_flag (jerry_value_t value)
 **See also**
 
 - [jerry_acquire_value](#jerry_acquire_value)
-- [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
+- [jerry_value_clear_error](#jerry_value_clear_error)
 
 # Getter functions of 'jerry_value_t'
 
@@ -2934,7 +2934,7 @@ jerry_create_error (jerry_error_t error_type,
 **See also**
 
 - [jerry_value_is_error](#jerry_value_is_error)
-- [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
+- [jerry_value_clear_error](#jerry_value_clear_error)
 - [jerry_value_set_error_flag](#jerry_value_set_error_flag)
 
 

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -926,10 +926,10 @@ jerry_value_has_abort_flag (const jerry_value_t value) /**< api value */
 } /* jerry_value_has_abort_flag */
 
 /**
- * Clear the error flag
+ * Clear the error and abort value.
  */
 void
-jerry_value_clear_error_flag (jerry_value_t *value_p)
+jerry_value_clear_error (jerry_value_t *value_p)
 {
   jerry_assert_api_available ();
 
@@ -937,7 +937,7 @@ jerry_value_clear_error_flag (jerry_value_t *value_p)
   {
     *value_p = ecma_clear_error_reference (*value_p, false);
   }
-} /* jerry_value_clear_error_flag */
+} /* jerry_value_clear_error */
 
 /**
  * Set the error flag if the value is not an error reference.
@@ -956,7 +956,7 @@ jerry_value_set_error_flag (jerry_value_t *value_p)
       return;
     }
 
-    jerry_value_clear_error_flag (value_p);
+    jerry_value_clear_error (value_p);
   }
 
   *value_p = ecma_create_error_reference (*value_p, true);
@@ -979,7 +979,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p)
       return;
     }
 
-    jerry_value_clear_error_flag (value_p);
+    jerry_value_clear_error (value_p);
   }
 
   *value_p = ecma_create_error_reference (*value_p, false);

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -374,7 +374,7 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature);
  * Error manipulation functions.
  */
 bool jerry_value_has_abort_flag (const jerry_value_t value);
-void jerry_value_clear_error_flag (jerry_value_t *value_p);
+void jerry_value_clear_error (jerry_value_t *value_p);
 void jerry_value_set_error_flag (jerry_value_t *value_p);
 void jerry_value_set_abort_flag (jerry_value_t *value_p);
 jerry_value_t jerry_get_value_without_error_flag (jerry_value_t value);

--- a/jerry-main/main-unix-snapshot.c
+++ b/jerry-main/main-unix-snapshot.c
@@ -320,7 +320,7 @@ process_generate (cli_state_t *cli_state_p, /**< cli state */
   {
     jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: Generating snapshot failed!\n");
 
-    jerry_value_clear_error_flag (&snapshot_result);
+    jerry_value_clear_error (&snapshot_result);
 
     print_unhandled_exception (snapshot_result);
 

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -265,7 +265,7 @@ register_js_function (const char *name_p, /**< name of the function */
   if (jerry_value_is_error (result_val))
   {
     jerry_port_log (JERRY_LOG_LEVEL_WARNING, "Warning: failed to register '%s' method.", name_p);
-    jerry_value_clear_error_flag (&result_val);
+    jerry_value_clear_error (&result_val);
     print_unhandled_exception (result_val);
   }
 
@@ -770,13 +770,13 @@ main (int argc,
 
           if (jerry_value_is_error (ret_val_eval))
           {
-            jerry_value_clear_error_flag (&ret_val_eval);
+            jerry_value_clear_error (&ret_val_eval);
             print_unhandled_exception (ret_val_eval);
           }
         }
         else
         {
-          jerry_value_clear_error_flag (&ret_val_eval);
+          jerry_value_clear_error (&ret_val_eval);
           print_unhandled_exception (ret_val_eval);
         }
 
@@ -789,7 +789,7 @@ main (int argc,
 
   if (jerry_value_is_error (ret_value))
   {
-    jerry_value_clear_error_flag (&ret_value);
+    jerry_value_clear_error (&ret_value);
     print_unhandled_exception (ret_value);
 
     ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
@@ -801,7 +801,7 @@ main (int argc,
 
   if (jerry_value_is_error (ret_value))
   {
-    jerry_value_clear_error_flag (&ret_value);
+    jerry_value_clear_error (&ret_value);
     print_unhandled_exception (ret_value);
     ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;
   }

--- a/targets/curie_bsp/jerry_app/quark/main.c
+++ b/targets/curie_bsp/jerry_app/quark/main.c
@@ -46,7 +46,7 @@ void jerry_resolve_error (jerry_value_t ret_value)
 {
   if (jerry_value_is_error (ret_value))
   {
-    jerry_value_clear_error_flag (&ret_value);
+    jerry_value_clear_error (&ret_value);
     jerry_value_t err_str_val = jerry_value_to_string (ret_value);
     jerry_size_t err_str_size = jerry_get_string_size (err_str_val);
     jerry_char_t *err_str_buf = (jerry_char_t *) balloc (err_str_size, NULL);

--- a/targets/zephyr/src/main-zephyr.c
+++ b/targets/zephyr/src/main-zephyr.c
@@ -60,7 +60,7 @@ static int shell_cmd_handler (char *source_buffer)
     printf ("Error executing statement: ");
     /* Clear error flag, otherwise print call below won't produce any
        output. */
-    jerry_value_clear_error_flag (&ret_val);
+    jerry_value_clear_error (&ret_val);
   }
 
   if (!jerry_value_is_error (print_function))

--- a/tests/unit-core/test-api-errortype.c
+++ b/tests/unit-core/test-api-errortype.c
@@ -40,7 +40,7 @@ main (void)
     TEST_ASSERT (jerry_value_is_error (error_obj));
     TEST_ASSERT (jerry_get_error_type (error_obj) == errors[idx]);
 
-    jerry_value_clear_error_flag (&error_obj);
+    jerry_value_clear_error (&error_obj);
 
     TEST_ASSERT (jerry_get_error_type (error_obj) == errors[idx]);
 

--- a/tests/unit-core/test-api-set-and-clear-error-flag.c
+++ b/tests/unit-core/test-api-set-and-clear-error-flag.c
@@ -27,7 +27,7 @@ main (void)
   jerry_value_set_error_flag (&obj_val);
   jerry_value_t err_val = jerry_acquire_value (obj_val);
 
-  jerry_value_clear_error_flag (&obj_val);
+  jerry_value_clear_error (&obj_val);
   jerry_release_value (obj_val);
 
   jerry_release_value (err_val);

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -1076,7 +1076,7 @@ main (void)
                                    strlen (parser_err_src_p),
                                    JERRY_PARSE_NO_OPTS);
     TEST_ASSERT (jerry_value_is_error (parsed_code_val));
-    jerry_value_clear_error_flag (&parsed_code_val);
+    jerry_value_clear_error (&parsed_code_val);
     jerry_value_t err_str_val = jerry_value_to_string (parsed_code_val);
     jerry_size_t err_str_size = jerry_get_string_size (err_str_val);
     jerry_char_t err_str_buf[256];

--- a/tests/unit-core/test-backtrace.c
+++ b/tests/unit-core/test-backtrace.c
@@ -175,7 +175,7 @@ main (void)
 
   TEST_ASSERT (jerry_value_is_error (error));
 
-  jerry_value_clear_error_flag (&error);
+  jerry_value_clear_error (&error);
 
   TEST_ASSERT (jerry_value_is_object (error));
 


### PR DESCRIPTION
Rename the function to represent it's real functionality.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu