### PR TITLE
Use logging macros in jerry-core/debugger

### DIFF
--- a/jerry-core/debugger/debugger-ws.c
+++ b/jerry-core/debugger/debugger-ws.c
@@ -101,10 +101,10 @@ jerry_debugger_close_connection_tcp (bool log_error) /**< log error */
 
   if (log_error)
   {
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: %s\n", strerror (errno));
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
   }
 
-  jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Debugger client connection closed.\n");
+  JERRY_DEBUG_MSG ("Debugger client connection closed.\n");
 
   close (JERRY_CONTEXT (debugger_connection));
   JERRY_CONTEXT (debugger_connection) = -1;
@@ -226,7 +226,7 @@ jerry_process_handshake (int client_socket, /**< client socket */
 
     if (length == 0)
     {
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Handshake buffer too small.\n");
+      JERRY_ERROR_MSG ("Handshake buffer too small.\n");
       return false;
     }
 
@@ -234,7 +234,7 @@ jerry_process_handshake (int client_socket, /**< client socket */
 
     if (size < 0)
     {
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: %s\n", strerror (errno));
+      JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
       return false;
     }
 
@@ -255,7 +255,7 @@ jerry_process_handshake (int client_socket, /**< client socket */
   if ((size_t) (request_end_p - request_buffer_p) < text_len
       || memcmp (request_buffer_p, text_p, text_len) != 0)
   {
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid handshake format.\n");
+    JERRY_ERROR_MSG ("Invalid handshake format.\n");
     return false;
   }
 
@@ -268,7 +268,7 @@ jerry_process_handshake (int client_socket, /**< client socket */
   {
     if ((size_t) (request_end_p - websocket_key_p) < text_len)
     {
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Sec-WebSocket-Key not found.\n");
+      JERRY_ERROR_MSG ("Sec-WebSocket-Key not found.\n");
       return false;
     }
 
@@ -367,7 +367,7 @@ jerry_debugger_accept_connection (void)
 
   if ((server_socket = socket (AF_INET, SOCK_STREAM, 0)) == -1)
   {
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: %s\n", strerror (errno));
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
     return false;
   }
 
@@ -376,32 +376,32 @@ jerry_debugger_accept_connection (void)
   if (setsockopt (server_socket, SOL_SOCKET, SO_REUSEADDR, &opt_value, sizeof (int)) == -1)
   {
     close (server_socket);
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: %s\n", strerror (errno));
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
     return false;
   }
 
   if (bind (server_socket, (struct sockaddr *)&addr, sizeof (struct sockaddr)) == -1)
   {
     close (server_socket);
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: %s\n", strerror (errno));
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
     return false;
   }
 
   if (listen (server_socket, 1) == -1)
   {
     close (server_socket);
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: %s\n", strerror (errno));
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
     return false;
   }
 
-  jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Waiting for client connection\n");
+  JERRY_DEBUG_MSG ("Waiting for client connection\n");
 
   JERRY_CONTEXT (debugger_connection) = accept (server_socket, (struct sockaddr *)&addr, &sin_size);
 
   if (JERRY_CONTEXT (debugger_connection) == -1)
   {
     close (server_socket);
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: %s\n", strerror (errno));
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
     return false;
   }
 
@@ -444,7 +444,7 @@ jerry_debugger_accept_connection (void)
     return false;
   }
 
-  jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Connected from: %s\n", inet_ntoa (addr.sin_addr));
+  JERRY_DEBUG_MSG ("Connected from: %s\n", inet_ntoa (addr.sin_addr));
 
   JERRY_DEBUGGER_SET_FLAGS (JERRY_DEBUGGER_VM_STOP);
   JERRY_CONTEXT (debugger_stop_context) = NULL;
@@ -541,14 +541,14 @@ jerry_debugger_receive (jerry_debugger_uint8_data_t **message_data_p) /**< [out]
         || (recv_buffer_p[1] & JERRY_DEBUGGER_WEBSOCKET_LENGTH_MASK) > JERRY_CONTEXT (debugger_max_receive_size)
         || !(recv_buffer_p[1] & JERRY_DEBUGGER_WEBSOCKET_MASK_BIT))
     {
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Unsupported Websocket message.\n");
+      JERRY_ERROR_MSG ("Unsupported Websocket message.\n");
       jerry_debugger_close_connection ();
       return true;
     }
 
     if ((recv_buffer_p[0] & JERRY_DEBUGGER_WEBSOCKET_OPCODE_MASK) != JERRY_DEBUGGER_WEBSOCKET_BINARY_FRAME)
     {
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Unsupported Websocket opcode.\n");
+      JERRY_ERROR_MSG ("Unsupported Websocket opcode.\n");
       jerry_debugger_close_connection ();
       return true;
     }

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -247,7 +247,7 @@ jerry_debugger_sleep (void)
 #define JERRY_DEBUGGER_CHECK_PACKET_SIZE(type) \
   if (message_size != sizeof (type)) \
   { \
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid message size\n"); \
+    JERRY_ERROR_MSG ("Invalid message size\n"); \
     jerry_debugger_close_connection (); \
     return false; \
   }
@@ -270,7 +270,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
   if (recv_buffer_p[0] >= JERRY_DEBUGGER_CONTINUE
       && !(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_BREAKPOINT_MODE))
   {
-    jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Message requires breakpoint mode\n");
+    JERRY_ERROR_MSG ("Message requires breakpoint mode\n");
     jerry_debugger_close_connection ();
     return false;
   }
@@ -285,7 +285,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
     if (recv_buffer_p[0] != *expected_message_type_p)
     {
       jmem_heap_free_block (uint8_data_p, uint8_data_p->uint8_size + sizeof (jerry_debugger_uint8_data_t));
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Unexpected message\n");
+      JERRY_ERROR_MSG ("Unexpected message\n");
       jerry_debugger_close_connection ();
       return false;
     }
@@ -295,7 +295,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
     if (message_size < sizeof (jerry_debugger_receive_uint8_data_part_t) + 1)
     {
       jmem_heap_free_block (uint8_data_p, uint8_data_p->uint8_size + sizeof (jerry_debugger_uint8_data_t));
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid message size\n");
+      JERRY_ERROR_MSG ("Invalid message size\n");
       jerry_debugger_close_connection ();
       return false;
     }
@@ -307,7 +307,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
     if (message_size > expected_data)
     {
       jmem_heap_free_block (uint8_data_p, uint8_data_p->uint8_size + sizeof (jerry_debugger_uint8_data_t));
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid message size\n");
+      JERRY_ERROR_MSG ("Invalid message size\n");
       jerry_debugger_close_connection ();
       return false;
     }
@@ -357,7 +357,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
 
       if (byte_code_free_cp != JERRY_CONTEXT (debugger_byte_code_free_tail))
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid byte code free order\n");
+        JERRY_ERROR_MSG ("Invalid byte code free order\n");
         jerry_debugger_close_connection ();
         return false;
       }
@@ -482,12 +482,12 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
       if (exception_config_p->enable == 0)
       {
         JERRY_DEBUGGER_SET_FLAGS (JERRY_DEBUGGER_VM_IGNORE_EXCEPTION);
-        jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Stop at exception disabled\n");
+        JERRY_DEBUG_MSG ("Stop at exception disabled\n");
       }
       else
       {
         JERRY_DEBUGGER_CLEAR_FLAGS (JERRY_DEBUGGER_VM_IGNORE_EXCEPTION);
-        jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Stop at exception enabled\n");
+        JERRY_DEBUG_MSG ("Stop at exception enabled\n");
       }
 
       return true;
@@ -501,12 +501,12 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
       if (parser_config_p->enable_wait != 0)
       {
         JERRY_DEBUGGER_SET_FLAGS (JERRY_DEBUGGER_PARSER_WAIT);
-        jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Waiting after parsing enabled\n");
+        JERRY_DEBUG_MSG ("Waiting after parsing enabled\n");
       }
       else
       {
         JERRY_DEBUGGER_CLEAR_FLAGS (JERRY_DEBUGGER_PARSER_WAIT);
-        jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Waiting after parsing disabled\n");
+        JERRY_DEBUG_MSG ("Waiting after parsing disabled\n");
       }
 
       return true;
@@ -518,7 +518,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
 
       if (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_PARSER_WAIT_MODE))
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Not in parser wait mode\n");
+        JERRY_ERROR_MSG ("Not in parser wait mode\n");
         jerry_debugger_close_connection ();
         return false;
       }
@@ -531,7 +531,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
     {
       if (message_size < sizeof (jerry_debugger_receive_eval_first_t) + 1)
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid message size\n");
+        JERRY_ERROR_MSG ("Invalid message size\n");
         jerry_debugger_close_connection ();
         return false;
       }
@@ -545,7 +545,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
       {
         if (eval_size != message_size - sizeof (jerry_debugger_receive_eval_first_t))
         {
-          jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid message size\n");
+          JERRY_ERROR_MSG ("Invalid message size\n");
           jerry_debugger_close_connection ();
           return false;
         }
@@ -581,14 +581,14 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
     {
       if (message_size <= sizeof (jerry_debugger_receive_client_source_first_t))
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid message size\n");
+        JERRY_ERROR_MSG ("Invalid message size\n");
         jerry_debugger_close_connection ();
         return false;
       }
 
       if (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CLIENT_SOURCE_MODE))
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Not in client source mode\n");
+        JERRY_ERROR_MSG ("Not in client source mode\n");
         jerry_debugger_close_connection ();
         return false;
       }
@@ -603,7 +603,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
       if (client_source_size <= JERRY_CONTEXT (debugger_max_receive_size) - header_size
           && client_source_size != message_size - header_size)
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Invalid message size\n");
+        JERRY_ERROR_MSG ("Invalid message size\n");
         jerry_debugger_close_connection ();
         return false;
       }
@@ -640,7 +640,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
     {
       if (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CLIENT_SOURCE_MODE))
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Not in client source mode\n");
+        JERRY_ERROR_MSG ("Not in client source mode\n");
         jerry_debugger_close_connection ();
         return false;
       }
@@ -658,7 +658,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
     {
       if (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CLIENT_SOURCE_MODE))
       {
-        jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Not in client source mode\n");
+        JERRY_ERROR_MSG ("Not in client source mode\n");
         jerry_debugger_close_connection ();
         return false;
       }
@@ -674,7 +674,7 @@ jerry_debugger_process_message (uint8_t *recv_buffer_p, /**< pointer to the rece
 
     default:
     {
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Unexpected message.");
+      JERRY_ERROR_MSG ("Unexpected message.");
       jerry_debugger_close_connection ();
       return false;
     }


### PR DESCRIPTION
...instead of directly calling the logging port API function.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu