### PR TITLE
Rename the jerry_get_value_without_error_flag

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1857,7 +1857,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p);
 - [jerry_value_set_error_flag](#jerry_value_set_error_flag)
 
 
-## jerry_get_value_without_error_flag
+## jerry_get_value_without_error
 
 **Summary**
 
@@ -1871,7 +1871,7 @@ when it is no longer needed.
 
 ```c
 jerry_value_t
-jerry_get_value_without_error_flag (jerry_value_t value)
+jerry_get_value_without_error (jerry_value_t value)
 ```
 
 - `value` - api value
@@ -1885,10 +1885,10 @@ jerry_get_value_without_error_flag (jerry_value_t value)
 
   jerry_value_set_error_flag (&value);
 
-  jerry_value_t real_value = jerry_get_value_without_error_flag (value);
+  jerry_value_t real_value = jerry_get_value_without_error (value);
   ... // process the real_value. Different from `jerry_value_clear_error_flag`,
       // the error `value` will not be automatically released after calling
-      // `jerry_get_value_without_error_flag`.
+      // `jerry_get_value_without_error`.
 
   jerry_release_value (value);
   jerry_release_value (real_value);

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -994,10 +994,10 @@ jerry_value_set_abort_flag (jerry_value_t *value_p)
  *
  * @return the real value of the jerry_value
  */
-jerry_value_t jerry_get_value_without_error_flag (jerry_value_t value) /**< api value */
+jerry_value_t jerry_get_value_without_error (jerry_value_t value) /**< api value */
 {
   return jerry_acquire_value (jerry_get_arg_value (value));
-} /* jerry_get_value_without_error_flag */
+} /* jerry_get_value_without_error */
 
 /**
  * Return the type of the Error object if possible.

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -377,7 +377,7 @@ bool jerry_value_has_abort_flag (const jerry_value_t value);
 void jerry_value_clear_error_flag (jerry_value_t *value_p);
 void jerry_value_set_error_flag (jerry_value_t *value_p);
 void jerry_value_set_abort_flag (jerry_value_t *value_p);
-jerry_value_t jerry_get_value_without_error_flag (jerry_value_t value);
+jerry_value_t jerry_get_value_without_error (jerry_value_t value);
 
 /**
  * Error object function(s).

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -152,7 +152,7 @@ print_unhandled_exception (jerry_value_t error_value, /**< error value */
 {
   assert (jerry_value_is_error (error_value));
 
-  error_value = jerry_get_value_without_error_flag (error_value);
+  error_value = jerry_get_value_without_error (error_value);
   jerry_value_t err_str_val = jerry_value_to_string (error_value);
   jerry_size_t err_str_size = jerry_get_string_size (err_str_val);
   jerry_char_t err_str_buf[256];

--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
@@ -130,7 +130,7 @@ print_unhandled_exception (jerry_value_t error_value, /**< error value */
 {
   assert (jerry_value_is_error (error_value));
 
-  error_value = jerry_get_value_without_error_flag (error_value);
+  error_value = jerry_get_value_without_error (error_value);
   jerry_value_t err_str_val = jerry_value_to_string (error_value);
   jerry_size_t err_str_size = jerry_get_string_size (err_str_val);
   jerry_char_t err_str_buf[256];

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -1049,13 +1049,13 @@ main (void)
 
   TEST_ASSERT (test_api_is_free_callback_was_called);
 
-  /* Test: jerry_get_value_without_error_flag */
+  /* Test: jerry_get_value_without_error */
   {
     jerry_init (JERRY_INIT_EMPTY);
     jerry_value_t num_val = jerry_create_number (123);
     jerry_value_set_error_flag (&num_val);
     TEST_ASSERT (jerry_value_is_error (num_val));
-    jerry_value_t num2_val = jerry_get_value_without_error_flag (num_val);
+    jerry_value_t num2_val = jerry_get_value_without_error (num_val);
     TEST_ASSERT (!jerry_value_is_error (num2_val));
     double num = jerry_get_number_value (num2_val);
     TEST_ASSERT (num == 123);


### PR DESCRIPTION
Rename the function to represent it's real functionality.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu