### PR TITLE
Revert the Mbed Travis CI job to sudo-based VM to avoid sporadic OOMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,6 +139,7 @@ matrix:
           packages: [gperf, texinfo, wget]
 
     - env: JOBNAME="Mbed/K64F Build Test"
+      sudo: true # keep on sudo-enabled VM to avoid gcc dying of OOM
       addons:
         apt:
           sources:


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu