### PR TITLE
Build fix after landing #2249

### DIFF
--- a/tests/unit-core/test-typedarray.c
+++ b/tests/unit-core/test-typedarray.c
@@ -408,7 +408,7 @@ static void test_property_by_index (test_entry_t test_entries[])
     }
 
     jerry_value_t set_undefined = jerry_set_property_by_index (typedarray, 100, jerry_create_number (50));
-    TEST_ASSERT (jerry_value_has_error_flag (set_undefined));
+    TEST_ASSERT (jerry_value_is_error (set_undefined));
     jerry_value_t get_undefined = jerry_get_property_by_index (typedarray, 100);
     TEST_ASSERT (jerry_value_is_undefined (get_undefined));
 


### PR DESCRIPTION
The old `jerry_value_has_error_flag` function was used
when the #2249 PR was merged.

Replaced with the correct `jerry_value_is_error` call.

JerryScript-DCO-1.0-Signed-off-by: Peter Gal pgal.u-szeged@partner.samsung.com