### PR TITLE
Remove jerry_get_arg_value function.

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -13,16 +13,17 @@ Enum that contains the following elements:
 
 ## jerry_type_t
 
-Enum that contains a set of elements to represent JavaScript type:
+Enum that contains JerryScript API value types:
 
  - JERRY_TYPE_NONE - no type information
- - JERRY_TYPE_UNDEFINED - undefined value
- - JERRY_TYPE_NULL - null value
- - JERRY_TYPE_BOOLEAN - boolean value
- - JERRY_TYPE_NUMBER - number value
- - JERRY_TYPE_STRING - string value
- - JERRY_TYPE_OBJECT - object value
- - JERRY_TYPE_FUNCTION - function value
+ - JERRY_TYPE_UNDEFINED - undefined type
+ - JERRY_TYPE_NULL - null type
+ - JERRY_TYPE_BOOLEAN - boolean type
+ - JERRY_TYPE_NUMBER - number type
+ - JERRY_TYPE_STRING - string type
+ - JERRY_TYPE_OBJECT - object type
+ - JERRY_TYPE_FUNCTION - function type
+ - JERRY_TYPE_ERROR - error/abort type
 
 ## jerry_error_t
 

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -367,6 +367,7 @@ typedef enum
   JERRY_TYPE_STRING,    /**< string type */
   JERRY_TYPE_OBJECT,    /**< object type */
   JERRY_TYPE_FUNCTION,  /**< function type */
+  JERRY_TYPE_ERROR,     /**< error/abort type */
 } jerry_type_t;
 
 jerry_type_t jerry_value_get_type (const jerry_value_t value);
@@ -386,7 +387,7 @@ jerry_value_t jerry_get_value_from_error (jerry_value_t value, bool release);
 /**
  * Error object function(s).
  */
-jerry_error_t jerry_get_error_type (const jerry_value_t value);
+jerry_error_t jerry_get_error_type (jerry_value_t value);
 
 /**
  * Getter functions of 'jerry_value_t'.

--- a/jerry-ext/module/module.c
+++ b/jerry-ext/module/module.c
@@ -35,10 +35,14 @@ jerryx_module_create_error (jerry_error_t error_type, /**< the type of error to 
                             const jerry_value_t module_name) /**< the module name */
 {
   jerry_value_t ret = jerry_create_error (error_type, message);
+
+  jerry_value_t error_object = jerry_get_value_from_error (ret, false);
   jerry_value_t property_name = jerry_create_string (module_name_property_name);
 
-  jerry_release_value (jerry_set_property (ret, property_name, module_name));
+  jerry_release_value (jerry_set_property (error_object, property_name, module_name));
+
   jerry_release_value (property_name);
+  jerry_release_value (error_object);
   return ret;
 } /* jerryx_module_create_error */
 

--- a/tests/unit-core/test-api-value-type.c
+++ b/tests/unit-core/test-api-value-type.c
@@ -63,7 +63,7 @@ main (void)
 
     ENTRY (JERRY_TYPE_OBJECT, jerry_create_object ()),
     ENTRY (JERRY_TYPE_OBJECT, jerry_create_array (10)),
-    ENTRY (JERRY_TYPE_OBJECT, jerry_create_error (JERRY_ERROR_TYPE, (const jerry_char_t *) "error")),
+    ENTRY (JERRY_TYPE_ERROR, jerry_create_error (JERRY_ERROR_TYPE, (const jerry_char_t *) "error")),
 
     ENTRY (JERRY_TYPE_NULL, jerry_create_null ()),
 

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -854,6 +854,7 @@ main (void)
   jerry_release_value (val_t);
 
   /* 'res' should contain exception object */
+  res = jerry_get_value_from_error (res, true);
   TEST_ASSERT (jerry_value_is_object (res));
   jerry_release_value (res);
 
@@ -863,6 +864,7 @@ main (void)
   TEST_ASSERT (jerry_value_is_error (res));
 
   /* 'res' should contain exception object */
+  res = jerry_get_value_from_error (res, true);
   TEST_ASSERT (jerry_value_is_object (res));
   jerry_release_value (res);
 
@@ -878,6 +880,7 @@ main (void)
   jerry_release_value (val_t);
 
   /* 'res' should contain exception object */
+  res = jerry_get_value_from_error (res, true);
   TEST_ASSERT (jerry_value_is_object (res));
   jerry_release_value (res);
 
@@ -887,6 +890,7 @@ main (void)
   TEST_ASSERT (jerry_value_is_error (res));
 
   /* 'res' should contain exception object */
+  res = jerry_get_value_from_error (res, true);
   TEST_ASSERT (jerry_value_is_object (res));
   jerry_release_value (res);
 

--- a/tests/unit-ext/test-ext-module-empty.c
+++ b/tests/unit-ext/test-ext-module-empty.c
@@ -39,6 +39,7 @@ main (int argc, char **argv)
   TEST_ASSERT (jerry_value_is_error (module));
 
   /* Retrieve the error message. */
+  module = jerry_get_value_from_error (module, true);
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "message");
   jerry_value_t prop = jerry_get_property (module, prop_name);
 


### PR DESCRIPTION
Remove automatic conversion of errors. Errors are primary values, just like numbers or strings.