### PR TITLE
Fix literal free when show opcodes is enabled.

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -636,12 +636,6 @@ parser_generate_initializers (parser_context_t *context_p, /**< context */
                                                                          literal_p->prop.length);
             literal_pool_p[literal_p->prop.index] = lit_value;
           }
-
-          if (!context_p->is_show_opcodes
-              && !(literal_p->status_flags & LEXER_FLAG_SOURCE_PTR))
-          {
-            jmem_heap_free_block ((void *) literal_p->u.char_p, literal_p->prop.length);
-          }
 #else /* !PARSER_DUMP_BYTE_CODE */
           if (!(literal_p->status_flags & LEXER_FLAG_UNUSED_IDENT))
           {
@@ -649,6 +643,14 @@ parser_generate_initializers (parser_context_t *context_p, /**< context */
           }
 #endif /* PARSER_DUMP_BYTE_CODE */
         }
+
+#ifdef PARSER_DUMP_BYTE_CODE
+        if (!context_p->is_show_opcodes
+            && !(literal_p->status_flags & LEXER_FLAG_SOURCE_PTR))
+        {
+          jmem_heap_free_block ((void *) literal_p->u.char_p, literal_p->prop.length);
+        }
+#endif /* PARSER_DUMP_BYTE_CODE */
       }
       else if ((literal_p->type == LEXER_FUNCTION_LITERAL)
                || (literal_p->type == LEXER_REGEXP_LITERAL))

--- a/tests/jerry/regression-test-issue-2398.js
+++ b/tests/jerry/regression-test-issue-2398.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This issue was triggered when show opcodes was enabled at compile
+// time but not enabled in runtime. A memory leak was created.
+
+function f()
+{
+  var \u0042 = true;
+};


### PR DESCRIPTION
A literal might be not freed if it is stored in a register, and PARSER_DUMP_BYTE_CODE is enabled, but opcodes are not shown.

It is easy to trigger, but there is no test for this:
`function f(){var \u0042 = true;};`
