### PR TITLE
Split string-sending debugger API into output- and log-sending functions

### DIFF
--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -359,20 +359,51 @@ Sends the program's output to the debugger client.
 **Prototype**
 
 ```c
-  void
-  jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t string_size, uint8_t type)
+void
+jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t string_size)
 ```
 
 **Example**
 
 ```c
+{
   jerry_init (JERRY_INIT_EMPTY);
   jerry_debugger_init (5001);
 
   jerry_char_t my_output = "Hey, this should be sent too!";
   jerry_size_t my_output_size = sizeof (my_output);
 
-  jerry_debugger_send_output (my_output, my_output_size, JERRY_DEBUGGER_OUTPUT_OK);
+  jerry_debugger_send_output (my_output, my_output_size);
 
   jerry_cleanup ();
+}
+```
+
+### jerry_debugger_send_log
+
+**Summary**
+
+Sends the program's log to the debugger client.
+
+**Prototype**
+
+```c
+void
+jerry_debugger_send_log (jerry_log_level_t level, jerry_char_t buffer[], jerry_size_t string_size)
+```
+
+**Example**
+
+```c
+{
+  jerry_init (JERRY_INIT_EMPTY);
+  jerry_debugger_init (5001);
+
+  jerry_char_t my_log = "Custom diagnostics";
+  jerry_size_t my_log_size = sizeof (my_log);
+
+  jerry_debugger_send_log (JERRY_LOG_LEVEL_DEBUG, my_log, my_log_size);
+
+  jerry_cleanup ();
+}
 ```

--- a/jerry-core/api/jerry-debugger.c
+++ b/jerry-core/api/jerry-debugger.c
@@ -190,20 +190,41 @@ jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t
  */
 void
 jerry_debugger_send_output (jerry_char_t buffer[], /**< buffer */
-                            jerry_size_t str_size, /**< string size */
-                            uint8_t type) /**< type of output */
+                            jerry_size_t str_size) /**< string size */
 {
 #ifdef JERRY_DEBUGGER
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
     jerry_debugger_send_string (JERRY_DEBUGGER_OUTPUT_RESULT,
-                                type,
+                                JERRY_DEBUGGER_OUTPUT_OK,
                                 (const uint8_t *) buffer,
                                 sizeof (uint8_t) * str_size);
   }
 #else /* !JERRY_DEBUGGER */
   JERRY_UNUSED (buffer);
   JERRY_UNUSED (str_size);
-  JERRY_UNUSED (type);
 #endif /* JERRY_DEBUGGER */
 } /* jerry_debugger_send_output */
+
+/**
+ * Send the log of the program to the debugger client.
+ */
+void
+jerry_debugger_send_log (jerry_log_level_t level, /**< level of the diagnostics message */
+                         jerry_char_t buffer[], /**< buffer */
+                         jerry_size_t str_size) /**< string size */
+{
+#ifdef JERRY_DEBUGGER
+  if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
+  {
+    jerry_debugger_send_string (JERRY_DEBUGGER_OUTPUT_RESULT,
+                                (uint8_t) (level + 2),
+                                (const uint8_t *) buffer,
+                                sizeof (uint8_t) * str_size);
+  }
+#else /* !JERRY_DEBUGGER */
+  JERRY_UNUSED (level);
+  JERRY_UNUSED (buffer);
+  JERRY_UNUSED (str_size);
+#endif /* JERRY_DEBUGGER */
+} /* jerry_debugger_send_log */

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -212,6 +212,10 @@ typedef enum
 
 /**
  * Subtypes of output_result.
+ *
+ * Note:
+ *      This enum has to be kept in sync with jerry_log_level_t with an offset
+ *      of +2.
  */
 typedef enum
 {

--- a/jerry-core/include/jerryscript-debugger-transport.h
+++ b/jerry-core/include/jerryscript-debugger-transport.h
@@ -16,7 +16,9 @@
 #ifndef JERRYSCRIPT_DEBUGGER_TRANSPORT_H
 #define JERRYSCRIPT_DEBUGGER_TRANSPORT_H
 
-#include "jerryscript-core.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C"

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -17,6 +17,7 @@
 #define JERRYSCRIPT_DEBUGGER_H
 
 #include "jerryscript-core.h"
+#include "jerryscript-port.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -60,7 +61,8 @@ void jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint);
 jerry_debugger_wait_for_source_status_t
 jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t callback_p,
                                        void *user_p, jerry_value_t *return_value);
-void jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t str_size, uint8_t type);
+void jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t str_size);
+void jerry_debugger_send_log (jerry_log_level_t level, jerry_char_t buffer[], jerry_size_t str_size);
 
 /**
  * @}

--- a/jerry-ext/handler/handler-print.c
+++ b/jerry-ext/handler/handler-print.c
@@ -14,7 +14,7 @@
  */
 
 #include "jerryscript-ext/handler.h"
-#include "debugger.h"
+#include "jerryscript-debugger.h"
 
 /**
  * Provide a 'print' implementation for scripts.
@@ -72,7 +72,7 @@ jerryx_handler_print (const jerry_value_t func_obj_val, /**< function object */
                                                                  256)) != 0)
       {
 #ifdef JERRY_DEBUGGER
-        jerry_debugger_send_output (substr_buf, substr_size, JERRY_DEBUGGER_OUTPUT_OK);
+        jerry_debugger_send_output (substr_buf, substr_size);
 #endif /* JERRY_DEBUGGER */
         for (jerry_size_t chr_index = 0; chr_index < substr_size; chr_index++)
         {

--- a/jerry-port/default/default-io.c
+++ b/jerry-port/default/default-io.c
@@ -17,7 +17,7 @@
 
 #include "jerryscript-port.h"
 #include "jerryscript-port-default.h"
-#include "debugger.h"
+#include "jerryscript-debugger.h"
 
 #ifndef DISABLE_EXTRA_API
 
@@ -91,10 +91,7 @@ jerry_port_log (jerry_log_level_t level, /**< message log level */
     vsnprintf (buffer, (size_t) length + 1, format, args);
 
     fprintf (stderr, "%s", buffer);
-    if (jerry_debugger_transport_is_connected ())
-    {
-      jerry_debugger_send_output ((jerry_char_t *) buffer, (jerry_size_t) length, (uint8_t) (level + 2));
-    }
+    jerry_debugger_send_log (level, (jerry_char_t *) buffer, (jerry_size_t) length);
 #else /* If jerry-debugger isn't defined, libc is turned on */
     vfprintf (stderr, format, args);
 #endif /* JERRY_DEBUGGER */

--- a/jerry-port/default/include/jerryscript-port-default.h
+++ b/jerry-port/default/include/jerryscript-port-default.h
@@ -16,10 +16,10 @@
 #ifndef JERRYSCRIPT_PORT_DEFAULT_H
 #define JERRYSCRIPT_PORT_DEFAULT_H
 
+#include <stdbool.h>
+
 #include "jerryscript.h"
 #include "jerryscript-port.h"
-
-#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
This helps to avoid the use of non-public headers and
protocol-internal constants in external code (e.g., in jerry-port
and jerry-ext).

The patch also cleans up the necessary includes in jerry-core public
headers, and the include order in jerry-port/default public headers.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu