### PR TITLE
Move (almost all) Travis CI jobs to container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: c
 
-# Default test platform: Ubuntu Trusty with sudo support.
+# Default environment: Container-based (sudo-less) Ubuntu Trusty 14.04.
 os: linux
 dist: trusty
-sudo: required
+sudo: false
 
-# Default dependency installation step #1: install dependencies for linux.
-# Other platforms can change this by redefining the 'before_install' stage in
-# the matrix below.
-before_install: tools/apt-get-install-deps.sh
-
-# Default dependency installation step #2: nop intentionally.
-# Jobs can add their own dependencies on top of 'before_install' by redefinig
-# the 'install' stage in the matrix below.
+# Default dependency installation step: nop intentionally.
+# Jobs can add their own dependencies by redefinig the 'install' stage in the matrix below.
 install: true
 
 # Default job task: run tests as defined in the $OPT environment variable.
@@ -22,23 +16,88 @@ script: tools/run-tests.py $OPTS
 # All the job definitions in the matrix.
 matrix:
   include:
-    - env: OPTS="--check-signed-off=travis --check-cppcheck --check-doxygen --check-vera --check-license --check-magic-strings --check-pylint"
+    - env:
+        - JOBNAME="Checks"
+        - OPTS="--check-signed-off=travis --check-cppcheck --check-doxygen --check-vera --check-license --check-magic-strings --check-pylint"
       install: pip install --user pylint==1.6.5
-    - env: OPTS="--jerry-debugger"
-    - env: OPTS="--quiet --jerry-tests --jerry-test-suite"
-    - env: OPTS="--quiet --jerry-tests --jerry-test-suite --toolchain=cmake/toolchain_linux_armv7l.cmake" TIMEOUT=300
-      install: tools/apt-get-install-qemu-arm.sh
-    - env: OPTS="--buildoption-test"
-    - env: OPTS="--quiet --jerry-tests --jerry-test-suite --buildoptions=--jerry-libc=off,--compile-flag=-m32,--cpointer-32bit=on"
-    - env: OPTS="--unittests"
-    - env: OPTS="--unittests --buildoptions=--cmake-param=-DFEATURE_INIT_FINI=ON"
-    - env: OPTS="--test262"
-      install: sudo timedatectl set-timezone America/Los_Angeles
-    - os: osx
-      before_install: tools/brew-install-deps.sh
-      env: OPTS="--quiet --jerry-tests --jerry-test-suite --unittests"
-    - install: echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
-      env:
+      addons:
+        apt:
+          packages: [doxygen, cppcheck, vera++]
+
+    - env:
+        - JOBNAME="Linux/x86-64 Build & Correctness Tests"
+        - OPTS="--quiet --jerry-tests --jerry-test-suite"
+
+    - env:
+        - JOBNAME="Linux/x86 (cpointer-32bit) Build & Correctness Tests"
+        - OPTS="--quiet --jerry-tests --jerry-test-suite --buildoptions=--jerry-libc=off,--compile-flag=-m32,--cpointer-32bit=on"
+      addons:
+        apt:
+          packages: [gcc-multilib]
+
+    - env:
+        - JOBNAME="Linux/ARM Build & Correctness Tests"
+        - OPTS="--quiet --jerry-tests --jerry-test-suite --toolchain=cmake/toolchain_linux_armv7l.cmake"
+        - TIMEOUT=300
+      sudo: true # keep on sudo-enabled VM to allow qemu to register itself to binfmt_misc
+      addons:
+        apt:
+          packages: [gcc-arm-linux-gnueabihf, libc6-dev-armhf-cross, qemu-user-static]
+
+    - env:
+        - JOBNAME="OSX/x86-64 Build, Correctness & Unit Tests"
+        - OPTS="--quiet --jerry-tests --jerry-test-suite --unittests"
+      os: osx
+      install: tools/brew-install-deps.sh
+
+    - env:
+        - JOBNAME="Build Tests"
+        - OPTS="--buildoption-test"
+      addons:
+        apt:
+          packages: [gcc-multilib]
+
+    - env:
+        - JOBNAME="Unit Tests"
+        - OPTS="--unittests"
+
+    - env:
+        - JOBNAME="Unit Tests (INIT_FINI)"
+        - OPTS="--unittests --buildoptions=--cmake-param=-DFEATURE_INIT_FINI=ON"
+
+    - env:
+        - JOBNAME="Debugger Tests"
+        - OPTS="--jerry-debugger"
+
+    - env:
+        - JOBNAME="Conformance Tests"
+        - OPTS="--test262"
+        - TZ=America/Los_Angeles
+
+    - env:
+        - JOBNAME="ASAN Tests"
+        - OPTS="--quiet --jerry-tests --jerry-test-suite --skip-list=parser-oom.js --buildoptions=--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--jerry-libc=off,--static-link=off,--system-allocator=on,--linker-flag=-fuse-ld=gold"
+        - ASAN_OPTIONS=detect_stack_use_after_return=1:check_initialization_order=true:strict_init_order=true
+        - TIMEOUT=600
+      compiler: gcc-5
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: [gcc-5, gcc-5-multilib]
+
+    - env:
+        - JOBNAME="UBSAN Tests"
+        - OPTS="--quiet --jerry-tests --jerry-test-suite --skip-list=parser-oom.js --buildoptions=--compile-flag=-fsanitize=undefined,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--debug,--jerry-libc=off,--static-link=off,--system-allocator=on,--linker-flag=-fuse-ld=gold"
+        - UBSAN_OPTIONS=print_stacktrace=1
+        - TIMEOUT=600
+      compiler: gcc-5
+      addons:
+        apt:
+          sources: ubuntu-toolchain-r-test
+          packages: [gcc-5, gcc-5-multilib]
+
+    - env:
+        - JOBNAME="Coverity Scan"
         # Declaration of the encrypted COVERITY_SCAN_TOKEN, created via the
         # "travis encrypt" command using the project repo's public key.
         - secure: "V7BdXv3FCVkFGEfKfWto6I+Sytou1zTCGyn49xurkBfKNsG/3vbkXfsbK1m6lCZxmY7W/1odpfjixpAPZgy2L4FgPZK6/UyVvC8pIFjDOubcEniN48haleSvm/ZFPLDifxDL2+VVFtK1oRYPtDBzzSoUCcfwovgk+Wy+tSBnhnyRLqO/WaI6PqFof7ECYMTRlJVjioZARVP4YmkBruIPmGDdR/3EvwowlxfuiFoPheix61ug4x3tpTBW2qWgvFjDyCZXFz4pJrBQPTAIbyKMxHcBykJjl9eR+dWAOsvE1Uw48tFOJxjKDfUttVQUPsyKFllmcCVS0fDYB5pzZOmRUPxJmox1jt8J1FY85Ri1PGY0THBPM2H7to4Yf2418Y3539epbN8p+79dwaM7e2OiJ2owukbWI7PoNqIz5DV5zxpIKsOQfeWuNLJOgsBePEIU7lz133Si/2d5W/7If46B1d+hZRBJfSYksgDqDU6G/voZkPf0K5bKe2O2BxiIW1DYk4yQ1ecZAkqGjZ8jG3zYGMG3mSF4VyuU4UGFG1Pg8fw7Ap5zuHxSVY1H9dtu4T6JQG3aj/x1omlzfw48DjgkwxVhf7Xvl3yfR7pzydYheLX3MZYtcVo7rWnglZFZoUjWDK1StbmzsvPftvwWtoDTWlzo4xeSXhahSJvJyc4U8Wc="
@@ -51,24 +110,7 @@ matrix:
           build_command: "tools/build.py --clean"
           branch_pattern: master
       script: true # Changed to nop, Coverity Scan has already built the project by the time 'script' stage is reached.
-    - compiler: gcc-5
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-            - gcc-5-multilib
-      env: OPTS="--quiet --jerry-tests --jerry-test-suite --skip-list=parser-oom.js --buildoptions=--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--jerry-libc=off,--static-link=off,--system-allocator=on,--linker-flag=-fuse-ld=gold" ASAN_OPTIONS=detect_stack_use_after_return=1:check_initialization_order=true:strict_init_order=true TIMEOUT=600
-    - compiler: gcc-5
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-5
-            - gcc-5-multilib
-      env: OPTS="--quiet --jerry-tests --jerry-test-suite --skip-list=parser-oom.js --buildoptions=--compile-flag=-fsanitize=undefined,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--debug,--jerry-libc=off,--static-link=off,--system-allocator=on,--linker-flag=-fuse-ld=gold" UBSAN_OPTIONS=print_stacktrace=1 TIMEOUT=600
+
     - env: JOBNAME="SonarQube"
       addons:
         sonarcloud:
@@ -87,49 +129,63 @@ matrix:
       cache:
         directories:
           - '${HOME}/.sonar/cache'
+
     - env: JOBNAME="ESP8266 Build Test"
       cache: ccache
-      install: make -f ./targets/esp8266/Makefile.travis install
+      install: make -f ./targets/esp8266/Makefile.travis install-noapt
       script: make -f ./targets/esp8266/Makefile.travis script
+      addons:
+        apt:
+          packages: [gperf, texinfo, wget]
+
     - env: JOBNAME="Mbed/K64F Build Test"
       addons:
         apt:
           sources:
             - sourceline: ppa:team-gcc-arm-embedded/ppa
-          packages:
-            - gcc-arm-embedded
-      install: make -f ./targets/mbed/Makefile.travis install
+          packages: [gcc-arm-embedded, ninja-build, libffi-dev, libssl-dev]
+      install: make -f ./targets/mbed/Makefile.travis install-noapt
       script: make -f ./targets/mbed/Makefile.travis script
+
     - env: JOBNAME="Mbed OS 5/K64F Build Test"
       addons:
         apt:
           sources:
             - sourceline: ppa:team-gcc-arm-embedded/ppa
-          packages:
-            - gcc-arm-embedded
+          packages: [gcc-arm-embedded]
       install: make -f ./targets/mbedos5/Makefile.travis install
       script: make -f ./targets/mbedos5/Makefile.travis script
+
     - env: JOBNAME="NuttX/STM32F4 Build Test"
-      install: make -f targets/nuttx-stm32f4/Makefile.travis install
+      install: make -f targets/nuttx-stm32f4/Makefile.travis install-noapt
       script: make -f targets/nuttx-stm32f4/Makefile.travis script
+      addons:
+        apt:
+          packages: [gcc-arm-none-eabi, libnewlib-arm-none-eabi, gperf]
+
     - env: JOBNAME="RIOT/STM32F4 Build Test"
-      install: make -f ./targets/riot-stm32f4/Makefile.travis install
+      install: make -f ./targets/riot-stm32f4/Makefile.travis install-noapt
       script: make -f ./targets/riot-stm32f4/Makefile.travis script
+      addons:
+        apt:
+          packages: [gcc-arm-none-eabi, libnewlib-arm-none-eabi]
+
     - env: JOBNAME="Tizen RT/Artik053 Build Test"
       addons:
         apt:
           sources:
             - sourceline: ppa:team-gcc-arm-embedded/ppa
-          packages:
-            - gcc-arm-embedded
+          packages: [gcc-arm-embedded]
       install: make -f ./targets/tizenrt-artik053/Makefile.travis install
       script: make -f ./targets/tizenrt-artik053/Makefile.travis script
+
     - env: JOBNAME="Zephyr/Arduino 101 Build Test"
-      install: make -f ./targets/zephyr/Makefile.travis install
+      install: make -f ./targets/zephyr/Makefile.travis install-noapt
       script: make -f ./targets/zephyr/Makefile.travis script
-  allow_failures:
-    - env: JOBNAME="Mbed/K64F Build Test"
-    - env: JOBNAME="Zephyr/Arduino 101 Build Test"
+      addons:
+        apt:
+          packages: [gperf, dfu-util, device-tree-compiler, python3-ply, python3-pip]
+
   fast_finish: true
 
 # The channel name "chat.freenode.net#jerryscript"

--- a/targets/esp8266/Makefile.travis
+++ b/targets/esp8266/Makefile.travis
@@ -41,7 +41,8 @@ install-espressif-sdk:
 	wget https://github.com/esp8266/esp8266-wiki/raw/master/libs/libhal.a -O ../ESP8266_SDK/lib/libhal.a
 
 # Perform all the necessary (JerryScript-independent) installation steps.
-install: install-apt-get-deps install-xtensa-kx106-gcc install-espressif-sdk
+install-noapt: install-xtensa-kx106-gcc install-espressif-sdk
+install: install-apt-get-deps install-noapt
 
 
 ## Targets for building ESP8266 with JerryScript.

--- a/targets/mbed/Makefile.mbed
+++ b/targets/mbed/Makefile.mbed
@@ -74,6 +74,7 @@ js2c:
 
 yotta:
 	cd targets/mbed; \
+	 export WCMAKE=`which cmake`; export PATH=`pwd`:$$PATH; \
 	 yotta target $(YOTTA_TARGET); \
 	 yotta build
 

--- a/targets/mbed/Makefile.travis
+++ b/targets/mbed/Makefile.travis
@@ -27,12 +27,12 @@ install-apt-get-deps:
 
 # Install yotta
 install-yotta:
-	pyenv global 2.7.13 # force the python version to a newer one
 	pip install --user "pyOpenSSL<17.5" # fix for failures with pyOpenSSL 17.5
 	pip install --user yotta
 
 # Perform all the necessary (JerryScript-independent) installation steps.
-install: install-apt-get-deps install-yotta
+install-noapt: install-yotta
+install: install-apt-get-deps install-noapt
 
 
 ## Targets for building Mbed with JerryScript.

--- a/targets/mbed/cmake
+++ b/targets/mbed/cmake
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# HACK:
+#       Wrapping cmake to ensure that yotta-driven cmake (3.6+) accepts
+#       arm-none-eabi-gcc as working compiler.
+#       WCMAKE variable must be set to the full path of the wrapped cmake.
+#       Related yotta issue: https://github.com/ARMmbed/yotta/issues/783
+$WCMAKE -DCMAKE_C_COMPILER_WORKS=TRUE $@

--- a/targets/nuttx-stm32f4/Makefile.travis
+++ b/targets/nuttx-stm32f4/Makefile.travis
@@ -43,7 +43,8 @@ install-clone-nuttx:
 	git clone https://bitbucket.org/nuttx/nuttx.git ../nuttx -b nuttx-7.22
 
 # Perform all the necessary (JerryScript-independent) installation steps.
-install: install-apt-get-deps install-kconfig install-clone-nuttx
+install-noapt: install-kconfig install-clone-nuttx
+install: install-apt-get-deps install-noapt
 
 
 ## Targets for building NuttX with JerryScript.

--- a/targets/riot-stm32f4/Makefile.travis
+++ b/targets/riot-stm32f4/Makefile.travis
@@ -30,7 +30,8 @@ install-clone-riot:
 	git clone git://github.com/RIOT-OS/RIOT.git ../RIOT -b 2017.10
 
 # Perform all the necessary (JerryScript-independent) installation steps.
-install: install-apt-get-deps install-clone-riot
+install-noapt: install-clone-riot
+install: install-apt-get-deps install-noapt
 
 
 ## Targets for building RIOT with JerryScript.

--- a/targets/zephyr/Makefile.travis
+++ b/targets/zephyr/Makefile.travis
@@ -29,17 +29,17 @@ install-apt-get-deps:
 install-zephyr-sdk:
 	wget https://github.com/zephyrproject-rtos/meta-zephyr-sdk/releases/download/0.9.2/zephyr-sdk-0.9.2-setup.run -O ../zephyr-sdk-0.9.2-setup.run
 	sh ../zephyr-sdk-0.9.2-setup.run -- -y -d $(CURDIR)/../zephyr-sdk-0.9.2
-	wget https://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.sh
-	sudo sh cmake-3.8.2-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
 	cmake --version
 
 # Fetch Zephyr Project repository and install python dependencies.
-install-zephyr: install-apt-get-deps
+install-zephyr:
 	git clone https://github.com/zephyrproject-rtos/zephyr.git ../zephyr -b v1.10.0
+	pip3 install --user -U setuptools
 	pip3 install --user -r ../zephyr/scripts/requirements.txt
 
 # Perform all the necessary (JerryScript-independent) installation steps.
-install: install-zephyr-sdk install-zephyr
+install-noapt: install-zephyr-sdk install-zephyr
+install: install-apt-get-deps install-noapt
 
 
 ## Targets for building Zephyr with JerryScript.


### PR DESCRIPTION
Container-based VMs promise significantly faster boot times.

More or less related changes:
- Added a JOBNAME to all jobs.
- Added `install-noapt` target to several Makefile.travis files to
  avoid `sudo apt-get install ...` steps. Those installations are
  now handled by the apt addon of Travis. The `install` targets are
  kept anyway to keep the makefiles self-contained.
- Removed a legacy workaround from the Coverity Scan job as it
  isn't necessary anymore to fiddle with the cerificates of
  scan.coverity.com.
- Fixed the Mbed and the Zephyr jobs.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu