### PR TITLE
Rework JerryScript transport layer.

### DIFF
--- a/docs/13.DEBUGGER-TRANSPORT.md
+++ b/docs/13.DEBUGGER-TRANSPORT.md
@@ -1,0 +1,248 @@
+# JerryScript debugger transport interface
+
+The transport interface support allows dynamic selection of transportation
+layers which can encode/decode or send/receive messages transmitted between
+the debugger client and server.
+
+# Types
+
+## jerry_debugger_transport_receive_context_t
+
+**Summary**
+
+This context represents the current status of processing received data.
+The final state is returned by
+[jerry_debugger_transport_receive](#jerry_debugger_transport_receive)
+and must be passed to
+[jerry_debugger_transport_receive_completed](#jerry_debugger_transport_receive_completed)
+after the message is processed.
+
+**Prototype**
+
+```c
+typedef struct
+{
+  uint8_t *buffer_p; /**< buffer for storing the received data */
+  size_t received_length; /**< number of currently received bytes */
+  uint8_t *message_p; /**< start of the received message */
+  size_t message_length; /**< length of the received message */
+  size_t message_total_length; /**< total length for datagram protocols,
+                                *   0 for stream protocols */
+} jerry_debugger_transport_receive_context_t;
+```
+
+## jerry_debugger_transport_header_t
+
+**Summary**
+
+Shared header for each transport interface. It mostly contains callback functions
+used by the JerryScript debugger server.
+
+**Prototype**
+
+```c
+typedef struct jerry_debugger_transport_layer_t
+{
+  /* The following fields must be filled before calling jerry_debugger_transport_add(). */
+  jerry_debugger_transport_close_t close; /**< close connection callback */
+  jerry_debugger_transport_send_t send;  /**< send data callback */
+  jerry_debugger_transport_receive_t receive; /**< receive data callback */
+
+  /* The following fields are filled by jerry_debugger_transport_add(). */
+  struct jerry_debugger_transport_layer_t *next_p; /**< next transport layer */
+} jerry_debugger_transport_header_t;
+```
+
+## jerry_debugger_transport_close_t
+
+**Summary**
+
+Called when the connection is closed. Must release all resources (including the
+memory area for the transport interface) allocated for the transport interface.
+
+**Prototype**
+
+```c
+typedef void (*jerry_debugger_transport_close_t) (struct jerry_debugger_transport_interface_t *header_p);
+```
+
+## jerry_debugger_transport_send_t
+
+**Summary**
+
+Called when a message needs to be sent. Must either transmit the message or call
+the `header_p->next_p->send()` method.
+
+**Prototype**
+
+```c
+typedef bool (*jerry_debugger_transport_send_t) (struct jerry_debugger_transport_interface_t *header_p,
+                                                 uint8_t *message_p, size_t message_length);
+```
+
+## jerry_debugger_transport_receive_t
+
+**Summary**
+
+Called during message processing. If messages are available it must return with
+the next message.
+
+**Prototype**
+
+```c
+typedef bool (*jerry_debugger_transport_receive_t) (struct jerry_debugger_transport_interface_t *header_p,
+                                                    jerry_debugger_transport_receive_context_t *context_p);
+```
+
+# Transport interface API functions
+
+## jerry_debugger_transport_malloc
+
+**Summary**
+
+Allocates memory for the transport interface.
+
+**Prototype**
+
+```c
+void * jerry_debugger_transport_malloc (size_t size);
+```
+
+- `size`: size of the memory block.
+- return value: non-NULL pointer, if the memory is successfully allocated,
+                NULL otherwise.
+
+## jerry_debugger_transport_free
+
+**Summary**
+
+Free memory allocated by [jerry_debugger_transport_malloc](#jerry_debugger_transport_malloc)
+
+**Prototype**
+
+```c
+void jerry_debugger_transport_free (void *mem_p, size_t size);
+```
+
+- `header_p`: header of a transporation interface.
+- `size`: total size of the transportation interface.
+
+## jerry_debugger_transport_add
+
+**Summary**
+
+Add a new interface to the transporation interface chain. The interface
+will be the first item of the interface chain.
+
+**Prototype**
+
+```c
+void jerry_debugger_transport_add (jerry_debugger_transport_header_t *header_p,
+                                   size_t send_message_header_size, size_t max_send_message_size,
+                                   size_t receive_message_header_size, size_t max_receive_message_size);
+```
+
+- `header_p`: header of a transporation interface.
+- `send_message_header_size`: size of the outgoing message header, can be 0.
+- `max_send_message_size`: maximum outgoing message size supported by the interface.
+- `receive_message_header_size`: size of the incoming message header, can be 0.
+- `max_receive_message_size`: maximum incoming message size supported by the interface.
+
+## jerry_debugger_transport_start
+
+**Summary**
+
+Starts the communication to the debugger client. Must be called after the
+connection is successfully established.
+
+**Prototype**
+
+```c
+void jerry_debugger_transport_start (void);
+```
+
+## jerry_debugger_transport_is_connected
+
+**Summary**
+
+Tells whether a debugger client is connected to the debugger server.
+
+**Prototype**
+
+```c
+bool jerry_debugger_transport_is_connected (void);
+```
+
+- return value: `true`, if a client is connected, `false` otherwise.
+
+## jerry_debugger_transport_close
+
+**Summary**
+
+Disconnect from the current debugger client. It does nothing if a client is
+not connected, 
+
+**Prototype**
+
+```c
+void jerry_debugger_transport_close (void);
+```
+
+## jerry_debugger_transport_send
+
+**Summary**
+
+Send message to the client.
+
+**Prototype**
+
+```c
+bool jerry_debugger_transport_send (const uint8_t *message_p, size_t message_length);
+```
+
+- `message_p`: message to be sent.
+- `message_length`: message length in bytes.
+- return value: `true`, if a client is still connected, `false` otherwise.
+
+## jerry_debugger_transport_receive
+
+**Summary**
+
+Receive message from the client.
+
+**Prototype**
+
+```c
+bool jerry_debugger_transport_receive (jerry_debugger_transport_receive_context_t *context_p);
+```
+
+- `context_p`: an unused [jerry_debugger_transport_receive_context_t](#jerry_debugger_transport_receive_context_t).
+- return value: `true`, if a client is still connected, `false` otherwise.
+
+## jerry_debugger_transport_receive_completed
+
+**Summary**
+
+Must be called after [jerry_debugger_transport_receive](#jerry_debugger_transport_receive)
+returns with a valid message. Must not be called otherwise.
+
+**Prototype**
+
+```c
+void jerry_debugger_transport_receive_completed (jerry_debugger_transport_receive_context_t *context_p);
+```
+
+- `context_p`: a [jerry_debugger_transport_receive_context_t](#jerry_debugger_transport_receive_context_t)
+               passed to [jerry_debugger_transport_receive](#jerry_debugger_transport_receive).
+
+## jerry_debugger_transport_sleep
+
+**Summary**
+
+Can be used to wait for incoming messages. Currently the delay is 100ms.
+
+**Prototype**
+
+```c
+void jerry_debugger_transport_sleep (void);
+```

--- a/jerry-core/api/jerry-debugger-transport.c
+++ b/jerry-core/api/jerry-debugger-transport.c
@@ -1,0 +1,273 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "debugger.h"
+#include "jcontext.h"
+#include "jerryscript.h"
+
+#ifdef JERRY_DEBUGGER
+
+/**
+ * Minimum number of bytes transmitted or received.
+ */
+#define JERRY_DEBUGGER_TRANSPORT_MIN_BUFFER_SIZE 64
+
+/**
+ * Sleep time in milliseconds between each jerry_debugger_receive call
+ */
+#define JERRY_DEBUGGER_TRANSPORT_TIMEOUT 100
+
+/**
+ * Allocate memory for a connection.
+ *
+ * @return allocated memory on success
+ *         NULL otherwise
+ */
+void *
+jerry_debugger_transport_malloc (size_t size) /**< size of the memory block */
+{
+  return jmem_heap_alloc_block_null_on_error (size);
+} /* jerry_debugger_transport_malloc */
+
+/**
+ * Free memory allocated for a connection.
+ */
+void
+jerry_debugger_transport_free (void *mem_p, /**< value returned by jerry_debugger_transport_malloc() */
+                               size_t size) /**< same size passed to jerry_debugger_transport_malloc() */
+{
+  jmem_heap_free_block (mem_p, size);
+} /* jerry_debugger_transport_free */
+
+/**
+ * Add a new transport layer.
+ */
+void
+jerry_debugger_transport_add (jerry_debugger_transport_header_t *header_p, /**< transport implementation */
+                              size_t send_message_header_size, /**< header bytes reserved for outgoing messages */
+                              size_t max_send_message_size, /**< maximum number of bytes transmitted in a message */
+                              size_t receive_message_header_size, /**< header bytes reserved for incoming messages */
+                              size_t max_receive_message_size) /**< maximum number of bytes received in a message */
+{
+  JERRY_ASSERT (max_send_message_size > JERRY_DEBUGGER_TRANSPORT_MIN_BUFFER_SIZE
+                && max_receive_message_size > JERRY_DEBUGGER_TRANSPORT_MIN_BUFFER_SIZE);
+
+  header_p->next_p = JERRY_CONTEXT (debugger_transport_header_p);
+  JERRY_CONTEXT (debugger_transport_header_p) = header_p;
+
+  uint8_t *payload_p;
+  size_t max_send_size;
+  size_t max_receive_size;
+
+  if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
+  {
+    payload_p = JERRY_CONTEXT (debugger_send_buffer_payload_p);
+    max_send_size = JERRY_CONTEXT (debugger_max_send_size);
+    max_receive_size = JERRY_CONTEXT (debugger_max_receive_size);
+  }
+  else
+  {
+    JERRY_DEBUGGER_SET_FLAGS (JERRY_DEBUGGER_CONNECTED);
+    payload_p = JERRY_CONTEXT (debugger_send_buffer);
+    max_send_size = JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE;
+    max_receive_size = JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE;
+  }
+
+  JERRY_ASSERT (max_send_size > JERRY_DEBUGGER_TRANSPORT_MIN_BUFFER_SIZE + send_message_header_size);
+  JERRY_ASSERT (max_receive_size > JERRY_DEBUGGER_TRANSPORT_MIN_BUFFER_SIZE + receive_message_header_size);
+
+  JERRY_CONTEXT (debugger_send_buffer_payload_p) = payload_p + send_message_header_size;
+
+  max_send_size = max_send_size - send_message_header_size;
+  max_receive_size = max_receive_size - receive_message_header_size;
+
+  if (max_send_size > max_send_message_size)
+  {
+    max_send_size = max_send_message_size;
+  }
+
+  if (max_receive_size > max_receive_message_size)
+  {
+    max_receive_size = max_receive_message_size;
+  }
+
+  JERRY_CONTEXT (debugger_max_send_size) = (uint8_t) max_send_size;
+  JERRY_CONTEXT (debugger_max_receive_size) = (uint8_t) max_receive_size;
+} /* jerry_debugger_transport_add */
+
+/**
+ * Starts the communication to the debugger client.
+ * Must be called after the connection is successfully established.
+ */
+void
+jerry_debugger_transport_start (void)
+{
+  JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
+
+  if (jerry_debugger_send_configuration (JERRY_CONTEXT (debugger_max_receive_size)))
+  {
+    JERRY_DEBUGGER_SET_FLAGS (JERRY_DEBUGGER_VM_STOP);
+    JERRY_CONTEXT (debugger_stop_context) = NULL;
+  }
+} /* jerry_debugger_transport_start */
+
+/**
+ * Returns true if a debugger client is connected.
+ *
+ * @return true - a debugger client is connected,
+ *         false - otherwise
+ */
+bool
+jerry_debugger_transport_is_connected (void)
+{
+  return (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED) != 0;
+} /* jerry_debugger_transport_is_connected */
+
+/**
+ * Notifies the debugger server that the connection is closed.
+ */
+void
+jerry_debugger_transport_close (void)
+{
+  if (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED))
+  {
+    return;
+  }
+
+  jerry_debugger_transport_header_t *current_p = JERRY_CONTEXT (debugger_transport_header_p);
+
+  JERRY_ASSERT (current_p != NULL);
+
+  do
+  {
+    jerry_debugger_transport_header_t *next_p = current_p->next_p;
+
+    current_p->close (current_p);
+
+    current_p = next_p;
+  }
+  while (current_p != NULL);
+
+  JERRY_CONTEXT (debugger_flags) = JERRY_DEBUGGER_VM_IGNORE;
+
+  jerry_port_log (JERRY_LOG_LEVEL_DEBUG, "Debugger client connection closed.\n");
+
+  jerry_debugger_free_unreferenced_byte_code ();
+} /* jerry_debugger_transport_close */
+
+/**
+ * Send data over the current connection
+ *
+ * @return true - data sent successfully,
+ *         false - connection closed
+ */
+bool
+jerry_debugger_transport_send (const uint8_t *message_p, /**< message to be sent */
+                               size_t message_length) /**< message length in bytes */
+{
+  JERRY_ASSERT (jerry_debugger_transport_is_connected ());
+  JERRY_ASSERT (message_length > 0);
+
+  jerry_debugger_transport_header_t *header_p = JERRY_CONTEXT (debugger_transport_header_p);
+  uint8_t *payload_p = JERRY_CONTEXT (debugger_send_buffer_payload_p);
+  size_t max_send_size = JERRY_CONTEXT (debugger_max_send_size);
+
+  do
+  {
+    size_t fragment_length = (message_length <= max_send_size ? message_length
+                                                              : max_send_size);
+
+    memcpy (payload_p, message_p, fragment_length);
+
+    if (!header_p->send (header_p, payload_p, fragment_length))
+    {
+      return false;
+    }
+
+    message_p += fragment_length;
+    message_length -= fragment_length;
+  }
+  while (message_length > 0);
+
+  return true;
+} /* jerry_debugger_transport_send */
+
+/**
+ * Receive data from the current connection
+ *
+ * Note:
+ *   A message is received if message_start_p is not NULL
+ *
+ * @return true - function successfully completed,
+ *         false - connection closed
+ */
+bool
+jerry_debugger_transport_receive (jerry_debugger_transport_receive_context_t *context_p) /**< [out] receive
+                                                                                          *   context */
+{
+  JERRY_ASSERT (jerry_debugger_transport_is_connected ());
+
+  context_p->buffer_p = JERRY_CONTEXT (debugger_receive_buffer);
+  context_p->received_length = JERRY_CONTEXT (debugger_received_length);
+  context_p->message_p = NULL;
+  context_p->message_length = 0;
+  context_p->message_total_length = 0;
+
+  jerry_debugger_transport_header_t *header_p = JERRY_CONTEXT (debugger_transport_header_p);
+
+  return header_p->receive (header_p, context_p);
+} /* jerry_debugger_transport_receive */
+
+/**
+ * Clear the message buffer after the message is processed
+ */
+void
+jerry_debugger_transport_receive_completed (jerry_debugger_transport_receive_context_t *context_p) /**< receive
+                                                                                                    *   context */
+{
+  JERRY_ASSERT (context_p->message_p != NULL);
+  JERRY_ASSERT (context_p->buffer_p == JERRY_CONTEXT (debugger_receive_buffer));
+
+  size_t message_total_length = context_p->message_total_length;
+  size_t received_length = context_p->received_length;
+
+  JERRY_ASSERT (message_total_length <= received_length);
+
+  if (message_total_length == 0 || message_total_length == received_length)
+  {
+    /* All received data is processed. */
+    JERRY_CONTEXT (debugger_received_length) = 0;
+    return;
+  }
+
+  uint8_t *buffer_p = context_p->buffer_p;
+  received_length -= message_total_length;
+
+  memmove (buffer_p, buffer_p + message_total_length, received_length);
+
+  JERRY_CONTEXT (debugger_received_length) = (uint16_t) received_length;
+} /* jerry_debugger_transport_receive_completed */
+
+/**
+ * Suspend execution for a given time.
+ * Note: If the platform does not have nanosleep or usleep, this function does not sleep at all.
+ */
+void
+jerry_debugger_transport_sleep (void)
+{
+  jerry_port_sleep (JERRY_DEBUGGER_TRANSPORT_TIMEOUT);
+} /* jerry_debugger_transport_sleep */
+
+#endif /* JERRY_DEBUGGER */

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -35,6 +35,7 @@
 #include "ecma-typedarray-object.h"
 #include "jcontext.h"
 #include "jerryscript.h"
+#include "jerryscript-debugger-transport.h"
 #include "jmem.h"
 #include "js-parser.h"
 #include "re-compiler.h"
@@ -199,7 +200,7 @@ jerry_cleanup (void)
 #ifdef JERRY_DEBUGGER
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
-    jerry_debugger_close_connection ();
+    jerry_debugger_transport_close ();
   }
 #endif /* JERRY_DEBUGGER */
 

--- a/jerry-core/debugger/debugger-tcp.c
+++ b/jerry-core/debugger/debugger-tcp.c
@@ -1,0 +1,237 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "debugger-tcp.h"
+#include "jrt.h"
+
+#ifdef JERRY_DEBUGGER
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+/**
+ * Implementation of transport over tcp/ip.
+ */
+typedef struct
+{
+  jerry_debugger_transport_header_t header; /**< transport header */
+  int tcp_socket; /**< tcp socket */
+} jerry_debugger_transport_tcp_t;
+
+/**
+ * Log tcp error message.
+ */
+static void
+jerry_debugger_tcp_log_error (void)
+{
+  JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
+} /* jerry_debugger_tcp_log_error */
+
+/**
+ * Close a tcp connection.
+ */
+static void
+jerry_debugger_tcp_close (jerry_debugger_transport_header_t *header_p) /**< tcp implementation */
+{
+  JERRY_ASSERT (jerry_debugger_transport_is_connected ());
+
+  jerry_debugger_transport_tcp_t *tcp_p = (jerry_debugger_transport_tcp_t *) header_p;
+
+  JERRY_DEBUG_MSG ("TCP connection closed.\n");
+
+  close (tcp_p->tcp_socket);
+
+  jerry_debugger_transport_free ((void *) header_p, sizeof (jerry_debugger_transport_tcp_t));
+} /* jerry_debugger_tcp_close */
+
+/**
+ * Send data over a tcp connection.
+ *
+ * @return true - if the data has been sent successfully
+ *         false - otherwise
+ */
+static bool
+jerry_debugger_tcp_send (jerry_debugger_transport_header_t *header_p, /**< tcp implementation */
+                         uint8_t *message_p, /**< message to be sent */
+                         size_t message_length) /**< message length in bytes */
+{
+  JERRY_ASSERT (jerry_debugger_transport_is_connected ());
+
+  jerry_debugger_transport_tcp_t *tcp_p = (jerry_debugger_transport_tcp_t *) header_p;
+
+  do
+  {
+    ssize_t sent_bytes = send (tcp_p->tcp_socket, message_p, message_length, 0);
+
+    if (sent_bytes < 0)
+    {
+      if (errno == EWOULDBLOCK)
+      {
+        continue;
+      }
+
+      jerry_debugger_tcp_log_error ();
+      jerry_debugger_transport_close ();
+      return false;
+    }
+
+    message_p += sent_bytes;
+    message_length -= (size_t) sent_bytes;
+  }
+  while (message_length > 0);
+
+  return true;
+} /* jerry_debugger_tcp_send */
+
+/**
+ * Receive data from a tcp connection.
+ */
+static bool
+jerry_debugger_tcp_receive (jerry_debugger_transport_header_t *header_p, /**< tcp implementation */
+                            jerry_debugger_transport_receive_context_t *receive_context_p) /**< receive context */
+{
+  jerry_debugger_transport_tcp_t *tcp_p = (jerry_debugger_transport_tcp_t *) header_p;
+
+  uint8_t *buffer_p = receive_context_p->buffer_p + receive_context_p->received_length;
+  size_t buffer_size = JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE - receive_context_p->received_length;
+
+  ssize_t length = recv (tcp_p->tcp_socket, buffer_p, buffer_size, 0);
+
+  if (length < 0)
+  {
+    if (errno != EWOULDBLOCK)
+    {
+      jerry_debugger_tcp_log_error ();
+      jerry_debugger_transport_close ();
+      return false;
+    }
+    length = 0;
+  }
+
+  receive_context_p->received_length += (size_t) length;
+
+  if (receive_context_p->received_length > 0)
+  {
+    receive_context_p->message_p = receive_context_p->buffer_p;
+    receive_context_p->message_length = receive_context_p->received_length;
+  }
+
+  return true;
+} /* jerry_debugger_tcp_receive */
+
+/**
+ * Create a tcp connection.
+ *
+ * @return true if successful,
+ *         false otherwise
+ */
+bool
+jerry_debugger_tcp_create (uint16_t port) /**< listening port */
+{
+  int server_socket;
+  struct sockaddr_in addr;
+  socklen_t sin_size = sizeof (struct sockaddr_in);
+
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons (port);
+  addr.sin_addr.s_addr = INADDR_ANY;
+
+  if ((server_socket = socket (AF_INET, SOCK_STREAM, 0)) == -1)
+  {
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
+    return false;
+  }
+
+  int opt_value = 1;
+
+  if (setsockopt (server_socket, SOL_SOCKET, SO_REUSEADDR, &opt_value, sizeof (int)) == -1)
+  {
+    close (server_socket);
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
+    return false;
+  }
+
+  if (bind (server_socket, (struct sockaddr *)&addr, sizeof (struct sockaddr)) == -1)
+  {
+    close (server_socket);
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
+    return false;
+  }
+
+  if (listen (server_socket, 1) == -1)
+  {
+    close (server_socket);
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
+    return false;
+  }
+
+  JERRY_DEBUG_MSG ("Waiting for client connection\n");
+
+  int tcp_socket = accept (server_socket, (struct sockaddr *)&addr, &sin_size);
+
+  close (server_socket);
+
+  if (tcp_socket == -1)
+  {
+    JERRY_ERROR_MSG ("Error: %s\n", strerror (errno));
+    return false;
+  }
+
+  /* Set non-blocking mode. */
+  int socket_flags = fcntl (tcp_socket, F_GETFL, 0);
+
+  if (socket_flags < 0)
+  {
+    close (tcp_socket);
+    return false;
+  }
+
+  if (fcntl (tcp_socket, F_SETFL, socket_flags | O_NONBLOCK) == -1)
+  {
+    close (tcp_socket);
+    return false;
+  }
+
+  JERRY_DEBUG_MSG ("Connected from: %s\n", inet_ntoa (addr.sin_addr));
+
+  size_t size = sizeof (jerry_debugger_transport_tcp_t);
+
+  jerry_debugger_transport_header_t *header_p;
+  header_p = (jerry_debugger_transport_header_t *) jerry_debugger_transport_malloc (size);
+
+  if (!header_p)
+  {
+    close (tcp_socket);
+    return false;
+  }
+
+  header_p->close = jerry_debugger_tcp_close;
+  header_p->send = jerry_debugger_tcp_send;
+  header_p->receive = jerry_debugger_tcp_receive;
+
+  ((jerry_debugger_transport_tcp_t *) header_p)->tcp_socket = tcp_socket;
+
+  jerry_debugger_transport_add (header_p,
+                                0,
+                                JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE,
+                                0,
+                                JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE);
+
+  return true;
+} /* jerry_debugger_tcp_create */
+
+#endif /* JERRY_DEBUGGER */

--- a/jerry-core/debugger/debugger-tcp.h
+++ b/jerry-core/debugger/debugger-tcp.h
@@ -13,21 +13,15 @@
  * limitations under the License.
  */
 
-#ifndef DEBUGGER_WS_H
-#define DEBUGGER_WS_H
+#ifndef DEBUGGER_TCP_H
+#define DEBUGGER_TCP_H
 
 #include "jerryscript-debugger-transport.h"
 
 #ifdef JERRY_DEBUGGER
 
-/* JerryScript debugger protocol is a simplified version of RFC-6455 (WebSockets). */
-
-bool jerry_debugger_ws_create (void);
-
-void jerry_debugger_compute_sha1 (const uint8_t *input1, size_t input1_len,
-                                  const uint8_t *input2, size_t input2_len,
-                                  uint8_t output[20]);
+bool jerry_debugger_tcp_create (uint16_t port);
 
 #endif /* JERRY_DEBUGGER */
 
-#endif /* !DEBUGGER_WS_H */
+#endif /* !DEBUGGER_TCP_H */

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -18,6 +18,7 @@
 
 #include "debugger-ws.h"
 #include "ecma-globals.h"
+#include "jerryscript-debugger-transport.h"
 
 #ifdef JERRY_DEBUGGER
 
@@ -34,22 +35,17 @@
 #define JERRY_DEBUGGER_MESSAGE_FREQUENCY 5
 
 /**
- * Sleep time in milliseconds between each jerry_debugger_receive call
+ * This constant represents that the string to be sent has no subtype.
  */
-#define JERRY_DEBUGGER_TIMEOUT 100
-
-/**
-  * This constant represents that the string to be sent has no subtype.
-  */
 #define JERRY_DEBUGGER_NO_SUBTYPE 0
 
 /**
  * Limited resources available for the engine, so it is important to
  * check the maximum buffer size. It needs to be between 64 and 256 bytes.
  */
-#if JERRY_DEBUGGER_MAX_BUFFER_SIZE < 64 || JERRY_DEBUGGER_MAX_BUFFER_SIZE > 256
+#if JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE < 64 || JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE > 256
 #error Please define the MAX_BUFFER_SIZE between 64 and 256 bytes.
-#endif /* JERRY_DEBUGGER_MAX_BUFFER_SIZE < 64 || JERRY_DEBUGGER_MAX_BUFFER_SIZE > 256 */
+#endif /* JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE < 64 || JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE > 256 */
 
 /**
  * Calculate the maximum number of items for a given type
@@ -227,6 +223,15 @@ typedef enum
 } jerry_debugger_output_subtype_t;
 
 /**
+ * Byte data for evaluating expressions and receiving client source.
+ */
+typedef struct
+{
+  uint32_t uint8_size; /**< total size of the client source */
+  uint32_t uint8_offset; /**< current offset in the client source */
+} jerry_debugger_uint8_data_t;
+
+/**
  * Delayed free of byte code data.
  */
 typedef struct
@@ -400,11 +405,8 @@ typedef struct
 
 void jerry_debugger_free_unreferenced_byte_code (void);
 
-void jerry_debugger_sleep (void);
+bool jerry_debugger_receive (jerry_debugger_uint8_data_t **message_data_p);
 
-bool jerry_debugger_process_message (uint8_t *recv_buffer_p, uint32_t message_size,
-                                     bool *resume_exec_p, uint8_t *expected_message_p,
-                                     jerry_debugger_uint8_data_t **message_data_p);
 void jerry_debugger_breakpoint_hit (uint8_t message_type);
 
 void jerry_debugger_send_type (jerry_debugger_header_type_t type);

--- a/jerry-core/include/jerryscript-debugger-transport.h
+++ b/jerry-core/include/jerryscript-debugger-transport.h
@@ -1,0 +1,107 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef JERRYSCRIPT_DEBUGGER_TRANSPORT_H
+#define JERRYSCRIPT_DEBUGGER_TRANSPORT_H
+
+#include <jerryscript-core.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+/** \addtogroup jerry-debugger-transport Jerry engine debugger interface - transport control
+ * @{
+ */
+
+/**
+ * Maximum number of bytes transmitted or received.
+ */
+#define JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE 128
+
+/**
+ * Receive message context.
+ */
+typedef struct
+{
+  uint8_t *buffer_p; /**< buffer for storing the received data */
+  size_t received_length; /**< number of currently received bytes */
+  uint8_t *message_p; /**< start of the received message */
+  size_t message_length; /**< length of the received message */
+  size_t message_total_length; /**< total length for datagram protocols,
+                                *   0 for stream protocols */
+} jerry_debugger_transport_receive_context_t;
+
+/**
+ * Forward definition of jerry_debugger_transport_header_t.
+ */
+struct jerry_debugger_transport_interface_t;
+
+/**
+ * Close connection callback.
+ */
+typedef void (*jerry_debugger_transport_close_t) (struct jerry_debugger_transport_interface_t *header_p);
+
+/**
+ * Send data callback.
+ */
+typedef bool (*jerry_debugger_transport_send_t) (struct jerry_debugger_transport_interface_t *header_p,
+                                                 uint8_t *message_p, size_t message_length);
+
+/**
+ * Receive data callback.
+ */
+typedef bool (*jerry_debugger_transport_receive_t) (struct jerry_debugger_transport_interface_t *header_p,
+                                                    jerry_debugger_transport_receive_context_t *context_p);
+
+/**
+ * Transport layer header.
+ */
+typedef struct jerry_debugger_transport_interface_t
+{
+  /* The following fields must be filled before calling jerry_debugger_transport_add(). */
+  jerry_debugger_transport_close_t close; /**< close connection callback */
+  jerry_debugger_transport_send_t send;  /**< send data callback */
+  jerry_debugger_transport_receive_t receive; /**< receive data callback */
+
+  /* The following fields are filled by jerry_debugger_transport_add(). */
+  struct jerry_debugger_transport_interface_t *next_p; /**< next transport layer */
+} jerry_debugger_transport_header_t;
+
+void * jerry_debugger_transport_malloc (size_t size);
+void jerry_debugger_transport_free (void *mem_p, size_t size);
+void jerry_debugger_transport_add (jerry_debugger_transport_header_t *header_p,
+                                   size_t send_message_header_size, size_t max_send_message_size,
+                                   size_t receive_message_header_size, size_t max_receive_message_size);
+void jerry_debugger_transport_start (void);
+
+bool jerry_debugger_transport_is_connected (void);
+void jerry_debugger_transport_close (void);
+
+bool jerry_debugger_transport_send (const uint8_t *message_p, size_t message_length);
+bool jerry_debugger_transport_receive (jerry_debugger_transport_receive_context_t *context_p);
+void jerry_debugger_transport_receive_completed (jerry_debugger_transport_receive_context_t *context_p);
+
+void jerry_debugger_transport_sleep (void);
+
+/**
+ * @}
+ */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+#endif /* !JERRYSCRIPT_DEBUGGER_TRANSPORT_H */

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -16,7 +16,7 @@
 #ifndef JERRYSCRIPT_DEBUGGER_H
 #define JERRYSCRIPT_DEBUGGER_H
 
-#include <stdbool.h>
+#include <jerryscript-core.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -27,6 +27,7 @@
 #include "re-bytecode.h"
 #include "vm-defines.h"
 #include "jerryscript.h"
+#include "jerryscript-debugger-transport.h"
 
 /** \addtogroup context Context
  * @{
@@ -109,19 +110,18 @@ typedef struct
 #endif /* JERRY_VM_EXEC_STOP */
 
 #ifdef JERRY_DEBUGGER
-  uint8_t debugger_send_buffer[JERRY_DEBUGGER_MAX_BUFFER_SIZE]; /**< buffer for sending messages */
-  uint8_t debugger_receive_buffer[JERRY_DEBUGGER_MAX_BUFFER_SIZE]; /**< buffer for receiving messages */
+  uint8_t debugger_send_buffer[JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE]; /**< buffer for sending messages */
+  uint8_t debugger_receive_buffer[JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE]; /**< buffer for receiving messages */
+  jerry_debugger_transport_header_t *debugger_transport_header_p; /**< head of transport protocol chain */
   uint8_t *debugger_send_buffer_payload_p; /**< start where the outgoing message can be written */
   vm_frame_ctx_t *debugger_stop_context; /**< stop only if the current context is equal to this context */
   jmem_cpointer_t debugger_byte_code_free_head; /**< head of byte code free linked list */
   jmem_cpointer_t debugger_byte_code_free_tail; /**< tail of byte code free linked list */
   uint32_t debugger_flags; /**< debugger flags */
-  uint16_t debugger_receive_buffer_offset; /**< receive buffer offset */
-  uint16_t debugger_port; /**< debugger socket communication port */
+  uint16_t debugger_received_length; /**< length of currently received bytes */
   uint8_t debugger_message_delay; /**< call receive message when reaches zero */
-  uint8_t debugger_max_send_size; /**< maximum amount of data that can be written */
+  uint8_t debugger_max_send_size; /**< maximum amount of data that can be sent */
   uint8_t debugger_max_receive_size; /**< maximum amount of data that can be received */
-  int debugger_connection; /**< holds the file descriptor of the socket communication */
 #endif /* JERRY_DEBUGGER */
 
 #ifdef JERRY_ENABLE_LINE_INFO

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -228,6 +228,13 @@ typedef struct
 {
   uint32_t value;                             /**< line or offset of the breakpoint */
 } parser_breakpoint_info_t;
+
+/**
+ * Maximum number of breakpoint info.
+ */
+#define PARSER_MAX_BREAKPOINT_INFO_COUNT \
+  (JERRY_DEBUGGER_TRANSPORT_MAX_BUFFER_SIZE / sizeof (parser_breakpoint_info_t))
+
 #endif /* JERRY_DEBUGGER */
 
 /**
@@ -312,8 +319,7 @@ typedef struct
 #endif /* PARSER_DUMP_BYTE_CODE */
 
 #ifdef JERRY_DEBUGGER
-  /** extra data for each breakpoint */
-  parser_breakpoint_info_t breakpoint_info[JERRY_DEBUGGER_MAX_BUFFER_SIZE / sizeof (parser_breakpoint_info_t)];
+  parser_breakpoint_info_t breakpoint_info[PARSER_MAX_BREAKPOINT_INFO_COUNT]; /**< breakpoint info list */
   uint16_t breakpoint_info_count; /**< current breakpoint index */
   parser_line_counter_t last_breakpoint_line; /**< last line where breakpoint has been inserted */
 #endif /* JERRY_DEBUGGER */

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2897,7 +2897,7 @@ parser_parse_script (const uint8_t *arg_list_p, /**< function argument list */
         break;
       }
 
-      jerry_debugger_sleep ();
+      jerry_debugger_transport_sleep ();
     }
   }
 #endif /* JERRY_DEBUGGER */


### PR DESCRIPTION
Introducing jerryscript-debugger-transport.h interface, which allows chaining multiple protocols (e.g. tcp and websocket).