### PR TITLE
Use binary mode in snapshot tool for fopen

### DIFF
--- a/jerry-libc/target/posix/jerry-libc-target.c
+++ b/jerry-libc/target/posix/jerry-libc-target.c
@@ -113,16 +113,25 @@ fopen (const char *path, /**< file path */
   bool truncate = false;
   bool create_if_not_exist = false;
   bool position_at_end = false;
+  int modifier_position = 1;
 
   assert (path != NULL && mode != NULL);
-  assert (mode[1] == '+' || mode[1] == '\0');
+  assert (mode[1] == '\0'
+          || (mode[1] == '+' && mode[2] == '\0')
+          || (mode[1] == 'b' && mode[2] == '\0')
+          || (mode[1] == 'b' && mode[2] == '+' && mode[3] == '\0'));
+
+  if (mode[1] == 'b')
+  {
+    modifier_position = 2;
+  }
 
   switch (mode[0])
   {
     case 'r':
     {
       may_read = true;
-      may_write = (mode[1] == '+');
+      may_write = (mode[modifier_position] == '+');
       break;
     }
     case 'w':
@@ -130,7 +139,7 @@ fopen (const char *path, /**< file path */
       may_write = true;
       truncate = true;
       create_if_not_exist = true;
-      may_read = (mode[1] == '+');
+      may_read = (mode[modifier_position] == '+');
       break;
     }
     case 'a':
@@ -138,7 +147,7 @@ fopen (const char *path, /**< file path */
       may_write = true;
       position_at_end = true;
       create_if_not_exist = true;
-      if (mode[1] == '+')
+      if (mode[modifier_position] == '+')
       {
         assert (false && "unsupported mode a+");
       }

--- a/jerry-main/main-unix-snapshot.c
+++ b/jerry-main/main-unix-snapshot.c
@@ -92,7 +92,7 @@ static size_t
 read_file (uint8_t *input_pos_p, /**< next position in the input buffer */
            const char *file_name) /**< file name */
 {
-  FILE *file = fopen (file_name, "r");
+  FILE *file = fopen (file_name, "rb");
 
   if (file == NULL)
   {
@@ -331,7 +331,7 @@ process_generate (cli_state_t *cli_state_p, /**< cli state */
   size_t snapshot_size = (size_t) jerry_get_number_value (snapshot_result);
   jerry_release_value (snapshot_result);
 
-  FILE *snapshot_file_p = fopen (output_file_name_p, "w");
+  FILE *snapshot_file_p = fopen (output_file_name_p, "wb");
   if (snapshot_file_p == NULL)
   {
     jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: Unable to write snapshot file: '%s'\n", output_file_name_p);
@@ -357,7 +357,7 @@ process_generate (cli_state_t *cli_state_p, /**< cli state */
       return JERRY_STANDALONE_EXIT_CODE_FAIL;
     }
 
-    FILE *literal_file_p = fopen (save_literals_file_name_p, "w");
+    FILE *literal_file_p = fopen (save_literals_file_name_p, "wb");
 
     if (literal_file_p == NULL)
     {
@@ -486,7 +486,7 @@ process_merge (cli_state_t *cli_state_p, /**< cli state */
     return JERRY_STANDALONE_EXIT_CODE_FAIL;
   }
 
-  FILE *file_p = fopen (output_file_name_p, "w");
+  FILE *file_p = fopen (output_file_name_p, "wb");
 
   if (file_p != NULL)
   {

--- a/jerry-main/main-unix-test.c
+++ b/jerry-main/main-unix-test.c
@@ -36,7 +36,7 @@ static const uint8_t *
 read_file (const char *file_name,
            size_t *out_size_p)
 {
-  FILE *file = fopen (file_name, "r");
+  FILE *file = fopen (file_name, "rb");
   if (file == NULL)
   {
     jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: failed to open file: %s\n", file_name);

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -59,7 +59,7 @@ read_file (const char *file_name,
   }
   else
   {
-    file = fopen (file_name, "r");
+    file = fopen (file_name, "rb");
     if (file == NULL)
     {
       jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: failed to open file: %s\n", file_name);

--- a/tests/jerry/windows-line-ending.js
+++ b/tests/jerry/windows-line-ending.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test file should use CR-LF styled line endings to test if everything is
+// parsed correctly
+
+
+var value =
+  5;
+
+assert (value === 5);


### PR DESCRIPTION
In the snapshot tool the files were opened
in text mode. However the snapshot files
are binary files thus it is advised to use the
binary mode when opening the files.

Specifying the binary mode is a must on Windows
platform otherwise the read/write operations
are inserting extra '\r' characters.

Also update jerry-libc to accept the 'b' modifier.