### PR TITLE
Don't use a shell variable to store error output of doxygen

### DIFF
--- a/tools/check-doxygen.sh
+++ b/tools/check-doxygen.sh
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo -n "Generating documentation with doxygen ..."
-DOXYGEN_WARNINGS=$((doxygen > /dev/null) 2>&1)
-echo " finished"
-
-if [ -n "$DOXYGEN_WARNINGS" ]
+doxygen 2>&1 >/dev/null | head -n 1000 | tee doxygen.log
+if [ -s doxygen.log ]
 then
-  echo "$DOXYGEN_WARNINGS"
-  exit 1
+  EXIT=1
+else
+  EXIT=0
 fi
+rm -f doxygen.log
+exit $EXIT


### PR DESCRIPTION
Storing the error output of doxygen into a shell variable first and
echoing it later is error prone. In case of a long error output,
the whole shell will crash before being able to print the doxygen
diagnostics at all. This patch rewrites the check script to tee the
diagnostics (pipe them to console and store them to a file at the
same time) and check the output file size at the end.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu