### PR TITLE
Add explicit casts to enum-to-integer conversions

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -900,7 +900,7 @@ jerry_debugger_send_data (jerry_debugger_header_type_t type, /**< message type *
 
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_type_t, message_type_p);
 
-  message_type_p->type = type;
+  message_type_p->type = (uint8_t) type;
   memcpy (message_type_p + 1, data, size);
 
   jerry_debugger_send (sizeof (jerry_debugger_send_type_t) + size);

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -289,8 +289,8 @@ ecma_builtin_init_object (ecma_builtin_id_t obj_builtin_id, /**< built-in ID */
     built_in_props_p = &((ecma_extended_object_t *) obj_p)->u.built_in;
   }
 
-  built_in_props_p->id = obj_builtin_id;
-  built_in_props_p->routine_id = obj_builtin_id;
+  built_in_props_p->id = (uint8_t) obj_builtin_id;
+  built_in_props_p->routine_id = (uint16_t) obj_builtin_id;
   built_in_props_p->instantiated_bitset[0] = 0;
 
   if (property_count > 32)
@@ -518,7 +518,7 @@ ecma_builtin_make_function_object_for_routine (ecma_builtin_id_t builtin_id, /**
   JERRY_ASSERT (routine_id >= ECMA_BUILTIN_ID__COUNT);
 
   ecma_extended_object_t *ext_func_obj_p = (ecma_extended_object_t *) func_obj_p;
-  ext_func_obj_p->u.built_in.id = builtin_id;
+  ext_func_obj_p->u.built_in.id = (uint8_t) builtin_id;
   ext_func_obj_p->u.built_in.routine_id = routine_id;
   ext_func_obj_p->u.built_in.instantiated_bitset[0] = 0;
 

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -249,7 +249,7 @@ ecma_typedarray_create_object_with_length (ecma_length_t array_length, /**< leng
                                                 ECMA_OBJECT_TYPE_PSEUDO_ARRAY);
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
-  ext_object_p->u.pseudo_array.u1.class_id = class_id;
+  ext_object_p->u.pseudo_array.u1.class_id = (uint16_t) class_id;
   ext_object_p->u.pseudo_array.type = ECMA_PSEUDO_ARRAY_TYPEDARRAY;
   ext_object_p->u.pseudo_array.extra_info = element_size_shift;
   ext_object_p->u.pseudo_array.u2.arraybuffer = new_arraybuffer_p;
@@ -285,7 +285,7 @@ ecma_typedarray_create_object_with_buffer (ecma_object_t *arraybuffer_p, /**< th
   ecma_object_t *object_p = ecma_create_object (proto_p, object_size, ECMA_OBJECT_TYPE_PSEUDO_ARRAY);
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
-  ext_object_p->u.pseudo_array.u1.class_id = class_id;
+  ext_object_p->u.pseudo_array.u1.class_id = (uint16_t) class_id;
   ext_object_p->u.pseudo_array.type = ECMA_PSEUDO_ARRAY_TYPEDARRAY;
   ext_object_p->u.pseudo_array.extra_info = element_size_shift;
   ext_object_p->u.pseudo_array.u2.arraybuffer = ecma_make_object_value (arraybuffer_p);

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -558,7 +558,7 @@ lexer_parse_identifier (parser_context_t *context_p, /**< context */
           break;
         }
 
-        context_p->token.type = keyword_p->type;
+        context_p->token.type = (uint8_t) keyword_p->type;
         break;
       }
       keyword_p++;

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -203,7 +203,7 @@ parser_emit_unary_lvalue_opcode (parser_context_t *context_p, /**< context */
         break;
       }
     }
-    parser_emit_cbc (context_p, opcode);
+    parser_emit_cbc (context_p, (uint16_t) opcode);
   }
 } /* parser_emit_unary_lvalue_opcode */
 
@@ -1091,7 +1091,7 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
         }
       }
 
-      parser_emit_cbc_literal_from_token (context_p, opcode);
+      parser_emit_cbc_literal_from_token (context_p, (uint16_t) opcode);
       break;
     }
     case LEXER_KEYW_FUNCTION:
@@ -1770,7 +1770,7 @@ parser_process_binary_opcodes (parser_context_t *context_p, /**< context */
       if (cbc_flags[opcode] & CBC_HAS_LITERAL_ARG)
       {
         uint16_t index = parser_stack_pop_uint16 (context_p);
-        parser_emit_cbc_literal (context_p, opcode, index);
+        parser_emit_cbc_literal (context_p, (uint16_t) opcode, index);
 
         if (opcode == CBC_ASSIGN_PROP_THIS_LITERAL
             && (context_p->stack_depth >= context_p->stack_limit))
@@ -1830,7 +1830,7 @@ parser_process_binary_opcodes (parser_context_t *context_p, /**< context */
         continue;
       }
     }
-    parser_emit_cbc (context_p, opcode);
+    parser_emit_cbc (context_p, (uint16_t) opcode);
   }
 } /* parser_process_binary_opcodes */
 
@@ -1916,7 +1916,7 @@ parser_parse_expression (parser_context_t *context_p, /**< context */
           opcode = CBC_BRANCH_IF_TRUE_FORWARD;
         }
 
-        parser_emit_cbc_forward_branch (context_p, opcode, &cond_branch);
+        parser_emit_cbc_forward_branch (context_p, (uint16_t) opcode, &cond_branch);
 
         lexer_next_token (context_p);
         parser_parse_expression (context_p, PARSE_EXPR_NO_COMMA);

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -660,7 +660,7 @@ parser_parse_do_while_statement_end (parser_context_t *context_p) /**< context *
     parser_stack_iterator_skip (&iterator, sizeof (parser_loop_statement_t));
     parser_stack_iterator_read (&iterator, &do_while_statement, sizeof (parser_do_while_statement_t));
 
-    parser_emit_cbc_backward_branch (context_p, opcode, do_while_statement.start_offset);
+    parser_emit_cbc_backward_branch (context_p, (uint16_t) opcode, do_while_statement.start_offset);
   }
   else
   {
@@ -759,7 +759,7 @@ parser_parse_while_statement_end (parser_context_t *context_p) /**< context */
   parser_stack_pop (context_p, NULL, 1 + sizeof (parser_loop_statement_t) + sizeof (parser_while_statement_t));
   parser_stack_iterator_init (context_p, &context_p->last_statement);
 
-  parser_emit_cbc_backward_branch (context_p, opcode, while_statement.start_offset);
+  parser_emit_cbc_backward_branch (context_p, (uint16_t) opcode, while_statement.start_offset);
   parser_set_breaks_to_current_position (context_p, loop.branch_list_p);
 
   parser_set_range (context_p, &range);
@@ -1027,7 +1027,7 @@ parser_parse_for_statement_end (parser_context_t *context_p) /**< context */
   parser_stack_pop (context_p, NULL, 1 + sizeof (parser_loop_statement_t) + sizeof (parser_for_statement_t));
   parser_stack_iterator_init (context_p, &context_p->last_statement);
 
-  parser_emit_cbc_backward_branch (context_p, opcode, for_statement.start_offset);
+  parser_emit_cbc_backward_branch (context_p, (uint16_t) opcode, for_statement.start_offset);
   parser_set_breaks_to_current_position (context_p, loop.branch_list_p);
 
   parser_set_range (context_p, &range);
@@ -1427,7 +1427,7 @@ parser_parse_break_statement (parser_context_t *context_p) /**< context */
         if (lexer_compare_identifier_to_current (context_p, &label_statement.label_ident))
         {
           label_statement.break_list_p = parser_emit_cbc_forward_branch_item (context_p,
-                                                                              opcode,
+                                                                              (uint16_t) opcode,
                                                                               label_statement.break_list_p);
           parser_stack_iterator_write (&iterator, &label_statement, sizeof (parser_label_statement_t));
           lexer_next_token (context_p);
@@ -1470,7 +1470,7 @@ parser_parse_break_statement (parser_context_t *context_p) /**< context */
       parser_stack_iterator_skip (&iterator, 1);
       parser_stack_iterator_read (&iterator, &loop, sizeof (parser_loop_statement_t));
       loop.branch_list_p = parser_emit_cbc_forward_branch_item (context_p,
-                                                                opcode,
+                                                                (uint16_t) opcode,
                                                                 loop.branch_list_p);
       parser_stack_iterator_write (&iterator, &loop, sizeof (parser_loop_statement_t));
       return;
@@ -1526,7 +1526,7 @@ parser_parse_continue_statement (parser_context_t *context_p) /**< context */
           parser_stack_iterator_skip (&loop_iterator, 1);
           parser_stack_iterator_read (&loop_iterator, &loop, sizeof (parser_loop_statement_t));
           loop.branch_list_p = parser_emit_cbc_forward_branch_item (context_p,
-                                                                    opcode,
+                                                                    (uint16_t) opcode,
                                                                     loop.branch_list_p);
           loop.branch_list_p->branch.offset |= CBC_HIGHEST_BIT_MASK;
           parser_stack_iterator_write (&loop_iterator, &loop, sizeof (parser_loop_statement_t));
@@ -1583,7 +1583,7 @@ parser_parse_continue_statement (parser_context_t *context_p) /**< context */
       parser_stack_iterator_skip (&iterator, 1);
       parser_stack_iterator_read (&iterator, &loop, sizeof (parser_loop_statement_t));
       loop.branch_list_p = parser_emit_cbc_forward_branch_item (context_p,
-                                                                opcode,
+                                                                (uint16_t) opcode,
                                                                 loop.branch_list_p);
       loop.branch_list_p->branch.offset |= CBC_HIGHEST_BIT_MASK;
       parser_stack_iterator_write (&iterator, &loop, sizeof (parser_loop_statement_t));

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -117,7 +117,7 @@ parser_flush_cbc (parser_context_t *context_p) /**< context */
 
     JERRY_ASSERT (opcode < CBC_EXT_END);
     flags = cbc_ext_flags[opcode];
-    parser_emit_two_bytes (context_p, CBC_EXT_OPCODE, opcode);
+    parser_emit_two_bytes (context_p, CBC_EXT_OPCODE, (uint8_t) opcode);
     context_p->byte_code_size += 2;
   }
 

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1857,7 +1857,7 @@ parser_post_processing (parser_context_t *context_p) /**< context */
     }
 
     /* Storing the opcode */
-    *dst_p++ = opcode;
+    *dst_p++ = (uint8_t) opcode;
     real_offset++;
     PARSER_NEXT_BYTE_UPDATE (page_p, offset, real_offset);
     flags = cbc_flags[opcode];
@@ -1879,7 +1879,7 @@ parser_post_processing (parser_context_t *context_p) /**< context */
       branch_offset_length = CBC_BRANCH_OFFSET_LENGTH (ext_opcode);
 
       /* Storing the extended opcode */
-      *dst_p++ = ext_opcode;
+      *dst_p++ = (uint8_t) ext_opcode;
       opcode_p++;
       real_offset++;
       PARSER_NEXT_BYTE_UPDATE (page_p, offset, real_offset);

--- a/jerry-ext/include/jerryscript-ext/arg.impl.h
+++ b/jerry-ext/include/jerryscript-ext/arg.impl.h
@@ -94,7 +94,7 @@ typedef struct
         func = jerryx_arg_transform_ ## type; \
       } \
     } \
-    const jerryx_arg_int_option_t int_option = { .round = round_flag, .clamp = clamp_flag }; \
+    const jerryx_arg_int_option_t int_option = { .round = (uint8_t) round_flag, .clamp = (uint8_t) clamp_flag }; \
     return (jerryx_arg_t) \
     { \
       .func = func, \

--- a/jerry-port/default/default-fatal.c
+++ b/jerry-port/default/default-fatal.c
@@ -72,5 +72,5 @@ void jerry_port_fatal (jerry_fatal_code_t code) /**< cause of error */
   }
 #endif /* !DISABLE_EXTRA_API */
 
-  exit (code);
+  exit ((int) code);
 } /* jerry_port_fatal */


### PR DESCRIPTION
Clang 6 is more picky about implicit conversions and complains
about loss of presicion and/or change of signedness.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu