### PR TITLE
Change literal suffixes to uppercase.

### DIFF
--- a/jerry-core/debugger/debugger-ws.c
+++ b/jerry-core/debugger/debugger-ws.c
@@ -222,7 +222,7 @@ jerry_process_handshake (int client_socket, /**< client socket */
   /* Buffer request text until the double newlines are received. */
   while (true)
   {
-    size_t length = request_buffer_size - 1u - (size_t) (request_end_p - request_buffer_p);
+    size_t length = request_buffer_size - 1U - (size_t) (request_end_p - request_buffer_p);
 
     if (length == 0)
     {

--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -85,7 +85,7 @@
 #define ECMA_NUMBER_CONVERSION_128BIT_INTEGER_ROUND_HIGH_AND_MIDDLE_TO_UINT64(name, uint64_var) \
 { \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
-  uint64_var = ((name[3] << 32u) | (name[2])) + (((name[1] >> 31u) != 0 ? 1 : 0)); \
+  uint64_var = ((name[3] << 32U) | (name[2])) + (((name[1] >> 31U) != 0 ? 1 : 0)); \
 }
 
 /**
@@ -94,7 +94,7 @@
 #define ECMA_NUMBER_CONVERSION_128BIT_INTEGER_ROUND_MIDDLE_AND_LOW_TO_UINT64(name, uint64_var) \
 { \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
-  uint64_var = (name[1] << 32u) | (name[0]); \
+  uint64_var = (name[1] << 32U) | (name[0]); \
 }
 
 /**
@@ -142,13 +142,13 @@
 { \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
   \
-  name[3] = (uint32_t) (name[3] << 1u); \
-  name[3] |= name[2] >> 31u; \
-  name[2] = (uint32_t) (name[2] << 1u); \
-  name[2] |= name[1] >> 31u; \
-  name[1] = (uint32_t) (name[1] << 1u); \
-  name[1] |= name[0] >> 31u; \
-  name[0] = (uint32_t) (name[0] << 1u); \
+  name[3] = (uint32_t) (name[3] << 1U); \
+  name[3] |= name[2] >> 31U; \
+  name[2] = (uint32_t) (name[2] << 1U); \
+  name[2] |= name[1] >> 31U; \
+  name[1] = (uint32_t) (name[1] << 1U); \
+  name[1] |= name[0] >> 31U; \
+  name[0] = (uint32_t) (name[0] << 1U); \
   \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
 }
@@ -160,13 +160,13 @@
 { \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
   \
-  name[0] >>= 1u; \
-  name[0] |= (uint32_t) (name[1] << 31u); \
-  name[1] >>= 1u; \
-  name[1] |= (uint32_t) (name[2] << 31u); \
-  name[2] >>= 1u; \
-  name[2] |= (uint32_t) (name[3] << 31u); \
-  name[3] >>= 1u; \
+  name[0] >>= 1U; \
+  name[0] |= (uint32_t) (name[1] << 31U); \
+  name[1] >>= 1U; \
+  name[1] |= (uint32_t) (name[2] << 31U); \
+  name[2] >>= 1U; \
+  name[2] |= (uint32_t) (name[3] << 31U); \
+  name[3] >>= 1U; \
   \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
 }
@@ -179,11 +179,11 @@
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
   \
   name[0] += 1ull; \
-  name[1] += (name[0] >> 32u); \
+  name[1] += (name[0] >> 32U); \
   name[0] = (uint32_t) name[0]; \
-  name[2] += (name[1] >> 32u); \
+  name[2] += (name[1] >> 32U); \
   name[1] = (uint32_t) name[1]; \
-  name[3] += (name[2] >> 32u); \
+  name[3] += (name[2] >> 32U); \
   name[2] = (uint32_t) name[2]; \
   \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name); \
@@ -202,11 +202,11 @@
   name_add_to[2] += name_to_add[2]; \
   name_add_to[3] += name_to_add[3]; \
   \
-  name_add_to[1] += (name_add_to[0] >> 32u); \
+  name_add_to[1] += (name_add_to[0] >> 32U); \
   name_add_to[0] = (uint32_t) name_add_to[0]; \
-  name_add_to[2] += (name_add_to[1] >> 32u); \
+  name_add_to[2] += (name_add_to[1] >> 32U); \
   name_add_to[1] = (uint32_t) name_add_to[1]; \
-  name_add_to[3] += (name_add_to[2] >> 32u); \
+  name_add_to[3] += (name_add_to[2] >> 32U); \
   name_add_to[2] = (uint32_t) name_add_to[2]; \
   \
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_CHECK_PARTS_ARE_32BIT (name_add_to); \
@@ -261,57 +261,57 @@
   h2 = name[2] * div10_p_high; \
   h3 = name[3] * div10_p_high; \
   intermediate[0] += (uint32_t) l0; \
-  intermediate[1] += l0 >> 32u; \
+  intermediate[1] += l0 >> 32U; \
   \
   intermediate[1] += (uint32_t) l1; \
-  intermediate[2] += l1 >> 32u; \
+  intermediate[2] += l1 >> 32U; \
   intermediate[1] += (uint32_t) m0; \
-  intermediate[2] += m0 >> 32u; \
+  intermediate[2] += m0 >> 32U; \
   \
   intermediate[2] += (uint32_t) l2; \
-  intermediate[3] += l2 >> 32u; \
+  intermediate[3] += l2 >> 32U; \
   intermediate[2] += (uint32_t) m1; \
-  intermediate[3] += m1 >> 32u; \
+  intermediate[3] += m1 >> 32U; \
   intermediate[2] += (uint32_t) m0; \
-  intermediate[3] += m0 >> 32u; \
+  intermediate[3] += m0 >> 32U; \
   \
   intermediate[3] += (uint32_t) l3; \
-  intermediate[4] += l3 >> 32u; \
+  intermediate[4] += l3 >> 32U; \
   intermediate[3] += (uint32_t) m2; \
-  intermediate[4] += m2 >> 32u; \
+  intermediate[4] += m2 >> 32U; \
   intermediate[3] += (uint32_t) m1; \
-  intermediate[4] += m1 >> 32u; \
+  intermediate[4] += m1 >> 32U; \
   intermediate[3] += (uint32_t) h0; \
-  intermediate[4] += h0 >> 32u; \
+  intermediate[4] += h0 >> 32U; \
   \
   intermediate[4] += (uint32_t) m3; \
-  intermediate[5] += m3 >> 32u; \
+  intermediate[5] += m3 >> 32U; \
   intermediate[4] += (uint32_t) m2; \
-  intermediate[5] += m2 >> 32u; \
+  intermediate[5] += m2 >> 32U; \
   intermediate[4] += (uint32_t) h1; \
-  intermediate[5] += h1 >> 32u; \
+  intermediate[5] += h1 >> 32U; \
   \
   intermediate[5] += (uint32_t) m3; \
-  intermediate[6] += m3 >> 32u; \
+  intermediate[6] += m3 >> 32U; \
   intermediate[5] += (uint32_t) h2; \
-  intermediate[6] += h2 >> 32u; \
+  intermediate[6] += h2 >> 32U; \
   \
   intermediate[6] += (uint32_t) h3; \
-  intermediate[7] += h3 >> 32u; \
+  intermediate[7] += h3 >> 32U; \
   \
-  intermediate[1] += intermediate[0] >> 32u; \
+  intermediate[1] += intermediate[0] >> 32U; \
   intermediate[0] = (uint32_t) intermediate[0]; \
-  intermediate[2] += intermediate[1] >> 32u; \
+  intermediate[2] += intermediate[1] >> 32U; \
   intermediate[1] = (uint32_t) intermediate[1]; \
-  intermediate[3] += intermediate[2] >> 32u; \
+  intermediate[3] += intermediate[2] >> 32U; \
   intermediate[2] = (uint32_t) intermediate[2]; \
-  intermediate[4] += intermediate[3] >> 32u; \
+  intermediate[4] += intermediate[3] >> 32U; \
   intermediate[3] = (uint32_t) intermediate[3]; \
-  intermediate[5] += intermediate[4] >> 32u; \
+  intermediate[5] += intermediate[4] >> 32U; \
   intermediate[4] = (uint32_t) intermediate[4]; \
-  intermediate[6] += intermediate[5] >> 32u; \
+  intermediate[6] += intermediate[5] >> 32U; \
   intermediate[5] = (uint32_t) intermediate[5]; \
-  intermediate[7] += intermediate[6] >> 32u; \
+  intermediate[7] += intermediate[6] >> 32U; \
   intermediate[6] = (uint32_t) intermediate[6]; \
   \
   name[0] = intermediate[4]; \
@@ -663,7 +663,7 @@ ecma_utf8_string_to_number (const lit_utf8_byte_t *str_p, /**< utf-8 string */
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER (fraction_uint128);
   ECMA_NUMBER_CONVERSION_128BIT_INTEGER_INIT (fraction_uint128,
                                               0ull,
-                                              fraction_uint64 >> 32u,
+                                              fraction_uint64 >> 32U,
                                               (uint32_t) fraction_uint64,
                                               0ull);
 

--- a/jerry-core/ecma/base/ecma-helpers-errol.c
+++ b/jerry-core/ecma/base/ecma-helpers-errol.c
@@ -203,14 +203,14 @@ ecma_errol0_dtoa (double val, /**< ecma number */
 
     if ((high_bound.value == high_digit) && (high_bound.offset < 0))
     {
-      high_digit = (uint8_t) (high_digit - 1u);
+      high_digit = (uint8_t) (high_digit - 1U);
     }
 
     uint8_t low_digit = (uint8_t) low_bound.value;
 
     if ((low_bound.value == low_digit) && (low_bound.offset < 0))
     {
-      low_digit = (uint8_t) (low_digit - 1u);
+      low_digit = (uint8_t) (low_digit - 1U);
     }
 
     if (low_digit != high_digit)

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -51,10 +51,10 @@ ecma_number_pack (bool sign, /**< sign */
                   uint32_t biased_exp, /**< biased exponent */
                   uint64_t fraction) /**< fraction */
 {
-  JERRY_ASSERT ((biased_exp & ~((1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)) == 0);
+  JERRY_ASSERT ((biased_exp & ~((1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)) == 0);
   JERRY_ASSERT ((fraction & ~((1ull << ECMA_NUMBER_FRACTION_WIDTH) - 1)) == 0);
 
-  uint32_t packed_value = (((sign ? 1u : 0u) << ECMA_NUMBER_SIGN_POS) |
+  uint32_t packed_value = (((sign ? 1U : 0U) << ECMA_NUMBER_SIGN_POS) |
                            (biased_exp << ECMA_NUMBER_FRACTION_WIDTH) |
                            ((uint32_t) fraction));
 
@@ -95,12 +95,12 @@ ecma_number_unpack (ecma_number_t num, /**< ecma-number */
 
   if (biased_exp_p != NULL)
   {
-    *biased_exp_p = (((packed_value) & ~(1u << ECMA_NUMBER_SIGN_POS)) >> ECMA_NUMBER_FRACTION_WIDTH);
+    *biased_exp_p = (((packed_value) & ~(1U << ECMA_NUMBER_SIGN_POS)) >> ECMA_NUMBER_FRACTION_WIDTH);
   }
 
   if (fraction_p != NULL)
   {
-    *fraction_p = (packed_value & ((1u << ECMA_NUMBER_FRACTION_WIDTH) - 1));
+    *fraction_p = (packed_value & ((1U << ECMA_NUMBER_FRACTION_WIDTH) - 1));
   }
 } /* ecma_number_unpack */
 
@@ -130,7 +130,7 @@ ecma_number_pack (bool sign, /**< sign */
                            (((uint64_t) biased_exp) << ECMA_NUMBER_FRACTION_WIDTH) |
                            fraction);
 
-  JERRY_ASSERT ((biased_exp & ~((1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)) == 0);
+  JERRY_ASSERT ((biased_exp & ~((1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)) == 0);
   JERRY_ASSERT ((fraction & ~((1ull << ECMA_NUMBER_FRACTION_WIDTH) - 1)) == 0);
 
   union
@@ -250,7 +250,7 @@ ecma_number_is_nan (ecma_number_t num) /**< ecma-number */
   uint64_t fraction = ecma_number_get_fraction_field (num);
 
    /* IEEE-754 2008, 3.4, a */
-  bool is_nan_ieee754 = ((biased_exp == (1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)
+  bool is_nan_ieee754 = ((biased_exp == (1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)
                          && (fraction != 0));
 
   JERRY_ASSERT (is_nan == is_nan_ieee754);
@@ -268,8 +268,8 @@ ecma_number_t
 ecma_number_make_nan (void)
 {
   return ecma_number_pack (false,
-                           (1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1u,
-                           1u);
+                           (1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1U,
+                           1U);
 } /* ecma_number_make_nan */
 
 /**
@@ -283,8 +283,8 @@ ecma_number_make_infinity (bool sign) /**< true - for negative Infinity,
                                            false - for positive Infinity */
 {
   return ecma_number_pack (sign,
-                           (1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1u,
-                           0u);
+                           (1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1U,
+                           0U);
 } /* ecma_number_make_infinity */
 
 /**
@@ -342,7 +342,7 @@ ecma_number_is_infinity (ecma_number_t num) /**< ecma-number */
   uint64_t fraction = ecma_number_get_fraction_field (num);
 
   /* IEEE-754 2008, 3.4, b */
-  return ((biased_exp  == (1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)
+  return ((biased_exp  == (1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1)
           && (fraction == 0));
 } /* ecma_number_is_infinity */
 
@@ -395,7 +395,7 @@ ecma_number_get_fraction_and_exponent (ecma_number_t num, /**< ecma-number */
     /* IEEE-754 2008, 3.4, c */
     exponent = (int32_t) biased_exp - ecma_number_exponent_bias;
 
-    JERRY_ASSERT (biased_exp > 0 && biased_exp < (1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1);
+    JERRY_ASSERT (biased_exp > 0 && biased_exp < (1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1);
     JERRY_ASSERT ((fraction & (1ull << ECMA_NUMBER_FRACTION_WIDTH)) == 0);
     fraction |= 1ull << ECMA_NUMBER_FRACTION_WIDTH;
   }
@@ -415,7 +415,7 @@ ecma_number_make_normal_positive_from_fraction_and_exponent (uint64_t fraction, 
                                                              int32_t exponent) /**< exponent */
 {
   uint32_t biased_exp = (uint32_t) (exponent + ecma_number_exponent_bias);
-  JERRY_ASSERT (biased_exp > 0 && biased_exp < (1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1);
+  JERRY_ASSERT (biased_exp > 0 && biased_exp < (1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1);
   JERRY_ASSERT ((fraction & ~((1ull << (ECMA_NUMBER_FRACTION_WIDTH + 1)) - 1)) == 0);
   JERRY_ASSERT ((fraction & (1ull << ECMA_NUMBER_FRACTION_WIDTH)) != 0);
 
@@ -496,12 +496,12 @@ ecma_number_make_from_sign_mantissa_and_exponent (bool sign, /**< true - for neg
 
   uint32_t biased_exp = (uint32_t) biased_exp_signed;
 
-  if (biased_exp >= ((1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1))
+  if (biased_exp >= ((1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1))
   {
     return ecma_number_make_infinity (sign);
   }
 
-  JERRY_ASSERT (biased_exp < (1u << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1);
+  JERRY_ASSERT (biased_exp < (1U << ECMA_NUMBER_BIASED_EXP_WIDTH) - 1);
   JERRY_ASSERT ((mantissa & ~((1ull << ECMA_NUMBER_FRACTION_WIDTH) - 1)) == 0);
 
   return ecma_number_pack (sign,

--- a/jerry-core/ecma/base/ecma-literal-storage.c
+++ b/jerry-core/ecma/base/ecma-literal-storage.c
@@ -218,7 +218,7 @@ ecma_find_or_create_literal_number (ecma_number_t number_arg) /**< number to be 
 /**
  * Snapshot literal alignment.
  */
-#define JERRY_SNAPSHOT_LITERAL_ALIGNMENT (1u << JERRY_SNAPSHOT_LITERAL_ALIGNMENT_LOG)
+#define JERRY_SNAPSHOT_LITERAL_ALIGNMENT (1U << JERRY_SNAPSHOT_LITERAL_ALIGNMENT_LOG)
 
 /**
  * Literal offset shift.
@@ -228,7 +228,7 @@ ecma_find_or_create_literal_number (ecma_number_t number_arg) /**< number to be 
 /**
  * Literal value is number.
  */
-#define JERRY_SNAPSHOT_LITERAL_IS_NUMBER (1u << ECMA_VALUE_SHIFT)
+#define JERRY_SNAPSHOT_LITERAL_IS_NUMBER (1U << ECMA_VALUE_SHIFT)
 
 #ifdef JERRY_ENABLE_SNAPSHOT_SAVE
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -219,7 +219,7 @@ ecma_builtin_function_prototype_object_call (ecma_value_t this_arg, /**< this ar
       return ecma_op_function_call (func_obj_p,
                                     arguments_list_p[0],
                                     arguments_list_p + 1,
-                                    (ecma_length_t) (arguments_number - 1u));
+                                    (ecma_length_t) (arguments_number - 1U));
     }
   }
 } /* ecma_builtin_function_prototype_object_call */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -585,7 +585,7 @@ ecma_builtin_global_object_character_is_in (uint32_t character, /**< character *
                                             const uint8_t *bitset) /**< character set */
 {
   JERRY_ASSERT (character < 128);
-  return (bitset[character >> 3] & (1u << (character & 0x7))) != 0;
+  return (bitset[character >> 3] & (1U << (character & 0x7))) != 0;
 } /* ecma_builtin_global_object_character_is_in */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -632,7 +632,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
 
   uint32_t *bitset_p = built_in_props_p->instantiated_bitset + (index >> 5);
 
-  uint32_t bit_for_index = (uint32_t) (1u << (index & 0x1f));
+  uint32_t bit_for_index = (uint32_t) (1U << (index & 0x1f));
 
   if (*bitset_p & bit_for_index)
   {
@@ -854,7 +854,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
 
       ecma_string_t *name_p = ecma_get_magic_string (curr_property_p->magic_string_id);
 
-      uint32_t bit_for_index = (uint32_t) 1u << index;
+      uint32_t bit_for_index = (uint32_t) 1U << index;
 
       if (!(*bitset_p & bit_for_index) || ecma_op_object_has_own_property (object_p, name_p))
       {

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1469,9 +1469,9 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
       uint32_t bitmap_row = (uint32_t) (hash / bitmap_row_size);
       uint32_t bitmap_column = (uint32_t) (hash % bitmap_row_size);
 
-      if ((own_names_hashes_bitmap[bitmap_row] & (1u << bitmap_column)) == 0)
+      if ((own_names_hashes_bitmap[bitmap_row] & (1U << bitmap_column)) == 0)
       {
-        own_names_hashes_bitmap[bitmap_row] |= (1u << bitmap_column);
+        own_names_hashes_bitmap[bitmap_row] |= (1U << bitmap_column);
       }
     }
 
@@ -1514,7 +1514,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
             bool is_add = true;
 
-            if ((own_names_hashes_bitmap[bitmap_row] & (1u << bitmap_column)) != 0)
+            if ((own_names_hashes_bitmap[bitmap_row] & (1U << bitmap_column)) != 0)
             {
               ecma_value_p = ecma_collection_iterator_init (prop_names_p);
 
@@ -1533,7 +1533,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
             if (is_add)
             {
-              own_names_hashes_bitmap[bitmap_row] |= (1u << bitmap_column);
+              own_names_hashes_bitmap[bitmap_row] |= (1U << bitmap_column);
 
               ecma_append_to_values_collection (prop_names_p,
                                                 ecma_make_string_value (name_p),
@@ -1619,7 +1619,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
           while (move_pos > insertion_pos)
           {
-            array_index_names_p[move_pos] = array_index_names_p[move_pos - 1u];
+            array_index_names_p[move_pos] = array_index_names_p[move_pos - 1U];
 
             move_pos--;
           }
@@ -1668,10 +1668,10 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
       uint32_t bitmap_row = (uint32_t) (hash / bitmap_row_size);
       uint32_t bitmap_column = (uint32_t) (hash % bitmap_row_size);
 
-      if ((names_hashes_bitmap[bitmap_row] & (1u << bitmap_column)) == 0)
+      if ((names_hashes_bitmap[bitmap_row] & (1U << bitmap_column)) == 0)
       {
         /* This hash has not been used before (for non-skipped). */
-        names_hashes_bitmap[bitmap_row] |= (1u << bitmap_column);
+        names_hashes_bitmap[bitmap_row] |= (1U << bitmap_column);
       }
       else
       {
@@ -1710,7 +1710,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
       if (is_append)
       {
-        JERRY_ASSERT ((names_hashes_bitmap[bitmap_row] & (1u << bitmap_column)) != 0);
+        JERRY_ASSERT ((names_hashes_bitmap[bitmap_row] & (1U << bitmap_column)) != 0);
 
         ecma_append_to_values_collection (ret_p, ecma_make_string_value (names_p[i]), 0);
       }

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1263,7 +1263,7 @@ ecma_regexp_exec_helper (ecma_value_t regexp_value, /**< RegExp object */
 
   for (uint32_t i = 0; i < num_of_iter_length; i++)
   {
-    num_of_iter_p[i] = 0u;
+    num_of_iter_p[i] = 0U;
   }
 
   bool is_match = false;

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -346,8 +346,8 @@ ecma_typedarray_create_object_with_typedarray (ecma_object_t *typedarray_p, /**<
   }
   else
   {
-    uint32_t src_element_size = 1u << ecma_typedarray_get_element_size_shift (typedarray_p);
-    uint32_t dst_element_size = 1u << element_size_shift;
+    uint32_t src_element_size = 1U << ecma_typedarray_get_element_size_shift (typedarray_p);
+    uint32_t dst_element_size = 1U << element_size_shift;
 
     for (uint32_t i = 0; i < array_length; i++)
     {

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -436,7 +436,7 @@ lit_read_code_unit_from_hex (const lit_utf8_byte_t *buf_p, /**< buffer with char
 
   for (lit_utf8_size_t i = 0; i < number_of_characters; i++)
   {
-    code_unit = (ecma_char_t) (code_unit << 4u);
+    code_unit = (ecma_char_t) (code_unit << 4U);
 
     if (*buf_p >= LIT_CHAR_ASCII_DIGITS_BEGIN
         && *buf_p <= LIT_CHAR_ASCII_DIGITS_END)

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -47,7 +47,7 @@ static parser_line_counter_t
 align_column_to_tab (parser_line_counter_t column) /**< current column */
 {
   /* Tab aligns to zero column start position. */
-  return (parser_line_counter_t) (((column + (8u - 1u)) & ~ECMA_STRING_CONTAINER_MASK) + 1u);
+  return (parser_line_counter_t) (((column + (8U - 1U)) & ~ECMA_STRING_CONTAINER_MASK) + 1U);
 } /* align_column_to_tab */
 
 /**
@@ -720,7 +720,7 @@ lexer_parse_string (parser_context_t *context_p) /**< context */
                                                                     source_p + 1,
                                                                     hex_part_length));
         source_p += hex_part_length + 1;
-        PARSER_PLUS_EQUAL_LC (column, hex_part_length + 1u);
+        PARSER_PLUS_EQUAL_LC (column, hex_part_length + 1U);
         continue;
       }
     }

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -465,7 +465,7 @@ re_find_bytecode_in_cache (ecma_string_t *pattern_str_p, /**< pattern string */
 {
   uint8_t free_idx = RE_CACHE_SIZE;
 
-  for (uint8_t idx = 0u; idx < RE_CACHE_SIZE; idx++)
+  for (uint8_t idx = 0U; idx < RE_CACHE_SIZE; idx++)
   {
     const re_compiled_code_t *cached_bytecode_p = JERRY_CONTEXT (re_cache)[idx];
 
@@ -497,7 +497,7 @@ re_find_bytecode_in_cache (ecma_string_t *pattern_str_p, /**< pattern string */
 void
 re_cache_gc_run (void)
 {
-  for (uint32_t i = 0u; i < RE_CACHE_SIZE; i++)
+  for (uint32_t i = 0U; i < RE_CACHE_SIZE; i++)
   {
     const re_compiled_code_t *cached_bytecode_p = JERRY_CONTEXT (re_cache)[i];
 


### PR DESCRIPTION
Using upper case literal suffixes removes the potential ambiguity between
"1" (digit 1) and "l" (letter el) for declaring literals.
Fixes 'MISRA C++:2008, 2-13-4 - Literal suffixes shall be upper case' warnings.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com