### PR TITLE
targets: zephyr: Separate CMake definitions from options.

### DIFF
--- a/targets/zephyr/CMakeLists.txt
+++ b/targets/zephyr/CMakeLists.txt
@@ -40,7 +40,7 @@ add_custom_target(
   COMMAND echo Z_CFLAGS=${system_includes} ${includes} ${definitions} ${options}
   COMMAND echo NOSTDINC_FLAGS=${system_includes}
   COMMAND echo ZEPHYRINCLUDE=${includes}
-  COMMAND echo KBUILD_CFLAGS=${definitions}${options}
+  COMMAND echo KBUILD_CFLAGS=${definitions} ${options}
   VERBATIM
   USES_TERMINAL
 )


### PR DESCRIPTION
Add a space between definition and options substitution groups, otherwise
they make expand to something like -DFOO-DBAR.

JerryScript-DCO-1.0-Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org