### PR TITLE
Use #include<> for system headers and #include"" for own headers

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#include <math.h>
+
 #include "ecma-alloc.h"
 #include "ecma-builtin-helpers.h"
 #include "ecma-conversion.h"
@@ -22,7 +24,6 @@
 #include "ecma-helpers.h"
 #include "ecma-try-catch-macro.h"
 #include "lit-char-helpers.h"
-#include "math.h"
 
 #ifndef CONFIG_DISABLE_DATE_BUILTIN
 

--- a/jerry-core/include/jerryscript-debugger-transport.h
+++ b/jerry-core/include/jerryscript-debugger-transport.h
@@ -16,7 +16,7 @@
 #ifndef JERRYSCRIPT_DEBUGGER_TRANSPORT_H
 #define JERRYSCRIPT_DEBUGGER_TRANSPORT_H
 
-#include <jerryscript-core.h>
+#include "jerryscript-core.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -16,7 +16,7 @@
 #ifndef JERRYSCRIPT_DEBUGGER_H
 #define JERRYSCRIPT_DEBUGGER_H
 
-#include <jerryscript-core.h>
+#include "jerryscript-core.h"
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
They are no big differences between the two forms as "" falls back
to <>. There are some inconsistencies in the code, though, which
are fixed by this patch.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu