### PR TITLE
Add jerryscript-compiler.h public header to cover compiler incompatibilities

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -33,7 +33,7 @@
  *
  * @return configuration flags
  */
-static inline uint32_t __attr_always_inline___
+static inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 snapshot_get_global_flags (bool has_regex) /**< regex literal is present */
 {
   JERRY_UNUSED (has_regex);
@@ -55,7 +55,7 @@ snapshot_get_global_flags (bool has_regex) /**< regex literal is present */
  *
  * @return true if global_flags accepted, false otherwise
  */
-static inline bool __attr_always_inline___
+static inline bool JERRY_ATTR_ALWAYS_INLINE
 snapshot_check_global_flags (uint32_t global_flags) /**< global flags */
 {
 #ifndef CONFIG_DISABLE_REGEXP_BUILTIN
@@ -92,7 +92,7 @@ typedef struct
  * @return true - if write was successful, i.e. offset + data_size doesn't exceed buffer size,
  *         false - otherwise
  */
-static inline bool __attr_always_inline___
+static inline bool JERRY_ATTR_ALWAYS_INLINE
 snapshot_write_to_buffer_by_offset (uint8_t *buffer_p, /**< buffer */
                                     size_t buffer_size, /**< size of buffer */
                                     size_t *in_out_buffer_offset_p,  /**< [in,out] offset to write to

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -97,10 +97,10 @@ static const char * const wrong_args_msg_p = "wrong type of argument";
  *           - before jerry_init and after jerry_cleanup
  *           - between enter to and return from a native free callback
  */
-static inline void __attr_always_inline___
+static inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_assert_api_available (void)
 {
-  if (unlikely (!(JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE)))
+  if (JERRY_UNLIKELY (!(JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE)))
   {
     /* Terminates the execution. */
     JERRY_UNREACHABLE ();
@@ -110,7 +110,7 @@ jerry_assert_api_available (void)
 /**
  * Turn on API availability
  */
-static inline void __attr_always_inline___
+static inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_make_api_available (void)
 {
   JERRY_CONTEXT (status_flags) |= ECMA_STATUS_API_AVAILABLE;
@@ -119,7 +119,7 @@ jerry_make_api_available (void)
 /**
  * Turn off API availability
  */
-static inline void __attr_always_inline___
+static inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_make_api_unavailable (void)
 {
   JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_API_AVAILABLE;
@@ -133,10 +133,10 @@ jerry_make_api_unavailable (void)
  *
  * @return return value for Jerry API functions
  */
-static inline jerry_value_t __attr_always_inline___
+static inline jerry_value_t JERRY_ATTR_ALWAYS_INLINE
 jerry_get_arg_value (jerry_value_t value) /**< return value */
 {
-  if (unlikely (ecma_is_value_error_reference (value)))
+  if (JERRY_UNLIKELY (ecma_is_value_error_reference (value)))
   {
     value = ecma_get_error_reference_from_value (value)->value;
   }
@@ -165,7 +165,7 @@ jerry_return (jerry_value_t value) /**< return value */
  *
  * @return return value for Jerry API functions
  */
-static inline jerry_value_t __attr_always_inline___
+static inline jerry_value_t JERRY_ATTR_ALWAYS_INLINE
 jerry_throw (jerry_value_t value) /**< return value */
 {
   JERRY_ASSERT (ECMA_IS_VALUE_ERROR (value));
@@ -178,7 +178,7 @@ jerry_throw (jerry_value_t value) /**< return value */
 void
 jerry_init (jerry_init_flag_t flags) /**< combination of Jerry flags */
 {
-  if (unlikely (JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE))
   {
     /* This function cannot be called twice unless jerry_cleanup is called. */
     JERRY_UNREACHABLE ();
@@ -947,7 +947,7 @@ jerry_value_set_error_flag (jerry_value_t *value_p)
 {
   jerry_assert_api_available ();
 
-  if (unlikely (ecma_is_value_error_reference (*value_p)))
+  if (JERRY_UNLIKELY (ecma_is_value_error_reference (*value_p)))
   {
     /* This is a rare case so it is optimized for
      * binary size rather than performance. */
@@ -970,7 +970,7 @@ jerry_value_set_abort_flag (jerry_value_t *value_p)
 {
   jerry_assert_api_available ();
 
-  if (unlikely (ecma_is_value_error_reference (*value_p)))
+  if (JERRY_UNLIKELY (ecma_is_value_error_reference (*value_p)))
   {
     /* This is a rare case so it is optimized for
      * binary size rather than performance. */
@@ -1182,7 +1182,7 @@ jerry_acquire_value (jerry_value_t value) /**< API value */
 {
   jerry_assert_api_available ();
 
-  if (unlikely (ecma_is_value_error_reference (value)))
+  if (JERRY_UNLIKELY (ecma_is_value_error_reference (value)))
   {
     ecma_ref_error_reference (ecma_get_error_reference_from_value (value));
     return value;
@@ -1199,7 +1199,7 @@ jerry_release_value (jerry_value_t value) /**< API value */
 {
   jerry_assert_api_available ();
 
-  if (unlikely (ecma_is_value_error_reference (value)))
+  if (JERRY_UNLIKELY (ecma_is_value_error_reference (value)))
   {
     ecma_deref_error_reference (ecma_get_error_reference_from_value (value));
     return;

--- a/jerry-core/debugger/debugger-ws.c
+++ b/jerry-core/debugger/debugger-ws.c
@@ -455,7 +455,7 @@ jerry_debugger_accept_connection (void)
 /**
  * Close the socket connection to the client.
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_debugger_close_connection (void)
 {
   jerry_debugger_close_connection_tcp (false);

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -258,7 +258,7 @@ jerry_debugger_sleep (void)
  * @return true - if message is processed successfully
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the received data */
                                 uint32_t message_size, /**< message size */
                                 bool *resume_exec_p, /**< pointer to the resume exec flag */

--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -87,7 +87,7 @@ DECLARE_ROUTINES_FOR (number)
  *
  * @return pointer to allocated memory
  */
-inline ecma_object_t * __attr_always_inline___
+inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_object (void)
 {
 #ifdef JMEM_STATS
@@ -100,7 +100,7 @@ ecma_alloc_object (void)
 /**
  * Dealloc memory from an ecma-object
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_object (ecma_object_t *object_p) /**< object to be freed */
 {
 #ifdef JMEM_STATS
@@ -115,7 +115,7 @@ ecma_dealloc_object (ecma_object_t *object_p) /**< object to be freed */
  *
  * @return pointer to allocated memory
  */
-inline ecma_extended_object_t * __attr_always_inline___
+inline ecma_extended_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_extended_object (size_t size) /**< size of object */
 {
 #ifdef JMEM_STATS
@@ -128,7 +128,7 @@ ecma_alloc_extended_object (size_t size) /**< size of object */
 /**
  * Dealloc memory of an extended object
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_extended_object (ecma_object_t *object_p, /**< extended object */
                               size_t size) /**< size of object */
 {
@@ -144,7 +144,7 @@ ecma_dealloc_extended_object (ecma_object_t *object_p, /**< extended object */
  *
  * @return pointer to allocated memory
  */
-inline ecma_string_t * __attr_always_inline___
+inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_string (void)
 {
 #ifdef JMEM_STATS
@@ -157,7 +157,7 @@ ecma_alloc_string (void)
 /**
  * Dealloc memory from ecma-string descriptor
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_string (ecma_string_t *string_p) /**< string to be freed */
 {
 #ifdef JMEM_STATS
@@ -172,7 +172,7 @@ ecma_dealloc_string (ecma_string_t *string_p) /**< string to be freed */
  *
  * @return pointer to allocated memory
  */
-inline ecma_string_t * __attr_always_inline___
+inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_string_buffer (size_t size) /**< size of string */
 {
 #ifdef JMEM_STATS
@@ -185,7 +185,7 @@ ecma_alloc_string_buffer (size_t size) /**< size of string */
 /**
  * Dealloc memory of a string with character data
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_string_buffer (ecma_string_t *string_p, /**< string with data */
                             size_t size) /**< size of string */
 {
@@ -201,7 +201,7 @@ ecma_dealloc_string_buffer (ecma_string_t *string_p, /**< string with data */
  *
  * @return pointer to allocated memory
  */
-inline ecma_getter_setter_pointers_t * __attr_always_inline___
+inline ecma_getter_setter_pointers_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_getter_setter_pointers (void)
 {
 #ifdef JMEM_STATS
@@ -214,7 +214,7 @@ ecma_alloc_getter_setter_pointers (void)
 /**
  * Dealloc memory from getter-setter pointer pair
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *getter_setter_pointers_p) /**< pointer pair
                                                                                                 * to be freed */
 {
@@ -230,7 +230,7 @@ ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *getter_sette
  *
  * @return pointer to allocated memory
  */
-inline ecma_property_pair_t * __attr_always_inline___
+inline ecma_property_pair_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_property_pair (void)
 {
 #ifdef JMEM_STATS
@@ -243,7 +243,7 @@ ecma_alloc_property_pair (void)
 /**
  * Dealloc memory of an ecma-property
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_property_pair (ecma_property_pair_t *property_pair_p) /**< property pair to be freed */
 {
 #ifdef JMEM_STATS

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -124,7 +124,7 @@ ecma_init_gc_info (ecma_object_t *object_p) /**< object */
 void
 ecma_ref_object (ecma_object_t *object_p) /**< object */
 {
-  if (likely (object_p->type_flags_refs < ECMA_OBJECT_MAX_REF))
+  if (JERRY_LIKELY (object_p->type_flags_refs < ECMA_OBJECT_MAX_REF))
   {
     object_p->type_flags_refs = (uint16_t) (object_p->type_flags_refs + ECMA_OBJECT_REF_ONE);
   }
@@ -137,7 +137,7 @@ ecma_ref_object (ecma_object_t *object_p) /**< object */
 /**
  * Decrease reference counter of an object
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_deref_object (ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p->type_flags_refs >= ECMA_OBJECT_REF_ONE);
@@ -778,7 +778,7 @@ ecma_gc_run (jmem_free_unused_memory_severity_t severity) /**< gc severity */
     if (ecma_gc_is_object_visited (obj_iter_p))
     {
       /* Moving the object to list of marked objects. */
-      if (likely (obj_prev_p != NULL))
+      if (JERRY_LIKELY (obj_prev_p != NULL))
       {
         obj_prev_p->gc_next_cp = obj_iter_p->gc_next_cp;
       }
@@ -828,7 +828,7 @@ ecma_gc_run (jmem_free_unused_memory_severity_t severity) /**< gc severity */
       if (ecma_gc_is_object_visited (obj_iter_p))
       {
         /* Moving the object to list of marked objects */
-        if (likely (obj_prev_p != NULL))
+        if (JERRY_LIKELY (obj_prev_p != NULL))
         {
           obj_prev_p->gc_next_cp = obj_iter_p->gc_next_cp;
         }

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -218,7 +218,7 @@ enum
  * Checks whether the error flag is set.
  */
 #define ECMA_IS_VALUE_ERROR(value) \
-  (unlikely ((value) == ECMA_VALUE_ERROR))
+  (JERRY_UNLIKELY ((value) == ECMA_VALUE_ERROR))
 
 /**
  * Representation for native external pointer

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -818,7 +818,7 @@ ecma_uint32_to_utf8_string (uint32_t value, /**< value to convert */
 
   lit_utf8_size_t bytes_copied = (lit_utf8_size_t) (out_buffer_p + buffer_size - buf_p);
 
-  if (likely (buf_p != out_buffer_p))
+  if (JERRY_LIKELY (buf_p != out_buffer_p))
   {
     memmove (out_buffer_p, buf_p, bytes_copied);
   }
@@ -960,7 +960,7 @@ ecma_number_to_decimal (ecma_number_t num, /**< ecma-number */
  *
  * @return number of digits
  */
-inline static int32_t __attr_always_inline___
+inline static int32_t JERRY_ATTR_ALWAYS_INLINE
 ecma_number_of_digits (double val) /**< ecma number */
 {
   JERRY_ASSERT (fabs (fmod (val, 1.0)) < EPSILON);
@@ -978,7 +978,7 @@ ecma_number_of_digits (double val) /**< ecma number */
 /**
  * Convert double value to ASCII
  */
-inline static void __attr_always_inline___
+inline static void JERRY_ATTR_ALWAYS_INLINE
 ecma_double_to_ascii (double val, /**< ecma number */
                       lit_utf8_byte_t *buffer_p, /**< buffer to generate digits into */
                       int32_t num_of_digits, /**< number of digits */
@@ -1012,7 +1012,7 @@ ecma_double_to_ascii (double val, /**< ecma number */
  *
  * @return number of generated digits
  */
-static inline lit_utf8_size_t __attr_always_inline___
+static inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_double_to_binary_floating_point (double val, /**< ecma number */
                                       lit_utf8_byte_t *buffer_p, /**< buffer to generate digits into */
                                       int32_t *exp_p) /**< [out] exponent */

--- a/jerry-core/ecma/base/ecma-helpers-errol.c
+++ b/jerry-core/ecma/base/ecma-helpers-errol.c
@@ -73,7 +73,7 @@ typedef struct
 /**
  * Normalize the number by factoring in the error.
  */
-static inline void __attr_always_inline___
+static inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_normalize_high_prec_data (ecma_high_prec_t *hp_data_p) /**< [in, out] float pair */
 {
   double val = hp_data_p->value;
@@ -85,7 +85,7 @@ ecma_normalize_high_prec_data (ecma_high_prec_t *hp_data_p) /**< [in, out] float
 /**
  * Multiply the high-precision number by ten.
  */
-static inline void __attr_always_inline___
+static inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_multiply_high_prec_by_10 (ecma_high_prec_t *hp_data_p) /**< [in, out] high-precision number */
 {
   double value = hp_data_p->value;
@@ -127,7 +127,7 @@ ecma_divide_high_prec_by_10 (ecma_high_prec_t *hp_data_p) /**< [in, out] high-pr
  *
  * @return number of generated digits
  */
-inline lit_utf8_size_t __attr_always_inline___
+inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_errol0_dtoa (double val, /**< ecma number */
                   lit_utf8_byte_t *buffer_p, /**< buffer to generate digits into */
                   int32_t *exp_p) /**< [out] exponent */

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -238,7 +238,7 @@ ecma_number_get_sign_field (ecma_number_t num) /**< ecma-number */
                   fraction is filled with anything but not all zero bits,
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_number_is_nan (ecma_number_t num) /**< ecma-number */
 {
   bool is_nan = (num != num);
@@ -291,7 +291,7 @@ ecma_number_make_infinity (bool sign) /**< true - for negative Infinity,
  * @return true - if sign bit of ecma-number is set
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_number_is_negative (ecma_number_t num) /**< ecma-number */
 {
   JERRY_ASSERT (!ecma_number_is_nan (num));
@@ -360,7 +360,7 @@ ecma_number_get_fraction_and_exponent (ecma_number_t num, /**< ecma-number */
   uint64_t fraction = ecma_number_get_fraction_field (num);
   int32_t exponent;
 
-  if (unlikely (biased_exp == 0))
+  if (JERRY_UNLIKELY (biased_exp == 0))
   {
     /* IEEE-754 2008, 3.4, d */
     if (ecma_number_is_zero (num))
@@ -658,18 +658,18 @@ ecma_number_calc_remainder (ecma_number_t left_num, /**< left operand */
  *
  * @return number - result of multiplication.
  */
-inline ecma_value_t __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_integer_multiply (ecma_integer_value_t left_integer, /**< left operand */
                        ecma_integer_value_t right_integer) /**< right operand */
 {
 #if defined (__GNUC__) || defined (__clang__)
   /* Check if left_integer is power of 2 */
-  if (unlikely ((left_integer & (left_integer - 1)) == 0))
+  if (JERRY_UNLIKELY ((left_integer & (left_integer - 1)) == 0))
   {
     /* Right shift right_integer with log2 (left_integer) */
     return ecma_make_integer_value (right_integer << (__builtin_ctz ((unsigned int) left_integer)));
   }
-  else if (unlikely ((right_integer & (right_integer - 1)) == 0))
+  else if (JERRY_UNLIKELY ((right_integer & (right_integer - 1)) == 0))
   {
     /* Right shift left_integer with log2 (right_integer) */
     return ecma_make_integer_value (left_integer << (__builtin_ctz ((unsigned int) right_integer)));

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -219,7 +219,7 @@ ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *string_p, /**< utf-8 stri
   ecma_string_t *string_desc_p;
   lit_utf8_byte_t *data_p;
 
-  if (likely (string_size <= UINT16_MAX))
+  if (JERRY_LIKELY (string_size <= UINT16_MAX))
   {
     string_desc_p = ecma_alloc_string_buffer (sizeof (ecma_string_t) + string_size);
 
@@ -307,7 +307,7 @@ ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *string
 
     lit_utf8_byte_t *data_p;
 
-    if (likely (converted_string_size <= UINT16_MAX))
+    if (JERRY_LIKELY (converted_string_size <= UINT16_MAX))
     {
       string_desc_p = ecma_alloc_string_buffer (sizeof (ecma_string_t) + converted_string_size);
 
@@ -387,7 +387,7 @@ ecma_new_ecma_string_from_code_unit (ecma_char_t code_unit) /**< code unit */
 ecma_string_t *
 ecma_new_ecma_string_from_uint32 (uint32_t uint32_number) /**< uint32 value of the string */
 {
-  if (likely (uint32_number <= ECMA_DIRECT_STRING_MAX_IMM))
+  if (JERRY_LIKELY (uint32_number <= ECMA_DIRECT_STRING_MAX_IMM))
   {
     return (ecma_string_t *) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_UINT, (uintptr_t) uint32_number);
   }
@@ -473,7 +473,7 @@ ecma_new_ecma_string_from_number (ecma_number_t num) /**< ecma-number */
  *
  * @return pointer to ecma-string descriptor
  */
-inline ecma_string_t * __attr_always_inline___
+inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_get_magic_string (lit_magic_string_id_t id) /**< identifier of magic string */
 {
   JERRY_ASSERT (id < LIT_MAGIC_STRING__COUNT);
@@ -490,7 +490,7 @@ ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id) /**< 
 {
   JERRY_ASSERT (id < lit_get_magic_string_ex_count ());
 
-  if (likely (id <= ECMA_DIRECT_STRING_MAX_IMM))
+  if (JERRY_LIKELY (id <= ECMA_DIRECT_STRING_MAX_IMM))
   {
     return (ecma_string_t *) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC_EX, (uintptr_t) id);
   }
@@ -521,7 +521,7 @@ ecma_append_chars_to_string (ecma_string_t *string1_p, /**< base ecma-string */
 {
   JERRY_ASSERT (string1_p != NULL && cesu8_string2_size > 0 && cesu8_string2_length > 0);
 
-  if (unlikely (ecma_string_is_empty (string1_p)))
+  if (JERRY_UNLIKELY (ecma_string_is_empty (string1_p)))
   {
     return ecma_new_ecma_string_from_utf8 (cesu8_string2_p, cesu8_string2_size);
   }
@@ -673,7 +673,7 @@ ecma_append_chars_to_string (ecma_string_t *string1_p, /**< base ecma-string */
   ecma_string_t *string_desc_p;
   lit_utf8_byte_t *data_p;
 
-  if (likely (new_size <= UINT16_MAX))
+  if (JERRY_LIKELY (new_size <= UINT16_MAX))
   {
     string_desc_p = ecma_alloc_string_buffer (sizeof (ecma_string_t) + new_size);
 
@@ -734,12 +734,12 @@ ecma_concat_ecma_strings (ecma_string_t *string1_p, /**< first ecma-string */
 {
   JERRY_ASSERT (string1_p != NULL && string2_p != NULL);
 
-  if (unlikely (ecma_string_is_empty (string1_p)))
+  if (JERRY_UNLIKELY (ecma_string_is_empty (string1_p)))
   {
     ecma_ref_ecma_string (string2_p);
     return string2_p;
   }
-  else if (unlikely (ecma_string_is_empty (string2_p)))
+  else if (JERRY_UNLIKELY (ecma_string_is_empty (string2_p)))
   {
     return string1_p;
   }
@@ -842,7 +842,7 @@ ecma_string_t *
 ecma_append_magic_string_to_string (ecma_string_t *string1_p,
                                     lit_magic_string_id_t string2_id)
 {
-  if (unlikely (ecma_string_is_empty (string1_p)))
+  if (JERRY_UNLIKELY (ecma_string_is_empty (string1_p)))
   {
     return ecma_get_magic_string (string2_id);
   }
@@ -868,7 +868,7 @@ ecma_ref_ecma_string (ecma_string_t *string_p) /**< string descriptor */
 
   JERRY_ASSERT (string_p->refs_and_container >= ECMA_STRING_REF_ONE);
 
-  if (likely (string_p->refs_and_container < ECMA_STRING_MAX_REF))
+  if (JERRY_LIKELY (string_p->refs_and_container < ECMA_STRING_MAX_REF))
   {
     /* Increase reference counter. */
     string_p->refs_and_container = (uint16_t) (string_p->refs_and_container + ECMA_STRING_REF_ONE);
@@ -990,7 +990,7 @@ ecma_string_to_number (const ecma_string_t *string_p) /**< ecma-string */
  * @return ECMA_STRING_NOT_ARRAY_INDEX if string is not array index
  *         the array index otherwise
  */
-inline uint32_t __attr_always_inline___
+inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_get_array_index (const ecma_string_t *str_p) /**< ecma-string */
 {
   if (ECMA_IS_DIRECT_STRING (str_p))
@@ -1021,7 +1021,7 @@ ecma_string_get_array_index (const ecma_string_t *str_p) /**< ecma-string */
  *
  * @return number of bytes, actually copied to the buffer.
  */
-lit_utf8_size_t __attr_return_value_should_be_checked___
+lit_utf8_size_t JERRY_ATTR_WARN_UNUSED_RESULT
 ecma_string_copy_to_cesu8_buffer (const ecma_string_t *string_p, /**< ecma-string descriptor */
                                   lit_utf8_byte_t *buffer_p, /**< destination buffer pointer
                                                               * (can be NULL if buffer_size == 0) */
@@ -1071,7 +1071,7 @@ ecma_string_copy_to_cesu8_buffer (const ecma_string_t *string_p, /**< ecma-strin
  *
  * @return number of bytes, actually copied to the buffer.
  */
-lit_utf8_size_t __attr_return_value_should_be_checked___
+lit_utf8_size_t JERRY_ATTR_WARN_UNUSED_RESULT
 ecma_string_copy_to_utf8_buffer (const ecma_string_t *string_p, /**< ecma-string descriptor */
                                  lit_utf8_byte_t *buffer_p, /**< destination buffer pointer
                                                              * (can be NULL if buffer_size == 0) */
@@ -1347,7 +1347,7 @@ ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, /**< ecm
  * It is the caller's responsibility to make sure that the string fits in the buffer.
  * Check if the size of the string is equal with the size of the buffer.
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, /**< ecma-string descriptor */
                            lit_utf8_byte_t *buffer_p, /**< destination buffer pointer
                                                        * (can be NULL if buffer_size == 0) */
@@ -1364,7 +1364,7 @@ ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, /**< ecma-string 
  *
  * @return size in bytes
  */
-static inline ecma_length_t __attr_always_inline___
+static inline ecma_length_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_get_uint32_size (const uint32_t uint32_number) /**< number in the string-descriptor */
 {
   uint32_t prev_number = 1;
@@ -1453,7 +1453,7 @@ ecma_string_get_chars (const ecma_string_t *string_p, /**< ecma-string */
         result_p = lit_get_magic_string_ex_utf8 (id);
         length = 0;
 
-        if (unlikely (*flags_p & ECMA_STRING_FLAG_IS_ASCII))
+        if (JERRY_UNLIKELY (*flags_p & ECMA_STRING_FLAG_IS_ASCII))
         {
           length = lit_utf8_string_length (result_p, size);
         }
@@ -1500,7 +1500,7 @@ ecma_string_get_chars (const ecma_string_t *string_p, /**< ecma-string */
         size = lit_get_magic_string_ex_size (string_p->u.magic_string_ex_id);
         length = 0;
 
-        if (unlikely (*flags_p & ECMA_STRING_FLAG_IS_ASCII))
+        if (JERRY_UNLIKELY (*flags_p & ECMA_STRING_FLAG_IS_ASCII))
         {
           length = lit_utf8_string_length (lit_get_magic_string_ex_utf8 (string_p->u.magic_string_ex_id), size);
         }
@@ -1529,7 +1529,7 @@ ecma_string_get_chars (const ecma_string_t *string_p, /**< ecma-string */
  * @return true - if the string equals to the magic string id
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_compare_ecma_string_to_magic_id (const ecma_string_t *string_p, /**< property name */
                                       lit_magic_string_id_t id) /**< magic string id */
 {
@@ -1542,7 +1542,7 @@ ecma_compare_ecma_string_to_magic_id (const ecma_string_t *string_p, /**< proper
  * @return true - if the string is an empty string
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_string_is_empty (const ecma_string_t *string_p) /**< ecma-string */
 {
   return ecma_compare_ecma_string_to_magic_id (string_p, LIT_MAGIC_STRING__EMPTY);
@@ -1554,14 +1554,14 @@ ecma_string_is_empty (const ecma_string_t *string_p) /**< ecma-string */
  * @return true - if the string equals to "length"
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_string_is_length (const ecma_string_t *string_p) /**< property name */
 {
   return ecma_compare_ecma_string_to_magic_id (string_p, LIT_MAGIC_STRING_LENGTH);
 } /* ecma_string_is_length */
 
 
-static inline ecma_string_t * __attr_always_inline___
+static inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_property_to_string (ecma_property_t property, /**< property name type */
                          jmem_cpointer_t prop_name_cp) /**< property name compressed pointer */
 {
@@ -1575,7 +1575,7 @@ ecma_property_to_string (ecma_property_t property, /**< property name type */
  *
  * @return the compressed pointer part of the name
  */
-inline jmem_cpointer_t __attr_always_inline___
+inline jmem_cpointer_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_to_property_name (ecma_string_t *prop_name_p, /**< property name */
                               ecma_property_t *name_type_p) /**< [out] property name type */
 {
@@ -1619,7 +1619,7 @@ ecma_string_from_property_name (ecma_property_t property, /**< property name typ
  *
  * @return hash code of property name
  */
-inline lit_string_hash_t __attr_always_inline___
+inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_get_property_name_hash (ecma_property_t property, /**< property name type */
                                     jmem_cpointer_t prop_name_cp) /**< property name compressed pointer */
 {
@@ -1675,7 +1675,7 @@ ecma_string_get_property_index (ecma_property_t property, /**< property name typ
  * @return true if they are equals
  *         false otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_string_compare_to_property_name (ecma_property_t property, /**< property name type */
                                       jmem_cpointer_t prop_name_cp, /**< property name compressed pointer */
                                       const ecma_string_t *string_p) /**< other string */
@@ -1703,7 +1703,7 @@ ecma_string_compare_to_property_name (ecma_property_t property, /**< property na
  * @return true - if strings are equal;
  *         false - otherwise
  */
-static bool __attr_noinline___
+static bool JERRY_ATTR_NOINLINE
 ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /**< ecma-string */
                                     const ecma_string_t *string2_p) /**< ecma-string */
 {
@@ -1743,7 +1743,7 @@ ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /**< ecma-st
  * @return true - if strings are equal;
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_compare_ecma_strings (const ecma_string_t *string1_p, /**< ecma-string */
                            const ecma_string_t *string2_p) /**< ecma-string */
 {
@@ -1787,7 +1787,7 @@ ecma_compare_ecma_strings (const ecma_string_t *string1_p, /**< ecma-string */
  * @return true - if strings are equal;
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_compare_ecma_non_direct_strings (const ecma_string_t *string1_p, /**< ecma-string */
                                       const ecma_string_t *string2_p) /**< ecma-string */
 {
@@ -2219,7 +2219,7 @@ ecma_get_string_magic (const ecma_string_t *string_p) /**< ecma-string */
  *
  * @return calculated hash
  */
-inline lit_string_hash_t __attr_always_inline___
+inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_hash (const ecma_string_t *string_p) /**< ecma-string to calculate hash for */
 {
   if (!ECMA_IS_DIRECT_STRING (string_p))

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -63,7 +63,7 @@ JERRY_STATIC_ASSERT ((ECMA_VALUE_FALSE | (1 << ECMA_DIRECT_SHIFT)) == ECMA_VALUE
  *
  * @return type field
  */
-static inline ecma_type_t __attr_const___ __attr_always_inline___
+static inline ecma_type_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_get_value_type_field (ecma_value_t value) /**< ecma value */
 {
   return value & ECMA_VALUE_TYPE_MASK;
@@ -74,7 +74,7 @@ ecma_get_value_type_field (ecma_value_t value) /**< ecma value */
  *
  * @return ecma value
  */
-static inline ecma_value_t __attr_pure___ __attr_always_inline___
+static inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_pointer_to_ecma_value (const void *ptr) /**< pointer */
 {
 #ifdef ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
@@ -98,7 +98,7 @@ ecma_pointer_to_ecma_value (const void *ptr) /**< pointer */
  *
  * @return pointer
  */
-static inline void * __attr_pure___ __attr_always_inline___
+static inline void * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_pointer_from_ecma_value (ecma_value_t value) /**< value */
 {
 #ifdef ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
@@ -116,7 +116,7 @@ ecma_get_pointer_from_ecma_value (ecma_value_t value) /**< value */
  * @return true - if the value is a direct value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_direct (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT);
@@ -128,7 +128,7 @@ ecma_is_value_direct (ecma_value_t value) /**< ecma value */
  * @return true - if the value is a simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_simple (ecma_value_t value) /**< ecma value */
 {
   return (value & ECMA_DIRECT_TYPE_MASK) == ECMA_DIRECT_TYPE_SIMPLE_VALUE;
@@ -140,7 +140,7 @@ ecma_is_value_simple (ecma_value_t value) /**< ecma value */
  * @return true - if the value is equal to the given simple value,
  *         false - otherwise
  */
-static inline bool __attr_const___ __attr_always_inline___
+static inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_equal_to_simple_value (ecma_value_t value, /**< ecma value */
                                      ecma_value_t simple_value) /**< simple value */
 {
@@ -153,7 +153,7 @@ ecma_is_value_equal_to_simple_value (ecma_value_t value, /**< ecma value */
  * @return true - if the value contains implementation-defined empty simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_empty (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_EMPTY);
@@ -165,7 +165,7 @@ ecma_is_value_empty (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-undefined simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_UNDEFINED);
@@ -177,7 +177,7 @@ ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-null simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_null (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_NULL);
@@ -189,7 +189,7 @@ ecma_is_value_null (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true or ecma-false simple values,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_true (value | (1 << ECMA_DIRECT_SHIFT));
@@ -201,7 +201,7 @@ ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_true (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_TRUE);
@@ -213,7 +213,7 @@ ecma_is_value_true (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-false simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_false (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_FALSE);
@@ -225,7 +225,7 @@ ecma_is_value_false (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-not-found simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_found (ecma_value_t value) /**< ecma value */
 {
   return value != ECMA_VALUE_NOT_FOUND;
@@ -237,7 +237,7 @@ ecma_is_value_found (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-array-hole simple value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_ARRAY_HOLE);
@@ -249,7 +249,7 @@ ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains an integer ecma-number value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_integer_number (ecma_value_t value) /**< ecma value */
 {
   return (value & ECMA_DIRECT_TYPE_MASK) == ECMA_DIRECT_TYPE_INTEGER_VALUE;
@@ -261,7 +261,7 @@ ecma_is_value_integer_number (ecma_value_t value) /**< ecma value */
  * @return true - if both values contain integer ecma-number values,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_are_values_integer_numbers (ecma_value_t first_value, /**< first ecma value */
                                  ecma_value_t second_value) /**< second ecma value */
 {
@@ -277,7 +277,7 @@ ecma_are_values_integer_numbers (ecma_value_t first_value, /**< first ecma value
  * @return true - if the value contains a floating-point ecma-number value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_float_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_FLOAT);
@@ -289,7 +289,7 @@ ecma_is_value_float_number (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-number value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_is_value_integer_number (value)
@@ -305,7 +305,7 @@ JERRY_STATIC_ASSERT ((ECMA_TYPE_STRING | 0x4) == ECMA_TYPE_DIRECT_STRING,
  * @return true - if the value contains ecma-string value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_string (ecma_value_t value) /**< ecma value */
 {
   return ((value & (ECMA_VALUE_TYPE_MASK - 0x4)) == ECMA_TYPE_STRING);
@@ -317,7 +317,7 @@ ecma_is_value_string (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-string value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_direct_string (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT_STRING);
@@ -329,7 +329,7 @@ ecma_is_value_direct_string (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains object value,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_object (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_OBJECT);
@@ -341,7 +341,7 @@ ecma_is_value_object (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains an error reference,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_error_reference (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_ERROR);
@@ -353,7 +353,7 @@ ecma_is_value_error_reference (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains a collection chunk,
  *         false - otherwise
  */
-inline bool __attr_const___ __attr_always_inline___
+inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_collection_chunk (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_COLLECTION_CHUNK);
@@ -379,7 +379,7 @@ ecma_check_value_type_is_spec_defined (ecma_value_t value) /**< ecma value */
  *
  * @return boolean ecma_value
  */
-inline ecma_value_t __attr_const___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_make_boolean_value (bool boolean_value) /**< raw bool value from which the ecma value will be created */
 {
   return boolean_value ? ECMA_VALUE_TRUE : ECMA_VALUE_FALSE;
@@ -393,7 +393,7 @@ ecma_make_boolean_value (bool boolean_value) /**< raw bool value from which the 
  *
  * @return ecma-value
  */
-inline ecma_value_t __attr_const___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_make_integer_value (ecma_integer_value_t integer_value) /**< integer number to be encoded */
 {
   JERRY_ASSERT (ECMA_IS_INTEGER_NUMBER (integer_value));
@@ -421,7 +421,7 @@ ecma_create_float_number (ecma_number_t ecma_number) /**< value of the float num
  *
  * @return ecma-value
  */
-inline ecma_value_t __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_make_nan_value (void)
 {
   return ecma_create_float_number (ecma_number_make_nan ());
@@ -432,7 +432,7 @@ ecma_make_nan_value (void)
  *
  * @return true, if it is +0.0, false otherwise
  */
-static inline bool __attr_const___ __attr_always_inline___
+static inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_number_equal_to_positive_zero (ecma_number_t ecma_number) /**< number */
 {
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
@@ -513,7 +513,7 @@ ecma_make_uint32_value (uint32_t uint32_number) /**< uint32 number to be encoded
 /**
  * String value constructor
  */
-inline ecma_value_t __attr_pure___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to reference in value */
 {
   JERRY_ASSERT (ecma_string_p != NULL);
@@ -529,7 +529,7 @@ ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to refer
 /**
  * String value constructor
  */
-inline ecma_value_t __attr_pure___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_magic_string_value (lit_magic_string_id_t id) /**< magic string id */
 {
   return (ecma_value_t) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC, (uintptr_t) id);
@@ -538,7 +538,7 @@ ecma_make_magic_string_value (lit_magic_string_id_t id) /**< magic string id */
 /**
  * Object value constructor
  */
-inline ecma_value_t __attr_pure___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference in value */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -549,7 +549,7 @@ ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference 
 /**
  * Error reference constructor
  */
-inline ecma_value_t __attr_pure___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_error_reference_value (const ecma_error_reference_t *error_ref_p) /**< error reference */
 {
   JERRY_ASSERT (error_ref_p != NULL);
@@ -560,7 +560,7 @@ ecma_make_error_reference_value (const ecma_error_reference_t *error_ref_p) /**<
 /**
  * Collection chunk constructor
  */
-inline ecma_value_t __attr_pure___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_collection_chunk_value (const ecma_collection_chunk_t *collection_chunk_p) /**< collection chunk */
 {
 #ifdef ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
@@ -583,7 +583,7 @@ ecma_make_collection_chunk_value (const ecma_collection_chunk_t *collection_chun
  *
  * @return floating point value
  */
-inline ecma_integer_value_t __attr_const___ __attr_always_inline___
+inline ecma_integer_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_get_integer_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_integer_number (value));
@@ -591,7 +591,7 @@ ecma_get_integer_from_value (ecma_value_t value) /**< ecma value */
   return ((ecma_integer_value_t) value) >> ECMA_DIRECT_SHIFT;
 } /* ecma_get_integer_from_value */
 
-inline ecma_number_t __attr_pure___ __attr_always_inline___
+inline ecma_number_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_float_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_FLOAT);
@@ -604,7 +604,7 @@ ecma_get_float_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return floating point value
  */
-ecma_number_t __attr_pure___
+ecma_number_t JERRY_ATTR_PURE
 ecma_get_number_from_value (ecma_value_t value) /**< ecma value */
 {
   if (ecma_is_value_integer_number (value))
@@ -620,7 +620,7 @@ ecma_get_number_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the pointer
  */
-inline ecma_string_t *__attr_pure___ __attr_always_inline___
+inline ecma_string_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_string_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_string (value));
@@ -638,7 +638,7 @@ ecma_get_string_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the pointer
  */
-inline ecma_object_t *__attr_pure___ __attr_always_inline___
+inline ecma_object_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_object_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_object (value));
@@ -651,7 +651,7 @@ ecma_get_object_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the pointer
  */
-inline ecma_error_reference_t *__attr_pure___ __attr_always_inline___
+inline ecma_error_reference_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_error_reference_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_ERROR);
@@ -664,7 +664,7 @@ ecma_get_error_reference_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the pointer
  */
-inline ecma_collection_chunk_t *__attr_pure___ __attr_always_inline___
+inline ecma_collection_chunk_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_collection_chunk_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_COLLECTION_CHUNK);
@@ -681,7 +681,7 @@ ecma_get_collection_chunk_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return ecma value
  */
-inline ecma_value_t __attr_const___ __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_invert_boolean_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_boolean (value));
@@ -739,7 +739,7 @@ ecma_copy_value (ecma_value_t value)  /**< value description */
  *
  * @return copy of the given value
  */
-inline ecma_value_t __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_fast_copy_value (ecma_value_t value)  /**< value description */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT) ? value : ecma_copy_value (value);
@@ -934,7 +934,7 @@ ecma_free_value (ecma_value_t value) /**< value description */
  *   It also increases the binary size so it is recommended for
  *   critical code paths only.
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_fast_free_value (ecma_value_t value) /**< value description */
 {
   if (ecma_get_value_type_field (value) != ECMA_TYPE_DIRECT)

--- a/jerry-core/ecma/base/ecma-helpers-values-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-values-collection.c
@@ -105,7 +105,7 @@ ecma_append_to_values_collection (ecma_collection_header_t *header_p, /**< colle
   ecma_length_t item_index;
   ecma_collection_chunk_t *chunk_p;
 
-  if (unlikely (header_p->item_count == 0))
+  if (JERRY_UNLIKELY (header_p->item_count == 0))
   {
     item_index = 0;
     chunk_p = (ecma_collection_chunk_t *) jmem_heap_alloc_block (sizeof (ecma_collection_chunk_t));
@@ -120,7 +120,7 @@ ecma_append_to_values_collection (ecma_collection_header_t *header_p, /**< colle
     chunk_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_chunk_t,
                                          header_p->last_chunk_cp);
 
-    if (unlikely (item_index == 0))
+    if (JERRY_UNLIKELY (item_index == 0))
     {
       JERRY_ASSERT (ecma_is_value_collection_chunk (chunk_p->items[ECMA_COLLECTION_CHUNK_ITEMS])
                     && ecma_get_collection_chunk_from_value (chunk_p->items[ECMA_COLLECTION_CHUNK_ITEMS]) == NULL);
@@ -160,7 +160,7 @@ ecma_append_to_values_collection (ecma_collection_header_t *header_p, /**< colle
 ecma_value_t *
 ecma_collection_iterator_init (ecma_collection_header_t *header_p) /**< header of collection */
 {
-  if (unlikely (!header_p || header_p->item_count == 0))
+  if (JERRY_UNLIKELY (!header_p || header_p->item_count == 0))
   {
     return NULL;
   }
@@ -183,7 +183,7 @@ ecma_collection_iterator_next (ecma_value_t *ecma_value_p) /**< current value */
 
   ecma_value_p++;
 
-  if (unlikely (ecma_is_value_collection_chunk (*ecma_value_p)))
+  if (JERRY_UNLIKELY (ecma_is_value_collection_chunk (*ecma_value_p)))
   {
     ecma_value_p = ecma_get_collection_chunk_from_value (*ecma_value_p)->items;
 

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -175,7 +175,7 @@ ecma_create_object_lex_env (ecma_object_t *outer_lexical_environment_p, /**< out
 /**
  * Check if the object is lexical environment.
  */
-inline bool __attr_pure___
+inline bool JERRY_ATTR_PURE
 ecma_is_lexical_environment (const ecma_object_t *object_p) /**< object or lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -188,7 +188,7 @@ ecma_is_lexical_environment (const ecma_object_t *object_p) /**< object or lexic
 /**
  * Get value of [[Extensible]] object's internal property.
  */
-inline bool __attr_pure___
+inline bool JERRY_ATTR_PURE
 ecma_get_object_extensible (const ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -220,7 +220,7 @@ ecma_set_object_extensible (ecma_object_t *object_p, /**< object */
 /**
  * Get object's internal implementation-defined type.
  */
-inline ecma_object_type_t __attr_pure___
+inline ecma_object_type_t JERRY_ATTR_PURE
 ecma_get_object_type (const ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -232,7 +232,7 @@ ecma_get_object_type (const ecma_object_t *object_p) /**< object */
 /**
  * Get object's prototype.
  */
-inline ecma_object_t *__attr_pure___
+inline ecma_object_t *JERRY_ATTR_PURE
 ecma_get_object_prototype (const ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -247,7 +247,7 @@ ecma_get_object_prototype (const ecma_object_t *object_p) /**< object */
  *
  * @return true / false
  */
-inline bool __attr_pure___
+inline bool JERRY_ATTR_PURE
 ecma_get_object_is_builtin (const ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -299,7 +299,7 @@ ecma_get_object_builtin_id (ecma_object_t *object_p) /**< object */
 /**
  * Get type of lexical environment.
  */
-inline ecma_lexical_environment_type_t __attr_pure___
+inline ecma_lexical_environment_type_t JERRY_ATTR_PURE
 ecma_get_lex_env_type (const ecma_object_t *object_p) /**< lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -311,7 +311,7 @@ ecma_get_lex_env_type (const ecma_object_t *object_p) /**< lexical environment *
 /**
  * Get outer reference of lexical environment.
  */
-inline ecma_object_t *__attr_pure___
+inline ecma_object_t *JERRY_ATTR_PURE
 ecma_get_lex_env_outer_reference (const ecma_object_t *object_p) /**< lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -327,7 +327,7 @@ ecma_get_lex_env_outer_reference (const ecma_object_t *object_p) /**< lexical en
  * See also:
  *          ecma_op_object_get_property_names
  */
-inline ecma_property_header_t *__attr_pure___
+inline ecma_property_header_t *JERRY_ATTR_PURE
 ecma_get_property_list (const ecma_object_t *object_p) /**< object or lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -341,7 +341,7 @@ ecma_get_property_list (const ecma_object_t *object_p) /**< object or lexical en
 /**
  * Get lexical environment's 'provideThis' property
  */
-inline bool __attr_pure___
+inline bool JERRY_ATTR_PURE
 ecma_get_lex_env_provide_this (const ecma_object_t *object_p) /**< object-bound lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -355,7 +355,7 @@ ecma_get_lex_env_provide_this (const ecma_object_t *object_p) /**< object-bound 
 /**
  * Get lexical environment's bound object.
  */
-inline ecma_object_t *__attr_pure___
+inline ecma_object_t *JERRY_ATTR_PURE
 ecma_get_lex_env_binding_object (const ecma_object_t *object_p) /**< object-bound lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -1065,7 +1065,7 @@ ecma_assert_object_contains_the_property (const ecma_object_t *object_p, /**< ec
  * Note:
  *      value previously stored in the property is freed
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_named_data_property_assign_value (ecma_object_t *obj_p, /**< object */
                                        ecma_property_value_t *prop_value_p, /**< property value reference */
                                        ecma_value_t value) /**< value to assign */
@@ -1157,7 +1157,7 @@ ecma_set_named_accessor_property_setter (ecma_object_t *object_p, /**< the prope
  * @return true - property is writable,
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_writable (ecma_property_t property) /**< property */
 {
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_NAMEDDATA
@@ -1191,7 +1191,7 @@ ecma_set_property_writable_attr (ecma_property_t *property_p, /**< [in,out] prop
  * @return true - property is enumerable,
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_enumerable (ecma_property_t property) /**< property */
 {
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_NAMEDDATA
@@ -1227,7 +1227,7 @@ ecma_set_property_enumerable_attr (ecma_property_t *property_p, /**< [in,out] pr
  * @return true - property is configurable,
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_configurable (ecma_property_t property) /**< property */
 {
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_NAMEDDATA
@@ -1262,7 +1262,7 @@ ecma_set_property_configurable_attr (ecma_property_t *property_p, /**< [in,out] 
  *
  * @return true / false
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_lcached (ecma_property_t *property_p) /**< property */
 {
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (*property_p) == ECMA_PROPERTY_TYPE_NAMEDDATA
@@ -1274,7 +1274,7 @@ ecma_is_property_lcached (ecma_property_t *property_p) /**< property */
 /**
  * Set value of flag indicating whether the property is registered in LCache
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_set_property_lcached (ecma_property_t *property_p, /**< property */
                            bool is_lcached) /**< new value for lcached flag */
 {
@@ -1388,7 +1388,7 @@ ecma_create_error_reference_from_context (void)
  *
  * @return error reference value
  */
-inline ecma_value_t __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_create_error_object_reference (ecma_object_t *object_p) /**< referenced object */
 {
   return ecma_create_error_reference (ecma_make_object_value (object_p), true);
@@ -1400,7 +1400,7 @@ ecma_create_error_object_reference (ecma_object_t *object_p) /**< referenced obj
 void
 ecma_ref_error_reference (ecma_error_reference_t *error_ref_p) /**< error reference */
 {
-  if (likely (error_ref_p->refs_and_flags < ECMA_ERROR_MAX_REF))
+  if (JERRY_LIKELY (error_ref_p->refs_and_flags < ECMA_ERROR_MAX_REF))
   {
     error_ref_p->refs_and_flags += ECMA_ERROR_REF_ONE;
   }

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -138,48 +138,48 @@ typedef enum
 #define ECMA_BOOL_TO_BITFIELD(x) ((x) ? 1 : 0)
 
 /* ecma-helpers-value.c */
-bool ecma_is_value_direct (ecma_value_t value) __attr_const___;
-bool ecma_is_value_simple (ecma_value_t value) __attr_const___;
-bool ecma_is_value_empty (ecma_value_t value) __attr_const___;
-bool ecma_is_value_undefined (ecma_value_t value) __attr_const___;
-bool ecma_is_value_null (ecma_value_t value) __attr_const___;
-bool ecma_is_value_boolean (ecma_value_t value) __attr_const___;
-bool ecma_is_value_true (ecma_value_t value) __attr_const___;
-bool ecma_is_value_false (ecma_value_t value) __attr_const___;
-bool ecma_is_value_found (ecma_value_t value) __attr_const___;
-bool ecma_is_value_array_hole (ecma_value_t value) __attr_const___;
+bool JERRY_ATTR_CONST ecma_is_value_direct (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_simple (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_empty (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_undefined (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_null (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_boolean (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_true (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_false (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_found (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_array_hole (ecma_value_t value);
 
-bool ecma_is_value_integer_number (ecma_value_t value) __attr_const___;
-bool ecma_are_values_integer_numbers (ecma_value_t first_value, ecma_value_t second_value) __attr_const___;
-bool ecma_is_value_float_number (ecma_value_t value) __attr_const___;
-bool ecma_is_value_number (ecma_value_t value) __attr_const___;
-bool ecma_is_value_string (ecma_value_t value) __attr_const___;
-bool ecma_is_value_direct_string (ecma_value_t value) __attr_const___;
-bool ecma_is_value_object (ecma_value_t value) __attr_const___;
-bool ecma_is_value_error_reference (ecma_value_t value) __attr_const___;
-bool ecma_is_value_collection_chunk (ecma_value_t value) __attr_const___;
+bool JERRY_ATTR_CONST ecma_is_value_integer_number (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_are_values_integer_numbers (ecma_value_t first_value, ecma_value_t second_value);
+bool JERRY_ATTR_CONST ecma_is_value_float_number (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_number (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_string (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_direct_string (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_object (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_error_reference (ecma_value_t value);
+bool JERRY_ATTR_CONST ecma_is_value_collection_chunk (ecma_value_t value);
 
 void ecma_check_value_type_is_spec_defined (ecma_value_t value);
 
-ecma_value_t ecma_make_boolean_value (bool boolean_value) __attr_const___;
-ecma_value_t ecma_make_integer_value (ecma_integer_value_t integer_value) __attr_const___;
+ecma_value_t JERRY_ATTR_CONST ecma_make_boolean_value (bool boolean_value);
+ecma_value_t JERRY_ATTR_CONST ecma_make_integer_value (ecma_integer_value_t integer_value);
 ecma_value_t ecma_make_nan_value (void);
 ecma_value_t ecma_make_number_value (ecma_number_t ecma_number);
 ecma_value_t ecma_make_int32_value (int32_t int32_number);
 ecma_value_t ecma_make_uint32_value (uint32_t uint32_number);
-ecma_value_t ecma_make_string_value (const ecma_string_t *ecma_string_p) __attr_pure___;
-ecma_value_t ecma_make_magic_string_value (lit_magic_string_id_t id) __attr_pure___;
-ecma_value_t ecma_make_object_value (const ecma_object_t *object_p) __attr_pure___;
-ecma_value_t ecma_make_error_reference_value (const ecma_error_reference_t *error_ref_p) __attr_pure___;
-ecma_value_t ecma_make_collection_chunk_value (const ecma_collection_chunk_t *collection_chunk_p) __attr_pure___;
-ecma_integer_value_t ecma_get_integer_from_value (ecma_value_t value) __attr_const___;
-ecma_number_t ecma_get_float_from_value (ecma_value_t value) __attr_pure___;
-ecma_number_t ecma_get_number_from_value (ecma_value_t value) __attr_pure___;
-ecma_string_t *ecma_get_string_from_value (ecma_value_t value) __attr_pure___;
-ecma_object_t *ecma_get_object_from_value (ecma_value_t value) __attr_pure___;
-ecma_error_reference_t *ecma_get_error_reference_from_value (ecma_value_t value) __attr_pure___;
-ecma_collection_chunk_t *ecma_get_collection_chunk_from_value (ecma_value_t value) __attr_pure___;
-ecma_value_t ecma_invert_boolean_value (ecma_value_t value) __attr_const___;
+ecma_value_t JERRY_ATTR_PURE ecma_make_string_value (const ecma_string_t *ecma_string_p);
+ecma_value_t JERRY_ATTR_PURE ecma_make_magic_string_value (lit_magic_string_id_t id);
+ecma_value_t JERRY_ATTR_PURE ecma_make_object_value (const ecma_object_t *object_p);
+ecma_value_t JERRY_ATTR_PURE ecma_make_error_reference_value (const ecma_error_reference_t *error_ref_p);
+ecma_value_t JERRY_ATTR_PURE ecma_make_collection_chunk_value (const ecma_collection_chunk_t *collection_chunk_p);
+ecma_integer_value_t JERRY_ATTR_CONST ecma_get_integer_from_value (ecma_value_t value);
+ecma_number_t JERRY_ATTR_PURE ecma_get_float_from_value (ecma_value_t value);
+ecma_number_t JERRY_ATTR_PURE ecma_get_number_from_value (ecma_value_t value);
+ecma_string_t JERRY_ATTR_PURE *ecma_get_string_from_value (ecma_value_t value);
+ecma_object_t JERRY_ATTR_PURE *ecma_get_object_from_value (ecma_value_t value);
+ecma_error_reference_t JERRY_ATTR_PURE *ecma_get_error_reference_from_value (ecma_value_t value);
+ecma_collection_chunk_t JERRY_ATTR_PURE *ecma_get_collection_chunk_from_value (ecma_value_t value);
+ecma_value_t JERRY_ATTR_CONST ecma_invert_boolean_value (ecma_value_t value);
 ecma_value_t ecma_copy_value (ecma_value_t value);
 ecma_value_t ecma_fast_copy_value (ecma_value_t value);
 ecma_value_t ecma_copy_value_if_not_object (ecma_value_t value);
@@ -212,11 +212,11 @@ void ecma_deref_ecma_string (ecma_string_t *string_p);
 ecma_number_t ecma_string_to_number (const ecma_string_t *str_p);
 uint32_t ecma_string_get_array_index (const ecma_string_t *str_p);
 
-lit_utf8_size_t __attr_return_value_should_be_checked___
+lit_utf8_size_t JERRY_ATTR_WARN_UNUSED_RESULT
 ecma_string_copy_to_cesu8_buffer (const ecma_string_t *string_desc_p,
                                   lit_utf8_byte_t *buffer_p,
                                   lit_utf8_size_t buffer_size);
-lit_utf8_size_t __attr_return_value_should_be_checked___
+lit_utf8_size_t JERRY_ATTR_WARN_UNUSED_RESULT
 ecma_string_copy_to_utf8_buffer (const ecma_string_t *string_desc_p,
                                  lit_utf8_byte_t *buffer_p,
                                  lit_utf8_size_t buffer_size);
@@ -299,19 +299,19 @@ ecma_object_t *ecma_create_object (ecma_object_t *prototype_object_p, size_t ext
 ecma_object_t *ecma_create_decl_lex_env (ecma_object_t *outer_lexical_environment_p);
 ecma_object_t *ecma_create_object_lex_env (ecma_object_t *outer_lexical_environment_p, ecma_object_t *binding_obj_p,
                                            bool provide_this);
-bool ecma_is_lexical_environment (const ecma_object_t *object_p) __attr_pure___;
-bool ecma_get_object_extensible (const ecma_object_t *object_p) __attr_pure___;
+bool JERRY_ATTR_PURE ecma_is_lexical_environment (const ecma_object_t *object_p);
+bool JERRY_ATTR_PURE ecma_get_object_extensible (const ecma_object_t *object_p);
 void ecma_set_object_extensible (ecma_object_t *object_p, bool is_extensible);
-ecma_object_type_t ecma_get_object_type (const ecma_object_t *object_p) __attr_pure___;
-ecma_object_t *ecma_get_object_prototype (const ecma_object_t *object_p) __attr_pure___;
-bool ecma_get_object_is_builtin (const ecma_object_t *object_p) __attr_pure___;
+ecma_object_type_t JERRY_ATTR_PURE ecma_get_object_type (const ecma_object_t *object_p);
+ecma_object_t JERRY_ATTR_PURE *ecma_get_object_prototype (const ecma_object_t *object_p);
+bool JERRY_ATTR_PURE ecma_get_object_is_builtin (const ecma_object_t *object_p);
 void ecma_set_object_is_builtin (ecma_object_t *object_p);
 uint8_t ecma_get_object_builtin_id (ecma_object_t *object_p);
-ecma_lexical_environment_type_t ecma_get_lex_env_type (const ecma_object_t *object_p) __attr_pure___;
-ecma_object_t *ecma_get_lex_env_outer_reference (const ecma_object_t *object_p) __attr_pure___;
-ecma_property_header_t *ecma_get_property_list (const ecma_object_t *object_p) __attr_pure___;
-ecma_object_t *ecma_get_lex_env_binding_object (const ecma_object_t *object_p) __attr_pure___;
-bool ecma_get_lex_env_provide_this (const ecma_object_t *object_p) __attr_pure___;
+ecma_lexical_environment_type_t JERRY_ATTR_PURE ecma_get_lex_env_type (const ecma_object_t *object_p);
+ecma_object_t JERRY_ATTR_PURE *ecma_get_lex_env_outer_reference (const ecma_object_t *object_p);
+ecma_property_header_t JERRY_ATTR_PURE *ecma_get_property_list (const ecma_object_t *object_p);
+ecma_object_t JERRY_ATTR_PURE *ecma_get_lex_env_binding_object (const ecma_object_t *object_p);
+bool JERRY_ATTR_PURE ecma_get_lex_env_provide_this (const ecma_object_t *object_p);
 
 ecma_property_value_t *
 ecma_create_named_data_property (ecma_object_t *object_p, ecma_string_t *name_p, uint8_t prop_attributes,

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -50,7 +50,7 @@ ecma_lcache_init (void)
 /**
  * Invalidate specified LCache entry
  */
-static inline void __attr_always_inline___
+static inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_lcache_invalidate_entry (ecma_lcache_hash_entry_t *entry_p) /**< entry to invalidate */
 {
   JERRY_ASSERT (entry_p != NULL);
@@ -66,7 +66,7 @@ ecma_lcache_invalidate_entry (ecma_lcache_hash_entry_t *entry_p) /**< entry to i
  *
  * @return row index
  */
-static inline size_t __attr_always_inline___
+static inline size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_lcache_row_index (jmem_cpointer_t object_cp, /**< compressed pointer to object */
                        lit_string_hash_t name_hash) /**< property name hash */
 {
@@ -144,7 +144,7 @@ ecma_lcache_insert (ecma_object_t *object_p, /**< object */
  * @return a pointer to an ecma_property_t if the lookup is successful
  *         NULL otherwise
  */
-inline ecma_property_t * __attr_always_inline___
+inline ecma_property_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
                     const ecma_string_t *prop_name_p) /**< property's name */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -551,7 +551,7 @@ ecma_builtin_date_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< 
                                                                                     *   passed to routine */
                                               ecma_length_t arguments_number) /**< length of arguments' list */
 {
-  if (unlikely (builtin_routine_id == ECMA_DATE_PROTOTYPE_TO_JSON))
+  if (JERRY_UNLIKELY (builtin_routine_id == ECMA_DATE_PROTOTYPE_TO_JSON))
   {
     return ecma_builtin_date_prototype_to_json (this_arg);
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -81,7 +81,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
       name_to_str_completion = ecma_op_to_string (name_get_ret_value);
     }
 
-    if (unlikely (ECMA_IS_VALUE_ERROR (name_to_str_completion)))
+    if (JERRY_UNLIKELY (ECMA_IS_VALUE_ERROR (name_to_str_completion)))
     {
       ret_value = ecma_copy_value (name_to_str_completion);
     }
@@ -102,7 +102,7 @@ ecma_builtin_error_prototype_object_to_string (ecma_value_t this_arg) /**< this 
         msg_to_str_completion = ecma_op_to_string (msg_get_ret_value);
       }
 
-      if (unlikely (ECMA_IS_VALUE_ERROR (msg_to_str_completion)))
+      if (JERRY_UNLIKELY (ECMA_IS_VALUE_ERROR (msg_to_str_completion)))
       {
         ret_value = ecma_copy_value (msg_to_str_completion);
       }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -41,7 +41,7 @@
  *
  * @return time value for day number
  */
-inline ecma_number_t __attr_always_inline___
+inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_day (ecma_number_t time) /**< time value */
 {
   JERRY_ASSERT (!ecma_number_is_nan (time));
@@ -57,7 +57,7 @@ ecma_date_day (ecma_number_t time) /**< time value */
  *
  * @return time value within the day
  */
-inline ecma_number_t __attr_always_inline___
+inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_time_within_day (ecma_number_t time) /**< time value */
 {
   JERRY_ASSERT (!ecma_number_is_nan (time));
@@ -92,7 +92,7 @@ ecma_date_day_from_year (ecma_number_t year) /**< year value */
  *
  * @return  time value of the start of a year
  */
-static inline ecma_number_t __attr_always_inline___
+static inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_time_from_year (ecma_number_t year) /**< year value */
 {
   JERRY_ASSERT (!ecma_number_is_nan (year));
@@ -309,7 +309,7 @@ ecma_date_week_day (ecma_number_t time) /**< time value */
  *
  * @return local time zone adjustment
  */
-static inline ecma_number_t __attr_always_inline___
+static inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_local_tza (jerry_time_zone_t *tz) /**< time zone information */
 {
   return tz->offset * -ECMA_DATE_MS_PER_MINUTE;
@@ -323,7 +323,7 @@ ecma_date_local_tza (jerry_time_zone_t *tz) /**< time zone information */
  *
  * @return daylight saving time adjustment
  */
-static inline ecma_number_t __attr_always_inline___
+static inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_daylight_saving_ta (jerry_time_zone_t *tz, /**< time zone information */
                               ecma_number_t time) /**< time value */
 {
@@ -344,7 +344,7 @@ ecma_date_daylight_saving_ta (jerry_time_zone_t *tz, /**< time zone information 
  *
  * @return local time
  */
-inline ecma_number_t __attr_always_inline___
+inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_local_time_zone (ecma_number_t time) /**< time value */
 {
   jerry_time_zone_t tz;
@@ -610,7 +610,7 @@ ecma_date_time_clip (ecma_number_t time) /**< time value */
  *
  * @return timezone offset
  */
-inline ecma_number_t __attr_always_inline___
+inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_timezone_offset (ecma_number_t time) /**< time value */
 {
   JERRY_ASSERT (!ecma_number_is_nan (time));

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -115,7 +115,7 @@ ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *
     ecma_string_t *current_p = ecma_get_string_from_value (*ecma_value_p);
     ecma_value_p = ecma_collection_iterator_next (ecma_value_p);
 
-    if (likely (!first))
+    if (JERRY_LIKELY (!first))
     {
       properties_str_p = ecma_concat_ecma_strings (properties_str_p, separator_p);
     }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -122,7 +122,7 @@ ecma_builtin_math_object_max_min (bool is_max, /**< 'max' or 'min' operation */
       ecma_fast_free_value (value);
     }
 
-    if (unlikely (ecma_number_is_nan (arg_num)))
+    if (JERRY_UNLIKELY (ecma_number_is_nan (arg_num)))
     {
       result_num = arg_num;
       break;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -125,7 +125,7 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits_p, /**< 
   return (lit_utf8_size_t) (p - to_digits_p);
 } /* ecma_builtin_number_prototype_helper_to_string */
 
-static inline lit_utf8_size_t __attr_always_inline___
+static inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_binary_floating_number_to_string (lit_utf8_byte_t *digits_p, /**< number as string
                                                                            * in binary-floating point number */
                                                int32_t exponent, /**< decimal exponent */
@@ -164,7 +164,7 @@ ecma_builtin_binary_floating_number_to_string (lit_utf8_byte_t *digits_p, /**< n
  *
  * @return rounded number
  */
-static inline lit_utf8_size_t __attr_always_inline___
+static inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_number_prototype_helper_round (lit_utf8_byte_t *digits_p, /**< [in,out] number as a string in decimal
                                                                         *   form */
                                             lit_utf8_size_t num_digits, /**< length of the string representation */

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -177,7 +177,7 @@ ecma_builtin_get (ecma_builtin_id_t builtin_id) /**< id of built-in to check on 
 {
   JERRY_ASSERT (builtin_id < ECMA_BUILTIN_ID__COUNT);
 
-  if (unlikely (JERRY_CONTEXT (ecma_builtin_objects)[builtin_id] == NULL))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (ecma_builtin_objects)[builtin_id] == NULL))
   {
     ecma_instantiate_builtin (builtin_id);
   }
@@ -193,7 +193,7 @@ ecma_builtin_get (ecma_builtin_id_t builtin_id) /**< id of built-in to check on 
  * @return true - if the function object is a built-in routine
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_function_is_routine (ecma_object_t *func_obj_p) /**< function object */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_FUNCTION);
@@ -233,7 +233,7 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
 
   ecma_object_t *obj_p = ecma_create_object (prototype_obj_p, ext_object_size, obj_type);
 
-  if (unlikely (!is_extensible))
+  if (JERRY_UNLIKELY (!is_extensible))
   {
     ecma_set_object_extensible (obj_p, false);
   }

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -171,7 +171,7 @@ ecma_is_arraybuffer (ecma_value_t target) /**< the target value */
  *
  * @return ecma_length_t, the length of the arraybuffer
  */
-ecma_length_t __attr_pure___
+ecma_length_t JERRY_ATTR_PURE
 ecma_arraybuffer_get_length (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));
@@ -185,7 +185,7 @@ ecma_arraybuffer_get_length (ecma_object_t *object_p) /**< pointer to the ArrayB
  *
  * @return pointer to the data buffer
  */
-inline lit_utf8_byte_t * __attr_pure___ __attr_always_inline___
+inline lit_utf8_byte_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_arraybuffer_get_buffer (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -38,10 +38,10 @@ ecma_object_t *
 ecma_arraybuffer_new_object_external (ecma_length_t length,
                                       void *buffer_p,
                                       ecma_object_native_free_callback_t free_cb);
-lit_utf8_byte_t *
-ecma_arraybuffer_get_buffer (ecma_object_t *obj_p) __attr_pure___;
-ecma_length_t
-ecma_arraybuffer_get_length (ecma_object_t *obj_p) __attr_pure___;
+lit_utf8_byte_t * JERRY_ATTR_PURE
+ecma_arraybuffer_get_buffer (ecma_object_t *obj_p);
+ecma_length_t JERRY_ATTR_PURE
+ecma_arraybuffer_get_length (ecma_object_t *obj_p);
 bool
 ecma_is_arraybuffer (ecma_value_t val);
 

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -372,7 +372,7 @@ ecma_op_to_string (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
-  if (unlikely (ecma_is_value_object (value)))
+  if (JERRY_UNLIKELY (ecma_is_value_object (value)))
   {
     ecma_value_t ret_value = ECMA_VALUE_EMPTY;
 

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -282,7 +282,7 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
       ecma_string_t *arg_string_p;
       const ecma_value_t arg_val = va_arg (args, ecma_value_t);
 
-      if (unlikely (ecma_is_value_object (arg_val)))
+      if (JERRY_UNLIKELY (ecma_is_value_object (arg_val)))
       {
         ecma_object_t *arg_object_p = ecma_get_object_from_value (arg_val);
         lit_magic_string_id_t class_name = ecma_object_get_class_name (arg_object_p);

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -40,7 +40,7 @@
  * @return true - if the type is a normal or arrow function;
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_normal_or_arrow_function (ecma_object_type_t type)
 {
 #ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
@@ -282,7 +282,7 @@ ecma_op_create_external_function_object (ecma_external_handler_t handler_cb) /**
  *
  * @return compiled code
  */
-inline const ecma_compiled_code_t * __attr_always_inline___
+inline const ecma_compiled_code_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p) /**< function pointer */
 {
 #ifdef JERRY_ENABLE_SNAPSHOT_EXEC
@@ -308,7 +308,7 @@ ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p) /**< fun
  *
  * @return compiled code
  */
-inline const ecma_compiled_code_t * __attr_always_inline___
+inline const ecma_compiled_code_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_op_arrow_function_get_compiled_code (ecma_arrow_function_t *arrow_function_p) /**< arrow function pointer */
 {
 #ifdef JERRY_ENABLE_SNAPSHOT_EXEC
@@ -434,7 +434,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
 
   if (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_FUNCTION)
   {
-    if (unlikely (ecma_get_object_is_builtin (func_obj_p)))
+    if (JERRY_UNLIKELY (ecma_get_object_is_builtin (func_obj_p)))
     {
       ret_value = ecma_builtin_dispatch_call (func_obj_p,
                                               this_arg_value,
@@ -561,7 +561,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
                                                        arguments_list_p,
                                                        arguments_list_len);
 
-    if (unlikely (ecma_is_value_error_reference (ret_value)))
+    if (JERRY_UNLIKELY (ecma_is_value_error_reference (ret_value)))
     {
       JERRY_CONTEXT (error_value) = ecma_clear_error_reference (ret_value, true);
       ret_value = ECMA_VALUE_ERROR;
@@ -741,7 +741,7 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
 
   if (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_FUNCTION)
   {
-    if (unlikely (ecma_get_object_is_builtin (func_obj_p)
+    if (JERRY_UNLIKELY (ecma_get_object_is_builtin (func_obj_p)
                   && !ecma_builtin_function_is_routine (func_obj_p)))
     {
       ret_value = ecma_builtin_dispatch_construct (func_obj_p,

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -50,7 +50,7 @@ ecma_op_get_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
   const bool is_unresolvable_reference = (ref_base_lex_env_p == NULL);
 
   /* 3. */
-  if (unlikely (is_unresolvable_reference))
+  if (JERRY_UNLIKELY (is_unresolvable_reference))
   {
 #ifdef JERRY_ENABLE_ERROR_MESSAGES
     ecma_value_t var_name_val = ecma_make_string_value (var_name_string_p);
@@ -151,7 +151,7 @@ ecma_op_put_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
   const bool is_unresolvable_reference = (ref_base_lex_env_p == NULL);
 
   /* 3. */
-  if (unlikely (is_unresolvable_reference))
+  if (JERRY_UNLIKELY (is_unresolvable_reference))
   {
     /* 3.a. */
     if (is_strict)

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -431,10 +431,10 @@ ecma_op_general_object_define_own_property (ecma_object_t *object_p, /**< the ob
   {
     /* No action required. */
   }
-  else if (likely (property_desc_type == current_property_type))
+  else if (JERRY_LIKELY (property_desc_type == current_property_type))
   {
     /* If property is configurable, there is no need for checks. */
-    if (unlikely (!is_current_configurable))
+    if (JERRY_UNLIKELY (!is_current_configurable))
     {
       if (property_desc_type == ECMA_PROPERTY_TYPE_NAMEDDATA)
       {

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -353,7 +353,7 @@ ecma_op_object_get_property (ecma_object_t *object_p, /**< the object */
  * @return true - if property is found
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_has_own_property (ecma_object_t *object_p, /**< the object */
                                  ecma_string_t *property_name_p) /**< property name */
 {
@@ -371,7 +371,7 @@ ecma_op_object_has_own_property (ecma_object_t *object_p, /**< the object */
  * @return true - if property is found
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_has_property (ecma_object_t *object_p, /**< the object */
                              ecma_string_t *property_name_p) /**< property name */
 {
@@ -639,7 +639,7 @@ ecma_op_object_find (ecma_object_t *object_p, /**< the object */
  * @return ecma value
  *         Returned value must be freed with ecma_free_value
  */
-inline ecma_value_t __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_get_own_data_prop (ecma_object_t *object_p, /**< the object */
                                   ecma_string_t *property_name_p) /**< property name */
 {
@@ -718,7 +718,7 @@ ecma_op_object_get (ecma_object_t *object_p, /**< the object */
  * @return ecma value
  *         Returned value must be freed with ecma_free_value
  */
-inline ecma_value_t __attr_always_inline___
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_get_by_magic_id (ecma_object_t *object_p, /**< the object */
                                 lit_magic_string_id_t property_id) /**< property magic string id */
 {
@@ -1872,7 +1872,7 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
  * @return value of the object if the class matches
  *         ECMA_VALUE_NOT_FOUND otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_object_class_is (ecma_object_t *object_p, /**< object */
                       uint32_t class_id) /**< class id */
 {

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -41,7 +41,7 @@
  * @return true - if the object is a promise.
  *         false - otherwise.
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_promise (ecma_object_t *obj_p) /**< points to object */
 {
   return ecma_object_class_is (obj_p, LIT_MAGIC_STRING_PROMISE_UL);
@@ -66,7 +66,7 @@ ecma_promise_get_result (ecma_object_t *obj_p) /**< points to promise object */
 /**
  * Set the PromiseResult of promise.
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_promise_set_result (ecma_object_t *obj_p, /**< points to promise object */
                          ecma_value_t result) /**< the result value */
 {
@@ -84,7 +84,7 @@ ecma_promise_set_result (ecma_object_t *obj_p, /**< points to promise object */
  *
  * @return the state's enum value
  */
-inline uint8_t __attr_always_inline___
+inline uint8_t JERRY_ATTR_ALWAYS_INLINE
 ecma_promise_get_state (ecma_object_t *obj_p) /**< points to promise object */
 {
   JERRY_ASSERT (ecma_is_promise (obj_p));
@@ -95,7 +95,7 @@ ecma_promise_get_state (ecma_object_t *obj_p) /**< points to promise object */
 /**
  * Set the PromiseState of promise.
  */
-inline void __attr_always_inline___
+inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_promise_set_state (ecma_object_t *obj_p, /**< points to promise object */
                         uint8_t state) /**< the state */
 {

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -302,7 +302,7 @@ ecma_op_create_regexp_object (ecma_string_t *pattern_p, /**< input pattern */
  *
  * @return ecma_char_t canonicalized character
  */
-inline ecma_char_t __attr_always_inline___
+inline ecma_char_t JERRY_ATTR_ALWAYS_INLINE
 re_canonicalize (ecma_char_t ch, /**< character */
                  bool is_ignorecase) /**< IgnoreCase flag */
 {

--- a/jerry-core/ecma/operations/ecma-try-catch-macro.h
+++ b/jerry-core/ecma/operations/ecma-try-catch-macro.h
@@ -69,7 +69,7 @@
   ecma_number_t num_var; \
   return_value = ecma_get_number (value, &num_var); \
   \
-  if (likely (ecma_is_value_empty (return_value))) \
+  if (JERRY_LIKELY (ecma_is_value_empty (return_value))) \
   {
 
 /**

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -490,7 +490,7 @@ ecma_op_typedarray_from (ecma_value_t items_val, /**< the source array-like obje
  *
  * @return the pointer to the internal arraybuffer
  */
-inline ecma_object_t * __attr_always_inline___
+inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_typedarray_get_arraybuffer (ecma_object_t *typedarray_p) /**< the pointer to the typedarray object */
 {
   JERRY_ASSERT (ecma_is_typedarray (ecma_make_object_value (typedarray_p)));

--- a/jerry-core/include/jerryscript-compiler.h
+++ b/jerry-core/include/jerryscript-compiler.h
@@ -1,0 +1,120 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYSCRIPT_COMPILER_H
+#define JERRYSCRIPT_COMPILER_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+/** \addtogroup jerry-compiler Jerry compiler compatibility components
+ * @{
+ */
+
+#ifdef __GNUC__
+
+/*
+ * Compiler-specific macros relevant for GCC.
+ */
+#define JERRY_ATTR_ALIGNED(ALIGNMENT) __attribute__((aligned(ALIGNMENT)))
+#define JERRY_ATTR_ALWAYS_INLINE __attribute__((always_inline))
+#define JERRY_ATTR_CONST __attribute__((const))
+#define JERRY_ATTR_DEPRECATED __attribute__((deprecated))
+#define JERRY_ATTR_FORMAT(...) __attribute__((format(__VA_ARGS__)))
+#define JERRY_ATTR_HOT __attribute__((hot))
+#define JERRY_ATTR_NOINLINE __attribute__((noinline))
+#define JERRY_ATTR_NORETURN __attribute__((noreturn))
+#define JERRY_ATTR_PURE __attribute__((pure))
+#define JERRY_ATTR_SECTION(SECTION) __attribute__((section(SECTION)))
+#define JERRY_ATTR_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+#define JERRY_LIKELY(x) __builtin_expect(!!(x), 1)
+#define JERRY_UNLIKELY(x) __builtin_expect(!!(x), 0)
+
+#endif /* __GNUC__ */
+
+/*
+ * Default empty definitions for all compiler-specific macros. Define any of
+ * these in a guarded block above (e.g., as for GCC) to fine tune compilation
+ * for your own compiler. */
+
+/*
+ * Attributes
+ */
+#ifndef JERRY_ATTR_ALIGNED
+#define JERRY_ATTR_ALIGNED(ALIGNMENT)
+#endif /* !JERRY_ATTR_ALIGNED */
+
+#ifndef JERRY_ATTR_ALWAYS_INLINE
+#define JERRY_ATTR_ALWAYS_INLINE
+#endif /* !JERRY_ATTR_ALWAYS_INLINE */
+
+#ifndef JERRY_ATTR_CONST
+#define JERRY_ATTR_CONST
+#endif /* !JERRY_ATTR_CONST */
+
+#ifndef JERRY_ATTR_DEPRECATED
+#define JERRY_ATTR_DEPRECATED
+#endif /* !JERRY_ATTR_DEPRECATED */
+
+#ifndef JERRY_ATTR_FORMAT
+#define JERRY_ATTR_FORMAT(...)
+#endif /* !JERRY_ATTR_FORMAT */
+
+#ifndef JERRY_ATTR_HOT
+#define JERRY_ATTR_HOT
+#endif /* !JERRY_ATTR_HOT */
+
+#ifndef JERRY_ATTR_NOINLINE
+#define JERRY_ATTR_NOINLINE
+#endif /* !JERRY_ATTR_NOINLINE */
+
+#ifndef JERRY_ATTR_NORETURN
+#define JERRY_ATTR_NORETURN
+#endif /* !JERRY_ATTR_NORETURN */
+
+#ifndef JERRY_ATTR_PURE
+#define JERRY_ATTR_PURE
+#endif /* !JERRY_ATTR_PURE */
+
+#ifndef JERRY_ATTR_SECTION
+#define JERRY_ATTR_SECTION(SECTION)
+#endif /* !JERRY_ATTR_SECTION */
+
+#ifndef JERRY_ATTR_WARN_UNUSED_RESULT
+#define JERRY_ATTR_WARN_UNUSED_RESULT
+#endif /* !JERRY_ATTR_WARN_UNUSED_RESULT */
+
+/*
+ * Condition likeliness, unlikeliness
+ */
+#ifndef JERRY_LIKELY
+#define JERRY_LIKELY(x) (x)
+#endif /* !JERRY_LIKELY */
+
+#ifndef JERRY_UNLIKELY
+#define JERRY_UNLIKELY(x) (x)
+#endif /* !JERRY_UNLIKELY */
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* !JERRYSCRIPT_COMPILER_H */

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -20,17 +20,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "jerryscript-compiler.h"
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif /* __cplusplus */
-
-#ifdef __GNUC__
-#define JERRY_DEPRECATED_API __attribute__((deprecated))
-#else /* !__GNUC__ */
-/* TODO: for other compilers */
-#define JERRY_DEPRECATED_API
-#endif /* __GNUC__ */
 
 /** \addtogroup jerry Jerry engine interface
  * @{
@@ -491,9 +486,9 @@ jerry_value_t jerry_get_object_keys (const jerry_value_t obj_val);
 jerry_value_t jerry_get_prototype (const jerry_value_t obj_val);
 jerry_value_t jerry_set_prototype (const jerry_value_t obj_val, const jerry_value_t proto_obj_val);
 
-JERRY_DEPRECATED_API
+JERRY_ATTR_DEPRECATED
 bool jerry_get_object_native_handle (const jerry_value_t obj_val, uintptr_t *out_handle_p);
-JERRY_DEPRECATED_API
+JERRY_ATTR_DEPRECATED
 void jerry_set_object_native_handle (const jerry_value_t obj_val, uintptr_t handle_p,
                                      jerry_object_free_callback_t freecb_p);
 

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "jerryscript-compiler.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -62,7 +64,7 @@ typedef enum
  *
  * Example: a libc-based port may implement this with exit() or abort(), or both.
  */
-void jerry_port_fatal (jerry_fatal_code_t code) __attribute__((noreturn));
+void JERRY_ATTR_NORETURN jerry_port_fatal (jerry_fatal_code_t code);
 
 /*
  *  I/O Port API
@@ -96,7 +98,7 @@ typedef enum
  * Example: a libc-based port may implement this with vfprintf(stderr) or
  * vfprintf(logfile), or both, depending on log level.
  */
-void jerry_port_log (jerry_log_level_t level, const char *format, ...) __attribute__ ((format (printf, 2, 3)));
+void JERRY_ATTR_FORMAT (printf, 2, 3) jerry_port_log (jerry_log_level_t level, const char *format, ...);
 
 /*
  * Date Port API

--- a/jerry-core/jcontext/jcontext.c
+++ b/jerry-core/jcontext/jcontext.c
@@ -31,14 +31,14 @@ jerry_context_t jerry_global_context;
 #ifndef JERRY_HEAP_SECTION_ATTR
 #define JERRY_GLOBAL_HEAP_SECTION
 #else /* JERRY_HEAP_SECTION_ATTR */
-#define JERRY_GLOBAL_HEAP_SECTION __attribute__ ((section (JERRY_HEAP_SECTION_ATTR)))
+#define JERRY_GLOBAL_HEAP_SECTION JERRY_ATTR_SECTION (JERRY_HEAP_SECTION_ATTR)
 #endif /* !JERRY_HEAP_SECTION_ATTR */
 
 #ifndef JERRY_SYSTEM_ALLOCATOR
 /**
  * Global heap.
  */
-jmem_heap_t jerry_global_heap __attribute__ ((aligned (JMEM_ALIGNMENT))) JERRY_GLOBAL_HEAP_SECTION;
+jmem_heap_t jerry_global_heap JERRY_ATTR_ALIGNED (JMEM_ALIGNMENT) JERRY_GLOBAL_HEAP_SECTION;
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
 
 #ifndef CONFIG_ECMA_LCACHE_DISABLE

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -187,7 +187,7 @@ struct jerry_instance_t
 
 #ifndef JERRY_SYSTEM_ALLOCATOR
 
-static inline jmem_heap_t * __attr_always_inline___
+static inline jmem_heap_t * JERRY_ATTR_ALWAYS_INLINE
 jerry_context_get_current_heap (void)
 {
   return JERRY_GET_CURRENT_INSTANCE ()->heap_p;
@@ -207,7 +207,7 @@ jerry_context_get_current_heap (void)
 
 #ifndef CONFIG_ECMA_LCACHE_DISABLE
 
-static inline jerry_hash_table_t * __attr_always_inline___
+static inline jerry_hash_table_t * JERRY_ATTR_ALWAYS_INLINE
 jerry_context_get_current_lcache (void)
 {
   return (jerry_hash_table_t *) (JERRY_GET_CURRENT_INSTANCE ()->lcache_p);

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -56,7 +56,7 @@ jmem_finalize (void)
  *
  * @return packed pointer
  */
-inline jmem_cpointer_t __attr_pure___ __attr_always_inline___
+inline jmem_cpointer_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 jmem_compress_pointer (const void *pointer_p) /**< pointer to compress */
 {
   JERRY_ASSERT (pointer_p != NULL);
@@ -90,7 +90,7 @@ jmem_compress_pointer (const void *pointer_p) /**< pointer to compress */
  *
  * @return unpacked pointer
  */
-inline void * __attr_pure___ __attr_always_inline___
+inline void * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 jmem_decompress_pointer (uintptr_t compressed_pointer) /**< pointer to decompress */
 {
   JERRY_ASSERT (compressed_pointer != JMEM_CP_NULL);

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -96,7 +96,7 @@
 /**
  * Get end of region
  */
-static inline jmem_heap_free_t *  __attr_always_inline___ __attr_pure___
+static inline jmem_heap_free_t *  JERRY_ATTR_ALWAYS_INLINE JERRY_ATTR_PURE
 jmem_heap_get_region_end (jmem_heap_free_t *curr_p) /**< current region */
 {
   return (jmem_heap_free_t *)((uint8_t *) curr_p + curr_p->size);
@@ -193,7 +193,7 @@ jmem_heap_finalize (void)
  * @return pointer to allocated memory block - if allocation is successful,
  *         NULL - if there is not enough memory.
  */
-static __attr_hot___ void *
+static void * JERRY_ATTR_HOT
 jmem_heap_alloc_block_internal (const size_t size)
 {
 #ifndef JERRY_SYSTEM_ALLOCATOR
@@ -205,7 +205,7 @@ jmem_heap_alloc_block_internal (const size_t size)
 
   /* Fast path for 8 byte chunks, first region is guaranteed to be sufficient. */
   if (required_size == JMEM_ALIGNMENT
-      && likely (JERRY_HEAP_CONTEXT (first).next_offset != JMEM_HEAP_END_OF_LIST))
+      && JERRY_LIKELY (JERRY_HEAP_CONTEXT (first).next_offset != JMEM_HEAP_END_OF_LIST))
   {
     data_space_p = JMEM_HEAP_GET_ADDR_FROM_OFFSET (JERRY_HEAP_CONTEXT (first).next_offset);
     JERRY_ASSERT (jmem_is_heap_pointer (data_space_p));
@@ -235,7 +235,7 @@ jmem_heap_alloc_block_internal (const size_t size)
 
     VALGRIND_UNDEFINED_SPACE (data_space_p, sizeof (jmem_heap_free_t));
 
-    if (unlikely (data_space_p == JERRY_CONTEXT (jmem_heap_list_skip_p)))
+    if (JERRY_UNLIKELY (data_space_p == JERRY_CONTEXT (jmem_heap_list_skip_p)))
     {
       JERRY_CONTEXT (jmem_heap_list_skip_p) = JMEM_HEAP_GET_ADDR_FROM_OFFSET (JERRY_HEAP_CONTEXT (first).next_offset);
     }
@@ -309,7 +309,7 @@ jmem_heap_alloc_block_internal (const size_t size)
 
   VALGRIND_NOACCESS_SPACE (&JERRY_HEAP_CONTEXT (first), sizeof (jmem_heap_free_t));
 
-  if (unlikely (!data_space_p))
+  if (JERRY_UNLIKELY (!data_space_p))
   {
     return NULL;
   }
@@ -341,7 +341,7 @@ jmem_heap_gc_and_alloc_block (const size_t size,      /**< required memory size 
                               bool ret_null_on_error) /**< indicates whether return null or terminate
                                                            with ERR_OUT_OF_MEMORY on out of memory */
 {
-  if (unlikely (size == 0))
+  if (JERRY_UNLIKELY (size == 0))
   {
     return NULL;
   }
@@ -359,7 +359,7 @@ jmem_heap_gc_and_alloc_block (const size_t size,      /**< required memory size 
 
   void *data_space_p = jmem_heap_alloc_block_internal (size);
 
-  if (likely (data_space_p != NULL))
+  if (JERRY_LIKELY (data_space_p != NULL))
   {
     VALGRIND_FREYA_MALLOCLIKE_SPACE (data_space_p, size);
     return data_space_p;
@@ -373,7 +373,7 @@ jmem_heap_gc_and_alloc_block (const size_t size,      /**< required memory size 
 
     data_space_p = jmem_heap_alloc_block_internal (size);
 
-    if (likely (data_space_p != NULL))
+    if (JERRY_LIKELY (data_space_p != NULL))
     {
       VALGRIND_FREYA_MALLOCLIKE_SPACE (data_space_p, size);
       return data_space_p;
@@ -400,7 +400,7 @@ jmem_heap_gc_and_alloc_block (const size_t size,      /**< required memory size 
  * @return NULL, if the required memory is 0
  *         pointer to allocated memory block, otherwise
  */
-inline void * __attr_hot___ __attr_always_inline___
+inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_heap_alloc_block (const size_t size)  /**< required memory size */
 {
   return jmem_heap_gc_and_alloc_block (size, false);
@@ -416,7 +416,7 @@ jmem_heap_alloc_block (const size_t size)  /**< required memory size */
  *         also NULL, if the allocation has failed
  *         pointer to the allocated memory block, otherwise
  */
-inline void * __attr_hot___ __attr_always_inline___
+inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_heap_alloc_block_null_on_error (const size_t size) /**< required memory size */
 {
   return jmem_heap_gc_and_alloc_block (size, true);
@@ -425,7 +425,7 @@ jmem_heap_alloc_block_null_on_error (const size_t size) /**< required memory siz
 /**
  * Free the memory block.
  */
-void __attr_hot___
+void JERRY_ATTR_HOT
 jmem_heap_free_block (void *ptr, /**< pointer to beginning of data space of the block */
                       const size_t size) /**< size of allocated region */
 {

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -76,7 +76,7 @@ jmem_pools_finalize (void)
  * @return pointer to allocated chunk, if allocation was successful,
  *         or NULL - if not enough memory.
  */
-inline void * __attr_hot___ __attr_always_inline___
+inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_pools_alloc (size_t size) /**< size of the chunk */
 {
 #ifdef JMEM_GC_BEFORE_EACH_ALLOC
@@ -131,7 +131,7 @@ jmem_pools_alloc (size_t size) /**< size of the chunk */
 /**
  * Free the chunk
  */
-inline void __attr_hot___ __attr_always_inline___
+inline void JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_pools_free (void *chunk_p, /**< pointer to the chunk */
                  size_t size) /**< size of the chunk */
 {

--- a/jerry-core/jmem/jmem.h
+++ b/jerry-core/jmem/jmem.h
@@ -164,8 +164,8 @@ void jmem_stats_free_property_bytes (size_t property_size);
 void jmem_heap_get_stats (jmem_heap_stats_t *);
 #endif /* JMEM_STATS */
 
-jmem_cpointer_t jmem_compress_pointer (const void *pointer_p) __attr_pure___;
-void *jmem_decompress_pointer (uintptr_t compressed_pointer) __attr_pure___;
+jmem_cpointer_t JERRY_ATTR_PURE jmem_compress_pointer (const void *pointer_p);
+void * JERRY_ATTR_PURE jmem_decompress_pointer (uintptr_t compressed_pointer);
 
 /**
  * A free memory callback routine type.
@@ -217,7 +217,7 @@ void jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t s
  * Get value of pointer from specified compressed pointer value
  */
 #define JMEM_CP_GET_POINTER(type, cp_value) \
-  (((unlikely ((cp_value) == JMEM_CP_NULL)) ? NULL : JMEM_CP_GET_NON_NULL_POINTER (type, cp_value)))
+  (((JERRY_UNLIKELY ((cp_value) == JMEM_CP_NULL)) ? NULL : JMEM_CP_GET_NON_NULL_POINTER (type, cp_value)))
 
 /**
  * Set value of non-null compressed pointer so that it will correspond
@@ -235,7 +235,7 @@ void jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t s
   { \
     void *ptr_value = (void *) non_compressed_pointer; \
     \
-    if (unlikely ((ptr_value) == NULL)) \
+    if (JERRY_UNLIKELY ((ptr_value) == NULL)) \
     { \
       (cp_value) = JMEM_CP_NULL; \
     } \

--- a/jerry-core/jrt/jrt-fatals.c
+++ b/jerry-core/jrt/jrt-fatals.c
@@ -26,7 +26,7 @@
  * If !JERRY_NDEBUG and code != 0, print status code with description
  * and call assertion fail handler.
  */
-void __noreturn
+void JERRY_ATTR_NORETURN
 jerry_fatal (jerry_fatal_code_t code) /**< status code */
 {
 #ifndef JERRY_NDEBUG
@@ -67,7 +67,7 @@ jerry_fatal (jerry_fatal_code_t code) /**< status code */
 /**
  * Handle failed assertion
  */
-void __noreturn
+void JERRY_ATTR_NORETURN
 jerry_assert_fail (const char *assertion, /**< assertion condition string */
                    const char *file, /**< file name */
                    const char *function, /**< function name */
@@ -85,7 +85,7 @@ jerry_assert_fail (const char *assertion, /**< assertion condition string */
 /**
  * Handle execution of control path that should be unreachable
  */
-void __noreturn
+void JERRY_ATTR_NORETURN
 jerry_unreachable (const char *file, /**< file name */
                    const char *function, /**< function name */
                    const uint32_t line) /**< line */

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -29,34 +29,6 @@
 #include "jrt-types.h"
 
 /*
- * Attributes
- */
-#define __noreturn __attribute__((noreturn))
-#define __attr_noinline___ __attribute__((noinline))
-#define __attr_return_value_should_be_checked___ __attribute__((warn_unused_result))
-#define __attr_hot___ __attribute__((hot))
-#ifndef __attr_always_inline___
-#define __attr_always_inline___ __attribute__((always_inline))
-#endif /* !__attr_always_inline___ */
-#ifndef __attr_const___
-#define __attr_const___ __attribute__((const))
-#endif /* !__attr_const___ */
-#ifndef __attr_pure___
-#define __attr_pure___ __attribute__((pure))
-#endif /* !__attr_pure___ */
-
-/*
- * Conditions' likeliness, unlikeliness.
- */
-#ifdef __GNUC__
-#define likely(x)       __builtin_expect(!!(x), 1)
-#define unlikely(x)     __builtin_expect(!!(x), 0)
-#else /* !__GNUC__ */
-#define likely(x)       (x)
-#define unlikely(x)     (x)
-#endif /* __GNUC__ */
-
-/*
  * Normally compilers store const(ant)s in ROM. Thus saving RAM.
  * But if your compiler does not support it then the directive below can force it.
  *
@@ -91,13 +63,15 @@
   enum { JERRY_STATIC_ASSERT_GLUE (static_assertion_failed_, __LINE__, msg) = 1 / (!!(x)) }
 
 #ifndef JERRY_NDEBUG
-void __noreturn jerry_assert_fail (const char *assertion, const char *file, const char *function, const uint32_t line);
-void __noreturn jerry_unreachable (const char *file, const char *function, const uint32_t line);
+void JERRY_ATTR_NORETURN
+jerry_assert_fail (const char *assertion, const char *file, const char *function, const uint32_t line);
+void JERRY_ATTR_NORETURN
+jerry_unreachable (const char *file, const char *function, const uint32_t line);
 
 #define JERRY_ASSERT(x) \
   do \
   { \
-    if (unlikely (!(x))) \
+    if (JERRY_UNLIKELY (!(x))) \
     { \
       jerry_assert_fail (#x, __FILE__, __func__, __LINE__); \
     } \
@@ -128,7 +102,7 @@ void __noreturn jerry_unreachable (const char *file, const char *function, const
 /**
  * Exit on fatal error
  */
-void __noreturn jerry_fatal (jerry_fatal_code_t code);
+void JERRY_ATTR_NORETURN jerry_fatal (jerry_fatal_code_t code);
 
 /*
  * Logging

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -23,7 +23,7 @@
  * @return number of the strings, if there were registered,
  *         zero - otherwise.
  */
-inline uint32_t __attr_always_inline___
+inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 lit_get_magic_string_ex_count (void)
 {
   return JERRY_CONTEXT (lit_magic_string_ex_count);

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -557,7 +557,7 @@ lit_utf8_decr (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characte
  *
  * @return ecma-string's hash
  */
-inline lit_string_hash_t __attr_always_inline___
+inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, /**< hash to be combined with */
                               const lit_utf8_byte_t *utf8_buf_p, /**< characters buffer */
                               lit_utf8_size_t utf8_buf_size) /**< number of characters in the buffer */
@@ -580,7 +580,7 @@ lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, /**< hash to be comb
  *
  * @return ecma-string's hash
  */
-inline lit_string_hash_t __attr_always_inline___
+inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 lit_utf8_string_calc_hash (const lit_utf8_byte_t *utf8_buf_p, /**< characters buffer */
                            lit_utf8_size_t utf8_buf_size) /**< number of characters in the buffer */
 {
@@ -621,7 +621,7 @@ lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 stri
  *
  * @return number of bytes occupied in CESU-8
  */
-inline lit_utf8_size_t __attr_always_inline___
+inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 lit_get_unicode_char_size_by_utf8_first_byte (const lit_utf8_byte_t first_byte) /**< buffer with characters */
 {
   if ((first_byte & LIT_UTF8_1_BYTE_MASK) == LIT_UTF8_1_BYTE_MARKER)

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -701,7 +701,7 @@ parser_parse_while_statement_start (parser_context_t *context_p) /**< context */
 /**
  * Parse while statement (ending part).
  */
-static void __attr_noinline___
+static void JERRY_ATTR_NOINLINE
 parser_parse_while_statement_end (parser_context_t *context_p) /**< context */
 {
   parser_while_statement_t while_statement;
@@ -947,7 +947,7 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
 /**
  * Parse for statement (ending part).
  */
-static void __attr_noinline___
+static void JERRY_ATTR_NOINLINE
 parser_parse_for_statement_end (parser_context_t *context_p) /**< context */
 {
   parser_for_statement_t for_statement;
@@ -1028,7 +1028,7 @@ parser_parse_for_statement_end (parser_context_t *context_p) /**< context */
 /**
  * Parse switch statement (starting part).
  */
-static void __attr_noinline___
+static void JERRY_ATTR_NOINLINE
 parser_parse_switch_statement_start (parser_context_t *context_p) /**< context */
 {
   parser_switch_statement_t switch_statement;
@@ -2202,7 +2202,7 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 /**
  * Free jumps stored on the stack if a parse error is occured.
  */
-void __attr_noinline___
+void JERRY_ATTR_NOINLINE
 parser_free_jumps (parser_stack_iterator_t iterator) /**< iterator position */
 {
   while (true)

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1228,7 +1228,7 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
   }
 
   byte_code_start_p += (unsigned int) (literal_end - register_end) * sizeof (ecma_value_t);
-  if (unlikely (compiled_code_p->status_flags & CBC_CODE_FLAGS_NON_STRICT_ARGUMENTS_NEEDED))
+  if (JERRY_UNLIKELY (compiled_code_p->status_flags & CBC_CODE_FLAGS_NON_STRICT_ARGUMENTS_NEEDED))
   {
     byte_code_start_p += argument_end * sizeof (ecma_value_t);
   }

--- a/jerry-core/parser/regexp/re-bytecode.c
+++ b/jerry-core/parser/regexp/re-bytecode.c
@@ -123,7 +123,7 @@ re_bytecode_list_insert (re_bytecode_ctx_t *bc_ctx_p, /**< RegExp bytecode conte
  *
  * @return ecma character
  */
-inline ecma_char_t __attr_always_inline___
+inline ecma_char_t JERRY_ATTR_ALWAYS_INLINE
 re_get_char (uint8_t **bc_p) /**< pointer to bytecode start */
 {
   ecma_char_t chr;
@@ -137,7 +137,7 @@ re_get_char (uint8_t **bc_p) /**< pointer to bytecode start */
  *
  * @return current RegExp opcode
  */
-inline re_opcode_t __attr_always_inline___
+inline re_opcode_t JERRY_ATTR_ALWAYS_INLINE
 re_get_opcode (uint8_t **bc_p) /**< pointer to bytecode start */
 {
   uint8_t bytecode = **bc_p;
@@ -150,7 +150,7 @@ re_get_opcode (uint8_t **bc_p) /**< pointer to bytecode start */
  *
  * @return opcode parameter
  */
-inline uint32_t __attr_always_inline___
+inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 re_get_value (uint8_t **bc_p) /**< pointer to bytecode start */
 {
   uint32_t value;
@@ -164,7 +164,7 @@ re_get_value (uint8_t **bc_p) /**< pointer to bytecode start */
  *
  * @return bytecode length (unsigned integer)
  */
-inline uint32_t __attr_pure___ __attr_always_inline___
+inline uint32_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 re_get_bytecode_length (re_bytecode_ctx_t *bc_ctx_p) /**< RegExp bytecode context */
 {
   return ((uint32_t) (bc_ctx_p->current_p - bc_ctx_p->block_start_p));

--- a/jerry-core/parser/regexp/re-bytecode.h
+++ b/jerry-core/parser/regexp/re-bytecode.h
@@ -103,7 +103,7 @@ typedef struct
 re_opcode_t re_get_opcode (uint8_t **bc_p);
 ecma_char_t re_get_char (uint8_t **bc_p);
 uint32_t re_get_value (uint8_t **bc_p);
-uint32_t re_get_bytecode_length (re_bytecode_ctx_t *bc_ctx_p) __attr_pure___;
+uint32_t JERRY_ATTR_PURE re_get_bytecode_length (re_bytecode_ctx_t *bc_ctx_p);
 
 void re_append_opcode (re_bytecode_ctx_t *bc_ctx_p, re_opcode_t opcode);
 void re_append_u32 (re_bytecode_ctx_t *bc_ctx_p, uint32_t value);

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -68,7 +68,7 @@ re_hex_lookup (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context */
  * @return true - if non-greedy character found
  *         false - otherwise
  */
-static inline bool __attr_always_inline___
+static inline bool JERRY_ATTR_ALWAYS_INLINE
 re_parse_non_greedy_char (re_parser_ctx_t *parser_ctx_p) /**< RegExp parser context */
 {
   if (parser_ctx_p->input_curr_p < parser_ctx_p->input_end_p

--- a/jerry-core/vm/vm-stack.c
+++ b/jerry-core/vm/vm-stack.c
@@ -75,7 +75,7 @@ vm_stack_context_abort (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
       {
         ecma_value_t value = chunk_p->items[index];
 
-        if (unlikely (ecma_is_value_collection_chunk (value)))
+        if (JERRY_UNLIKELY (ecma_is_value_collection_chunk (value)))
         {
           ecma_collection_chunk_t *next_chunk_p = ecma_get_collection_chunk_from_value (value);
           jmem_heap_free_block (chunk_p, sizeof (ecma_collection_chunk_t));

--- a/jerry-core/vm/vm-utils.c
+++ b/jerry-core/vm/vm-utils.c
@@ -44,7 +44,7 @@ vm_is_strict_mode (void)
  *                without 'this' argument,
  *         false - otherwise
  */
-inline bool __attr_always_inline___
+inline bool JERRY_ATTR_ALWAYS_INLINE
 vm_is_direct_eval_form_call (void)
 {
   return (JERRY_CONTEXT (status_flags) & ECMA_STATUS_DIRECT_EVAL) != 0;

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -86,7 +86,7 @@ vm_op_get_value (ecma_value_t object, /**< base object */
     }
   }
 
-  if (unlikely (ecma_is_value_undefined (object) || ecma_is_value_null (object)))
+  if (JERRY_UNLIKELY (ecma_is_value_undefined (object) || ecma_is_value_null (object)))
   {
 #ifdef JERRY_ENABLE_ERROR_MESSAGES
     ecma_value_t error_value = ecma_raise_standard_error_with_format (ECMA_ERROR_TYPE,
@@ -129,7 +129,7 @@ vm_op_set_value (ecma_value_t object, /**< base object */
                  ecma_value_t value, /**< ecma value */
                  bool is_strict) /**< strict mode */
 {
-  if (unlikely (!ecma_is_value_object (object)))
+  if (JERRY_UNLIKELY (!ecma_is_value_object (object)))
   {
     ecma_value_t to_object = ecma_op_to_object (object);
     ecma_free_value (object);
@@ -300,7 +300,7 @@ vm_construct_literal_object (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
 #ifdef JERRY_ENABLE_SNAPSHOT_EXEC
   ecma_compiled_code_t *bytecode_p;
 
-  if (likely (!(frame_ctx_p->bytecode_header_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION)))
+  if (JERRY_LIKELY (!(frame_ctx_p->bytecode_header_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION)))
   {
     bytecode_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_compiled_code_t,
                                                   lit_value);
@@ -365,7 +365,7 @@ vm_construct_literal_object (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
  * @return true - if the implicit 'this' value is updated,
  *         false - otherwise
  */
-static inline bool __attr_always_inline___
+static inline bool JERRY_ATTR_ALWAYS_INLINE
 vm_get_implicit_this_value (ecma_value_t *this_value_p) /**< [in,out] this value */
 {
   if (ecma_is_value_object (*this_value_p))
@@ -681,7 +681,7 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           {
             ecma_string_t *name_p = ecma_get_string_from_value (literal_start_p[literal_index]);
 
-            if (likely (!is_immutable_binding))
+            if (JERRY_LIKELY (!is_immutable_binding))
             {
               vm_var_decl (frame_ctx_p, name_p);
 
@@ -740,7 +740,7 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
  *
  * @return ecma value
  */
-static ecma_value_t __attr_noinline___
+static ecma_value_t JERRY_ATTR_NOINLINE
 vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 {
   const ecma_compiled_code_t *bytecode_header_p = frame_ctx_p->bytecode_header_p;
@@ -869,12 +869,12 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
         branch_offset = *(byte_code_p++);
 
-        if (unlikely (branch_offset_length != 1))
+        if (JERRY_UNLIKELY (branch_offset_length != 1))
         {
           branch_offset <<= 8;
           branch_offset |= *(byte_code_p++);
 
-          if (unlikely (branch_offset_length == 3))
+          if (JERRY_UNLIKELY (branch_offset_length == 3))
           {
             branch_offset <<= 8;
             branch_offset |= *(byte_code_p++);
@@ -1271,7 +1271,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
               int_increase = 1 << ECMA_DIRECT_SHIFT;
             }
 
-            if (likely (int_increase != 0))
+            if (JERRY_LIKELY (int_increase != 0))
             {
               /* Postfix operators require the unmodifed number value. */
               if (opcode_flags & VM_OC_POST_INCR_DECR_OPERATOR_FLAG)
@@ -2090,11 +2090,11 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
               {
                 branch_offset = *(byte_code_p++);
 
-                if (unlikely (branch_offset_length != 1))
+                if (JERRY_UNLIKELY (branch_offset_length != 1))
                 {
                   branch_offset <<= 8;
                   branch_offset |= *(byte_code_p++);
-                  if (unlikely (branch_offset_length == 3))
+                  if (JERRY_UNLIKELY (branch_offset_length == 3))
                   {
                     branch_offset <<= 8;
                     branch_offset |= *(byte_code_p++);
@@ -2327,7 +2327,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           *stack_top_p++ = chunk_p->items[index];
           index++;
 
-          if (likely (!ecma_is_value_collection_chunk (chunk_p->items[index])))
+          if (JERRY_LIKELY (!ecma_is_value_collection_chunk (chunk_p->items[index])))
           {
             context_top_p[-3] = index;
             continue;
@@ -2364,7 +2364,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
             ecma_string_t *prop_name_p = ecma_get_string_from_value (chunk_p->items[index]);
 
-            if (likely (ecma_op_object_has_property (object_p, prop_name_p)))
+            if (JERRY_LIKELY (ecma_op_object_has_property (object_p, prop_name_p)))
             {
               byte_code_p = byte_code_start_p + branch_offset;
               break;
@@ -2373,7 +2373,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             index++;
             ecma_value_t value = chunk_p->items[index];
 
-            if (likely (!ecma_is_value_collection_chunk (value)))
+            if (JERRY_LIKELY (!ecma_is_value_collection_chunk (value)))
             {
               stack_top_p[-3] = index;
             }
@@ -2898,7 +2898,7 @@ error:
  *
  * @return ecma value
  */
-static ecma_value_t __attr_noinline___
+static ecma_value_t JERRY_ATTR_NOINLINE
 vm_execute (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
             const ecma_value_t *arg_p, /**< arguments list */
             ecma_length_t arg_list_len) /**< length of arguments list */

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -283,8 +283,9 @@ wait_for_source_callback (const jerry_char_t *resource_name_p, /**< resource nam
                           size_t resource_name_size, /**< size of resource name */
                           const jerry_char_t *source_p, /**< source code */
                           size_t source_size, /**< source code size */
-                          void *user_p __attribute__((unused))) /**< user pointer */
+                          void *user_p) /**< user pointer */
 {
+  (void) user_p; /* unused */
   jerry_value_t ret_val = jerry_parse (resource_name_p,
                                        resource_name_size,
                                        source_p,
@@ -403,8 +404,9 @@ check_usage (bool condition, /**< the condition that must hold */
  */
 static void *
 instance_alloc (size_t size,
-                void *cb_data_p __attribute__((unused)))
+                void *cb_data_p)
 {
+  (void) cb_data_p; /* unused */
   return malloc (size);
 } /* instance_alloc */
 

--- a/tests/unit-core/test-common.h
+++ b/tests/unit-core/test-common.h
@@ -28,7 +28,7 @@
 #define TEST_ASSERT(x) \
   do \
   { \
-    if (unlikely (!(x))) \
+    if (JERRY_UNLIKELY (!(x))) \
     { \
       jerry_port_log (JERRY_LOG_LEVEL_ERROR, \
                       "TEST: Assertion '%s' failed at %s(%s):%lu.\n", \


### PR DESCRIPTION
In general, public headers should not have compiler-specific
constructs but both the core and the port headers have attributes,
which are non-standard. It's better to factor out such constructs
to a common place (a new header) and hide them behind macros, which
can then be defined on a per-compiler basis.

This patch moves the existing definitions of function attributes and
likely/unlikely builtins to the new header. At the same time, it
unifies the names of these attribute defines. Moreover, it touches
on jerry-main and removes the uses of `__attribute__((unused))`
entirely and replaces them with the elsewhere used `(void) ...`
pattern.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu