### PR TITLE
Move all (nano|u)sleep-related decisions to default port implementation

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -211,16 +211,6 @@ if(FEATURE_DEBUGGER)
     message(FATAL_ERROR "This configuration is not supported. Please build against your system libc to enable the JerryScript debugger.")
   endif()
 
-  # Sleep function availability check
-  INCLUDE (CheckIncludeFiles)
-  CHECK_INCLUDE_FILES (time.h HAVE_TIME_H)
-  CHECK_INCLUDE_FILES (unistd.h HAVE_UNISTD_H)
-  if(HAVE_TIME_H)
-    set(DEFINES_JERRY ${DEFINES_JERRY} HAVE_TIME_H)
-  elseif(HAVE_UNISTD_H)
-    set(DEFINES_JERRY ${DEFINES_JERRY} HAVE_UNISTD_H)
-  endif()
-
   set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_DEBUGGER)
 endif()
 

--- a/jerry-core/api/jerry-debugger-transport.c
+++ b/jerry-core/api/jerry-debugger-transport.c
@@ -261,8 +261,7 @@ jerry_debugger_transport_receive_completed (jerry_debugger_transport_receive_con
 } /* jerry_debugger_transport_receive_completed */
 
 /**
- * Suspend execution for a given time.
- * Note: If the platform does not have nanosleep or usleep, this function does not sleep at all.
+ * Suspend execution for a predefined time (JERRY_DEBUGGER_TRANSPORT_TIMEOUT ms).
  */
 void
 jerry_debugger_transport_sleep (void)

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -16,12 +16,6 @@
 #ifndef JRT_H
 #define JRT_H
 
-#if !defined (_XOPEN_SOURCE) || _XOPEN_SOURCE < 500
-#undef _XOPEN_SOURCE
-/* Required macro for sleep functions (nanosleep or usleep) */
-#define _XOPEN_SOURCE 500
-#endif
-
 #include <stdio.h>
 #include <string.h>
 

--- a/jerry-ext/common/jext-common.h
+++ b/jerry-ext/common/jext-common.h
@@ -16,12 +16,6 @@
 #ifndef JEXT_COMMON_H
 #define JEXT_COMMON_H
 
-#if !defined (_XOPEN_SOURCE) || _XOPEN_SOURCE < 500
-#undef _XOPEN_SOURCE
-/* Required macro for sleep functions (nanosleep or usleep) */
-#define _XOPEN_SOURCE 500
-#endif
-
 #include <stdio.h>
 #include <string.h>
 

--- a/jerry-port/default/CMakeLists.txt
+++ b/jerry-port/default/CMakeLists.txt
@@ -26,6 +26,16 @@ file(GLOB SOURCE_PORT_DEFAULT *.c)
 # (should only be necessary if we used compiler default libc but not checking that)
 set(DEFINES_PORT_DEFAULT _BSD_SOURCE _DEFAULT_SOURCE)
 
+# Sleep function availability check
+INCLUDE (CheckIncludeFiles)
+CHECK_INCLUDE_FILES (time.h HAVE_TIME_H)
+CHECK_INCLUDE_FILES (unistd.h HAVE_UNISTD_H)
+if(HAVE_TIME_H)
+  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_TIME_H)
+elseif(HAVE_UNISTD_H)
+  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_UNISTD_H)
+endif()
+
 # Default Jerry port implementation library variants:
 #   - default
 #   - default-minimal (no extra termination and log APIs)

--- a/jerry-port/default/default-debugger.c
+++ b/jerry-port/default/default-debugger.c
@@ -13,6 +13,12 @@
  * limitations under the License.
  */
 
+ #if !defined (_XOPEN_SOURCE) || _XOPEN_SOURCE < 500
+ #undef _XOPEN_SOURCE
+ /* Required macro for sleep functions (nanosleep or usleep) */
+ #define _XOPEN_SOURCE 500
+ #endif
+
 #ifdef HAVE_TIME_H
 #include <time.h>
 #elif defined (HAVE_UNISTD_H)


### PR DESCRIPTION
... where they belong.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu