### PR TITLE
Add checking return value

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -837,7 +837,7 @@ ecma_builtin_object_object_define_properties (ecma_value_t this_arg, /**< 'this'
     ecma_value_p = ecma_collection_iterator_init (prop_names_p);
 
     for (uint32_t index = 0;
-         index < property_number && ecma_is_value_empty (ret_value);
+         ecma_value_p != NULL && index < property_number && ecma_is_value_empty (ret_value);
          index++)
     {
       ECMA_TRY_CATCH (define_own_prop_ret,


### PR DESCRIPTION
ecma_collection_iterator_init and ecma_collection_iterator_next can return null pointer
so, return value should be checked in for loop

JerryScript-DCO-1.0-Signed-off-by: Haesik Jun haesik.jun@samsung.com