### PR TITLE
Fix jerry_get_value_from_error

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1722,7 +1722,7 @@ whether the input error value must be released or not. If it is set to `true`,
 then a [`jerry_release_value`](#jerry_release_value) function will be called
 for the first argument, so the error value won't be available after the call of
 `jerry_get_value_from_error`. The second argument should be false if both error
-and its represented value are needed. The first argument is returned unchanged if it is not an error.
+and its represented value are needed.
 
 *Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
 is no longer needed.

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -921,7 +921,7 @@ jerry_get_value_from_error (jerry_value_t value, /**< api value */
 
   if (!ecma_is_value_error_reference (value))
   {
-    return value;
+    return release ? value : ecma_copy_value (value);
   }
 
   jerry_value_t ret_val = jerry_acquire_value (ecma_get_error_reference_from_value (value)->value);

--- a/tests/unit-core/test-api-set-and-clear-error-flag.c
+++ b/tests/unit-core/test-api-set-and-clear-error-flag.c
@@ -33,6 +33,15 @@ main (void)
   jerry_release_value (err_val);
 
   jerry_value_t value = jerry_create_number (42);
+  value = jerry_get_value_from_error (value, true);
+  jerry_release_value (value);
+
+  value = jerry_create_number (42);
+  jerry_value_t value2 = jerry_get_value_from_error (value, false);
+  jerry_release_value (value);
+  jerry_release_value (value2);
+
+  value = jerry_create_number (42);
   jerry_value_t error = jerry_create_error_from_value (value, true);
   error = jerry_create_error_from_value (error, true);
   jerry_release_value (error);


### PR DESCRIPTION
Fix the function to take into account the second argument even if it is called with not
an error value.

JerryScript-DCO-1.0-Signed-off-by: Istvan Miklos imiklos2@inf.u-szeged.hu