### PR TITLE
Remove the leftover declaration of ecma_op_create_global_environment

### DIFF
--- a/jerry-core/ecma/operations/ecma-lex-env.h
+++ b/jerry-core/ecma/operations/ecma-lex-env.h
@@ -57,8 +57,6 @@ ecma_value_t ecma_op_implicit_this_value (ecma_object_t *lex_env_p);
 /* ECMA-262 v5, Table 18. Additional methods of Declarative Environment Records */
 void ecma_op_create_immutable_binding (ecma_object_t *lex_env_p, ecma_string_t *name_p, ecma_value_t value);
 
-ecma_object_t *ecma_op_create_global_environment (ecma_object_t *);
-
 /**
  * @}
  * @}


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu