### PR TITLE
On simple strings the utf8 substring copy api call created an assert

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -1226,7 +1226,7 @@ ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, /**< ecm
                                     lit_utf8_size_t buffer_size) /**< size of buffer */
 {
   JERRY_ASSERT (string_desc_p != NULL);
-  JERRY_ASSERT (string_desc_p->refs_and_container >= ECMA_STRING_REF_ONE);
+  JERRY_ASSERT (ECMA_IS_DIRECT_STRING (string_desc_p) || string_desc_p->refs_and_container >= ECMA_STRING_REF_ONE);
   JERRY_ASSERT (buffer_p != NULL || buffer_size == 0);
 
   lit_utf8_size_t size = 0;

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -514,6 +514,30 @@ main (void)
   TEST_ASSERT (utf8_sz == 12);
   jerry_release_value (args[0]);
 
+  /* Test string: '3' */
+  {
+    jerry_value_t test_str = jerry_create_string ((const jerry_char_t *) "3");
+    char result_string[1] = { 'E' };
+    jerry_size_t copied_utf8 = jerry_substring_to_utf8_char_buffer (test_str,
+                                                                    0,
+                                                                    1,
+                                                                    (jerry_char_t *) result_string,
+                                                                    sizeof (result_string));
+    TEST_ASSERT (copied_utf8 == 1);
+    TEST_ASSERT (result_string[0] == '3');
+
+    result_string[0] = 'E';
+    jerry_size_t copied = jerry_substring_to_char_buffer (test_str,
+                                                          0,
+                                                          1,
+                                                          (jerry_char_t *) result_string,
+                                                          sizeof (result_string));
+    TEST_ASSERT (copied == 1);
+    TEST_ASSERT (result_string[0] == '3');
+
+    jerry_release_value (test_str);
+  }
+
   /* Test jerry_substring_to_char_buffer */
   args[0] = jerry_create_string ((jerry_char_t *) "an ascii string");
 


### PR DESCRIPTION
When the `jerry_substring_to_utf8_char_buffer` was called
with direct strings the assert incorrectly assumed that the
string is a ref counted string and tried to access the
refcount value resulting in a failed assert.

Added direct string check for the underlying implementation
and created a test case for such simple string.