### PR TITLE
Improve lexer_expect_object_literal_id option handling

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2264,13 +2264,13 @@ lexer_expect_identifier (parser_context_t *context_p, /**< context */
  */
 void
 lexer_expect_object_literal_id (parser_context_t *context_p, /**< context */
-                                bool must_be_identifier) /**< only identifiers are accepted */
+                                uint32_t ident_opts) /**< lexer_obj_ident_opts_t option bits */
 {
   lexer_skip_spaces (context_p);
 
 #ifndef CONFIG_DISABLE_ES2015_CLASS
-  int is_class_method = ((context_p->status_flags & PARSER_IS_CLASS)
-                         && !must_be_identifier
+  int is_class_method = ((ident_opts & LEXER_OBJ_IDENT_CLASS_METHOD)
+                         && !(ident_opts & LEXER_OBJ_IDENT_ONLY_IDENTIFIERS)
                          && (context_p->token.type != LEXER_KEYW_STATIC));
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
 
@@ -2285,7 +2285,7 @@ lexer_expect_object_literal_id (parser_context_t *context_p, /**< context */
     {
       lexer_parse_identifier (context_p, false);
 
-      if (!must_be_identifier
+      if (!(ident_opts & LEXER_OBJ_IDENT_ONLY_IDENTIFIERS)
           && context_p->token.lit_location.length == 3)
       {
         lexer_skip_spaces (context_p);
@@ -2323,7 +2323,7 @@ lexer_expect_object_literal_id (parser_context_t *context_p, /**< context */
       lexer_parse_string (context_p);
       create_literal_object = true;
     }
-    else if (!must_be_identifier && context_p->source_p[0] == LIT_CHAR_RIGHT_BRACE)
+    else if (!(ident_opts & LEXER_OBJ_IDENT_ONLY_IDENTIFIERS) && context_p->source_p[0] == LIT_CHAR_RIGHT_BRACE)
     {
       context_p->token.type = LEXER_RIGHT_BRACE;
       context_p->source_p += 1;

--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -209,6 +209,17 @@ typedef enum
 } lexer_newline_flags_t;
 
 /**
+ * Lexer object identifier parse options.
+ */
+typedef enum
+{
+  LEXER_OBJ_IDENT_NO_OPTS = (1u << 0),          /**< no options */
+  LEXER_OBJ_IDENT_ONLY_IDENTIFIERS = (1u << 1), /**< only identifiers are accepted */
+  LEXER_OBJ_IDENT_CLASS_METHOD = (1u << 2),     /**< expect identifier inside a class body */
+} lexer_obj_ident_opts_t;
+
+
+/**
  * Lexer literal object types.
  */
 typedef enum

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -379,7 +379,7 @@ parser_parse_class_literal (parser_context_t *context_p, /**< context */
       lexer_skip_empty_statements (context_p);
     }
 
-    lexer_expect_object_literal_id (context_p, false);
+    lexer_expect_object_literal_id (context_p, LEXER_OBJ_IDENT_CLASS_METHOD);
 
     if (context_p->token.type == LEXER_RIGHT_BRACE)
     {
@@ -403,7 +403,7 @@ parser_parse_class_literal (parser_context_t *context_p, /**< context */
         opcode = is_static ? CBC_EXT_SET_STATIC_SETTER : CBC_EXT_SET_SETTER;
       }
 
-      lexer_expect_object_literal_id (context_p, true);
+      lexer_expect_object_literal_id (context_p, LEXER_OBJ_IDENT_CLASS_METHOD | LEXER_OBJ_IDENT_ONLY_IDENTIFIERS);
       literal_index = context_p->lit_object.index;
 
       if (!is_static && lexer_compare_raw_identifier_to_current (context_p, "constructor", 11))
@@ -556,7 +556,7 @@ parser_parse_class (parser_context_t *context_p, /**< context */
   bool is_strict = context_p->status_flags & PARSER_IS_STRICT;
 
   /* 14.5. A ClassBody is always strict code. */
-  context_p->status_flags |= PARSER_IS_STRICT | PARSER_IS_CLASS;
+  context_p->status_flags |= PARSER_IS_STRICT;
 
   /* ClassDeclaration is parsed. Continue with class body. */
   parser_parse_class_literal (context_p, constructor_literal_p);
@@ -586,8 +586,6 @@ parser_parse_class (parser_context_t *context_p, /**< context */
 
   parser_flush_cbc (context_p);
 
-  context_p->status_flags &= (uint32_t) ~PARSER_IS_CLASS;
-
   if (!is_strict)
   {
     /* Restore flag */
@@ -612,7 +610,7 @@ parser_parse_object_literal (parser_context_t *context_p) /**< context */
 
   while (true)
   {
-    lexer_expect_object_literal_id (context_p, false);
+    lexer_expect_object_literal_id (context_p, LEXER_OBJ_IDENT_NO_OPTS);
 
     if (context_p->token.type == LEXER_RIGHT_BRACE)
     {
@@ -640,7 +638,7 @@ parser_parse_object_literal (parser_context_t *context_p) /**< context */
         item_type = PARSER_OBJECT_PROPERTY_SETTER;
       }
 
-      lexer_expect_object_literal_id (context_p, true);
+      lexer_expect_object_literal_id (context_p, LEXER_OBJ_IDENT_ONLY_IDENTIFIERS);
       literal_index = context_p->lit_object.index;
 
       parser_append_object_literal_item (context_p, literal_index, item_type);

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -68,8 +68,7 @@ typedef enum
   PARSER_ARROW_PARSE_ARGS = (1u << 19),       /**< parse the argument list of an arrow function */
 #endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 #ifndef CONFIG_DISABLE_ES2015_CLASS
-  PARSER_IS_CLASS = (1u << 20),               /**< statements parsed inside class body */
-  PARSER_CLASS_CONSTRUCTOR = (1u << 21),      /**< a class constructor is parsed */
+  PARSER_CLASS_CONSTRUCTOR = (1u << 20),      /**< a class constructor is parsed */
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
 } parser_general_flags_t;
 
@@ -447,7 +446,7 @@ void lexer_parse_string (parser_context_t *context_p);
 void lexer_expect_identifier (parser_context_t *context_p, uint8_t literal_type);
 void lexer_scan_identifier (parser_context_t *context_p, bool propety_name);
 ecma_char_t lexer_hex_to_character (parser_context_t *context_p, const uint8_t *source_p, int length);
-void lexer_expect_object_literal_id (parser_context_t *context_p, bool must_be_identifier);
+void lexer_expect_object_literal_id (parser_context_t *context_p, uint32_t ident_opts);
 void lexer_construct_literal_object (parser_context_t *context_p, lexer_lit_location_t *literal_p,
                                      uint8_t literal_type);
 bool lexer_construct_number_object (parser_context_t *context_p, bool is_expr, bool is_negative_number);


### PR DESCRIPTION
This patch allows to add further options flags to `lexer_expect_object_literal_id` to handle unique behaviors more easily
also substitutes `PARSER_IS_CLASS` flag hence it is removed.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu