### PR TITLE
Maintenance and merging of Valgrind and Valgrind-Freya code paths

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -33,7 +33,6 @@ set(FEATURE_SNAPSHOT_EXEC      OFF     CACHE BOOL   "Enable executing snapshot f
 set(FEATURE_SNAPSHOT_SAVE      OFF     CACHE BOOL   "Enable saving snapshot files?")
 set(FEATURE_SYSTEM_ALLOCATOR   OFF     CACHE BOOL   "Enable system allocator?")
 set(FEATURE_VALGRIND           OFF     CACHE BOOL   "Enable Valgrind support?")
-set(FEATURE_VALGRIND_FREYA     OFF     CACHE BOOL   "Enable Valgrind-Freya support?")
 set(FEATURE_VM_EXEC_STOP       OFF     CACHE BOOL   "Enable VM execution stopping?")
 set(MEM_HEAP_SIZE_KB           "512"   CACHE STRING "Size of memory heap, in kilobytes")
 
@@ -75,7 +74,6 @@ message(STATUS "FEATURE_SNAPSHOT_EXEC       " ${FEATURE_SNAPSHOT_EXEC} ${FEATURE
 message(STATUS "FEATURE_SNAPSHOT_SAVE       " ${FEATURE_SNAPSHOT_SAVE} ${FEATURE_SNAPSHOT_SAVE_MESSAGE})
 message(STATUS "FEATURE_SYSTEM_ALLOCATOR    " ${FEATURE_SYSTEM_ALLOCATOR})
 message(STATUS "FEATURE_VALGRIND            " ${FEATURE_VALGRIND})
-message(STATUS "FEATURE_VALGRIND_FREYA      " ${FEATURE_VALGRIND_FREYA})
 message(STATUS "FEATURE_VM_EXEC_STOP        " ${FEATURE_VM_EXEC_STOP})
 message(STATUS "MEM_HEAP_SIZE_KB            " ${MEM_HEAP_SIZE_KB})
 
@@ -259,12 +257,6 @@ endif()
 # Valgrind
 if(FEATURE_VALGRIND)
   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_VALGRIND)
-  set(INCLUDE_CORE ${INCLUDE_CORE} ${INCLUDE_THIRD_PARTY_VALGRIND})
-endif()
-
-# Valgrind Freya
-if(FEATURE_VALGRIND_FREYA)
-  set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_VALGRIND_FREYA)
   set(INCLUDE_CORE ${INCLUDE_CORE} ${INCLUDE_THIRD_PARTY_VALGRIND})
 endif()
 

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -131,11 +131,6 @@ typedef struct
 #ifdef JMEM_STATS
   jmem_heap_stats_t jmem_heap_stats; /**< heap's memory usage statistics */
 #endif /* JMEM_STATS */
-
-#ifdef JERRY_VALGRIND_FREYA
-  uint8_t valgrind_freya_mempool_request; /**< Tells whether a pool manager
-                                           *   allocator request is in progress */
-#endif /* JERRY_VALGRIND_FREYA */
 } jerry_context_t;
 
 #ifndef CONFIG_ECMA_LCACHE_DISABLE

--- a/jerry-core/jmem/jmem-allocator-internal.h
+++ b/jerry-core/jmem/jmem-allocator-internal.h
@@ -24,6 +24,27 @@
  * @{
  */
 
+ /**
+  * @{
+  * Valgrind-related options and headers
+  */
+ #ifdef JERRY_VALGRIND
+ # include "memcheck.h"
+
+ # define JMEM_VALGRIND_NOACCESS_SPACE(p, s)   VALGRIND_MAKE_MEM_NOACCESS((p), (s))
+ # define JMEM_VALGRIND_UNDEFINED_SPACE(p, s)  VALGRIND_MAKE_MEM_UNDEFINED((p), (s))
+ # define JMEM_VALGRIND_DEFINED_SPACE(p, s)    VALGRIND_MAKE_MEM_DEFINED((p), (s))
+ # define JMEM_VALGRIND_MALLOCLIKE_SPACE(p, s) VALGRIND_MALLOCLIKE_BLOCK((p), (s), 0, 0)
+ # define JMEM_VALGRIND_FREELIKE_SPACE(p)      VALGRIND_FREELIKE_BLOCK((p), 0)
+ #else /* !JERRY_VALGRIND */
+ # define JMEM_VALGRIND_NOACCESS_SPACE(p, s)
+ # define JMEM_VALGRIND_UNDEFINED_SPACE(p, s)
+ # define JMEM_VALGRIND_DEFINED_SPACE(p, s)
+ # define JMEM_VALGRIND_MALLOCLIKE_SPACE(p, s)
+ # define JMEM_VALGRIND_FREELIKE_SPACE(p)
+ #endif /* JERRY_VALGRIND */
+ /** @} */
+
 #ifdef JMEM_STATS
 void jmem_heap_stats_reset_peak (void);
 void jmem_heap_stats_print (void);

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -32,33 +32,6 @@
  */
 
 /**
- * @{
- * Valgrind-related options and headers
- */
-#ifdef JERRY_VALGRIND
-# include "memcheck.h"
-
-# define VALGRIND_NOACCESS_SPACE(p, s)   VALGRIND_MAKE_MEM_NOACCESS((p), (s))
-# define VALGRIND_UNDEFINED_SPACE(p, s)  VALGRIND_MAKE_MEM_UNDEFINED((p), (s))
-# define VALGRIND_DEFINED_SPACE(p, s)    VALGRIND_MAKE_MEM_DEFINED((p), (s))
-#else /* !JERRY_VALGRIND */
-# define VALGRIND_NOACCESS_SPACE(p, s)
-# define VALGRIND_UNDEFINED_SPACE(p, s)
-# define VALGRIND_DEFINED_SPACE(p, s)
-#endif /* JERRY_VALGRIND */
-
-#ifdef JERRY_VALGRIND_FREYA
-# include "memcheck.h"
-
-# define VALGRIND_FREYA_MALLOCLIKE_SPACE(p, s) VALGRIND_MALLOCLIKE_BLOCK((p), (s), 0, 0)
-# define VALGRIND_FREYA_FREELIKE_SPACE(p)      VALGRIND_FREELIKE_BLOCK((p), 0)
-#else /* !JERRY_VALGRIND_FREYA */
-# define VALGRIND_FREYA_MALLOCLIKE_SPACE(p, s)
-# define VALGRIND_FREYA_FREELIKE_SPACE(p)
-#endif /* JERRY_VALGRIND_FREYA */
-/** @} */
-
-/**
  * Finalize pool manager
  */
 void
@@ -96,11 +69,11 @@ jmem_pools_alloc (size_t size) /**< size of the chunk */
     {
       const jmem_pools_chunk_t *const chunk_p = JERRY_CONTEXT (jmem_free_8_byte_chunk_p);
 
-      VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+      JMEM_VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
 
       JERRY_CONTEXT (jmem_free_8_byte_chunk_p) = chunk_p->next_p;
 
-      VALGRIND_UNDEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+      JMEM_VALGRIND_UNDEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
 
       return (void *) chunk_p;
     }
@@ -118,11 +91,11 @@ jmem_pools_alloc (size_t size) /**< size of the chunk */
   {
     const jmem_pools_chunk_t *const chunk_p = JERRY_CONTEXT (jmem_free_16_byte_chunk_p);
 
-    VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+    JMEM_VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
 
     JERRY_CONTEXT (jmem_free_16_byte_chunk_p) = chunk_p->next_p;
 
-    VALGRIND_UNDEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+    JMEM_VALGRIND_UNDEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
 
     return (void *) chunk_p;
   }
@@ -144,7 +117,7 @@ jmem_pools_free (void *chunk_p, /**< pointer to the chunk */
 
   jmem_pools_chunk_t *const chunk_to_free_p = (jmem_pools_chunk_t *) chunk_p;
 
-  VALGRIND_DEFINED_SPACE (chunk_to_free_p, size);
+  JMEM_VALGRIND_DEFINED_SPACE (chunk_to_free_p, size);
 
 #ifdef JERRY_CPOINTER_32_BIT
   if (size <= 8)
@@ -167,7 +140,7 @@ jmem_pools_free (void *chunk_p, /**< pointer to the chunk */
   }
 #endif /* JERRY_CPOINTER_32_BIT */
 
-  VALGRIND_NOACCESS_SPACE (chunk_to_free_p, size);
+  JMEM_VALGRIND_NOACCESS_SPACE (chunk_to_free_p, size);
 } /* jmem_pools_free */
 
 /**
@@ -181,9 +154,9 @@ jmem_pools_collect_empty (void)
 
   while (chunk_p)
   {
-    VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+    JMEM_VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
     jmem_pools_chunk_t *const next_p = chunk_p->next_p;
-    VALGRIND_NOACCESS_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+    JMEM_VALGRIND_NOACCESS_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
 
     jmem_heap_free_block (chunk_p, 8);
     chunk_p = next_p;
@@ -195,21 +168,15 @@ jmem_pools_collect_empty (void)
 
   while (chunk_p)
   {
-    VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+    JMEM_VALGRIND_DEFINED_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
     jmem_pools_chunk_t *const next_p = chunk_p->next_p;
-    VALGRIND_NOACCESS_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
+    JMEM_VALGRIND_NOACCESS_SPACE (chunk_p, sizeof (jmem_pools_chunk_t));
 
     jmem_heap_free_block (chunk_p, 16);
     chunk_p = next_p;
   }
 #endif /* JERRY_CPOINTER_32_BIT */
 } /* jmem_pools_collect_empty */
-
-#undef VALGRIND_NOACCESS_SPACE
-#undef VALGRIND_UNDEFINED_SPACE
-#undef VALGRIND_DEFINED_SPACE
-#undef VALGRIND_FREYA_MALLOCLIKE_SPACE
-#undef VALGRIND_FREYA_FREELIKE_SPACE
 
 /**
  * @}

--- a/tools/build.py
+++ b/tools/build.py
@@ -136,8 +136,6 @@ def get_arguments():
                           help=devhelp('enable regexp byte-code dumps (%(choices)s; default: %(default)s)'))
     devgroup.add_argument('--valgrind', metavar='X', choices=['ON', 'OFF'], default='OFF', type=str.upper,
                           help=devhelp('enable Valgrind support (%(choices)s; default: %(default)s)'))
-    devgroup.add_argument('--valgrind-freya', metavar='X', choices=['ON', 'OFF'], default='OFF', type=str.upper,
-                          help=devhelp('enable Valgrind-Freya support (%(choices)s; default: %(default)s)'))
 
     arguments = parser.parse_args(args)
     if arguments.devhelp:
@@ -193,7 +191,6 @@ def generate_build_options(arguments):
     build_options.append('-DFEATURE_REGEXP_STRICT_MODE=%s' % arguments.regexp_strict_mode)
     build_options.append('-DFEATURE_REGEXP_DUMP=%s' % arguments.show_regexp_opcodes)
     build_options.append('-DFEATURE_VALGRIND=%s' % arguments.valgrind)
-    build_options.append('-DFEATURE_VALGRIND_FREYA=%s' % arguments.valgrind_freya)
 
     build_options.extend(arguments.cmake_param)
 

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -139,8 +139,6 @@ JERRY_BUILDOPTIONS = [
             ['--all-in-one=on']),
     Options('buildoption_test-valgrind',
             ['--valgrind=on']),
-    Options('buildoption_test-valgrind_freya',
-            ['--valgrind-freya=on']),
     Options('buildoption_test-mem_stats',
             ['--mem-stats=on']),
     Options('buildoption_test-show_opcodes',


### PR DESCRIPTION
None of the code paths have been tested for long and especially the
Freya code paths have been long abandoned. This patch:
- Merges Valgrind-Freya into Valgrind code path (there should be no
  need to choose between them, Valgrind should work just fine).
- Removes leftover code (`VALGRIND_FREYA_CHECK_MEMPOOL_REQUEST` and
  `valgrind_freya_mempool_request`).
- Adds `JMEM_` prefix to Valgrind-related macros (to correctly
  leave the `VALGRIND_` prefix to Valgrind).
- Moves the definition of the Valgrind-related macros to a common
  header to avoid duplication.

Note: Adding a CI job to perform Valgrind Memchecks is left for
follow-up as it turns out to be excessively slow (>50 mins for a
`--jerry-tests --jerry-test-suite` run, and even a simple
`--jerry-tests` may get terminated prematurely because of timeout
issues).

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu