### PR TITLE
Use ecma_number_t instead of double where possible

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -303,7 +303,7 @@ ecma_builtin_number_prototype_object_to_string (ecma_value_t this_arg, /**< this
          * cases that can cause incorrect results due to precision issues, so we use a loop instead.
          */
         magnitude = 0;
-        double counter = this_arg_number;
+        ecma_number_t counter = this_arg_number;
         while (counter >= radix)
         {
           counter /= radix;

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -680,7 +680,7 @@ ecma_builtin_typedarray_prototype_set (ecma_value_t this_arg, /**< this argument
   {
     target_offset_num = 0;
   }
-  if (target_offset_num <= -1.0 || target_offset_num >= (double) UINT32_MAX + 0.5)
+  if (target_offset_num <= -1.0 || target_offset_num >= (ecma_number_t) UINT32_MAX + 0.5)
   {
     return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid offset"));
   }

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -138,7 +138,7 @@ ecma_op_create_arraybuffer_object (const ecma_value_t *arguments_list_p, /**< li
 
     const uint32_t maximum_size_in_byte = UINT32_MAX - sizeof (ecma_extended_object_t) - JMEM_ALIGNMENT + 1;
 
-    if (length_num <= -1.0 || length_num > (double) maximum_size_in_byte + 0.5)
+    if (length_num <= -1.0 || length_num > (ecma_number_t) maximum_size_in_byte + 0.5)
     {
       return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid ArrayBuffer length."));
     }


### PR DESCRIPTION
Some code paths explicitly used double instead of ecma_number_t
even though the values assigned from or compared to were of type
ecma_value_t.

Related to #2251

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu