### PR TITLE
Don't let doctests pollute the source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,4 @@ docs/doxygen
 
 # Tests
 tests/test262/
-tests/unit-doc/*.c
 .vs

--- a/tests/unit-doc/CMakeLists.txt
+++ b/tests/unit-doc/CMakeLists.txt
@@ -24,7 +24,7 @@ set(COMPILE_FLAGS_DOCTEST "-Wno-unused-parameter -Wno-unused-function -Wno-unuse
 # file names that will be generated. This allows the definition of proper
 # dependencies between the MarkDown files and the generated sources.
 execute_process(
-  COMMAND ${GEN_DOCTEST} --dry -d ${CMAKE_CURRENT_SOURCE_DIR} ${DOC_FILES}
+  COMMAND ${GEN_DOCTEST} --dry -d ${CMAKE_CURRENT_BINARY_DIR} ${DOC_FILES}
   OUTPUT_VARIABLE DOCTEST_OUTPUT
   RESULT_VARIABLE GEN_DOCTEST_RESULT
 )
@@ -53,7 +53,7 @@ endforeach()
 # Add custom command to run doctest generator if any of the MarkDown sources
 # changes.
 add_custom_command(
-  COMMAND ${GEN_DOCTEST} -d ${CMAKE_CURRENT_SOURCE_DIR} ${DOC_FILES}
+  COMMAND ${GEN_DOCTEST} -d ${CMAKE_CURRENT_BINARY_DIR} ${DOC_FILES}
   DEPENDS ${GEN_DOCTEST} ${DOC_FILES}
   OUTPUT ${DOCTEST_COMPILE} ${DOCTEST_LINK} ${DOCTEST_RUN}
   COMMENT "Generating doctests"


### PR DESCRIPTION
The patch changes the cmakelists of the doctests to extract the
test sources from the markdown docs into the binary tree.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu