### PR TITLE
Change ../../libapps paths in TizenRT configuration Makefile

### DIFF
--- a/targets/tizenrt-artik053/apps/jerryscript/Makefile
+++ b/targets/tizenrt-artik053/apps/jerryscript/Makefile
@@ -103,12 +103,12 @@ ifneq ($(CONFIG_BUILD_KERNEL),y)
 endif
 
 ifeq ($(CONFIG_WINDOWS_NATIVE),y)
-  BIN = ..\..\libapps$(LIBEXT)
+  BIN = $(APPDIR)\libapps$(LIBEXT)
 else
 ifeq ($(WINTOOL),y)
-  BIN = ..\\..\\libapps$(LIBEXT)
+  BIN = $(APPDIR)\\libapps$(LIBEXT)
 else
-  BIN = ../../libapps$(LIBEXT)
+  BIN = $(APPDIR)/libapps$(LIBEXT)
 endif
 endif
 


### PR DESCRIPTION
This change helps the symlink method to work also with TizenRT/jerryscript configuration, while maintaining the old cp method usability.

JerryScript-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu