### PR TITLE
Update Doxygen config file and fix Doxygen warnings

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -341,7 +341,7 @@ IDL_PROPERTY_SUPPORT   = YES
 # all members of a group must be documented explicitly.
 # The default value is: NO.
 
-DISTRIBUTE_GROUP_DOC   = NO
+DISTRIBUTE_GROUP_DOC   = YES
 
 # Set the SUBGROUPING tag to YES to allow class member groups of the same type
 # (for instance a group of public functions) to be put as a subgroup of that
@@ -409,7 +409,7 @@ LOOKUP_CACHE_SIZE      = 0
 # normally produced when WARNINGS is set to YES.
 # The default value is: NO.
 
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 
 # If the EXTRACT_PRIVATE tag is set to YES, all private members of a class will
 # be included in the documentation.
@@ -1960,7 +1960,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -1968,7 +1968,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2000,7 +2000,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = JERRY_STATIC_ASSERT(x,y)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -869,7 +869,8 @@ jerry_value_get_type (const jerry_value_t value) /**< input value to check */
  * @return true  - if the specified feature is enabled,
  *         false - otherwise
  */
-bool jerry_is_feature_enabled (const jerry_feature_t feature)
+bool
+jerry_is_feature_enabled (const jerry_feature_t feature) /**< feature to check */
 {
   JERRY_ASSERT (feature < JERRY_FEATURE__COUNT);
 
@@ -929,7 +930,7 @@ bool jerry_is_feature_enabled (const jerry_feature_t feature)
  * Clear the error flag
  */
 void
-jerry_value_clear_error_flag (jerry_value_t *value_p)
+jerry_value_clear_error_flag (jerry_value_t *value_p) /**< api value */
 {
   jerry_assert_api_available ();
 
@@ -943,7 +944,7 @@ jerry_value_clear_error_flag (jerry_value_t *value_p)
  * Set the error flag if the value is not an error reference.
  */
 void
-jerry_value_set_error_flag (jerry_value_t *value_p)
+jerry_value_set_error_flag (jerry_value_t *value_p) /**< api value */
 {
   jerry_assert_api_available ();
 
@@ -966,7 +967,7 @@ jerry_value_set_error_flag (jerry_value_t *value_p)
  * Set both the abort and error flags if the value is not an error reference.
  */
 void
-jerry_value_set_abort_flag (jerry_value_t *value_p)
+jerry_value_set_abort_flag (jerry_value_t *value_p) /**< api value */
 {
   jerry_assert_api_available ();
 
@@ -1505,7 +1506,7 @@ jerry_create_string_sz (const jerry_char_t *str_p, /**< pointer to string */
  * @return length of the given array
  */
 uint32_t
-jerry_get_array_length (const jerry_value_t value)
+jerry_get_array_length (const jerry_value_t value) /**< api value */
 {
   jerry_assert_api_available ();
 
@@ -1557,7 +1558,7 @@ jerry_get_string_size (const jerry_value_t value) /**< input string */
  * @return number of bytes in the buffer needed to represent the UTF-8 encoded string
  */
 jerry_size_t
-jerry_get_utf8_string_size (const jerry_value_t value)
+jerry_get_utf8_string_size (const jerry_value_t value) /**< input string */
 {
   jerry_assert_api_available ();
 
@@ -2494,8 +2495,9 @@ jerry_set_object_native_handle (const jerry_value_t obj_val, /**< object to set 
  * @return true - traversal was interrupted by the callback.
  *         false - otherwise - traversal visited all objects.
  */
-bool jerry_objects_foreach (jerry_objects_foreach_t foreach_p,
-                            void *user_data_p)
+bool
+jerry_objects_foreach (jerry_objects_foreach_t foreach_p, /**< function pointer of the iterator function */
+                       void *user_data_p) /**< pointer to user data */
 {
   jerry_assert_api_available ();
 
@@ -2522,9 +2524,11 @@ bool jerry_objects_foreach (jerry_objects_foreach_t foreach_p,
  *         false - otherwise - traversal visited all objects.
  */
 bool
-jerry_objects_foreach_by_native_info (const jerry_object_native_info_t *native_info_p,
-                                      jerry_objects_foreach_by_native_info_t foreach_p,
-                                      void *user_data_p)
+jerry_objects_foreach_by_native_info (const jerry_object_native_info_t *native_info_p, /**< the type info
+                                                                                        *   of the native pointer */
+                                      jerry_objects_foreach_by_native_info_t foreach_p, /**< function to apply for
+                                                                                         *   each matching object */
+                                      void *user_data_p) /**< pointer to user data */
 {
   jerry_assert_api_available ();
 
@@ -2757,7 +2761,7 @@ jerry_is_valid_cesu8_string (const jerry_char_t *cesu8_buf_p, /**< CESU-8 string
                                     (lit_utf8_size_t) buf_size);
 } /* jerry_is_valid_cesu8_string */
 
-/*
+/**
  * Create a jerry instance for external context.
  *
  * @return the pointer to the instance.
@@ -2866,7 +2870,7 @@ jerry_set_vm_exec_stop_callback (jerry_vm_exec_stop_callback_t stop_cb, /**< per
  * @return array value
  */
 jerry_value_t
-jerry_get_backtrace (uint32_t max_depth)
+jerry_get_backtrace (uint32_t max_depth) /**< depth limit of the backtrace */
 {
   return vm_get_backtrace (max_depth);
 } /* jerry_get_backtrace */
@@ -3143,14 +3147,20 @@ jerry_value_is_typedarray (jerry_value_t value) /**< value to check if it is a T
 } /* jerry_value_is_typedarray */
 
 #ifndef CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN
+/**
+ * TypedArray mapping type
+ */
 typedef struct
 {
-  jerry_typedarray_type_t api_type;
-  ecma_builtin_id_t prototype_id;
-  lit_magic_string_id_t lit_id;
-  uint8_t element_size_shift;
+  jerry_typedarray_type_t api_type; /**< api type */
+  ecma_builtin_id_t prototype_id; /**< prototype ID */
+  lit_magic_string_id_t lit_id; /**< literal ID */
+  uint8_t element_size_shift; /**< element size shift */
 } jerry_typedarray_mapping_t;
 
+/**
+ * List of TypedArray mappings
+ */
 static jerry_typedarray_mapping_t jerry_typedarray_mappings[] =
 {
 #define TYPEDARRAY_ENTRY(NAME, LIT_NAME, SIZE_SHIFT) \

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -55,6 +55,9 @@
 
 /**
  * Get next object in list of objects with same generation.
+ *
+ * @return pointer to the next ecma-object
+ *         NULL - if there is no next ecma-object
  */
 static inline ecma_object_t *
 ecma_gc_get_object_next (ecma_object_t *object_p) /**< object */
@@ -78,6 +81,9 @@ ecma_gc_set_object_next (ecma_object_t *object_p, /**< object */
 
 /**
  * Get visited flag of the object.
+ *
+ * @return true  - if visited
+ *         false - otherwise
  */
 static inline bool
 ecma_gc_is_object_visited (ecma_object_t *object_p) /**< object */

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -322,20 +322,29 @@
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
 }
 
+/**
+ * Value of epsilon
+ */
 #define EPSILON 0.0000001
 
 #if CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64
 /**
- * Number.MAX_VALUE and Number.MIN_VALUE exponent parts while using 64 bit float representation
+ * Number.MAX_VALUE exponent part when using 64 bit float representation.
  */
-# define NUMBER_MAX_DECIMAL_EXPONENT 308
-# define NUMBER_MIN_DECIMAL_EXPONENT -324
+#define NUMBER_MAX_DECIMAL_EXPONENT 308
+/**
+ * Number.MIN_VALUE exponent part when using 64 bit float representation.
+ */
+#define NUMBER_MIN_DECIMAL_EXPONENT -324
 #elif CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT32
 /**
- * Number.MAX_VALUE and Number.MIN_VALUE exponent parts while using 32 bit float representation
+ * Number.MAX_VALUE exponent part when using 32 bit float representation.
  */
-# define NUMBER_MAX_DECIMAL_EXPONENT 38
-# define NUMBER_MIN_DECIMAL_EXPONENT -45
+#define NUMBER_MAX_DECIMAL_EXPONENT 38
+/**
+ * Number.MIN_VALUE exponent part when using 32 bit float representation.
+ */
+#define NUMBER_MIN_DECIMAL_EXPONENT -45
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
 
 /**
@@ -934,13 +943,15 @@ ecma_number_to_int32 (ecma_number_t num) /**< ecma-number */
 } /* ecma_number_to_int32 */
 
 /**
-  * Perform conversion of ecma-number to decimal representation with decimal exponent
+  * Perform conversion of ecma-number to decimal representation with decimal exponent.
   *
   * Note:
   *      The calculated values correspond to s, n, k parameters in ECMA-262 v5, 9.8.1, item 5:
   *         - parameter out_digits_p corresponds to s, the digits of the number;
   *         - parameter out_decimal_exp_p corresponds to n, the decimal exponent;
   *         - return value corresponds to k, the number of digits.
+  *
+  * @return the number of digits
   */
 lit_utf8_size_t
 ecma_number_to_decimal (ecma_number_t num, /**< ecma-number */
@@ -1068,14 +1079,16 @@ ecma_double_to_binary_floating_point (double val, /**< ecma number */
 } /* ecma_double_to_binary_floating_point */
 
 /**
-  * Perform conversion of ecma-number to equivalent binary floating-point number representation with decimal exponent
-  *
-  * Note:
-  *      The calculated values correspond to s, n, k parameters in ECMA-262 v5, 9.8.1, item 5:
-  *         - parameter out_digits_p corresponds to s, the digits of the number;
-  *         - parameter out_decimal_exp_p corresponds to n, the decimal exponent;
-  *         - return value corresponds to k, the number of digits.
-  */
+ * Perform conversion of ecma-number to equivalent binary floating-point number representation with decimal exponent.
+ *
+ * Note:
+ *      The calculated values correspond to s, n, k parameters in ECMA-262 v5, 9.8.1, item 5:
+ *         - parameter out_digits_p corresponds to s, the digits of the number;
+ *         - parameter out_decimal_exp_p corresponds to n, the decimal exponent;
+ *         - return value corresponds to k, the number of digits.
+ *
+ * @return the number of digits
+ */
 lit_utf8_size_t
 ecma_number_to_binary_floating_point_number (ecma_number_t num, /**< ecma-number */
                                              lit_utf8_byte_t *out_digits_p, /**< [out] buffer to fill with digits */

--- a/jerry-core/ecma/base/ecma-helpers-errol.c
+++ b/jerry-core/ecma/base/ecma-helpers-errol.c
@@ -54,11 +54,17 @@
  */
 
 /**
- * Floating point format definitions
+ * Floating point format definitions (next float value)
  */
 #define ECMA_NEXT_FLOAT(value) (nextafter ((value), INFINITY))
+/**
+ * Floating point format definitions (previous float value)
+ */
 #define ECMA_PREV_FLOAT(value) (nextafter ((value), -INFINITY))
 
+/**
+ * Value of epsilon
+ */
 #define ERROL0_EPSILON 0.0000001
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -31,7 +31,9 @@ JERRY_STATIC_ASSERT (ECMA_DIRECT_SHIFT == ECMA_VALUE_SHIFT + 1,
 
 JERRY_STATIC_ASSERT (((1 << (ECMA_DIRECT_SHIFT - 1)) | ECMA_TYPE_DIRECT) == ECMA_DIRECT_TYPE_SIMPLE_VALUE,
                      currently_directly_encoded_values_start_after_direct_type_simple_value);
-
+/**
+ * Position of the sign bit in ecma-numbers
+ */
 #define ECMA_NUMBER_SIGN_POS (ECMA_NUMBER_FRACTION_WIDTH + \
                               ECMA_NUMBER_BIASED_EXP_WIDTH)
 

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -410,7 +410,7 @@ ecma_new_ecma_string_from_uint32 (uint32_t uint32_number) /**< uint32 value of t
  * @return pointer to ecma-string descriptor
  */
 ecma_string_t *
-ecma_get_ecma_string_from_uint32 (uint32_t uint32_number)
+ecma_get_ecma_string_from_uint32 (uint32_t uint32_number) /**< input number */
 {
   JERRY_ASSERT (uint32_number <= ECMA_DIRECT_STRING_MAX_IMM);
 
@@ -839,8 +839,8 @@ ecma_concat_ecma_strings (ecma_string_t *string1_p, /**< first ecma-string */
  * @return concatenation of an ecma-string and a magic string
  */
 ecma_string_t *
-ecma_append_magic_string_to_string (ecma_string_t *string1_p,
-                                    lit_magic_string_id_t string2_id)
+ecma_append_magic_string_to_string (ecma_string_t *string1_p, /**< string descriptor */
+                                    lit_magic_string_id_t string2_id) /**< magic string ID */
 {
   if (JERRY_UNLIKELY (ecma_string_is_empty (string1_p)))
   {
@@ -953,6 +953,8 @@ ecma_deref_ecma_string (ecma_string_t *string_p) /**< ecma-string */
 
 /**
  * Convert ecma-string to number
+ *
+ * @return converted ecma-number
  */
 ecma_number_t
 ecma_string_to_number (const ecma_string_t *string_p) /**< ecma-string */
@@ -1560,7 +1562,11 @@ ecma_string_is_length (const ecma_string_t *string_p) /**< property name */
   return ecma_compare_ecma_string_to_magic_id (string_p, LIT_MAGIC_STRING_LENGTH);
 } /* ecma_string_is_length */
 
-
+/**
+ * Converts a property name into a string
+ *
+ * @return pointer to the converted ecma string
+ */
 static inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_property_to_string (ecma_property_t property, /**< property name type */
                          jmem_cpointer_t prop_name_cp) /**< property name compressed pointer */
@@ -1914,7 +1920,7 @@ ecma_compare_ecma_strings_relational (const ecma_string_t *string1_p, /**< ecma-
                                               utf8_string2_size);
 } /* ecma_compare_ecma_strings_relational */
 
-/*
+/**
  * Special value to represent that no size is available.
  */
 #define ECMA_STRING_NO_ASCII_SIZE 0xffff

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -23,13 +23,6 @@
 
 #include "ecma-function-object.h"
 
-/** \addtogroup ecma ECMA
- * @{
- *
- * \addtogroup ecmahelpers Helpers for operations with ECMA data types
- * @{
- */
-
 JERRY_STATIC_ASSERT (ECMA_TYPE___MAX <= ECMA_VALUE_TYPE_MASK,
                      ecma_types_must_be_less_than_mask);
 
@@ -57,6 +50,13 @@ JERRY_STATIC_ASSERT (sizeof (uintptr_t) > sizeof (ecma_value_t),
 JERRY_STATIC_ASSERT ((ECMA_VALUE_FALSE | (1 << ECMA_DIRECT_SHIFT)) == ECMA_VALUE_TRUE
                      && ECMA_VALUE_FALSE != ECMA_VALUE_TRUE,
                      only_the_lowest_bit_must_be_different_for_simple_value_true_and_false);
+
+/** \addtogroup ecma ECMA
+ * @{
+ *
+ * \addtogroup ecmahelpers Helpers for operations with ECMA data types
+ * @{
+ */
 
 /**
  * Get type field of ecma value
@@ -512,6 +512,8 @@ ecma_make_uint32_value (uint32_t uint32_number) /**< uint32 number to be encoded
 
 /**
  * String value constructor
+ *
+ * @return ecma-value representation of the string argument
  */
 inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to reference in value */
@@ -528,6 +530,8 @@ ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to refer
 
 /**
  * String value constructor
+ *
+ * @return ecma-value representation of the string argument
  */
 inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_magic_string_value (lit_magic_string_id_t id) /**< magic string id */
@@ -537,6 +541,8 @@ ecma_make_magic_string_value (lit_magic_string_id_t id) /**< magic string id */
 
 /**
  * Object value constructor
+ *
+ * @return ecma-value representation of the object argument
  */
 inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference in value */
@@ -548,6 +554,8 @@ ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference 
 
 /**
  * Error reference constructor
+ *
+ * @return ecma-value representation of the Error reference
  */
 inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_error_reference_value (const ecma_error_reference_t *error_ref_p) /**< error reference */
@@ -559,6 +567,8 @@ ecma_make_error_reference_value (const ecma_error_reference_t *error_ref_p) /**<
 
 /**
  * Collection chunk constructor
+ *
+ * @return ecma-value representation of the collection chunk
  */
 inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_collection_chunk_value (const ecma_collection_chunk_t *collection_chunk_p) /**< collection chunk */
@@ -581,7 +591,7 @@ ecma_make_collection_chunk_value (const ecma_collection_chunk_t *collection_chun
 /**
  * Get integer value from an integer ecma value
  *
- * @return floating point value
+ * @return integer value
  */
 inline ecma_integer_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_get_integer_from_value (ecma_value_t value) /**< ecma value */
@@ -591,6 +601,11 @@ ecma_get_integer_from_value (ecma_value_t value) /**< ecma value */
   return ((ecma_integer_value_t) value) >> ECMA_DIRECT_SHIFT;
 } /* ecma_get_integer_from_value */
 
+/**
+ * Get floating point value from an ecma value
+ *
+ * @return floating point value
+ */
 inline ecma_number_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_float_from_value (ecma_value_t value) /**< ecma value */
 {
@@ -618,7 +633,7 @@ ecma_get_number_from_value (ecma_value_t value) /**< ecma value */
 /**
  * Get pointer to ecma-string from ecma value
  *
- * @return the pointer
+ * @return the string pointer
  */
 inline ecma_string_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_string_from_value (ecma_value_t value) /**< ecma value */

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -174,6 +174,9 @@ ecma_create_object_lex_env (ecma_object_t *outer_lexical_environment_p, /**< out
 
 /**
  * Check if the object is lexical environment.
+ *
+ * @return true  - if object is a lexical environment
+ *         false - otherwise
  */
 inline bool JERRY_ATTR_PURE
 ecma_is_lexical_environment (const ecma_object_t *object_p) /**< object or lexical environment */
@@ -187,6 +190,9 @@ ecma_is_lexical_environment (const ecma_object_t *object_p) /**< object or lexic
 
 /**
  * Get value of [[Extensible]] object's internal property.
+ *
+ * @return true  - if object is extensible
+ *         false - otherwise
  */
 inline bool JERRY_ATTR_PURE
 ecma_get_object_extensible (const ecma_object_t *object_p) /**< object */
@@ -219,6 +225,8 @@ ecma_set_object_extensible (ecma_object_t *object_p, /**< object */
 
 /**
  * Get object's internal implementation-defined type.
+ *
+ * @return type of the object (ecma_object_type_t)
  */
 inline ecma_object_type_t JERRY_ATTR_PURE
 ecma_get_object_type (const ecma_object_t *object_p) /**< object */
@@ -231,6 +239,9 @@ ecma_get_object_type (const ecma_object_t *object_p) /**< object */
 
 /**
  * Get object's prototype.
+ *
+ * @return pointer to the prototype object
+ *         NULL if there is no prototype
  */
 inline ecma_object_t *JERRY_ATTR_PURE
 ecma_get_object_prototype (const ecma_object_t *object_p) /**< object */
@@ -245,7 +256,8 @@ ecma_get_object_prototype (const ecma_object_t *object_p) /**< object */
 /**
  * Check if the object is a built-in object
  *
- * @return true / false
+ * @return true  - if object is a built-in object
+ *         false - otherwise
  */
 inline bool JERRY_ATTR_PURE
 ecma_get_object_is_builtin (const ecma_object_t *object_p) /**< object */
@@ -270,8 +282,10 @@ ecma_set_object_is_builtin (ecma_object_t *object_p) /**< object */
 } /* ecma_set_object_is_builtin */
 
 /**
- * Get the builtin id of the object.
+ * Get the built-in ID of the object.
  * If the object is not builtin, return ECMA_BUILTIN_ID__COUNT
+ *
+ * @return the ID of the built-in
  */
 inline uint8_t
 ecma_get_object_builtin_id (ecma_object_t *object_p) /**< object */
@@ -298,6 +312,8 @@ ecma_get_object_builtin_id (ecma_object_t *object_p) /**< object */
 
 /**
  * Get type of lexical environment.
+ *
+ * @return type of the lexical environment (ecma_lexical_environment_type_t)
  */
 inline ecma_lexical_environment_type_t JERRY_ATTR_PURE
 ecma_get_lex_env_type (const ecma_object_t *object_p) /**< lexical environment */
@@ -310,6 +326,8 @@ ecma_get_lex_env_type (const ecma_object_t *object_p) /**< lexical environment *
 
 /**
  * Get outer reference of lexical environment.
+ *
+ * @return pointer to the outer reference
  */
 inline ecma_object_t *JERRY_ATTR_PURE
 ecma_get_lex_env_outer_reference (const ecma_object_t *object_p) /**< lexical environment */
@@ -326,6 +344,8 @@ ecma_get_lex_env_outer_reference (const ecma_object_t *object_p) /**< lexical en
  *
  * See also:
  *          ecma_op_object_get_property_names
+ *
+ * @return pointer to the head of the property list
  */
 inline ecma_property_header_t *JERRY_ATTR_PURE
 ecma_get_property_list (const ecma_object_t *object_p) /**< object or lexical environment */
@@ -340,6 +360,9 @@ ecma_get_property_list (const ecma_object_t *object_p) /**< object or lexical en
 
 /**
  * Get lexical environment's 'provideThis' property
+ *
+ * @return true  - if it has 'this' property
+ *         false - otherwise
  */
 inline bool JERRY_ATTR_PURE
 ecma_get_lex_env_provide_this (const ecma_object_t *object_p) /**< object-bound lexical environment */
@@ -354,6 +377,8 @@ ecma_get_lex_env_provide_this (const ecma_object_t *object_p) /**< object-bound 
 
 /**
  * Get lexical environment's bound object.
+ *
+ * @return pointer to ecma object
  */
 inline ecma_object_t *JERRY_ATTR_PURE
 ecma_get_lex_env_binding_object (const ecma_object_t *object_p) /**< object-bound lexical environment */
@@ -1294,6 +1319,8 @@ ecma_set_property_lcached (ecma_property_t *property_p, /**< property */
 /**
  * Construct empty property descriptor, i.e.:
  *  property descriptor with all is_defined flags set to false and the rest - to default value.
+ *
+ * @return empty property descriptor
  */
 ecma_property_descriptor_t
 ecma_make_empty_property_descriptor (void)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -591,7 +591,7 @@ ecma_builtin_global_object_character_is_in (uint32_t character, /**< character *
   return (bitset[character >> 3] & (1u << (character & 0x7))) != 0;
 } /* ecma_builtin_global_object_character_is_in */
 
-/*
+/**
  * Unescaped URI characters bitset:
  *   One bit for each character between 0 - 127.
  *   Bit is set if the character is in the unescaped URI set.
@@ -602,7 +602,7 @@ static const uint8_t unescaped_uri_set[16] =
   0xff, 0xff, 0xff, 0x87, 0xfe, 0xff, 0xff, 0x47
 };
 
-/*
+/**
  * Unescaped URI component characters bitset:
  *   One bit for each character between 0 - 127.
  *   Bit is set if the character is in the unescaped component URI set.
@@ -613,17 +613,10 @@ static const uint8_t unescaped_uri_component_set[16] =
   0xfe, 0xff, 0xff, 0x87, 0xfe, 0xff, 0xff, 0x47
 };
 
-/*
+/**
  * Format is a percent sign followed by two hex digits.
  */
 #define URI_ENCODED_BYTE_SIZE (3)
-
-/*
- * These two types shows whether the byte is present in
- * the original stream or decoded from a %xx sequence.
- */
-#define URI_DECODE_ORIGINAL_BYTE 0
-#define URI_DECODE_DECODED_BYTE 1
 
 /**
  * Helper function to decode URI.
@@ -1100,17 +1093,17 @@ ecma_builtin_global_object_encode_uri_component (ecma_value_t this_arg, /**< thi
 
 #ifndef CONFIG_DISABLE_ANNEXB_BUILTIN
 
-/*
+/**
  * Maximum value of a byte.
  */
 #define ECMA_ESCAPE_MAXIMUM_BYTE_VALUE (255)
 
-/*
+/**
  * Format is a percent sign followed by lowercase u and four hex digits.
  */
 #define ECMA_ESCAPE_ENCODED_UNICODE_CHARACTER_SIZE (6)
 
-/*
+/**
  * Escape characters bitset:
  *   One bit for each character between 0 - 127.
  *   Bit is set if the character does not need to be converted to %xx form.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -125,6 +125,11 @@ ecma_builtin_number_prototype_helper_to_string (lit_utf8_byte_t *digits_p, /**< 
   return (lit_utf8_size_t) (p - to_digits_p);
 } /* ecma_builtin_number_prototype_helper_to_string */
 
+/**
+ * Helper function to convert a binary floating point number to string.
+ *
+ * @return size of result string
+ */
 static inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_binary_floating_number_to_string (lit_utf8_byte_t *digits_p, /**< number as string
                                                                            * in binary-floating point number */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -153,6 +153,9 @@ ecma_builtin_object_object_get_prototype_of (ecma_value_t this_arg, /**< 'this' 
  *
  * See also:
  *          ES2015 9.1.2
+ *
+ * @return true  - if success
+ *         false - otherwise
  */
 static bool
 ecma_set_prototype_of (ecma_value_t o_value, /**< O */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -629,7 +629,7 @@ typedef struct
   ecma_length_t match_end; /**< end position of the match */
 
   /* Replace value callable part. */
-  ecma_object_t *replace_function_p;
+  ecma_object_t *replace_function_p; /**< replace function */
 
   /* Replace value string part. */
   ecma_string_t *replace_string_p; /**< replace string */

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -39,13 +39,21 @@ static void ecma_instantiate_builtin (ecma_builtin_id_t id);
  */
 typedef const ecma_builtin_property_descriptor_t *ecma_builtin_property_list_reference_t;
 
+/**
+ * Definition of built-in dispatch routine function pointer.
+ */
 typedef ecma_value_t (*ecma_builtin_dispatch_routine_t)(uint16_t builtin_routine_id,
                                                         ecma_value_t this_arg,
                                                         const ecma_value_t arguments_list[],
                                                         ecma_length_t arguments_number);
+/**
+ * Definition of built-in dispatch call function pointer.
+ */
 typedef ecma_value_t (*ecma_builtin_dispatch_call_t)(const ecma_value_t arguments_list[],
                                                      ecma_length_t arguments_number);
-
+/**
+ * List of the built-in routines.
+ */
 static const ecma_builtin_dispatch_routine_t ecma_builtin_routines[] =
 {
   #define BUILTIN(a, b, c, d, e)
@@ -70,6 +78,9 @@ static const ecma_builtin_dispatch_routine_t ecma_builtin_routines[] =
   #undef BUILTIN_ROUTINE
 };
 
+/**
+ * List of the built-in call functions.
+ */
 static const ecma_builtin_dispatch_call_t ecma_builtin_call_functions[] =
 {
   #define BUILTIN(a, b, c, d, e)
@@ -84,6 +95,9 @@ static const ecma_builtin_dispatch_call_t ecma_builtin_call_functions[] =
   #undef BUILTIN
 };
 
+/**
+ * List of the built-in construct functions.
+ */
 static const ecma_builtin_dispatch_call_t ecma_builtin_construct_functions[] =
 {
   #define BUILTIN(a, b, c, d, e)
@@ -131,7 +145,7 @@ static const ecma_builtin_property_list_reference_t ecma_builtin_property_list_r
  * @return the number of properties
  */
 static size_t
-ecma_builtin_get_property_count (ecma_builtin_id_t builtin_id)
+ecma_builtin_get_property_count (ecma_builtin_id_t builtin_id) /**< built-in ID */
 {
   const ecma_builtin_property_descriptor_t *property_list_p = ecma_builtin_property_list_references[builtin_id];
 
@@ -147,6 +161,9 @@ ecma_builtin_get_property_count (ecma_builtin_id_t builtin_id)
 
 /**
  * Check if passed object is the instance of specified built-in.
+ *
+ * @return true  - if the object is instance of the specified built-in
+ *         false - otherwise
  */
 bool
 ecma_builtin_is (ecma_object_t *obj_p, /**< pointer to an object */

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -305,7 +305,8 @@ ecma_op_to_number (ecma_value_t value) /**< ecma value */
  *         Returned value must be freed with ecma_free_value
  */
 ecma_value_t
-ecma_get_number (ecma_value_t value, ecma_number_t *number_p)
+ecma_get_number (ecma_value_t value, /**< ecma value*/
+                 ecma_number_t *number_p) /**< [out] ecma number */
 {
   if (ecma_is_value_integer_number (value))
   {

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -34,12 +34,19 @@
  * \addtogroup exceptions Exceptions
  * @{
  */
+
+/**
+ * Map error type to error prototype.
+ */
 typedef struct
 {
-  ecma_standard_error_t error_type;
-  ecma_builtin_id_t error_prototype_id;
+  ecma_standard_error_t error_type; /**< Native error type */
+  ecma_builtin_id_t error_prototype_id; /**< ID of the error prototype */
 } ecma_error_mapping_t;
 
+/**
+ * List of error type mappings
+ */
 const ecma_error_mapping_t ecma_error_mappings[] =
 {
 #define ERROR_ELEMENT(TYPE, ID) { TYPE, ID }

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -41,7 +41,7 @@
  *         false - otherwise
  */
 inline bool JERRY_ATTR_ALWAYS_INLINE
-ecma_is_normal_or_arrow_function (ecma_object_type_t type)
+ecma_is_normal_or_arrow_function (ecma_object_type_t type) /**< object type */
 {
 #ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
   return (type == ECMA_OBJECT_TYPE_FUNCTION || type == ECMA_OBJECT_TYPE_ARROW_FUNCTION);

--- a/jerry-core/ecma/operations/ecma-jobqueue.c
+++ b/jerry-core/ecma/operations/ecma-jobqueue.c
@@ -46,7 +46,7 @@ typedef struct
 {
   ecma_value_t promise; /**< promise to be resolved */
   ecma_value_t thenable; /**< thenbale object */
-  ecma_value_t then; /** 'then' function */
+  ecma_value_t then; /**< 'then' function */
 } ecma_job_promise_resolve_thenable_t;
 
 /**

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1281,6 +1281,9 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
  *
  * See also:
  *          ECMA-262 v5, 8.6.2; ECMA-262 v5, Table 9
+ *
+ * @return ecma value containing a boolean value or an error
+ *         Returned value must be freed with ecma_free_value
  */
 ecma_value_t
 ecma_op_object_has_instance (ecma_object_t *obj_p, /**< the object */
@@ -1729,6 +1732,9 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
 /**
  * The function is used in the assert of ecma_object_get_class_name
+ *
+ * @return true  - if class name is an object
+ *         false - otherwise
  */
 inline static bool
 ecma_object_check_class_name_is_object (ecma_object_t *obj_p) /**< object */

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -52,6 +52,10 @@
  *   [n+1] n/2 th group end
  */
 #define RE_GLOBAL_START_IDX 0
+
+/**
+ * @copydoc RE_GLOBAL_START_IDX
+ */
 #define RE_GLOBAL_END_IDX   1
 
 /**

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -32,7 +32,8 @@
  * @{
  */
 
-/*
+/**
+ * @{
  * Valgrind-related options and headers
  */
 #ifdef JERRY_VALGRIND
@@ -47,7 +48,6 @@
 # define VALGRIND_UNDEFINED_SPACE(p, s)
 # define VALGRIND_DEFINED_SPACE(p, s)
 #endif /* JERRY_VALGRIND */
-
 #ifdef JERRY_VALGRIND_FREYA
 
 #ifdef JERRY_VALGRIND
@@ -77,12 +77,16 @@
 # define VALGRIND_FREYA_MALLOCLIKE_SPACE(p, s)
 # define VALGRIND_FREYA_FREELIKE_SPACE(p)
 #endif /* JERRY_VALGRIND_FREYA */
+/** @} */
 
 /**
  * End of list marker.
  */
 #define JMEM_HEAP_END_OF_LIST ((uint32_t) 0xffffffff)
 
+/**
+ * @{
+ */
 #ifdef ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
 /* In this case we simply store the pointer, since it fits anyway. */
 #define JMEM_HEAP_GET_OFFSET_FROM_ADDR(p) ((uint32_t) (p))
@@ -91,10 +95,15 @@
 #define JMEM_HEAP_GET_OFFSET_FROM_ADDR(p) ((uint32_t) ((uint8_t *) (p) - JERRY_HEAP_CONTEXT (area)))
 #define JMEM_HEAP_GET_ADDR_FROM_OFFSET(u) ((jmem_heap_free_t *) (JERRY_HEAP_CONTEXT (area) + (u)))
 #endif /* ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY */
+/**
+ * @}
+ */
 
 #ifndef JERRY_SYSTEM_ALLOCATOR
 /**
  * Get end of region
+ *
+ * @return pointer to the end of the region
  */
 static inline jmem_heap_free_t *  JERRY_ATTR_ALWAYS_INLINE JERRY_ATTR_PURE
 jmem_heap_get_region_end (jmem_heap_free_t *curr_p) /**< current region */
@@ -122,7 +131,10 @@ static void jmem_heap_stat_nonskip (void);
 static void jmem_heap_stat_alloc_iter (void);
 static void jmem_heap_stat_free_iter (void);
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
-
+/**
+ * @{
+ * JMEM_HEAP_STAT_xxx definitions
+ */
 #  define JMEM_HEAP_STAT_INIT() jmem_heap_stat_init ()
 #  define JMEM_HEAP_STAT_ALLOC(v1) jmem_heap_stat_alloc (v1)
 #  define JMEM_HEAP_STAT_FREE(v1) jmem_heap_stat_free (v1)
@@ -130,7 +142,12 @@ static void jmem_heap_stat_free_iter (void);
 #  define JMEM_HEAP_STAT_NONSKIP() jmem_heap_stat_nonskip ()
 #  define JMEM_HEAP_STAT_ALLOC_ITER() jmem_heap_stat_alloc_iter ()
 #  define JMEM_HEAP_STAT_FREE_ITER() jmem_heap_stat_free_iter ()
+/** @} */
 #else /* !JMEM_STATS */
+/**
+ * @{
+ * JMEM_HEAP_STAT_xxx definitions
+ */
 #  define JMEM_HEAP_STAT_INIT()
 #  define JMEM_HEAP_STAT_ALLOC(v1)
 #  define JMEM_HEAP_STAT_FREE(v1)
@@ -138,6 +155,7 @@ static void jmem_heap_stat_free_iter (void);
 #  define JMEM_HEAP_STAT_NONSKIP()
 #  define JMEM_HEAP_STAT_ALLOC_ITER()
 #  define JMEM_HEAP_STAT_FREE_ITER()
+/** @} */
 #endif /* JMEM_STATS */
 
 /**
@@ -194,7 +212,7 @@ jmem_heap_finalize (void)
  *         NULL - if there is not enough memory.
  */
 static void * JERRY_ATTR_HOT
-jmem_heap_alloc_block_internal (const size_t size)
+jmem_heap_alloc_block_internal (const size_t size) /**< size of requested block */
 {
 #ifndef JERRY_SYSTEM_ALLOCATOR
   /* Align size. */

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -31,7 +31,8 @@
  * @{
  */
 
-/*
+/**
+ * @{
  * Valgrind-related options and headers
  */
 #ifdef JERRY_VALGRIND
@@ -55,6 +56,7 @@
 # define VALGRIND_FREYA_MALLOCLIKE_SPACE(p, s)
 # define VALGRIND_FREYA_FREELIKE_SPACE(p)
 #endif /* JERRY_VALGRIND_FREYA */
+/** @} */
 
 /**
  * Finalize pool manager

--- a/jerry-core/parser/js/byte-code.c
+++ b/jerry-core/parser/js/byte-code.c
@@ -33,6 +33,9 @@ JERRY_STATIC_ASSERT ((sizeof (cbc_uint16_arguments_t) % sizeof (jmem_cpointer_t)
  * @{
  */
 
+/**
+ * Compact bytecode definition
+ */
 #define CBC_OPCODE(arg1, arg2, arg3, arg4) \
   ((arg2) | (((arg3) + CBC_STACK_ADJUST_BASE) << CBC_STACK_ADJUST_SHIFT)),
 

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -33,6 +33,9 @@
  * @{
  */
 
+/**
+ * Check whether the UTF-8 intermediate is an octet or not
+ */
 #define IS_UTF8_INTERMEDIATE_OCTET(byte) (((byte) & LIT_UTF8_EXTRA_BYTE_MASK) == LIT_UTF8_2_BYTE_CODE_POINT_MIN)
 
 /**
@@ -279,12 +282,17 @@ lexer_skip_spaces (parser_context_t *context_p) /**< context */
  */
 typedef struct
 {
-  const uint8_t *keyword_p;     /**< keyword string */
-  lexer_token_type_t type;      /**< keyword token type */
+  const uint8_t *keyword_p; /**< keyword string */
+  lexer_token_type_t type;  /**< keyword token type */
 } keyword_string_t;
 
+/**
+ * @{
+ * Keyword defines
+ */
 #define LEXER_KEYWORD(name, type) { (const uint8_t *) (name), (type) }
 #define LEXER_KEYWORD_END()       { (const uint8_t *) NULL, LEXER_EOS }
+/** @} */
 
 /**
  * Keywords with 2 characters.
@@ -971,6 +979,12 @@ lexer_parse_number (parser_context_t *context_p) /**< context */
   context_p->source_p = source_p;
 } /* lexer_parse_number */
 
+/**
+ * One character long token (e.g. comma).
+ *
+ * @param char1 character
+ * @param type1 type
+ */
 #define LEXER_TYPE_A_TOKEN(char1, type1) \
   case (uint8_t) (char1) : \
   { \
@@ -979,6 +993,14 @@ lexer_parse_number (parser_context_t *context_p) /**< context */
     break; \
   }
 
+/**
+ * Token pair, where the first token is prefix of the second (e.g. % and %=).
+ *
+ * @param char1 first character
+ * @param type1 type of the first character
+ * @param char2 second character
+ * @param type2 type of the second character
+ */
 #define LEXER_TYPE_B_TOKEN(char1, type1, char2, type2) \
   case (uint8_t) (char1) : \
   { \
@@ -994,6 +1016,16 @@ lexer_parse_number (parser_context_t *context_p) /**< context */
     break; \
   }
 
+/**
+ * Three tokens, where the first is the prefix of the other two (e.g. &, &&, &=).
+ *
+ * @param char1 first character
+ * @param type1 type of the first character
+ * @param char2 second character
+ * @param type2 type of the second character
+ * @param char3 third character
+ * @param type3 type of the third character
+ */
 #define LEXER_TYPE_C_TOKEN(char1, type1, char2, type2, char3, type3) \
   case (uint8_t) (char1) : \
   { \
@@ -1393,7 +1425,9 @@ lexer_process_char_literal (parser_context_t *context_p, /**< context */
   context_p->literal_count++;
 } /* lexer_process_char_literal */
 
-/* Maximum buffer size for identifiers which contains escape sequences. */
+/**
+ * Maximum local buffer size for identifiers which contains escape sequences.
+ */
 #define LEXER_MAX_LITERAL_LOCAL_BUFFER_SIZE 48
 
 /**
@@ -2113,11 +2147,17 @@ lexer_expect_identifier (parser_context_t *context_p, /**< context */
   parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
 } /* lexer_expect_identifier */
 
+/**
+ * Description of "get" literal string.
+ */
 static const lexer_lit_location_t lexer_get_literal =
 {
   (const uint8_t *) "get", 3, LEXER_IDENT_LITERAL, false
 };
 
+/**
+ * Description of "set" literal string.
+ */
 static const lexer_lit_location_t lexer_set_literal =
 {
   (const uint8_t *) "set", 3, LEXER_IDENT_LITERAL, false

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -31,9 +31,13 @@
  * @{
  */
 
-/* Strict mode string literal in directive prologues */
+/**
+ * @{
+ * Strict mode string literal in directive prologues
+ */
 #define PARSER_USE_STRICT_LITERAL  "use strict"
 #define PARSER_USE_STRICT_LENGTH   10
+/** @} */
 
 /**
  * Parser statement types.
@@ -253,6 +257,8 @@ parser_stack_iterator_init (parser_context_t *context_p, /**< context */
 
 /**
  * Read the next byte from the stack.
+ *
+ * @return byte
  */
 static inline uint8_t
 parser_stack_iterator_read_uint8 (parser_stack_iterator_t *iterator) /**< iterator */
@@ -496,6 +502,9 @@ parser_parse_if_statement_start (parser_context_t *context_p) /**< context */
 
 /**
  * Parse if statement (ending part).
+ *
+ * @return true  - if parsing an 'else' statement
+ *         false - otherwise
  */
 static bool
 parser_parse_if_statement_end (parser_context_t *context_p) /**< context */

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -72,6 +72,12 @@ parser_emit_two_bytes (parser_context_t *context_p, /**< context */
   }
 } /* parser_emit_two_bytes */
 
+/**
+ * Append byte to the end of the current byte code stream.
+ *
+ * @param context_p parser context
+ * @param byte byte
+ */
 #define PARSER_APPEND_TO_BYTE_CODE(context_p, byte) \
   if ((context_p)->byte_code.last_position >= PARSER_CBC_STREAM_PAGE_SIZE) \
   { \
@@ -476,7 +482,9 @@ parser_emit_cbc_forward_branch (parser_context_t *context_p, /**< context */
 } /* parser_emit_cbc_forward_branch */
 
 /**
- * Append a branch byte code and create an item
+ * Append a branch byte code and create an item.
+ *
+ * @return newly created parser branch node
  */
 parser_branch_node_t *
 parser_emit_cbc_forward_branch_item (parser_context_t *context_p, /**< context */

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1361,6 +1361,12 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
 
 #endif /* PARSER_DUMP_BYTE_CODE */
 
+/**
+ * Forward iterator: move to the next byte code
+ *
+ * @param page_p page
+ * @param offset offset
+ */
 #define PARSER_NEXT_BYTE(page_p, offset) \
   do { \
     if (++(offset) >= PARSER_CBC_STREAM_PAGE_SIZE) \
@@ -1370,6 +1376,13 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
     } \
   } while (0)
 
+/**
+ * Forward iterator: move to the next byte code. Also updates the offset of the previous byte code.
+ *
+ * @param page_p page
+ * @param offset offset
+ * @param real_offset real offset
+ */
 #define PARSER_NEXT_BYTE_UPDATE(page_p, offset, real_offset) \
   do { \
     page_p->bytes[offset] = real_offset; \

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -195,6 +195,7 @@ vm_op_set_value (ecma_value_t object, /**< base object */
   return completion_value;
 } /* vm_op_set_value */
 
+/** Compact bytecode define */
 #define CBC_OPCODE(arg1, arg2, arg3, arg4) arg4,
 
 /**
@@ -513,6 +514,11 @@ opfunc_construct (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
   frame_ctx_p->stack_top_p = stack_top_p;
 } /* opfunc_construct */
 
+/**
+ * Read literal index from the byte code stream into destination.
+ *
+ * @param destination destination
+ */
 #define READ_LITERAL_INDEX(destination) \
   do \
   { \
@@ -524,9 +530,16 @@ opfunc_construct (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
   } \
   while (0)
 
-/* TODO: For performance reasons, we define this as a macro.
+/**
+ * Get literal value by literal index.
+ *
+ * @param literal_index literal index
+ * @param target_value target value
+ *
+ * TODO: For performance reasons, we define this as a macro.
  * When we are able to construct a function with similar speed,
- * we can remove this macro. */
+ * we can remove this macro.
+ */
 #define READ_LITERAL(literal_index, target_value) \
   do \
   { \


### PR DESCRIPTION
A lot of warnings remained hibben because 'EXTRACT_ALL' was previously set to YES.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com