### PR TITLE
Add start to backtrace for debugger

### DIFF
--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -376,6 +376,7 @@ typedef struct
 typedef struct
 {
   uint8_t type; /**< type of the message */
+  uint8_t min_depth[sizeof (uint32_t)]; /**< minimum depth*/
   uint8_t max_depth[sizeof (uint32_t)]; /**< maximum depth (0 - unlimited) */
 } jerry_debugger_receive_get_backtrace_t;
 

--- a/tests/debugger/do_backtrace.cmd
+++ b/tests/debugger/do_backtrace.cmd
@@ -4,9 +4,15 @@ next
 step
 next
 s
+bt 1 2
 bt
+bt 2
 n
 n
 s
 backtrace
+bt 4 4
+bt 600 919
+bt 3 500
+bt 4 3
 c

--- a/tests/debugger/do_backtrace.expected
+++ b/tests/debugger/do_backtrace.expected
@@ -14,10 +14,15 @@ out: function test
 Stopped at tests/debugger/do_backtrace.js:33 (in test() at line:30, col:1)
 (jerry-debugger) s
 Stopped at tests/debugger/do_backtrace.js:23 (in foo() at line:21, col:1)
+(jerry-debugger) bt 1 2
+Frame 1: tests/debugger/do_backtrace.js:33 (in test() at line:30, col:1)
 (jerry-debugger) bt
 Frame 0: tests/debugger/do_backtrace.js:23 (in foo() at line:21, col:1)
 Frame 1: tests/debugger/do_backtrace.js:33 (in test() at line:30, col:1)
 Frame 2: tests/debugger/do_backtrace.js:40
+(jerry-debugger) bt 2
+Frame 0: tests/debugger/do_backtrace.js:23 (in foo() at line:21, col:1)
+Frame 1: tests/debugger/do_backtrace.js:33 (in test() at line:30, col:1)
 (jerry-debugger) n
 out: function foo
 Stopped at tests/debugger/do_backtrace.js:24 (in foo() at line:21, col:1)
@@ -30,5 +35,11 @@ Frame 0: tests/debugger/do_backtrace.js:18 (in f4() at line:17, col:1)
 Frame 1: tests/debugger/do_backtrace.js:25 (in foo() at line:21, col:1)
 Frame 2: tests/debugger/do_backtrace.js:33 (in test() at line:30, col:1)
 Frame 3: tests/debugger/do_backtrace.js:40
+(jerry-debugger) bt 4 4
+(jerry-debugger) bt 600 919
+(jerry-debugger) bt 3 500
+Frame 3: tests/debugger/do_backtrace.js:40
+(jerry-debugger) bt 4 3
+Error: Start depth needs to be lower than or equal to max depth
 (jerry-debugger) c
 out: function f4


### PR DESCRIPTION
With this you can add a start where you want to start listing the backtraces, not just maximum depth.

JerryScript-DCO-1.0-Signed-off-by: Daniella Barsony bella@inf.u-szeged.hu