### PR TITLE
[WIP] Support for shorthand object literal notation.

### DIFF
--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -147,6 +147,7 @@ typedef enum
   LEXER_EXPRESSION_START,        /**< expression start */
   LEXER_PROPERTY_GETTER,         /**< property getter function */
   LEXER_PROPERTY_SETTER,         /**< property setter function */
+  LEXER_PROPERTY_METHOD,         /**< property method (ES6+) */
   LEXER_COMMA_SEP_LIST,          /**< comma separated bracketed expression list */
   LEXER_SCAN_SWITCH,             /**< special value for switch pre-scan */
   LEXER_CLASS_CONSTRUCTOR,       /**< special value for class constructor method */
@@ -216,6 +217,7 @@ typedef enum
   LEXER_OBJ_IDENT_NO_OPTS = (1u << 0),          /**< no options */
   LEXER_OBJ_IDENT_ONLY_IDENTIFIERS = (1u << 1), /**< only identifiers are accepted */
   LEXER_OBJ_IDENT_CLASS_METHOD = (1u << 2),     /**< expect identifier inside a class body */
+  LEXER_OBJ_IDENT_OBJ_METHOD = (1u << 3),       /**< expect method identifier inside object */
 } lexer_obj_ident_opts_t;
 
 /**

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -433,10 +433,15 @@ void parser_set_continues_to_current_position (parser_context_t *context_p, pars
 
 /* Lexer functions */
 
+#ifndef CONFIG_DISABLE_ES2015_OBJECT_INITIALIZER
+bool lexer_is_identifier_keyword (parser_context_t *context_p);
+#endif /* !CONFIG_DISABLE_ES2015_OBJECT_INITIALIZER */
 void lexer_next_token (parser_context_t *context_p);
 bool lexer_check_colon (parser_context_t *context_p);
-#ifndef CONFIG_DISABLE_ES2015_CLASS
+#if !defined (CONFIG_DISABLE_ES2015_CLASS) || !defined (CONFIG_DISABLE_ES2015_OBJECT_INITIALIZER)
 bool lexer_check_left_paren (parser_context_t *context_p);
+#endif /* !CONFIG_DISABLE_ES2015_CLASS || !CONFIG_DISABLE_ES2015_OBJECT_INITIALIZER */
+#ifndef CONFIG_DISABLE_ES2015_CLASS
 void lexer_skip_empty_statements (parser_context_t *context_p);
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
 #ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION

--- a/jerry-core/profiles/README.md
+++ b/jerry-core/profiles/README.md
@@ -96,4 +96,4 @@ In JerryScript all of the features are enabled by default, so an empty profile f
 * `CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN`:
   Disable the [ArrayBuffer](http://www.ecma-international.org/ecma-262/6.0/#sec-arraybuffer-objects) and [TypedArray](http://www.ecma-international.org/ecma-262/6.0/#sec-typedarray-objects) built-ins.
 * `CONFIG_DISABLE_ES2015`: Disable all of the implemented [ECMAScript2015 features](http://www.ecma-international.org/ecma-262/6.0/).
-  (equivalent to `CONFIG_DISABLE_ES2015_ARROW_FUNCTION`, `CONFIG_DISABLE_ES2015_BUILTIN`, `CONFIG_DISABLE_ES2015_CLASS`, `CONFIG_DISABLE_ES2015_PROMISE_BUILTIN`, `CONFIG_DISABLE_ES2015_TEMPLATE_STRINGS`, and `CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN`).
+  (equivalent to `CONFIG_DISABLE_ES2015_ARROW_FUNCTION`, `CONFIG_DISABLE_ES2015_BUILTIN`, `CONFIG_DISABLE_ES2015_CLASS`, `CONFIG_DISABLE_ES2015_PROMISE_BUILTIN`, `CONFIG_DISABLE_ES2015_TEMPLATE_STRINGS`, `CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN`, and `CONFIG_DISABLE_ES2015_OBJECT_INITIALIZER`).

--- a/tests/jerry/es2015/object-literal-shorthand-notation.js
+++ b/tests/jerry/es2015/object-literal-shorthand-notation.js
@@ -1,0 +1,125 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var x = 1, y = 2, z = 3;
+var obj = { x, y, z: { z } };
+assert(obj.x === 1);
+assert(obj.y === 2);
+assert(obj.z.z === 3);
+
+try {
+  var a = { get, set };
+  assert(false);
+} catch (e) {
+  assert(e instanceof ReferenceError);
+}
+
+function checkReservedAsVars() {
+  var get = 1, set = 2;
+  var a = { get, set };
+  assert(a.get + a.set === 3);
+}
+checkReservedAsVars();
+
+var one = 1;
+assert({ one, one }.one === 1);
+assert({ one: 0, one }.one === 1);
+assert({ one, one: 0 }.one === 0);
+
+var obj2 = { one };
+assert({ obj2 }.obj2.one === 1);
+
+try {
+  eval('({ true, false, null })');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+
+try {
+  eval('({ 1 })');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+
+try {
+  eval('({ "foo" })');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+
+try {
+  eval('({ {} })');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+
+try {
+  eval('({ 1, "foo", {} })');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+
+try {
+  eval('({ static foo() {} })');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+
+var obj3 = { f() { return 1; } };
+assert(obj3.f() === 1);
+
+var obj4 = { one, one() { return one; } };
+assert(typeof obj4.one === 'function');
+assert(obj4.one() === 1);
+
+var obj5 = { x: 123, getX() { return this.x; } };
+assert(obj5.getX() === 123);
+
+var obj6 = {
+  if() { return 1; }, else() { return 1; }, try() { return 1; }, catch() { return 1; },
+  finally() { return 1; }, let() { return 1; }, true() { return 1; }, false() { return 1; },
+  null() { return 1; }, function() { return 1; }
+};
+assert(
+  obj6.if() + obj6.else() + obj6.try() + obj6.catch() + obj6.finally() + obj6.let() +
+  obj6.true() + obj6.false() + obj6.null() + obj6.function() === 10
+);
+
+var obj7 = {
+  _x: 0,
+
+  get x() {
+    return thix._x;
+  },
+
+  set x(x_value) {
+    this._x = x_value;
+  }
+};
+assert(obj7._x === 7);
+assert(obj7.x === 7);
+obj7.x = 1;
+assert(obj7._x === 1);
+assert(obj7.x === 1);
+
+var obj8 = {
+  constructor() { return 1; }, static() { return 1; }, get() { return 1; }, set() { return 1; }
+};
+assert(obj8.constructor() + obj8.static() + obj8.get() + obj8.set() === 4);


### PR DESCRIPTION
This pull request adds support for object literal shorthand notation (properties and methods). In code:
```js
let foo = 1;
let bar = { foo }; // Equivalent to: { foo: foo }
let baz = {
  fn() {
    return 123;
  }
}; // Equivalent to: { fn: function() { return 123; } }
```
JerryScript-DCO-1.0-Signed-off-by: Anthony Calandra anthony@anthony-calandra.com