### PR TITLE
Rename debugger-ws.h to debugger-sha1.h in debugger extension

### DIFF
--- a/jerry-ext/debugger/debugger-sha1.c
+++ b/jerry-ext/debugger/debugger-sha1.c
@@ -40,7 +40,7 @@
  *  http://www.itl.nist.gov/fipspubs/fip180-1.htm
  */
 
-#include "debugger-ws.h"
+#include "debugger-sha1.h"
 #include "jext-common.h"
 
 #ifdef JERRY_DEBUGGER

--- a/jerry-ext/debugger/debugger-sha1.h
+++ b/jerry-ext/debugger/debugger-sha1.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#ifndef DEBUGGER_WS_H
-#define DEBUGGER_WS_H
+#ifndef DEBUGGER_SHA1_H
+#define DEBUGGER_SHA1_H
 
 #include "jerryscript-debugger-transport.h"
 
@@ -28,4 +28,4 @@ void jerryx_debugger_compute_sha1 (const uint8_t *input1, size_t input1_len,
 
 #endif /* JERRY_DEBUGGER */
 
-#endif /* !DEBUGGER_WS_H */
+#endif /* !DEBUGGER_SHA1_H */

--- a/jerry-ext/debugger/debugger-ws.c
+++ b/jerry-ext/debugger/debugger-ws.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include "debugger-ws.h"
+#include "debugger-sha1.h"
 #include "jerryscript-ext/debugger.h"
 #include "jext-common.h"
 


### PR DESCRIPTION
The renamed header doesn't contain any declarations related to
debugger-ws.c but contains the declaration of a function from
debugger-sha1.c.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu