### PR TITLE
Remove the indentation of preprocessor directives.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -56,26 +56,26 @@ typedef ecma_value_t (*ecma_builtin_dispatch_call_t)(const ecma_value_t argument
  */
 static const ecma_builtin_dispatch_routine_t ecma_builtin_routines[] =
 {
-  #define BUILTIN(a, b, c, d, e)
-  #define BUILTIN_ROUTINE(builtin_id, \
-                          object_type, \
-                          object_prototype_builtin_id, \
-                          is_extensible, \
-                          lowercase_name) \
-    ecma_builtin_ ## lowercase_name ## _dispatch_routine,
-  #include "ecma-builtins.inc.h"
-  #undef BUILTIN
-  #undef BUILTIN_ROUTINE
-  #define BUILTIN_ROUTINE(a, b, c, d, e)
-  #define BUILTIN(builtin_id, \
-                  object_type, \
-                  object_prototype_builtin_id, \
-                  is_extensible, \
-                  lowercase_name) \
-    ecma_builtin_ ## lowercase_name ## _dispatch_routine,
-  #include "ecma-builtins.inc.h"
-  #undef BUILTIN
-  #undef BUILTIN_ROUTINE
+#define BUILTIN(a, b, c, d, e)
+#define BUILTIN_ROUTINE(builtin_id, \
+                        object_type, \
+                        object_prototype_builtin_id, \
+                        is_extensible, \
+                        lowercase_name) \
+  ecma_builtin_ ## lowercase_name ## _dispatch_routine,
+#include "ecma-builtins.inc.h"
+#undef BUILTIN
+#undef BUILTIN_ROUTINE
+#define BUILTIN_ROUTINE(a, b, c, d, e)
+#define BUILTIN(builtin_id, \
+                object_type, \
+                object_prototype_builtin_id, \
+                is_extensible, \
+                lowercase_name) \
+  ecma_builtin_ ## lowercase_name ## _dispatch_routine,
+#include "ecma-builtins.inc.h"
+#undef BUILTIN
+#undef BUILTIN_ROUTINE
 };
 
 /**
@@ -83,16 +83,16 @@ static const ecma_builtin_dispatch_routine_t ecma_builtin_routines[] =
  */
 static const ecma_builtin_dispatch_call_t ecma_builtin_call_functions[] =
 {
-  #define BUILTIN(a, b, c, d, e)
-  #define BUILTIN_ROUTINE(builtin_id, \
-                          object_type, \
-                          object_prototype_builtin_id, \
-                          is_extensible, \
-                          lowercase_name) \
-    ecma_builtin_ ## lowercase_name ## _dispatch_call,
-  #include "ecma-builtins.inc.h"
-  #undef BUILTIN_ROUTINE
-  #undef BUILTIN
+#define BUILTIN(a, b, c, d, e)
+#define BUILTIN_ROUTINE(builtin_id, \
+                        object_type, \
+                        object_prototype_builtin_id, \
+                        is_extensible, \
+                        lowercase_name) \
+  ecma_builtin_ ## lowercase_name ## _dispatch_call,
+#include "ecma-builtins.inc.h"
+#undef BUILTIN_ROUTINE
+#undef BUILTIN
 };
 
 /**
@@ -100,16 +100,16 @@ static const ecma_builtin_dispatch_call_t ecma_builtin_call_functions[] =
  */
 static const ecma_builtin_dispatch_call_t ecma_builtin_construct_functions[] =
 {
-  #define BUILTIN(a, b, c, d, e)
-  #define BUILTIN_ROUTINE(builtin_id, \
-                          object_type, \
-                          object_prototype_builtin_id, \
-                          is_extensible, \
-                          lowercase_name) \
-    ecma_builtin_ ## lowercase_name ## _dispatch_construct,
-  #include "ecma-builtins.inc.h"
-  #undef BUILTIN_ROUTINE
-  #undef BUILTIN
+#define BUILTIN(a, b, c, d, e)
+#define BUILTIN_ROUTINE(builtin_id, \
+                        object_type, \
+                        object_prototype_builtin_id, \
+                        is_extensible, \
+                        lowercase_name) \
+  ecma_builtin_ ## lowercase_name ## _dispatch_construct,
+#include "ecma-builtins.inc.h"
+#undef BUILTIN_ROUTINE
+#undef BUILTIN
 };
 
 /**

--- a/jerry-core/jmem/jmem-allocator-internal.h
+++ b/jerry-core/jmem/jmem-allocator-internal.h
@@ -24,26 +24,26 @@
  * @{
  */
 
- /**
-  * @{
-  * Valgrind-related options and headers
-  */
- #ifdef JERRY_VALGRIND
- # include "memcheck.h"
+/**
+ * @{
+ * Valgrind-related options and headers
+ */
+#ifdef JERRY_VALGRIND
+# include "memcheck.h"
 
- # define JMEM_VALGRIND_NOACCESS_SPACE(p, s)   VALGRIND_MAKE_MEM_NOACCESS((p), (s))
- # define JMEM_VALGRIND_UNDEFINED_SPACE(p, s)  VALGRIND_MAKE_MEM_UNDEFINED((p), (s))
- # define JMEM_VALGRIND_DEFINED_SPACE(p, s)    VALGRIND_MAKE_MEM_DEFINED((p), (s))
- # define JMEM_VALGRIND_MALLOCLIKE_SPACE(p, s) VALGRIND_MALLOCLIKE_BLOCK((p), (s), 0, 0)
- # define JMEM_VALGRIND_FREELIKE_SPACE(p)      VALGRIND_FREELIKE_BLOCK((p), 0)
- #else /* !JERRY_VALGRIND */
- # define JMEM_VALGRIND_NOACCESS_SPACE(p, s)
- # define JMEM_VALGRIND_UNDEFINED_SPACE(p, s)
- # define JMEM_VALGRIND_DEFINED_SPACE(p, s)
- # define JMEM_VALGRIND_MALLOCLIKE_SPACE(p, s)
- # define JMEM_VALGRIND_FREELIKE_SPACE(p)
- #endif /* JERRY_VALGRIND */
- /** @} */
+# define JMEM_VALGRIND_NOACCESS_SPACE(p, s)   VALGRIND_MAKE_MEM_NOACCESS((p), (s))
+# define JMEM_VALGRIND_UNDEFINED_SPACE(p, s)  VALGRIND_MAKE_MEM_UNDEFINED((p), (s))
+# define JMEM_VALGRIND_DEFINED_SPACE(p, s)    VALGRIND_MAKE_MEM_DEFINED((p), (s))
+# define JMEM_VALGRIND_MALLOCLIKE_SPACE(p, s) VALGRIND_MALLOCLIKE_BLOCK((p), (s), 0, 0)
+# define JMEM_VALGRIND_FREELIKE_SPACE(p)      VALGRIND_FREELIKE_BLOCK((p), 0)
+#else /* !JERRY_VALGRIND */
+# define JMEM_VALGRIND_NOACCESS_SPACE(p, s)
+# define JMEM_VALGRIND_UNDEFINED_SPACE(p, s)
+# define JMEM_VALGRIND_DEFINED_SPACE(p, s)
+# define JMEM_VALGRIND_MALLOCLIKE_SPACE(p, s)
+# define JMEM_VALGRIND_FREELIKE_SPACE(p)
+#endif /* JERRY_VALGRIND */
+/** @} */
 
 #ifdef JMEM_STATS
 void jmem_heap_stats_reset_peak (void);


### PR DESCRIPTION
Indenting preprocessor directives reduces the code readability, because it make preprocessor directives harder to spot.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com