### PR TITLE
Revisit unused global functions in jerry-core

### DIFF
--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -185,35 +185,6 @@ ecma_dealloc_string_buffer (ecma_string_t *string_p, /**< string with data */
 } /* ecma_dealloc_string_buffer */
 
 /**
- * Allocate memory for getter-setter pointer pair
- *
- * @return pointer to allocated memory
- */
-inline ecma_getter_setter_pointers_t * JERRY_ATTR_ALWAYS_INLINE
-ecma_alloc_getter_setter_pointers (void)
-{
-#ifdef JMEM_STATS
-  jmem_stats_allocate_property_bytes (sizeof (ecma_property_pair_t));
-#endif /* JMEM_STATS */
-
-  return (ecma_getter_setter_pointers_t *) jmem_pools_alloc (sizeof (ecma_getter_setter_pointers_t));
-} /* ecma_alloc_getter_setter_pointers */
-
-/**
- * Dealloc memory from getter-setter pointer pair
- */
-inline void JERRY_ATTR_ALWAYS_INLINE
-ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *getter_setter_pointers_p) /**< pointer pair
-                                                                                                * to be freed */
-{
-#ifdef JMEM_STATS
-  jmem_stats_free_property_bytes (sizeof (ecma_property_pair_t));
-#endif /* JMEM_STATS */
-
-  jmem_pools_free (getter_setter_pointers_p, sizeof (ecma_getter_setter_pointers_t));
-} /* ecma_dealloc_getter_setter_pointers */
-
-/**
  * Allocate memory for ecma-property pair
  *
  * @return pointer to allocated memory

--- a/jerry-core/ecma/base/ecma-alloc.h
+++ b/jerry-core/ecma/base/ecma-alloc.h
@@ -86,18 +86,6 @@ ecma_string_t *ecma_alloc_string_buffer (size_t size);
 void ecma_dealloc_string_buffer (ecma_string_t *string_p, size_t size);
 
 /**
- * Allocate memory for getter-setter pointer pair
- *
- * @return pointer to allocated memory
- */
-ecma_getter_setter_pointers_t *ecma_alloc_getter_setter_pointers (void);
-
-/**
- * Dealloc memory from getter-setter pointer pair
- */
-void ecma_dealloc_getter_setter_pointers (ecma_getter_setter_pointers_t *getter_setter_pointers_p);
-
-/**
  * Allocate memory for ecma-property pair
  *
  * @return pointer to allocated memory

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -351,7 +351,7 @@ ecma_number_is_infinity (ecma_number_t num) /**< ecma-number */
  *
  * @return shift of dot in the fraction
  */
-int32_t
+static int32_t
 ecma_number_get_fraction_and_exponent (ecma_number_t num, /**< ecma-number */
                                        uint64_t *out_fraction_p, /**< [out] fraction of the number */
                                        int32_t *out_exponent_p) /**< [out] exponent of the number */
@@ -410,7 +410,7 @@ ecma_number_get_fraction_and_exponent (ecma_number_t num, /**< ecma-number */
  *
  * @return ecma-number
  */
-ecma_number_t
+static ecma_number_t
 ecma_number_make_normal_positive_from_fraction_and_exponent (uint64_t fraction, /**< fraction */
                                                              int32_t exponent) /**< exponent */
 {

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -176,6 +176,30 @@ ecma_string_get_chars_fast (const ecma_string_t *string_p, /**< ecma-string */
 } /* ecma_string_get_chars_fast */
 
 /**
+ * Allocate new ecma-string and fill it with reference to ECMA magic string
+ *
+ * @return pointer to ecma-string descriptor
+ */
+static ecma_string_t *
+ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id) /**< identifier of externl magic string */
+{
+  JERRY_ASSERT (id < lit_get_magic_string_ex_count ());
+
+  if (JERRY_LIKELY (id <= ECMA_DIRECT_STRING_MAX_IMM))
+  {
+    return (ecma_string_t *) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC_EX, (uintptr_t) id);
+  }
+
+  ecma_string_t *string_desc_p = ecma_alloc_string ();
+
+  string_desc_p->refs_and_container = ECMA_STRING_CONTAINER_MAGIC_STRING_EX | ECMA_STRING_REF_ONE;
+  string_desc_p->hash = (lit_string_hash_t) (LIT_MAGIC_STRING__COUNT + id);
+  string_desc_p->u.magic_string_ex_id = id;
+
+  return string_desc_p;
+} /* ecma_new_ecma_string_from_magic_string_ex_id */
+
+/**
  * Allocate new ecma-string and fill it with characters from the utf8 string
  *
  * @return pointer to ecma-string descriptor
@@ -479,30 +503,6 @@ ecma_get_magic_string (lit_magic_string_id_t id) /**< identifier of magic string
   JERRY_ASSERT (id < LIT_MAGIC_STRING__COUNT);
   return (ecma_string_t *) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC, (uintptr_t) id);
 } /* ecma_get_magic_string */
-
-/**
- * Allocate new ecma-string and fill it with reference to ECMA magic string
- *
- * @return pointer to ecma-string descriptor
- */
-ecma_string_t *
-ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id) /**< identifier of externl magic string */
-{
-  JERRY_ASSERT (id < lit_get_magic_string_ex_count ());
-
-  if (JERRY_LIKELY (id <= ECMA_DIRECT_STRING_MAX_IMM))
-  {
-    return (ecma_string_t *) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC_EX, (uintptr_t) id);
-  }
-
-  ecma_string_t *string_desc_p = ecma_alloc_string ();
-
-  string_desc_p->refs_and_container = ECMA_STRING_CONTAINER_MAGIC_STRING_EX | ECMA_STRING_REF_ONE;
-  string_desc_p->hash = (lit_string_hash_t) (LIT_MAGIC_STRING__COUNT + id);
-  string_desc_p->u.magic_string_ex_id = id;
-
-  return string_desc_p;
-} /* ecma_new_ecma_string_from_magic_string_ex_id */
 
 /**
  * Append a cesu8 string after an ecma-string

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -200,7 +200,6 @@ ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t uint32_number);
 ecma_string_t *ecma_get_ecma_string_from_uint32 (uint32_t uint32_number);
 ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t num);
 ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t id);
-ecma_string_t *ecma_new_ecma_string_from_magic_string_ex_id (lit_magic_string_ex_id_t id);
 ecma_string_t *ecma_append_chars_to_string (ecma_string_t *string1_p,
                                             const lit_utf8_byte_t *cesu8_string2_p,
                                             lit_utf8_size_t cesu8_string2_size,
@@ -268,10 +267,6 @@ bool ecma_number_is_nan (ecma_number_t num);
 bool ecma_number_is_negative (ecma_number_t num);
 bool ecma_number_is_zero (ecma_number_t num);
 bool ecma_number_is_infinity (ecma_number_t num);
-int32_t
-ecma_number_get_fraction_and_exponent (ecma_number_t num, uint64_t *out_fraction_p, int32_t *out_exponent_p);
-ecma_number_t
-ecma_number_make_normal_positive_from_fraction_and_exponent (uint64_t fraction, int32_t exponent);
 ecma_number_t
 ecma_number_make_from_sign_mantissa_and_exponent (bool sign, uint64_t mantissa, int32_t exponent);
 ecma_number_t ecma_number_get_prev (ecma_number_t num);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -100,7 +100,7 @@ ecma_has_string_value_in_collection (ecma_collection_header_t *collection_p, /**
  * @return pointer to ecma-string
  *         Returned value must be freed with ecma_deref_ecma_string.
  */
-ecma_string_t *
+static ecma_string_t *
 ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *partial_p, /**< key-value pairs*/
                                                       ecma_string_t *separator_p) /**< separator*/
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -158,8 +158,6 @@ ecma_value_t ecma_builtin_json_string_from_object (const ecma_value_t arg1);
 bool ecma_json_has_object_in_stack (ecma_json_occurence_stack_item_t *stack_p, ecma_object_t *object_p);
 bool ecma_has_string_value_in_collection (ecma_collection_header_t *collection_p, ecma_value_t string_value);
 
-ecma_string_t *
-ecma_builtin_helper_json_create_separated_properties (ecma_collection_header_t *partial_p, ecma_string_t *separator_p);
 ecma_value_t
 ecma_builtin_helper_json_create_formatted_json (lit_utf8_byte_t left_bracket, lit_utf8_byte_t right_bracket,
                                                 ecma_string_t *stepback_p, ecma_collection_header_t *partial_p,

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -218,7 +218,7 @@ ecma_new_standard_error_with_message (ecma_standard_error_t error_type, /**< nat
  * @return ecma value
  *         Returned value must be freed with ecma_free_value
  */
-ecma_value_t
+static ecma_value_t
 ecma_raise_standard_error (ecma_standard_error_t error_type, /**< error type */
                            const lit_utf8_byte_t *msg_p) /**< error message */
 {
@@ -342,20 +342,6 @@ ecma_raise_common_error (const char *msg_p) /**< error message */
 {
   return ecma_raise_standard_error (ECMA_ERROR_COMMON, (const lit_utf8_byte_t *) msg_p);
 } /* ecma_raise_common_error */
-
-/**
- * Raise an EvalError with the given message.
- *
- * See also: ECMA-262 v5, 15.11.6.1
- *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
- */
-ecma_value_t
-ecma_raise_eval_error (const char *msg_p) /**< error message */
-{
-  return ecma_raise_standard_error (ECMA_ERROR_EVAL, (const lit_utf8_byte_t *) msg_p);
-} /* ecma_raise_eval_error */
 
 /**
  * Raise a RangeError with the given message.

--- a/jerry-core/ecma/operations/ecma-exceptions.h
+++ b/jerry-core/ecma/operations/ecma-exceptions.h
@@ -53,12 +53,10 @@ typedef enum
 ecma_standard_error_t ecma_get_error_type (ecma_object_t *error_object);
 ecma_object_t *ecma_new_standard_error (ecma_standard_error_t error_type);
 ecma_object_t *ecma_new_standard_error_with_message (ecma_standard_error_t error_type, ecma_string_t *message_string_p);
-ecma_value_t ecma_raise_standard_error (ecma_standard_error_t error_type, const lit_utf8_byte_t *msg_p);
 #ifdef JERRY_ENABLE_ERROR_MESSAGES
 ecma_value_t ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, const char *msg_p, ...);
 #endif /* JERRY_ENABLE_ERROR_MESSAGES */
 ecma_value_t ecma_raise_common_error (const char *msg_p);
-ecma_value_t ecma_raise_eval_error (const char *msg_p);
 ecma_value_t ecma_raise_range_error (const char *msg_p);
 ecma_value_t ecma_raise_reference_error (const char *msg_p);
 ecma_value_t ecma_raise_syntax_error (const char *msg_p);

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -312,7 +312,7 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
  * @return pointer to a property - if it exists,
  *         NULL (i.e. ecma-undefined) - otherwise.
  */
-ecma_property_t
+static ecma_property_t
 ecma_op_object_get_property (ecma_object_t *object_p, /**< the object */
                              ecma_string_t *property_name_p, /**< property name */
                              ecma_property_ref_t *property_ref_p, /**< property reference */

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -28,8 +28,6 @@
 
 ecma_property_t ecma_op_object_get_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
                                                  ecma_property_ref_t *property_ref_p, uint32_t options);
-ecma_property_t ecma_op_object_get_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
-                                             ecma_property_ref_t *property_ref_p, uint32_t options);
 bool ecma_op_object_has_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
 bool ecma_op_object_has_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
 ecma_value_t ecma_op_object_find_own (ecma_value_t base_value, ecma_object_t *object_p, ecma_string_t *property_name_p);

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -53,7 +53,7 @@ ecma_is_promise (ecma_object_t *obj_p) /**< points to object */
  * @return ecma value of the promise result.
  *         Returned value must be freed with ecma_free_value
  */
-inline ecma_value_t
+static inline ecma_value_t
 ecma_promise_get_result (ecma_object_t *obj_p) /**< points to promise object */
 {
   JERRY_ASSERT (ecma_is_promise (obj_p));
@@ -66,7 +66,7 @@ ecma_promise_get_result (ecma_object_t *obj_p) /**< points to promise object */
 /**
  * Set the PromiseResult of promise.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+static inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_promise_set_result (ecma_object_t *obj_p, /**< points to promise object */
                          ecma_value_t result) /**< the result value */
 {
@@ -84,7 +84,7 @@ ecma_promise_set_result (ecma_object_t *obj_p, /**< points to promise object */
  *
  * @return the state's enum value
  */
-inline uint8_t JERRY_ATTR_ALWAYS_INLINE
+static inline uint8_t JERRY_ATTR_ALWAYS_INLINE
 ecma_promise_get_state (ecma_object_t *obj_p) /**< points to promise object */
 {
   JERRY_ASSERT (ecma_is_promise (obj_p));
@@ -95,7 +95,7 @@ ecma_promise_get_state (ecma_object_t *obj_p) /**< points to promise object */
 /**
  * Set the PromiseState of promise.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+static inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_promise_set_state (ecma_object_t *obj_p, /**< points to promise object */
                         uint8_t state) /**< the state */
 {

--- a/jerry-core/ecma/operations/ecma-promise-object.h
+++ b/jerry-core/ecma/operations/ecma-promise-object.h
@@ -86,10 +86,6 @@ typedef enum
 } ecma_promise_property_symbolic_constant_t;
 
 bool ecma_is_promise (ecma_object_t *obj_p);
-ecma_value_t ecma_promise_get_result (ecma_object_t *obj_p);
-void ecma_promise_set_result (ecma_object_t *obj_p, ecma_value_t result);
-uint8_t ecma_promise_get_state (ecma_object_t *obj_p);
-void ecma_promise_set_state (ecma_object_t *obj_p, uint8_t state);
 ecma_value_t
 ecma_op_create_promise_object (ecma_value_t executor, ecma_promise_executor_type_t type);
 ecma_value_t ecma_promise_new_capability (void);

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -24,6 +24,134 @@
 #define JMEM_ALLOCATOR_INTERNAL
 #include "jmem-allocator-internal.h"
 
+#ifdef JMEM_STATS
+/**
+ * Print memory usage statistics
+ */
+static void
+jmem_stats_print (void)
+{
+  jmem_heap_stats_print ();
+} /* jmem_stats_print */
+
+/**
+ * Register byte code allocation.
+ */
+void
+jmem_stats_allocate_byte_code_bytes (size_t byte_code_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  heap_stats->byte_code_bytes += byte_code_size;
+
+  if (heap_stats->byte_code_bytes >= heap_stats->peak_byte_code_bytes)
+  {
+    heap_stats->peak_byte_code_bytes = heap_stats->byte_code_bytes;
+  }
+} /* jmem_stats_allocate_byte_code_bytes */
+
+/**
+ * Register byte code free.
+ */
+void
+jmem_stats_free_byte_code_bytes (size_t byte_code_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  JERRY_ASSERT (heap_stats->byte_code_bytes >= byte_code_size);
+
+  heap_stats->byte_code_bytes -= byte_code_size;
+} /* jmem_stats_free_byte_code_bytes */
+
+/**
+ * Register string allocation.
+ */
+void
+jmem_stats_allocate_string_bytes (size_t string_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  heap_stats->string_bytes += string_size;
+
+  if (heap_stats->string_bytes >= heap_stats->peak_string_bytes)
+  {
+    heap_stats->peak_string_bytes = heap_stats->string_bytes;
+  }
+} /* jmem_stats_allocate_string_bytes */
+
+/**
+ * Register string free.
+ */
+void
+jmem_stats_free_string_bytes (size_t string_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  JERRY_ASSERT (heap_stats->string_bytes >= string_size);
+
+  heap_stats->string_bytes -= string_size;
+} /* jmem_stats_free_string_bytes */
+
+/**
+ * Register object allocation.
+ */
+void
+jmem_stats_allocate_object_bytes (size_t object_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  heap_stats->object_bytes += object_size;
+
+  if (heap_stats->object_bytes >= heap_stats->peak_object_bytes)
+  {
+    heap_stats->peak_object_bytes = heap_stats->object_bytes;
+  }
+} /* jmem_stats_allocate_object_bytes */
+
+/**
+ * Register object free.
+ */
+void
+jmem_stats_free_object_bytes (size_t object_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  JERRY_ASSERT (heap_stats->object_bytes >= object_size);
+
+  heap_stats->object_bytes -= object_size;
+} /* jmem_stats_free_object_bytes */
+
+/**
+ * Register property allocation.
+ */
+void
+jmem_stats_allocate_property_bytes (size_t property_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  heap_stats->property_bytes += property_size;
+
+  if (heap_stats->property_bytes >= heap_stats->peak_property_bytes)
+  {
+    heap_stats->peak_property_bytes = heap_stats->property_bytes;
+  }
+} /* jmem_stats_allocate_property_bytes */
+
+/**
+ * Register property free.
+ */
+void
+jmem_stats_free_property_bytes (size_t property_size)
+{
+  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
+
+  JERRY_ASSERT (heap_stats->property_bytes >= property_size);
+
+  heap_stats->property_bytes -= property_size;
+} /* jmem_stats_free_property_bytes */
+
+#endif /* JMEM_STATS */
+
 /**
  * Initialize memory allocators.
  */
@@ -150,131 +278,3 @@ jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t severi
 
   jmem_pools_collect_empty ();
 } /* jmem_run_free_unused_memory_callbacks */
-
-#ifdef JMEM_STATS
-/**
- * Print memory usage statistics
- */
-void
-jmem_stats_print (void)
-{
-  jmem_heap_stats_print ();
-} /* jmem_stats_print */
-
-/**
- * Register byte code allocation.
- */
-void
-jmem_stats_allocate_byte_code_bytes (size_t byte_code_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  heap_stats->byte_code_bytes += byte_code_size;
-
-  if (heap_stats->byte_code_bytes >= heap_stats->peak_byte_code_bytes)
-  {
-    heap_stats->peak_byte_code_bytes = heap_stats->byte_code_bytes;
-  }
-} /* jmem_stats_allocate_byte_code_bytes */
-
-/**
- * Register byte code free.
- */
-void
-jmem_stats_free_byte_code_bytes (size_t byte_code_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  JERRY_ASSERT (heap_stats->byte_code_bytes >= byte_code_size);
-
-  heap_stats->byte_code_bytes -= byte_code_size;
-} /* jmem_stats_free_byte_code_bytes */
-
-/**
- * Register string allocation.
- */
-void
-jmem_stats_allocate_string_bytes (size_t string_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  heap_stats->string_bytes += string_size;
-
-  if (heap_stats->string_bytes >= heap_stats->peak_string_bytes)
-  {
-    heap_stats->peak_string_bytes = heap_stats->string_bytes;
-  }
-} /* jmem_stats_allocate_string_bytes */
-
-/**
- * Register string free.
- */
-void
-jmem_stats_free_string_bytes (size_t string_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  JERRY_ASSERT (heap_stats->string_bytes >= string_size);
-
-  heap_stats->string_bytes -= string_size;
-} /* jmem_stats_free_string_bytes */
-
-/**
- * Register object allocation.
- */
-void
-jmem_stats_allocate_object_bytes (size_t object_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  heap_stats->object_bytes += object_size;
-
-  if (heap_stats->object_bytes >= heap_stats->peak_object_bytes)
-  {
-    heap_stats->peak_object_bytes = heap_stats->object_bytes;
-  }
-} /* jmem_stats_allocate_object_bytes */
-
-/**
- * Register object free.
- */
-void
-jmem_stats_free_object_bytes (size_t object_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  JERRY_ASSERT (heap_stats->object_bytes >= object_size);
-
-  heap_stats->object_bytes -= object_size;
-} /* jmem_stats_free_object_bytes */
-
-/**
- * Register property allocation.
- */
-void
-jmem_stats_allocate_property_bytes (size_t property_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  heap_stats->property_bytes += property_size;
-
-  if (heap_stats->property_bytes >= heap_stats->peak_property_bytes)
-  {
-    heap_stats->peak_property_bytes = heap_stats->property_bytes;
-  }
-} /* jmem_stats_allocate_property_bytes */
-
-/**
- * Register property free.
- */
-void
-jmem_stats_free_property_bytes (size_t property_size)
-{
-  jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
-
-  JERRY_ASSERT (heap_stats->property_bytes >= property_size);
-
-  heap_stats->property_bytes -= property_size;
-} /* jmem_stats_free_property_bytes */
-
-#endif /* JMEM_STATS */

--- a/jerry-core/jmem/jmem.h
+++ b/jerry-core/jmem/jmem.h
@@ -151,7 +151,6 @@ typedef struct
   size_t free_iter_count; /**< Number of iterations required for inserting free blocks */
 } jmem_heap_stats_t;
 
-void jmem_stats_print (void);
 void jmem_stats_allocate_byte_code_bytes (size_t property_size);
 void jmem_stats_free_byte_code_bytes (size_t property_size);
 void jmem_stats_allocate_string_bytes (size_t string_size);

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -102,20 +102,6 @@ search_char_in_interval_array (ecma_char_t c,               /**< code unit */
 } /* search_char_in_interval_array */
 
 /**
- * Check if specified character is one of the Format-Control characters
- *
- * @return true - if the character is one of characters, listed in ECMA-262 v5, Table 1,
- *         false - otherwise
- */
-bool
-lit_char_is_format_control (ecma_char_t c) /**< code unit */
-{
-  return (c == LIT_CHAR_ZWNJ
-          || c == LIT_CHAR_ZWJ
-          || c == LIT_CHAR_BOM);
-} /* lit_char_is_format_control */
-
-/**
  * Check if specified character is one of the Whitespace characters including those
  * that fall into "Space, Separator" ("Zs") Unicode character category.
  *

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -27,8 +27,6 @@
 #define LIT_CHAR_ZWJ  ((ecma_char_t) 0x200D) /* zero width joiner */
 #define LIT_CHAR_BOM  ((ecma_char_t) 0xFEFF) /* byte order mark */
 
-bool lit_char_is_format_control (ecma_char_t c);
-
 /*
  * Whitespace characters (ECMA-262 v5, Table 2)
  */

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -81,7 +81,7 @@ lit_get_magic_string_size (lit_magic_string_id_t id) /**< magic string id */
  *
  * @return magic string id
  */
-lit_magic_string_id_t
+static lit_magic_string_id_t
 lit_get_magic_string_size_block_start (lit_utf8_size_t size) /**< magic string size */
 {
   static const lit_magic_string_id_t lit_magic_string_size_block_starts[] JERRY_CONST_DATA =

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -52,7 +52,6 @@ uint32_t lit_get_magic_string_ex_count (void);
 
 const lit_utf8_byte_t *lit_get_magic_string_utf8 (lit_magic_string_id_t id);
 lit_utf8_size_t lit_get_magic_string_size (lit_magic_string_id_t id);
-lit_magic_string_id_t lit_get_magic_string_size_block_start (lit_utf8_size_t size);
 
 const lit_utf8_byte_t *lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id);
 lit_utf8_size_t lit_get_magic_string_ex_size (lit_magic_string_ex_id_t id);

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -514,7 +514,6 @@ void parser_raise_error (parser_context_t *context_p, parser_error_t error);
 #ifdef JERRY_DEBUGGER
 
 void parser_append_breakpoint_info (parser_context_t *context_p, jerry_debugger_header_type_t type, uint32_t value);
-void parser_send_breakpoints (parser_context_t *context_p, jerry_debugger_header_type_t type);
 
 #endif /* JERRY_DEBUGGER */
 


### PR DESCRIPTION
There are some leftover global functions in the code that are not
referenced at all anymore. These functions are removed by this
patch.

There are also some global functions that are only used in their
own modules. These functions are made static by this patch.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu