### PR TITLE
Remove legacy jerry_get_memory_limits API function and unused configuration macros

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -665,47 +665,6 @@ main (void)
 - [jerry_parse_and_save_literals](#jerry_parse_and_save_literals)
 
 
-## jerry_get_memory_limits
-
-**Summary**
-
-Gets configured memory limits of JerryScript.
-
-**Prototype**
-
-```c
-void
-jerry_get_memory_limits (size_t *out_data_bss_brk_limit_p,
-                         size_t *out_stack_limit_p);
-```
-
-- `out_data_bss_brk_limit_p` - out parameter, that gives the maximum size of data + bss + brk sections.
-- `out_stack_limit_p` - out parameter, that gives the maximum size of the stack.
-
-**Example**
-
-[doctest]: # ()
-
-```c
-#include "jerryscript.h"
-
-int
-main (void)
-{
-  jerry_init (JERRY_INIT_EMPTY);
-
-  size_t stack_limit;
-  size_t data_bss_brk_limit;
-  jerry_get_memory_limits (&stack_limit, &data_bss_brk_limit);
-}
-```
-
-**See also**
-
-- [jerry_init](#jerry_init)
-- [jerry_cleanup](#jerry_cleanup)
-
-
 ## jerry_get_memory_stats
 
 **Summary**

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -293,18 +293,6 @@ jerry_register_magic_strings (const jerry_char_ptr_t *ex_str_items_p, /**< chara
 } /* jerry_register_magic_strings */
 
 /**
- * Get Jerry configured memory limits
- */
-void
-jerry_get_memory_limits (size_t *out_data_bss_brk_limit_p, /**< [out] Jerry's maximum usage of
-                                                            *         data + bss + brk sections */
-                         size_t *out_stack_limit_p) /**< [out] Jerry's maximum usage of stack */
-{
-  *out_data_bss_brk_limit_p = CONFIG_MEM_HEAP_AREA_SIZE + CONFIG_MEM_DATA_LIMIT_MINUS_HEAP_SIZE;
-  *out_stack_limit_p = CONFIG_MEM_STACK_LIMIT;
-} /* jerry_get_memory_limits */
-
-/**
  * Run garbage collection
  */
 void

--- a/jerry-core/config.h
+++ b/jerry-core/config.h
@@ -44,16 +44,6 @@
 #endif /* CONFIG_DISABLE_ES2015 */
 
 /**
- * Limit of data (system heap, engine's data except engine's own heap)
- */
-#define CONFIG_MEM_DATA_LIMIT_MINUS_HEAP_SIZE (1024)
-
-/**
- * Limit of stack size
- */
-#define CONFIG_MEM_STACK_LIMIT (4096)
-
-/**
  * Size of heap
  */
 #ifndef CONFIG_MEM_HEAP_AREA_SIZE
@@ -108,16 +98,5 @@
  *                1.0 / CONFIG_ECMA_GC_NEW_OBJECTS_SHARE_TO_START_GC
  */
 #define CONFIG_ECMA_GC_NEW_OBJECTS_SHARE_TO_START_GC (16)
-
-/**
- * Link Global Environment to an empty declarative lexical environment
- * instead of lexical environment bound to Global Object.
- */
-// #define CONFIG_ECMA_GLOBAL_ENVIRONMENT_DECLARATIVE
-
-/**
- * Number of ecma values inlined into VM stack frame
- */
-#define CONFIG_VM_STACK_FRAME_INLINED_VALUES_NUMBER (16)
 
 #endif /* !CONFIG_H */

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -39,15 +39,11 @@
 void
 ecma_init_global_lex_env (void)
 {
-#ifdef CONFIG_ECMA_GLOBAL_ENVIRONMENT_DECLARATIVE
-  JERRY_CONTEXT (ecma_global_lex_env_p) = ecma_create_decl_lex_env (NULL);
-#else /* !CONFIG_ECMA_GLOBAL_ENVIRONMENT_DECLARATIVE */
   ecma_object_t *glob_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL);
 
   JERRY_CONTEXT (ecma_global_lex_env_p) = ecma_create_object_lex_env (NULL, glob_obj_p, false);
 
   ecma_deref_object (glob_obj_p);
-#endif /* CONFIG_ECMA_GLOBAL_ENVIRONMENT_DECLARATIVE */
 } /* ecma_init_global_lex_env */
 
 /**

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -303,7 +303,6 @@ void jerry_init (jerry_init_flag_t flags);
 void jerry_cleanup (void);
 void jerry_register_magic_strings (const jerry_char_ptr_t *ex_str_items_p, uint32_t count,
                                    const jerry_length_t *str_lengths_p);
-void jerry_get_memory_limits (size_t *out_data_bss_brk_limit_p, size_t *out_stack_limit_p);
 void jerry_gc (void);
 void *jerry_get_context_data (const jerry_context_data_manager_t *manager_p);
 

--- a/jerry-core/vm/vm-stack.h
+++ b/jerry-core/vm/vm-stack.h
@@ -26,11 +26,6 @@
  */
 
 /**
- * Number of ecma values inlined into stack frame
- */
-#define VM_STACK_FRAME_INLINED_VALUES_NUMBER CONFIG_VM_STACK_FRAME_INLINED_VALUES_NUMBER
-
-/**
  * Header of a ECMA stack frame's chunk
  */
 typedef struct


### PR DESCRIPTION
Also remove the legacy `jerry_get_memory_limits` API function as it
does not report either useful or valid information.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu