### PR TITLE
Fix sign-conversion warning on gcc when compiling to raspberry pi 2

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -259,7 +259,7 @@ void jerry_port_sleep (uint32_t sleep_time)
 #ifdef HAVE_TIME_H
   nanosleep (&(const struct timespec)
   {
-    sleep_time / 1000, (sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
+    (time_t) sleep_time / 1000, ((long int) sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
   }
   , NULL);
 #elif defined (HAVE_UNISTD_H)

--- a/jerry-port/default/default-debugger.c
+++ b/jerry-port/default/default-debugger.c
@@ -28,7 +28,7 @@ void jerry_port_sleep (uint32_t sleep_time)
 #ifdef HAVE_TIME_H
   nanosleep (&(const struct timespec)
   {
-    sleep_time / 1000, (sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
+    (time_t) sleep_time / 1000, ((long int) sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
   }
   , NULL);
 #elif defined (HAVE_UNISTD_H)


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu