### PR TITLE
Refactor/fix/document the default port implementation

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -87,6 +87,7 @@ typedef struct
  *      CONFIG_DISABLE_DATE_BUILTIN is _not_ defined. Otherwise this function is
  *      not used.
  *
+ * @param[out] tz_p time zone structure to fill.
  * @return true  - if success
  *         false - otherwise
  */
@@ -134,6 +135,8 @@ struct jerry_instance_t *jerry_port_get_current_instance (void);
  * Note:
  *      This port function is called by jerry-core when JERRY_DEBUGGER is
  *      defined. Otherwise this function is not used.
+ *
+ * @param sleep_time milliseconds to sleep.
  */
 void jerry_port_sleep (uint32_t sleep_time);
 ```

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -119,6 +119,7 @@ typedef struct
  *      CONFIG_DISABLE_DATE_BUILTIN is _not_ defined. Otherwise this function is
  *      not used.
  *
+ * @param[out] tz_p time zone structure to fill.
  * @return true  - if success
  *         false - otherwise
  */
@@ -156,6 +157,8 @@ struct jerry_instance_t *jerry_port_get_current_instance (void);
  * Note:
  *      This port function is called by jerry-core when JERRY_DEBUGGER is
  *      defined. Otherwise this function is not used.
+ *
+ * @param sleep_time milliseconds to sleep.
  */
 void jerry_port_sleep (uint32_t sleep_time);
 

--- a/jerry-port/default/default-date.c
+++ b/jerry-port/default/default-date.c
@@ -37,18 +37,16 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p) /**< [out] time zone str
   tz.tz_minuteswest = 0;
   tz.tz_dsttime = 0;
 
-  if (gettimeofday (&tv, &tz) != 0)
+  if (gettimeofday (&tv, &tz) == 0)
   {
-    return false;
+    tz_p->offset = tz.tz_minuteswest;
+    tz_p->daylight_saving_time = tz.tz_dsttime > 0 ? 1 : 0;
+
+    return true;
   }
-
-  tz_p->offset = tz.tz_minuteswest;
-  tz_p->daylight_saving_time = tz.tz_dsttime > 0 ? 1 : 0;
-
-  return true;
-#else /* !__GNUC__ */
-  return false;
 #endif /* __GNUC__ */
+
+  return false;
 } /* jerry_port_get_time_zone */
 
 /**
@@ -64,13 +62,11 @@ double jerry_port_get_current_time (void)
 #ifdef __GNUC__
   struct timeval tv;
 
-  if (gettimeofday (&tv, NULL) != 0)
+  if (gettimeofday (&tv, NULL) == 0)
   {
-    return 0.0;
+    return ((double) tv.tv_sec) * 1000.0 + ((double) tv.tv_usec) / 1000.0;
   }
-
-  return ((double) tv.tv_sec) * 1000.0 + ((double) tv.tv_usec) / 1000.0;
-#else /* __!GNUC__ */
-  return 0.0;
 #endif /* __GNUC__ */
+
+  return 0.0;
 } /* jerry_port_get_current_time */

--- a/jerry-port/default/default-debugger.c
+++ b/jerry-port/default/default-debugger.c
@@ -13,27 +13,30 @@
  * limitations under the License.
  */
 
-#include "jerryscript-port.h"
-#include "jerryscript-port-default.h"
-
 #ifdef HAVE_TIME_H
 #include <time.h>
 #elif defined (HAVE_UNISTD_H)
 #include <unistd.h>
 #endif /* HAVE_TIME_H */
 
-#ifdef JERRY_DEBUGGER
-void jerry_port_sleep (uint32_t sleep_time)
+#include "jerryscript-port.h"
+#include "jerryscript-port-default.h"
+
+/**
+ * Default implementation of jerry_port_sleep. Uses 'nanosleep' or 'usleep' if
+ * available on the system, does nothing otherwise.
+ */
+void jerry_port_sleep (uint32_t sleep_time) /**< milliseconds to sleep */
 {
 #ifdef HAVE_TIME_H
-  nanosleep (&(const struct timespec)
-  {
-    (time_t) sleep_time / 1000, ((long int) sleep_time % 1000) * 1000000L /* Seconds, nanoseconds */
-  }
-  , NULL);
+  struct timespec sleep_timespec;
+  sleep_timespec.tv_sec = (time_t) sleep_time / 1000;
+  sleep_timespec.tv_nsec = ((long int) sleep_time % 1000) * 1000000L;
+
+  nanosleep (&sleep_timespec, NULL);
 #elif defined (HAVE_UNISTD_H)
   usleep ((useconds_t) sleep_time * 1000);
-#endif /* HAVE_TIME_H */
+#else
   (void) sleep_time;
+#endif /* HAVE_TIME_H */
 } /* jerry_port_sleep */
-#endif /* JERRY_DEBUGGER */

--- a/jerry-port/default/default-fatal.c
+++ b/jerry-port/default/default-fatal.c
@@ -61,20 +61,16 @@ bool jerry_port_default_is_abort_on_fail (void)
  *      The "abort-on-fail" behaviour is only available if the port
  *      implementation library is compiled without the DISABLE_EXTRA_API macro.
  */
-void jerry_port_fatal (jerry_fatal_code_t code)
+void jerry_port_fatal (jerry_fatal_code_t code) /**< cause of error */
 {
 #ifndef DISABLE_EXTRA_API
   if (code != 0
       && code != ERR_OUT_OF_MEMORY
-      && jerry_port_default_is_abort_on_fail ())
+      && abort_on_fail)
   {
     abort ();
   }
-  else
-  {
 #endif /* !DISABLE_EXTRA_API */
-    exit (code);
-#ifndef DISABLE_EXTRA_API
-  }
-#endif /* !DISABLE_EXTRA_API */
+
+  exit (code);
 } /* jerry_port_fatal */


### PR DESCRIPTION
- Various constructs could be expressed with simpler and/or more
  readable code.
- The jerry_port_log implementation for the debugger case was prone
  to buffer overflow error.
- Some documentation was still missing (even from
  jerryscript-port.h).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu