### PR TITLE
[API] Save literals to a file while merging the snapshots

### DIFF
--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -64,7 +64,9 @@ jerry_value_t jerry_load_function_snapshot (const uint32_t *function_snapshot_p,
                                             size_t func_index, uint32_t exec_snapshot_opts);
 
 size_t jerry_merge_snapshots (const uint32_t **inp_buffers_p, size_t *inp_buffer_sizes_p, size_t number_of_snapshots,
-                              uint32_t *out_buffer_p, size_t out_buffer_size, const char **error_p);
+                              uint32_t *out_buffer_p, size_t out_buffer_size, uint32_t *out_literals_p,
+                              size_t *out_literals_size, bool is_save_literals_mode_in_c_format, bool get_literals,
+                              const char **error_p);
 size_t jerry_parse_and_save_literals (const jerry_char_t *source_p, size_t source_size, bool is_strict,
                                       uint32_t *buffer_p, size_t buffer_size, bool is_c_format);
 /**

--- a/tests/unit-core/test-snapshot.c
+++ b/tests/unit-core/test-snapshot.c
@@ -330,12 +330,18 @@ main (void)
 
     snapshot_buffers[0] = snapshot_buffer_0;
     snapshot_buffers[1] = snapshot_buffer_1;
+    uint32_t out_literals_p[SNAPSHOT_BUFFER_SIZE / 4];
+    size_t out_literals_size = 0;
 
     size_t merged_size = jerry_merge_snapshots (snapshot_buffers,
                                                 snapshot_sizes,
                                                 2,
                                                 merged_snapshot_buffer,
                                                 SNAPSHOT_BUFFER_SIZE,
+                                                out_literals_p,
+                                                &out_literals_size,
+                                                false,
+                                                false,
                                                 &error_p);
 
     jerry_cleanup ();


### PR DESCRIPTION
Add command line options to snapshot merge:
--save-literals-list-format
--save-literals-c-format

JerryScript-DCO-1.0-Signed-off-by: Tamas Zakor ztamas@inf.u-szeged.hu