### PR TITLE
Cleanup code around JERRY_UNREACHABLEs

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -154,9 +154,9 @@ snapshot_add_compiled_code (ecma_compiled_code_t *compiled_code_p, /**< compiled
   uint8_t *copied_code_start_p = snapshot_buffer_p + globals_p->snapshot_buffer_write_offset;
   ecma_compiled_code_t *copied_code_p = (ecma_compiled_code_t *) copied_code_start_p;
 
+#ifndef CONFIG_DISABLE_REGEXP_BUILTIN
   if (!(compiled_code_p->status_flags & CBC_CODE_FLAGS_FUNCTION))
   {
-#ifndef CONFIG_DISABLE_REGEXP_BUILTIN
     /* Regular expression. */
     if (globals_p->snapshot_buffer_write_offset + sizeof (ecma_compiled_code_t) > snapshot_buffer_size)
     {
@@ -204,11 +204,11 @@ snapshot_add_compiled_code (ecma_compiled_code_t *compiled_code_p, /**< compiled
 
     copied_code_p->status_flags = compiled_code_p->status_flags;
 
-#else /* CONFIG_DISABLE_REGEXP_BUILTIN */
-    JERRY_UNREACHABLE (); /* RegExp is not supported in the selected profile. */
-#endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */
     return start_offset;
   }
+#endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */
+
+  JERRY_ASSERT (compiled_code_p->status_flags & CBC_CODE_FLAGS_FUNCTION);
 
   if (!snapshot_write_to_buffer_by_offset (snapshot_buffer_p,
                                            snapshot_buffer_size,
@@ -536,9 +536,9 @@ snapshot_load_compiled_code (const uint8_t *base_addr_p, /**< base address of th
   ecma_compiled_code_t *bytecode_p = (ecma_compiled_code_t *) base_addr_p;
   uint32_t code_size = ((uint32_t) bytecode_p->size) << JMEM_ALIGNMENT_LOG;
 
+#ifndef CONFIG_DISABLE_REGEXP_BUILTIN
   if (!(bytecode_p->status_flags & CBC_CODE_FLAGS_FUNCTION))
   {
-#ifndef CONFIG_DISABLE_REGEXP_BUILTIN
     const re_compiled_code_t *re_bytecode_p = NULL;
 
     const uint8_t *regex_start_p = ((const uint8_t *) bytecode_p) + sizeof (ecma_compiled_code_t);
@@ -554,10 +554,10 @@ snapshot_load_compiled_code (const uint8_t *base_addr_p, /**< base address of th
     ecma_deref_ecma_string (pattern_str_p);
 
     return (ecma_compiled_code_t *) re_bytecode_p;
-#else /* CONFIG_DISABLE_REGEXP_BUILTIN */
-    JERRY_UNREACHABLE (); /* RegExp is not supported in the selected profile. */
-#endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */
   }
+#endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */
+
+  JERRY_ASSERT (bytecode_p->status_flags & CBC_CODE_FLAGS_FUNCTION);
 
   size_t header_size;
   uint32_t argument_end = 0;

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -100,11 +100,7 @@ static const char * const wrong_args_msg_p = "wrong type of argument";
 static inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_assert_api_available (void)
 {
-  if (JERRY_UNLIKELY (!(JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE)))
-  {
-    /* Terminates the execution. */
-    JERRY_UNREACHABLE ();
-  }
+  JERRY_ASSERT (JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE);
 } /* jerry_assert_api_available */
 
 /**
@@ -178,11 +174,8 @@ jerry_throw (jerry_value_t value) /**< return value */
 void
 jerry_init (jerry_init_flag_t flags) /**< combination of Jerry flags */
 {
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE))
-  {
-    /* This function cannot be called twice unless jerry_cleanup is called. */
-    JERRY_UNREACHABLE ();
-  }
+  /* This function cannot be called twice unless jerry_cleanup is called. */
+  JERRY_ASSERT (!(JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE));
 
   /* Zero out all members. */
   memset (&JERRY_CONTEXT (JERRY_CONTEXT_FIRST_MEMBER), 0, sizeof (jerry_context_t));
@@ -834,21 +827,16 @@ jerry_value_get_type (const jerry_value_t value) /**< input value to check */
     {
       return JERRY_TYPE_FUNCTION;
     }
-    case LIT_MAGIC_STRING_OBJECT:
+    default:
     {
+      JERRY_ASSERT (lit_id == LIT_MAGIC_STRING_OBJECT);
+
       /* Based on the ECMA 262 5.1 standard the 'null' value is an object.
        * Thus we'll do an extra check for 'null' here.
        */
       return ecma_is_value_null (argument) ? JERRY_TYPE_NULL : JERRY_TYPE_OBJECT;
     }
-    default:
-    {
-      JERRY_UNREACHABLE ();
-      break;
-    }
   }
-
-  return JERRY_TYPE_NONE;
 } /* jerry_value_get_type */
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -930,12 +930,6 @@ ecma_deref_ecma_string (ecma_string_t *string_p) /**< ecma-string */
       ecma_dealloc_string_buffer (string_p, string_p->u.long_utf8_string_size + sizeof (ecma_long_string_t));
       return;
     }
-    case ECMA_STRING_CONTAINER_UINT32_IN_DESC:
-    case ECMA_STRING_CONTAINER_MAGIC_STRING_EX:
-    {
-      /* only the string descriptor itself should be freed */
-      break;
-    }
     case ECMA_STRING_LITERAL_NUMBER:
     {
       ecma_free_value (string_p->u.lit_number);
@@ -943,7 +937,10 @@ ecma_deref_ecma_string (ecma_string_t *string_p) /**< ecma-string */
     }
     default:
     {
-      JERRY_UNREACHABLE ();
+      JERRY_ASSERT (ECMA_STRING_GET_CONTAINER (string_p) == ECMA_STRING_CONTAINER_UINT32_IN_DESC
+                    || ECMA_STRING_GET_CONTAINER (string_p) == ECMA_STRING_CONTAINER_MAGIC_STRING_EX);
+
+      /* only the string descriptor itself should be freed */
       break;
     }
   }
@@ -2107,6 +2104,7 @@ ecma_string_get_size (const ecma_string_t *string_p) /**< ecma-string */
     default:
     {
       JERRY_ASSERT (ECMA_STRING_GET_CONTAINER (string_p) == ECMA_STRING_CONTAINER_MAGIC_STRING_EX);
+
       return lit_get_magic_string_ex_size (string_p->u.magic_string_ex_id);
     }
   }

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -714,11 +714,6 @@ ecma_copy_value (ecma_value_t value)  /**< value description */
 {
   switch (ecma_get_value_type_field (value))
   {
-    case ECMA_TYPE_DIRECT:
-    case ECMA_TYPE_DIRECT_STRING:
-    {
-      return value;
-    }
     case ECMA_TYPE_FLOAT:
     {
       ecma_number_t *num_p = (ecma_number_t *) ecma_get_pointer_from_ecma_value (value);
@@ -737,8 +732,10 @@ ecma_copy_value (ecma_value_t value)  /**< value description */
     }
     default:
     {
-      JERRY_UNREACHABLE ();
-      return ECMA_VALUE_UNDEFINED;
+      JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT
+                    || ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT_STRING);
+
+      return value;
     }
   }
 } /* ecma_copy_value */
@@ -905,13 +902,6 @@ ecma_free_value (ecma_value_t value) /**< value description */
 {
   switch (ecma_get_value_type_field (value))
   {
-    case ECMA_TYPE_DIRECT:
-    case ECMA_TYPE_DIRECT_STRING:
-    {
-      /* no memory is allocated */
-      break;
-    }
-
     case ECMA_TYPE_FLOAT:
     {
       ecma_number_t *number_p = (ecma_number_t *) ecma_get_pointer_from_ecma_value (value);
@@ -934,7 +924,10 @@ ecma_free_value (ecma_value_t value) /**< value description */
 
     default:
     {
-      JERRY_UNREACHABLE ();
+      JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT
+                    || ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT_STRING);
+
+      /* no memory is allocated */
       break;
     }
   }

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -784,8 +784,9 @@ ecma_free_property (ecma_object_t *object_p, /**< object the property belongs to
       ecma_free_value_if_not_object (ECMA_PROPERTY_VALUE_PTR (property_p)->value);
       break;
     }
-    case ECMA_PROPERTY_TYPE_NAMEDACCESSOR:
+    default:
     {
+      JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (*property_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 #ifdef JERRY_CPOINTER_32_BIT
       ecma_getter_setter_pointers_t *getter_setter_pair_p;
       getter_setter_pair_p = ECMA_GET_POINTER (ecma_getter_setter_pointers_t,
@@ -793,11 +794,6 @@ ecma_free_property (ecma_object_t *object_p, /**< object the property belongs to
       jmem_pools_free (getter_setter_pair_p, sizeof (ecma_getter_setter_pointers_t));
 #endif /* JERRY_CPOINTER_32_BIT */
       break;
-    }
-    default:
-    {
-      JERRY_UNREACHABLE ();
-      return;
     }
   }
 
@@ -1056,8 +1052,9 @@ ecma_assert_object_contains_the_property (const ecma_object_t *object_p, /**< ec
                                     prop_iter_p->next_property_cp);
   }
 
-  while (prop_iter_p != NULL)
+  while (true)
   {
+    JERRY_ASSERT (prop_iter_p != NULL);
     JERRY_ASSERT (ECMA_PROPERTY_IS_PROPERTY_PAIR (prop_iter_p));
 
     ecma_property_pair_t *prop_pair_p = (ecma_property_pair_t *) prop_iter_p;
@@ -1074,9 +1071,6 @@ ecma_assert_object_contains_the_property (const ecma_object_t *object_p, /**< ec
     prop_iter_p = ECMA_GET_POINTER (ecma_property_header_t,
                                     prop_iter_p->next_property_cp);
   }
-
-  JERRY_UNREACHABLE ();
-
 #else /* JERRY_NDEBUG */
   JERRY_UNUSED (object_p);
   JERRY_UNUSED (prop_value_p);

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -232,8 +232,11 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
   size_t row_index = ecma_lcache_row_index (object_cp, name_hash);
   ecma_lcache_hash_entry_t *entry_p = JERRY_HASH_TABLE_CONTEXT (table) [row_index];
 
-  for (uint32_t entry_index = 0; entry_index < ECMA_LCACHE_HASH_ROW_LENGTH; entry_index++)
+  while (true)
   {
+    /* The property must be present. */
+    JERRY_ASSERT (entry_p - JERRY_HASH_TABLE_CONTEXT (table) [row_index] < ECMA_LCACHE_HASH_ROW_LENGTH);
+
     if (entry_p->object_cp != ECMA_NULL_POINTER && entry_p->prop_p == prop_p)
     {
       JERRY_ASSERT (entry_p->object_cp == object_cp);
@@ -243,9 +246,6 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
     }
     entry_p++;
   }
-
-  /* The property must be present. */
-  JERRY_UNREACHABLE ();
 #else  /* CONFIG_ECMA_LCACHE_DISABLE */
   JERRY_UNUSED (name_cp);
 #endif /* !CONFIG_ECMA_LCACHE_DISABLE */

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -539,8 +539,6 @@ ecma_property_hashmap_find (ecma_property_hashmap_t *hashmap_p, /**< hashmap */
       JERRY_ASSERT (entry_index != start_entry_index);
 #endif /* !JERRY_NDEBUG */
     }
-
-    JERRY_UNREACHABLE ();
   }
 
   while (true)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -259,6 +259,7 @@ ecma_builtin_date_prototype_dispatch_get (uint16_t builtin_routine_id, /**< buil
     default:
     {
       JERRY_ASSERT (builtin_routine_id == ECMA_DATE_PROTOTYPE_GET_UTC_TIMEZONE_OFFSET);
+
       date_num = ecma_date_timezone_offset (date_num);
       break;
     }
@@ -342,6 +343,7 @@ ecma_builtin_date_prototype_dispatch_set (uint16_t builtin_routine_id, /**< buil
     {
       JERRY_ASSERT (builtin_routine_id == ECMA_DATE_PROTOTYPE_SET_HOURS
                     || builtin_routine_id == ECMA_DATE_PROTOTYPE_SET_UTC_HOURS);
+
       conversions = 4;
       break;
     }
@@ -429,6 +431,7 @@ ecma_builtin_date_prototype_dispatch_set (uint16_t builtin_routine_id, /**< buil
       {
         JERRY_ASSERT (builtin_routine_id == ECMA_DATE_PROTOTYPE_SET_DATE
                       || builtin_routine_id == ECMA_DATE_PROTOTYPE_SET_UTC_DATE);
+
         day = converted_number[0];
         break;
       }
@@ -511,6 +514,7 @@ ecma_builtin_date_prototype_dispatch_set (uint16_t builtin_routine_id, /**< buil
       {
         JERRY_ASSERT (builtin_routine_id == ECMA_DATE_PROTOTYPE_SET_UTC_MILLISECONDS
                       || builtin_routine_id == ECMA_DATE_PROTOTYPE_SET_MILLISECONDS);
+
         ms = converted_number[0];
         break;
       }
@@ -643,6 +647,7 @@ ecma_builtin_date_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< 
     default:
     {
       JERRY_ASSERT (builtin_routine_id == ECMA_DATE_PROTOTYPE_TO_UTC_STRING);
+
       return ecma_date_value_to_utc_string (*prim_value_p);
     }
   }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -264,13 +264,10 @@ ecma_builtin_global_object_parse_int (ecma_value_t this_arg, /**< this argument 
           {
             current_number =  (ecma_number_t) current_char - LIT_CHAR_UPPERCASE_A + 10;
           }
-          else if (lit_char_is_decimal_digit (current_char))
-          {
-            current_number =  (ecma_number_t) current_char - LIT_CHAR_0;
-          }
           else
           {
-            JERRY_UNREACHABLE ();
+            JERRY_ASSERT (lit_char_is_decimal_digit (current_char));
+            current_number =  (ecma_number_t) current_char - LIT_CHAR_0;
           }
 
           value += current_number * multiplier;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -740,8 +740,10 @@ ecma_date_to_string_format (ecma_number_t datetime_number, /**< datetime */
         number_length = 2;
         break;
       }
-      case LIT_CHAR_UPPERCASE_Z: /* Time zone seconds part. */
+      default:
       {
+        JERRY_ASSERT (*format_p == LIT_CHAR_UPPERCASE_Z); /* Time zone seconds part. */
+
         int32_t time_zone = (int32_t) ecma_date_local_time_zone (datetime_number);
 
         if (time_zone < 0)
@@ -751,11 +753,6 @@ ecma_date_to_string_format (ecma_number_t datetime_number, /**< datetime */
 
         number = time_zone % (int32_t) ECMA_DATE_MS_PER_HOUR;
         number_length = 2;
-        break;
-      }
-      default:
-      {
-        JERRY_UNREACHABLE ();
         break;
       }
     }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1266,6 +1266,7 @@ ecma_builtin_json_quote (ecma_string_t *string_p) /**< string that should be quo
         default:
         {
           JERRY_ASSERT (current_char == LIT_CHAR_BACKSLASH || current_char == LIT_CHAR_DOUBLE_QUOTE);
+
           break;
         }
       }

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -416,6 +416,7 @@ ecma_instantiate_builtin_helper (ecma_builtin_id_t builtin_id, /**< built-in id 
 static void
 ecma_instantiate_builtin (ecma_builtin_id_t id) /**< built-in id */
 {
+  JERRY_ASSERT (id < ECMA_BUILTIN_ID__COUNT);
   switch (id)
   {
 #define BUILTIN(builtin_id, \
@@ -437,8 +438,6 @@ ecma_instantiate_builtin (ecma_builtin_id_t id) /**< built-in id */
 #undef BUILTIN_ROUTINE
     default:
     {
-      JERRY_ASSERT (id < ECMA_BUILTIN_ID__COUNT);
-
       JERRY_UNREACHABLE (); /* The built-in is not implemented. */
     }
   }
@@ -685,11 +684,6 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
       {
         switch (curr_property_p->value)
         {
-          case ECMA_BUILTIN_NUMBER_NAN:
-          {
-            num = ecma_number_make_nan ();
-            break;
-          }
           case ECMA_BUILTIN_NUMBER_POSITIVE_INFINITY:
           {
             num = ecma_number_make_infinity (false);
@@ -702,7 +696,9 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
           }
           default:
           {
-            JERRY_UNREACHABLE ();
+            JERRY_ASSERT (curr_property_p->value == ECMA_BUILTIN_NUMBER_NAN);
+
+            num = ecma_number_make_nan ();
             break;
           }
         }
@@ -739,17 +735,14 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
       setter_p = ecma_builtin_make_function_object_for_setter_accessor (builtin_id, setter_id);
       break;
     }
-    case ECMA_BUILTIN_PROPERTY_ACCESSOR_READ_ONLY:
+    default:
     {
+      JERRY_ASSERT (curr_property_p->type == ECMA_BUILTIN_PROPERTY_ACCESSOR_READ_ONLY);
+
       is_accessor = true;
       getter_p = ecma_builtin_make_function_object_for_getter_accessor (builtin_id,
                                                                         curr_property_p->value);
       break;
-    }
-    default:
-    {
-      JERRY_UNREACHABLE ();
-      return NULL;
     }
   }
 

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.c
@@ -90,8 +90,7 @@ ecma_typedarray_helper_get_shift_size (uint8_t builtin_id) /**< the builtin id o
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
     default:
     {
-      JERRY_ASSERT (false);
-      return ECMA_BUILTIN_ID__COUNT;
+      JERRY_UNREACHABLE ();
     }
   }
 } /* ecma_typedarray_helper_get_shift_size */
@@ -125,8 +124,7 @@ ecma_typedarray_helper_get_magic_string (uint8_t builtin_id) /**< the builtin id
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
     default:
     {
-      JERRY_ASSERT (false);
-      return LIT_MAGIC_STRING__COUNT;
+      JERRY_UNREACHABLE ();
     }
   }
 #undef TYPEDARRAY_ID_CASE
@@ -161,8 +159,7 @@ ecma_typedarray_helper_get_prototype_id (uint8_t builtin_id) /**< the builtin id
 #endif /* CONFIG_ECMA_NUMBER_TYPE == CONFIG_ECMA_NUMBER_FLOAT64 */
     default:
     {
-      JERRY_ASSERT (false);
-      return ECMA_BUILTIN_ID__COUNT;
+      JERRY_UNREACHABLE ();
     }
   }
 #undef TYPEDARRAY_ID_CASE

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -82,12 +82,6 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 
   switch (error_type)
   {
-    case ECMA_ERROR_COMMON:
-    {
-      prototype_id = ECMA_BUILTIN_ID_ERROR_PROTOTYPE;
-      break;
-    }
-
     case ECMA_ERROR_EVAL:
     {
       prototype_id = ECMA_BUILTIN_ID_EVAL_ERROR_PROTOTYPE;
@@ -124,9 +118,11 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
       break;
     }
 
-    case ECMA_ERROR_NONE:
+    default:
     {
-      JERRY_UNREACHABLE ();
+      JERRY_ASSERT (error_type == ECMA_ERROR_COMMON);
+
+      prototype_id = ECMA_BUILTIN_ID_ERROR_PROTOTYPE;
       break;
     }
   }

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -169,18 +169,15 @@ ecma_op_general_object_delete (ecma_object_t *obj_p, /**< the object */
     /* b. */
     return ECMA_VALUE_TRUE;
   }
-  else if (is_throw)
+
+  /* 4. */
+  if (is_throw)
   {
-    /* 4. */
     return ecma_raise_type_error (ECMA_ERR_MSG ("Expected a configurable property."));
   }
-  else
-  {
-    /* 5. */
-    return ECMA_VALUE_FALSE;
-  }
 
-  JERRY_UNREACHABLE ();
+  /* 5. */
+  return ECMA_VALUE_FALSE;
 } /* ecma_op_general_object_delete */
 
 /**

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1136,18 +1136,24 @@ ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
                                                        is_throw);
     }
 
-    case ECMA_OBJECT_TYPE_PSEUDO_ARRAY:
+    default:
     {
+      JERRY_ASSERT (type == ECMA_OBJECT_TYPE_PSEUDO_ARRAY);
+
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
+#ifndef CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN
       if (ext_object_p->u.pseudo_array.type == ECMA_PSEUDO_ARRAY_ARGUMENTS)
       {
+#else /* CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */
+        JERRY_ASSERT (ext_object_p->u.pseudo_array.type == ECMA_PSEUDO_ARRAY_ARGUMENTS);
+#endif /* !CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */
         return ecma_op_arguments_object_define_own_property (obj_p,
                                                              property_name_p,
                                                              property_desc_p,
                                                              is_throw);
-      }
 #ifndef CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN
+      }
       /* ES2015 9.4.5.3 */
       if (ecma_is_typedarray (ecma_make_object_value (obj_p)))
       {
@@ -1184,19 +1190,10 @@ ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
                                                          property_name_p,
                                                          property_desc_p,
                                                          is_throw);
-
 #endif /* !CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */
       break;
     }
-    default:
-    {
-      JERRY_ASSERT (false);
-    }
   }
-
-  JERRY_UNREACHABLE ();
-
-  return ecma_reject (is_throw);
 } /* ecma_op_object_define_own_property */
 
 /**
@@ -1391,10 +1388,6 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
     {
       switch (type)
       {
-        case ECMA_OBJECT_TYPE_GENERAL:
-        {
-          break;
-        }
         case ECMA_OBJECT_TYPE_PSEUDO_ARRAY:
         {
 #ifndef CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN
@@ -1454,7 +1447,8 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
         }
         default:
         {
-          JERRY_UNREACHABLE ();
+          JERRY_ASSERT (type == ECMA_OBJECT_TYPE_GENERAL);
+
           break;
         }
       }
@@ -1795,10 +1789,6 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
 
       switch (ext_obj_p->u.pseudo_array.type)
       {
-        case ECMA_PSEUDO_ARRAY_ARGUMENTS:
-        {
-          return LIT_MAGIC_STRING_ARGUMENTS_UL;
-        }
 #ifndef CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN
         case ECMA_PSEUDO_ARRAY_TYPEDARRAY:
         case ECMA_PSEUDO_ARRAY_TYPEDARRAY_WITH_INFO:
@@ -1808,11 +1798,12 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
 #endif /* !CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */
         default:
         {
-          JERRY_UNREACHABLE ();
+          JERRY_ASSERT (ext_obj_p->u.pseudo_array.type == ECMA_PSEUDO_ARRAY_ARGUMENTS);
+
+          return LIT_MAGIC_STRING_ARGUMENTS_UL;
         }
       }
 
-      JERRY_UNREACHABLE ();
       break;
     }
     case ECMA_OBJECT_TYPE_FUNCTION:

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -364,21 +364,19 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
                  const lit_utf8_byte_t *str_p, /**< input string pointer */
                  const lit_utf8_byte_t **out_str_p) /**< [out] matching substring iterator */
 {
-  ecma_value_t ret_value = ECMA_VALUE_EMPTY;
-  re_opcode_t op;
-
   const lit_utf8_byte_t *str_curr_p = str_p;
 
-  while ((op = re_get_opcode (&bc_p)))
+  while (true)
   {
+    re_opcode_t op = re_get_opcode (&bc_p);
+
     switch (op)
     {
       case RE_OP_MATCH:
       {
         JERRY_TRACE_MSG ("Execute RE_OP_MATCH: match\n");
         *out_str_p = str_curr_p;
-        ret_value = ECMA_VALUE_TRUE;
-        return ret_value; /* match */
+        return ECMA_VALUE_TRUE; /* match */
       }
       case RE_OP_CHAR:
       {
@@ -1086,8 +1084,10 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         }
         return ECMA_VALUE_FALSE; /* fail */
       }
-      case RE_OP_GREEDY_ITERATOR:
+      default:
       {
+        JERRY_ASSERT (op == RE_OP_GREEDY_ITERATOR);
+
         uint32_t min, max, offset, num_of_iter;
         const lit_utf8_byte_t *sub_str_p = NULL;
 
@@ -1142,16 +1142,8 @@ re_match_regexp (re_matcher_ctx_t *re_ctx_p, /**< RegExp matcher context */
         }
         return ECMA_VALUE_FALSE; /* fail */
       }
-      default:
-      {
-        JERRY_TRACE_MSG ("UNKNOWN opcode (%u)!\n", (unsigned int) op);
-        return ecma_raise_common_error (ECMA_ERR_MSG ("Unknown RegExp opcode."));
-      }
     }
   }
-
-  JERRY_UNREACHABLE ();
-  return ECMA_VALUE_FALSE; /* fail */
 } /* re_match_regexp */
 
 /**

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -94,7 +94,6 @@ ecma_get_typedarray_element (lit_utf8_byte_t *src, /**< the location in the inte
     default:
     {
       JERRY_UNREACHABLE ();
-      return 0;
     }
   }
 } /* ecma_get_typedarray_element */

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -108,12 +108,9 @@ lit_get_magic_string_size_block_start (lit_utf8_size_t size) /**< magic string s
 const lit_utf8_byte_t *
 lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id) /**< extern magic string id */
 {
-  if (JERRY_CONTEXT (lit_magic_string_ex_array) && id < JERRY_CONTEXT (lit_magic_string_ex_count))
-  {
-    return JERRY_CONTEXT (lit_magic_string_ex_array)[id];
-  }
+  JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_array) && id < JERRY_CONTEXT (lit_magic_string_ex_count));
 
-  JERRY_UNREACHABLE ();
+  return JERRY_CONTEXT (lit_magic_string_ex_array)[id];
 } /* lit_get_magic_string_ex_utf8 */
 
 /**

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -373,14 +373,11 @@ lit_read_code_point_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with ch
     bytes_count = 3;
     ret = ((lit_code_point_t) (c & LIT_UTF8_LAST_4_BITS_MASK));
   }
-  else if ((c & LIT_UTF8_4_BYTE_MASK) == LIT_UTF8_4_BYTE_MARKER)
-  {
-    bytes_count = 4;
-    ret = ((lit_code_point_t) (c & LIT_UTF8_LAST_3_BITS_MASK));
-  }
   else
   {
-    JERRY_ASSERT (false);
+    JERRY_ASSERT ((c & LIT_UTF8_4_BYTE_MASK) == LIT_UTF8_4_BYTE_MARKER);
+    bytes_count = 4;
+    ret = ((lit_code_point_t) (c & LIT_UTF8_LAST_3_BITS_MASK));
   }
 
   JERRY_ASSERT (buf_size >= bytes_count);

--- a/jerry-core/vm/vm-stack.c
+++ b/jerry-core/vm/vm-stack.c
@@ -65,8 +65,10 @@ vm_stack_context_abort (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
       vm_stack_top_p -= PARSER_TRY_CONTEXT_STACK_ALLOCATION;
       break;
     }
-    case VM_CONTEXT_FOR_IN:
+    default:
     {
+      JERRY_ASSERT (VM_GET_CONTEXT_TYPE (vm_stack_top_p[-1]) == VM_CONTEXT_FOR_IN);
+
       ecma_collection_chunk_t *chunk_p;
       chunk_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (ecma_collection_chunk_t, vm_stack_top_p[-2]);
       uint32_t index = vm_stack_top_p[-3];
@@ -94,11 +96,6 @@ vm_stack_context_abort (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
 
       VM_MINUS_EQUAL_U16 (frame_ctx_p->context_depth, PARSER_FOR_IN_CONTEXT_STACK_ALLOCATION);
       vm_stack_top_p -= PARSER_FOR_IN_CONTEXT_STACK_ALLOCATION;
-      break;
-    }
-    default:
-    {
-      JERRY_UNREACHABLE ();
       break;
     }
   }


### PR DESCRIPTION
`JERRY_UNREACHABLE`s often signal code structure that could be
improved: they can usually either be rewritten to `JERRY_ASSERT`s
or eliminated by restructuring loops, `if`s or `#if`s. Roughly,
the only valid occurences are in default cases of `switch`es.

Moreover, it is dangerous to write meaningful code after
`JERRY_UNREACHABLE` because it pretends as if there was a way to
recover from an impossible situation.

This patch rewrites/eliminates `JERRY_UNREACHABLE`s where possible
and removes misleading code from after them.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu