### PR TITLE
Fix heap buffer overflow in lit_utf_incr

### DIFF
--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -262,7 +262,10 @@ re_count_num_of_groups (re_parser_ctx_t *parser_ctx_p) /**< RegExp parser contex
     {
       case LIT_CHAR_BACKSLASH:
       {
-        lit_utf8_incr (&curr_p);
+        if (curr_p < parser_ctx_p->input_end_p)
+        {
+          lit_utf8_incr (&curr_p);
+        }
         break;
       }
       case LIT_CHAR_LEFT_SQUARE:

--- a/tests/jerry/fail/regression-test-issue-2344.js
+++ b/tests/jerry/fail/regression-test-issue-2344.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+new RegExp().compile("\\1\\");


### PR DESCRIPTION
This patch fixes #2344.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu