### PR TITLE
Simplify code paths within PARSER_DUMP_BYTE_CODE

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1670,9 +1670,6 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
   {
     lexer_lit_location_t lit_location;
     uint32_t status_flags = context_p->status_flags;
-#ifdef PARSER_DUMP_BYTE_CODE
-    bool switch_to_strict_mode = false;
-#endif /* PARSER_DUMP_BYTE_CODE */
 
     JERRY_ASSERT (context_p->stack_depth == 0);
 
@@ -1683,10 +1680,6 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
         && memcmp (PARSER_USE_STRICT_LITERAL, lit_location.char_p, PARSER_USE_STRICT_LENGTH) == 0)
     {
       context_p->status_flags |= PARSER_IS_STRICT;
-
-#ifdef PARSER_DUMP_BYTE_CODE
-      switch_to_strict_mode = true;
-#endif /* PARSER_DUMP_BYTE_CODE */
     }
 
     lexer_next_token (context_p);
@@ -1731,7 +1724,8 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 
 #ifdef PARSER_DUMP_BYTE_CODE
     if (context_p->is_show_opcodes
-        && switch_to_strict_mode)
+        && !(status_flags & PARSER_IS_STRICT)
+        && (context_p->status_flags & PARSER_IS_STRICT))
     {
       JERRY_DEBUG_MSG ("  Note: switch to strict mode\n\n");
     }

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1238,13 +1238,9 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
 
   while (byte_code_p < byte_code_end_p)
   {
-    cbc_opcode_t opcode;
-    cbc_ext_opcode_t ext_opcode;
-    size_t cbc_offset;
-
-    opcode = (cbc_opcode_t) *byte_code_p;
-    ext_opcode = CBC_EXT_NOP;
-    cbc_offset = (size_t) (byte_code_p - byte_code_start_p);
+    cbc_opcode_t opcode = (cbc_opcode_t) *byte_code_p;
+    cbc_ext_opcode_t ext_opcode = CBC_EXT_NOP;
+    size_t cbc_offset = (size_t) (byte_code_p - byte_code_start_p);
 
     if (opcode != CBC_EXT_OPCODE)
     {
@@ -1274,15 +1270,15 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
 
       if (opcode == CBC_PUSH_NUMBER_POS_BYTE)
       {
-        int value = *byte_code_p++;
-        JERRY_DEBUG_MSG (" number:%d\n", value + 1);
+        JERRY_DEBUG_MSG (" number:%d\n", *byte_code_p + 1);
+        byte_code_p++;
         continue;
       }
 
       if (opcode == CBC_PUSH_NUMBER_NEG_BYTE)
       {
-        int value = *byte_code_p++;
-        JERRY_DEBUG_MSG (" number:%d\n", -(value + 1));
+        JERRY_DEBUG_MSG (" number:%d\n", -(*byte_code_p + 1));
+        byte_code_p++;
         continue;
       }
     }
@@ -1342,13 +1338,9 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
 
     if (flags & CBC_HAS_BRANCH_ARG)
     {
-      size_t branch_offset_length = CBC_BRANCH_OFFSET_LENGTH (opcode);
+      size_t branch_offset_length = (opcode != CBC_EXT_OPCODE ? CBC_BRANCH_OFFSET_LENGTH (opcode)
+                                                              : CBC_BRANCH_OFFSET_LENGTH (ext_opcode));
       size_t offset = 0;
-
-      if (opcode == CBC_EXT_OPCODE)
-      {
-        branch_offset_length = CBC_BRANCH_OFFSET_LENGTH (ext_opcode);
-      }
 
       do
       {
@@ -1356,14 +1348,9 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
       }
       while (--branch_offset_length > 0);
 
-      if (CBC_BRANCH_IS_FORWARD (flags))
-      {
-        JERRY_DEBUG_MSG (" offset:%d(->%d)", (int) offset, (int) (cbc_offset + offset));
-      }
-      else
-      {
-        JERRY_DEBUG_MSG (" offset:%d(->%d)", (int) offset, (int) (cbc_offset - offset));
-      }
+      JERRY_DEBUG_MSG (" offset:%d(->%d)",
+                       (int) offset,
+                       (int) (cbc_offset + (CBC_BRANCH_IS_FORWARD (flags) ? offset : -offset)));
     }
 
     JERRY_DEBUG_MSG ("\n");


### PR DESCRIPTION
Also fix an uncovered issue in the reporting of switching to strict
mode.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu