### PR TITLE
Improve license checker line ending validation

### DIFF
--- a/tools/check-license.py
+++ b/tools/check-license.py
@@ -16,6 +16,7 @@
 
 from __future__ import print_function
 
+import io
 import os
 import re
 import sys
@@ -78,7 +79,7 @@ def main():
             for fname in files:
                 if any(fname.endswith(ext) for ext in EXTENSIONS):
                     fpath = os.path.join(root, fname)
-                    with open(fpath) as curr_file:
+                    with io.open(fpath, 'r', errors='ignore') as curr_file:
                         if not LICENSE.search(curr_file.read()):
                             print('%s: incorrect license' % fpath)
                             is_ok = False


### PR DESCRIPTION
The license checker previously assumed that the
lines of the license will always end with \n
characters. However when checking a file
it could happen that other line endings are
returned (should only happen for test files) thus
the checker can incorrectly report invalid license
as the line endings are incorrect.

Additional note #1: in Python when reading a file
in text mode it can happen that the line endings are
converted to the host system's line ending.
However on Travis the conversion did not happen when
using the open built-in method. By switching to the
io.open call the conversion is enforced and
all line endings are converted to '\n' regardless of
the host system's line ending.

Additional note #2: it is possible that there
are input test files which are not utf-8 conformant
(eg.: to test the parser). These files can't be read
as utf-8 strings and an exception would occur.
By ignoring these errors the tool can check
the file's license. In the license text there is no
invalid utf-8 character so the check will work
correctly.