### PR TITLE
Rework function call.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -205,6 +205,22 @@ ecma_builtin_get (ecma_builtin_id_t builtin_id) /**< id of built-in to check on 
 } /* ecma_builtin_get */
 
 /**
+ * Get reference to the global object
+ *
+ * Note:
+ *   Does not increase the reference counter.
+ *
+ * @return pointer to the global object
+ */
+inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
+ecma_builtin_get_global (void)
+{
+  JERRY_ASSERT (JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL] != NULL);
+
+  return JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL];
+} /* ecma_builtin_get_global */
+
+/**
  * Checks whether the given function is a built-in routine
  *
  * @return true - if the function object is a built-in routine

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -96,6 +96,8 @@ bool
 ecma_builtin_is (ecma_object_t *obj_p, ecma_builtin_id_t builtin_id);
 ecma_object_t *
 ecma_builtin_get (ecma_builtin_id_t builtin_id);
+ecma_object_t *
+ecma_builtin_get_global (void);
 bool
 ecma_builtin_function_is_routine (ecma_object_t *func_obj_p);
 

--- a/tests/jerry/es2015/regression-test-issue-2414.js
+++ b/tests/jerry/es2015/regression-test-issue-2414.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  // By default bound functions always support new operator.
+  // However, arrow functions must throw an error even in this case.
+
+  var f = (() => 1).bind();
+
+  new f;
+
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
Furthermore add a construct flag, which disallows calling certain functions without new. Constructing bound arrow functions correctly throws error now.

It seems the change has close to no effect:
Binary: 50 byte reduction, perf: -0.004%, mem: 0.000%