### PR TITLE
Declare parser_error_to_string conditionally

### DIFF
--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -135,7 +135,9 @@ ecma_value_t parser_parse_script (const uint8_t *arg_list_p, size_t arg_list_siz
                                   const uint8_t *source_p, size_t source_size,
                                   bool is_strict, ecma_compiled_code_t **bytecode_data_p);
 
+#ifdef JERRY_ENABLE_ERROR_MESSAGES
 const char *parser_error_to_string (parser_error_t);
+#endif /* JERRY_ENABLE_ERROR_MESSAGES */
 
 /**
  * @}


### PR DESCRIPTION
Its implementation is only available if `JERRY_ENABLE_ERROR_MESSAGES`
is defined.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu