### PR TITLE
Fix broken pipe error in Jerry Debugger

### DIFF
--- a/jerry-port/default/default-io.c
+++ b/jerry-port/default/default-io.c
@@ -91,7 +91,10 @@ jerry_port_log (jerry_log_level_t level, /**< message log level */
     vsnprintf (buffer, (size_t) length + 1, format, args);
 
     fprintf (stderr, "%s", buffer);
-    jerry_debugger_send_output ((jerry_char_t *) buffer, (jerry_size_t) length, (uint8_t) (level + 2));
+    if (jerry_debugger_transport_is_connected ())
+    {
+      jerry_debugger_send_output ((jerry_char_t *) buffer, (jerry_size_t) length, (uint8_t) (level + 2));
+    }
 #else /* If jerry-debugger isn't defined, libc is turned on */
     vfprintf (stderr, format, args);
 #endif /* JERRY_DEBUGGER */


### PR DESCRIPTION
This patch fixes an error caused by trying to send data to a closed socket.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu