### PR TITLE
Fix heap buffer overflow in re_parse_char_class

### DIFF
--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -409,7 +409,7 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
           }
         }
       }
-      else if (ch == LIT_CHAR_LOWERCASE_X)
+      else if (ch == LIT_CHAR_LOWERCASE_X && re_hex_lookup (parser_ctx_p, 2))
       {
         ecma_char_t code_unit;
 
@@ -419,7 +419,9 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
         }
 
         parser_ctx_p->input_curr_p += 2;
-        if (is_range == false && lit_utf8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
+        if (parser_ctx_p->input_curr_p < parser_ctx_p->input_end_p
+            && is_range == false
+            && lit_utf8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
         {
           start = code_unit;
           continue;
@@ -427,7 +429,7 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
 
         ch = code_unit;
       }
-      else if (ch == LIT_CHAR_LOWERCASE_U)
+      else if (ch == LIT_CHAR_LOWERCASE_U && re_hex_lookup (parser_ctx_p, 4))
       {
         ecma_char_t code_unit;
 
@@ -437,7 +439,9 @@ re_parse_char_class (re_parser_ctx_t *parser_ctx_p, /**< number of classes */
         }
 
         parser_ctx_p->input_curr_p += 4;
-        if (is_range == false && lit_utf8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
+        if (parser_ctx_p->input_curr_p < parser_ctx_p->input_end_p
+            && is_range == false
+            && lit_utf8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
         {
           start = code_unit;
           continue;

--- a/tests/jerry/regression-test-issue-2230.js
+++ b/tests/jerry/regression-test-issue-2230.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+try {
+  ((new RegExp("[\\u0")).exec("u"));
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}
+
+try {
+  ((new RegExp("[\\x0")).exec("x"));
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}

--- a/tests/jerry/regression-test-issue-2237.js
+++ b/tests/jerry/regression-test-issue-2237.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+try {
+  (new RegExp("[\\u0020")).exec("u");
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}
+
+try {
+  (new RegExp("[\\x20")).exec("x");
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #2230 and fixes #2237.
Test cases are added for both issues and also adds new cases which caused the same error.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu