### PR TITLE
Add ESP job to the list of allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,6 +170,8 @@ matrix:
           packages: [gperf, dfu-util, device-tree-compiler, python3-ply, python3-pip]
 
   fast_finish: true
+  allow_failures:
+    - env: JOBNAME="ESP8266 Build Test"
 
 # The channel name "chat.freenode.net#jerryscript"
 # is encrypted against Samsung/jerryscript


### PR DESCRIPTION
The toolchain build that is part of the ESP job relies on external
components. The isl.gforge.inria.fr server of the isl-0.14
dependency is experiencing (hopefully transient) errors. It has
been unreachable for more than a day and is thus blocking all
Travis CI builds.

Once the server becomes reachable again, the ESP job may be
reinstated as a full right job.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu