### PR TITLE
Rename the jerry_value_set_abort_flag function

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1783,7 +1783,7 @@ jerry_value_clear_error_flag (jerry_value_t *value_p);
 
 - [jerry_value_t](#jerry_value_t)
 - [jerry_value_set_error_flag](#jerry_value_set_error_flag)
-- [jerry_value_set_abort_flag](#jerry_value_set_abort_flag)
+- [jerry_value_set_abort](#jerry_value_set_abort)
 
 
 ## jerry_value_set_error_flag
@@ -1818,20 +1818,20 @@ jerry_value_set_error_flag (jerry_value_t *value_p);
 
 - [jerry_value_t](#jerry_value_t)
 - [jerry_value_clear_error_flag](#jerry_value_clear_error_flag)
-- [jerry_value_set_abort_flag](#jerry_value_set_abort_flag)
+- [jerry_value_set_abort](#jerry_value_set_abort)
 
 
-## jerry_value_set_abort_flag
+## jerry_value_set_abort
 
 **Summary**
 
-Set both the error and abort flags.
+Set both the error and abort values.
 
 **Prototype**
 
 ```c
 void
-jerry_value_set_abort_flag (jerry_value_t *value_p);
+jerry_value_set_abort (jerry_value_t *value_p);
 ```
 
 - `value_p` - pointer to an api value
@@ -1843,7 +1843,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p);
   jerry_value_t value;
   ... // create or acquire value
 
-  jerry_value_set_abort_flag (&value);
+  jerry_value_set_abort (&value);
 
   jerry_release_value (value);
 }

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -963,10 +963,10 @@ jerry_value_set_error_flag (jerry_value_t *value_p)
 } /* jerry_value_set_error_flag */
 
 /**
- * Set both the abort and error flags if the value is not an error reference.
+ * Set both the abort and error values if the value is not an error reference.
  */
 void
-jerry_value_set_abort_flag (jerry_value_t *value_p)
+jerry_value_set_abort (jerry_value_t *value_p)
 {
   jerry_assert_api_available ();
 
@@ -983,7 +983,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p)
   }
 
   *value_p = ecma_create_error_reference (*value_p, false);
-} /* jerry_value_set_abort_flag */
+} /* jerry_value_set_abort */
 
 /**
  * If the input value is an error value, then return a new reference to its referenced value.

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -376,7 +376,7 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature);
  */
 void jerry_value_clear_error_flag (jerry_value_t *value_p);
 void jerry_value_set_error_flag (jerry_value_t *value_p);
-void jerry_value_set_abort_flag (jerry_value_t *value_p);
+void jerry_value_set_abort (jerry_value_t *value_p);
 jerry_value_t jerry_get_value_without_error_flag (jerry_value_t value);
 
 /**

--- a/tests/unit-core/test-abort.c
+++ b/tests/unit-core/test-abort.c
@@ -30,7 +30,7 @@ callback_func (const jerry_value_t function_obj,
   JERRY_UNUSED (args_count);
 
   jerry_value_t value = jerry_create_string ((jerry_char_t *) "Abort run!");
-  jerry_value_set_abort_flag (&value);
+  jerry_value_set_abort (&value);
   return value;
 } /* callback_func */
 
@@ -114,7 +114,7 @@ main (void)
   TEST_ASSERT (!jerry_value_is_abort (value));
   TEST_ASSERT (!jerry_value_is_error (value));
 
-  jerry_value_set_abort_flag (&value);
+  jerry_value_set_abort (&value);
   TEST_ASSERT (jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 
@@ -122,7 +122,7 @@ main (void)
   TEST_ASSERT (!jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 
-  jerry_value_set_abort_flag (&value);
+  jerry_value_set_abort (&value);
   TEST_ASSERT (jerry_value_is_abort (value));
   TEST_ASSERT (jerry_value_is_error (value));
 


### PR DESCRIPTION
Rename the function to represent it's real functionality.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu