### PR TITLE
Rename the jerry_value_set_error_flag function

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1782,21 +1782,21 @@ jerry_value_clear_error_flag (jerry_value_t *value_p);
 **See also**
 
 - [jerry_value_t](#jerry_value_t)
-- [jerry_value_set_error_flag](#jerry_value_set_error_flag)
+- [jerry_value_set_error](#jerry_value_set_error)
 - [jerry_value_set_abort_flag](#jerry_value_set_abort_flag)
 
 
-## jerry_value_set_error_flag
+## jerry_value_set_error
 
 **Summary**
 
-Set the error flag.
+Set the error value.
 
 **Prototype**
 
 ```c
 void
-jerry_value_set_error_flag (jerry_value_t *value_p);
+jerry_value_set_error (jerry_value_t *value_p);
 ```
 
 - `value_p` - pointer to an api value
@@ -1808,7 +1808,7 @@ jerry_value_set_error_flag (jerry_value_t *value_p);
   jerry_value_t value;
   ... // create or acquire value
 
-  jerry_value_set_error_flag (&value);
+  jerry_value_set_error (&value);
 
   jerry_release_value (value);
 }
@@ -1853,7 +1853,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p);
 
 - [jerry_value_t](#jerry_value_t)
 - [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
-- [jerry_value_set_error_flag](#jerry_value_set_error_flag)
+- [jerry_value_set_error](#jerry_value_set_error)
 
 
 ## jerry_get_value_without_error_flag
@@ -1882,7 +1882,7 @@ jerry_get_value_without_error_flag (jerry_value_t value)
   jerry_value_t value;
   ... // create or acquire value
 
-  jerry_value_set_error_flag (&value);
+  jerry_value_set_error (&value);
 
   jerry_value_t real_value = jerry_get_value_without_error_flag (value);
   ... // process the real_value. Different from `jerry_value_clear_error_flag`,
@@ -2934,7 +2934,7 @@ jerry_create_error (jerry_error_t error_type,
 
 - [jerry_value_is_error](#jerry_value_is_error)
 - [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
-- [jerry_value_set_error_flag](#jerry_value_set_error_flag)
+- [jerry_value_set_error](#jerry_value_set_error)
 
 
 ## jerry_create_error_sz

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -940,10 +940,10 @@ jerry_value_clear_error_flag (jerry_value_t *value_p)
 } /* jerry_value_clear_error_flag */
 
 /**
- * Set the error flag if the value is not an error reference.
+ * Set the error value if the value is not an error reference.
  */
 void
-jerry_value_set_error_flag (jerry_value_t *value_p)
+jerry_value_set_error (jerry_value_t *value_p)
 {
   jerry_assert_api_available ();
 
@@ -960,7 +960,7 @@ jerry_value_set_error_flag (jerry_value_t *value_p)
   }
 
   *value_p = ecma_create_error_reference (*value_p, true);
-} /* jerry_value_set_error_flag */
+} /* jerry_value_set_error */
 
 /**
  * Set both the abort and error flags if the value is not an error reference.

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -375,7 +375,7 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature);
  * Error manipulation functions.
  */
 void jerry_value_clear_error_flag (jerry_value_t *value_p);
-void jerry_value_set_error_flag (jerry_value_t *value_p);
+void jerry_value_set_error (jerry_value_t *value_p);
 void jerry_value_set_abort_flag (jerry_value_t *value_p);
 jerry_value_t jerry_get_value_without_error_flag (jerry_value_t value);
 

--- a/tests/unit-core/test-abort.c
+++ b/tests/unit-core/test-abort.c
@@ -118,7 +118,7 @@ main (void)
   TEST_ASSERT (jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 
-  jerry_value_set_error_flag (&value);
+  jerry_value_set_error (&value);
   TEST_ASSERT (!jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 

--- a/tests/unit-core/test-api-set-and-clear-error-flag.c
+++ b/tests/unit-core/test-api-set-and-clear-error-flag.c
@@ -24,7 +24,7 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   jerry_value_t obj_val = jerry_create_object ();
-  jerry_value_set_error_flag (&obj_val);
+  jerry_value_set_error (&obj_val);
   jerry_value_t err_val = jerry_acquire_value (obj_val);
 
   jerry_value_clear_error_flag (&obj_val);

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -1053,7 +1053,7 @@ main (void)
   {
     jerry_init (JERRY_INIT_EMPTY);
     jerry_value_t num_val = jerry_create_number (123);
-    jerry_value_set_error_flag (&num_val);
+    jerry_value_set_error (&num_val);
     TEST_ASSERT (jerry_value_is_error (num_val));
     jerry_value_t num2_val = jerry_get_value_without_error_flag (num_val);
     TEST_ASSERT (!jerry_value_is_error (num2_val));


### PR DESCRIPTION
Rename the function to represent it's real functionality.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu