### PR TITLE
Remove usage of comma operator in array prototype

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -64,7 +64,7 @@ ecma_builtin_array_prototype_helper_set_length (ecma_object_t *object, /**< obje
   ret_value = ecma_op_object_put (object,
                                   ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH),
                                   length_value,
-                                  true),
+                                  true);
 
   ecma_free_value (length_value);
   return ret_value;


### PR DESCRIPTION
There was a typo in the `ecma_builtin_array_prototype_helper_set_length`
method as the comma operator was used to close the statement, incorrectly

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com