### PR TITLE
Fix parse_print_final_cbc dump when arguments is used

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1228,10 +1228,6 @@ parse_print_final_cbc (ecma_compiled_code_t *compiled_code_p, /**< compiled code
   }
 
   byte_code_start_p += (unsigned int) (literal_end - register_end) * sizeof (ecma_value_t);
-  if (JERRY_UNLIKELY (compiled_code_p->status_flags & CBC_CODE_FLAGS_NON_STRICT_ARGUMENTS_NEEDED))
-  {
-    byte_code_start_p += argument_end * sizeof (ecma_value_t);
-  }
 
   byte_code_end_p = byte_code_start_p + length;
   byte_code_p = byte_code_start_p;

--- a/tests/jerry/regression-test-issue-2400.js
+++ b/tests/jerry/regression-test-issue-2400.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Wrong byte codes were dumped for this function when show opcodes had been enabled
+
+function abc(a,b) {
+  var c = 6;
+  return arguments[0] + b + c;
+}
+
+abc(1, 2);


### PR DESCRIPTION
Currently the byte code start is incorrectly set when a non-strict arguments object is present, and a random memory area is dumped as byte code.

Example:
```
function abc(a,b) {
  var c = 6;
  return arguments[0] + b + c;
}
```

The begin is wrong and several CBC_EXT_NOP opcodes are printed at the end.