### PR TITLE
Decrease the amount of JERRY_GET_CURRENT_CONTEXT macro calls

### DIFF
--- a/jerry-core/api/jerry-debugger-transport.c
+++ b/jerry-core/api/jerry-debugger-transport.c
@@ -39,6 +39,7 @@ jerry_debugger_transport_add (jerry_debugger_transport_header_t *header_p, /**< 
                               size_t receive_message_header_size, /**< header bytes reserved for incoming messages */
                               size_t max_receive_message_size) /**< maximum number of bytes received in a message */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (max_send_message_size > JERRY_DEBUGGER_TRANSPORT_MIN_BUFFER_SIZE
                 && max_receive_message_size > JERRY_DEBUGGER_TRANSPORT_MIN_BUFFER_SIZE);
 
@@ -92,6 +93,7 @@ jerry_debugger_transport_add (jerry_debugger_transport_header_t *header_p, /**< 
 void
 jerry_debugger_transport_start (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   if (jerry_debugger_send_configuration (JERRY_CONTEXT (debugger_max_receive_size)))
@@ -110,6 +112,7 @@ jerry_debugger_transport_start (void)
 bool
 jerry_debugger_transport_is_connected (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED) != 0;
 } /* jerry_debugger_transport_is_connected */
 
@@ -119,6 +122,7 @@ jerry_debugger_transport_is_connected (void)
 void
 jerry_debugger_transport_close (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED))
   {
     return;
@@ -155,6 +159,7 @@ bool
 jerry_debugger_transport_send (const uint8_t *message_p, /**< message to be sent */
                                size_t message_length) /**< message length in bytes */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (jerry_debugger_transport_is_connected ());
   JERRY_ASSERT (message_length > 0);
 
@@ -195,6 +200,7 @@ bool
 jerry_debugger_transport_receive (jerry_debugger_transport_receive_context_t *context_p) /**< [out] receive
                                                                                           *   context */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (jerry_debugger_transport_is_connected ());
 
   context_p->buffer_p = JERRY_CONTEXT (debugger_receive_buffer);
@@ -215,6 +221,7 @@ void
 jerry_debugger_transport_receive_completed (jerry_debugger_transport_receive_context_t *context_p) /**< receive
                                                                                                     *   context */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (context_p->message_p != NULL);
   JERRY_ASSERT (context_p->buffer_p == JERRY_CONTEXT (debugger_receive_buffer));
 

--- a/jerry-core/api/jerry-debugger.c
+++ b/jerry-core/api/jerry-debugger.c
@@ -27,6 +27,7 @@ bool
 jerry_debugger_is_connected (void)
 {
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED;
 #else /* !JERRY_DEBUGGER */
   return false;
@@ -40,6 +41,7 @@ void
 jerry_debugger_stop (void)
 {
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
       && !(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_BREAKPOINT_MODE))
   {
@@ -56,6 +58,7 @@ void
 jerry_debugger_continue (void)
 {
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
       && !(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_BREAKPOINT_MODE))
   {
@@ -72,6 +75,7 @@ void
 jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint) /**< enable/disable stop at breakpoint */
 {
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED
       && !(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_BREAKPOINT_MODE))
   {
@@ -105,6 +109,7 @@ jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t
   *return_value = jerry_create_undefined ();
 
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
       && !(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_BREAKPOINT_MODE))
   {
@@ -193,6 +198,7 @@ jerry_debugger_send_output (const jerry_char_t *buffer, /**< buffer */
                             jerry_size_t str_size) /**< string size */
 {
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
     jerry_debugger_send_string (JERRY_DEBUGGER_OUTPUT_RESULT,
@@ -215,6 +221,7 @@ jerry_debugger_send_log (jerry_log_level_t level, /**< level of the diagnostics 
                          jerry_size_t str_size) /**< string size */
 {
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
     jerry_debugger_send_string (JERRY_DEBUGGER_OUTPUT_RESULT,

--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -739,6 +739,7 @@ jerry_generate_snapshot_with_args (const jerry_char_t *resource_name_p, /**< scr
   JERRY_UNUSED (resource_name_length);
 
 #ifdef JERRY_ENABLE_LINE_INFO
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (resource_name) = ECMA_VALUE_UNDEFINED;
 #endif /* JERRY_ENABLE_LINE_INFO */
 

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -101,6 +101,7 @@ static const char * const wrong_args_msg_p = "wrong type of argument";
 static inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_assert_api_available (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE);
 } /* jerry_assert_api_available */
 
@@ -110,6 +111,7 @@ jerry_assert_api_available (void)
 static inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_make_api_available (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (status_flags) |= ECMA_STATUS_API_AVAILABLE;
 } /* jerry_make_api_available */
 
@@ -119,6 +121,7 @@ jerry_make_api_available (void)
 static inline void JERRY_ATTR_ALWAYS_INLINE
 jerry_make_api_unavailable (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_API_AVAILABLE;
 } /* jerry_make_api_unavailable */
 
@@ -156,6 +159,7 @@ jerry_throw (jerry_value_t value) /**< return value */
 void
 jerry_init (jerry_init_flag_t flags) /**< combination of Jerry flags */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   /* This function cannot be called twice unless jerry_cleanup is called. */
   JERRY_ASSERT (!(JERRY_CONTEXT (status_flags) & ECMA_STATUS_API_AVAILABLE));
 
@@ -177,6 +181,7 @@ jerry_init (jerry_init_flag_t flags) /**< combination of Jerry flags */
 void
 jerry_cleanup (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jerry_assert_api_available ();
 
 #ifdef JERRY_DEBUGGER
@@ -228,6 +233,7 @@ jerry_cleanup (void)
 void *
 jerry_get_context_data (const jerry_context_data_manager_t *manager_p)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   void *ret = NULL;
   jerry_context_data_header_t *item_p;
 
@@ -366,6 +372,7 @@ jerry_parse (const jerry_char_t *resource_name_p, /**< resource name (usually a 
              uint32_t parse_opts) /**< jerry_parse_opts_t option bits */
 {
 #if defined JERRY_DEBUGGER && !defined JERRY_DISABLE_JS_PARSER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
       && resource_name_length > 0)
   {
@@ -436,6 +443,7 @@ jerry_parse_function (const jerry_char_t *resource_name_p, /**< resource name (u
                       uint32_t parse_opts) /**< jerry_parse_opts_t option bits */
 {
 #if defined JERRY_DEBUGGER && !defined JERRY_DISABLE_JS_PARSER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
     jerry_debugger_send_string (JERRY_DEBUGGER_SOURCE_CODE_NAME,
@@ -2372,6 +2380,7 @@ jerry_objects_foreach (jerry_objects_foreach_t foreach_p, /**< function pointer 
   jerry_assert_api_available ();
 
   JERRY_ASSERT (foreach_p != NULL);
+  JERRY_DEFINE_CURRENT_CONTEXT ();
 
   for (ecma_object_t *iter_p = JERRY_CONTEXT (ecma_gc_objects_p);
        iter_p != NULL;
@@ -2406,6 +2415,7 @@ jerry_objects_foreach_by_native_info (const jerry_object_native_info_t *native_i
   JERRY_ASSERT (foreach_p != NULL);
 
   ecma_native_pointer_t *native_pointer_p;
+  JERRY_DEFINE_CURRENT_CONTEXT ();
 
   for (ecma_object_t *iter_p = JERRY_CONTEXT (ecma_gc_objects_p);
        iter_p != NULL;
@@ -2551,6 +2561,7 @@ jerry_foreach_object_property (const jerry_value_t obj_val, /**< object value */
     return true;
   }
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_free_value (JERRY_CONTEXT (error_value));
   return false;
 } /* jerry_foreach_object_property */
@@ -2736,6 +2747,7 @@ jerry_set_vm_exec_stop_callback (jerry_vm_exec_stop_callback_t stop_cb, /**< per
     frequency = 1;
   }
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (vm_exec_stop_frequency) = frequency;
   JERRY_CONTEXT (vm_exec_stop_counter) = frequency;
   JERRY_CONTEXT (vm_exec_stop_user_p) = user_p;

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -67,6 +67,7 @@ JERRY_STATIC_ASSERT (JERRY_DEBUGGER_MESSAGES_OUT_MAX_COUNT == 28
 void
 jerry_debugger_free_unreferenced_byte_code (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jerry_debugger_byte_code_free_t *byte_code_free_p;
 
   byte_code_free_p = JMEM_CP_GET_POINTER (jerry_debugger_byte_code_free_t,
@@ -94,6 +95,7 @@ jerry_debugger_free_unreferenced_byte_code (void)
 static bool
 jerry_debugger_send (size_t message_length) /**< message length in bytes */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (message_length <= JERRY_CONTEXT (debugger_max_send_size));
 
   jerry_debugger_transport_header_t *header_p = JERRY_CONTEXT (debugger_transport_header_p);
@@ -108,6 +110,7 @@ jerry_debugger_send (size_t message_length) /**< message length in bytes */
 static void
 jerry_debugger_send_backtrace (const uint8_t *recv_buffer_p) /**< pointer to the received data */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_DEBUGGER_RECEIVE_BUFFER_AS (jerry_debugger_receive_get_backtrace_t, get_backtrace_p);
 
   uint32_t min_depth;
@@ -205,6 +208,7 @@ static bool
 jerry_debugger_send_eval (const lit_utf8_byte_t *eval_string_p, /**< evaluated string */
                           size_t eval_string_size) /**< evaluated string size */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
   JERRY_ASSERT (!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_VM_IGNORE));
 
@@ -316,6 +320,7 @@ jerry_debugger_process_message (const uint8_t *recv_buffer_p, /**< pointer to th
                                 uint8_t *expected_message_type_p, /**< message type */
                                 jerry_debugger_uint8_data_t **message_data_p) /**< custom message data */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   /* Process the received message. */
 
   if (recv_buffer_p[0] >= JERRY_DEBUGGER_CONTINUE
@@ -745,6 +750,7 @@ jerry_debugger_process_message (const uint8_t *recv_buffer_p, /**< pointer to th
 bool
 jerry_debugger_receive (jerry_debugger_uint8_data_t **message_data_p) /**< [out] data received from client */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (jerry_debugger_transport_is_connected ());
 
   JERRY_ASSERT (message_data_p != NULL ? !!(JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_RECEIVE_DATA_MODE)
@@ -803,6 +809,7 @@ jerry_debugger_receive (jerry_debugger_uint8_data_t **message_data_p) /**< [out]
 void
 jerry_debugger_breakpoint_hit (uint8_t message_type) /**< message type */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_breakpoint_hit_t, breakpoint_hit_p);
@@ -849,6 +856,7 @@ jerry_debugger_breakpoint_hit (uint8_t message_type) /**< message type */
 void
 jerry_debugger_send_type (jerry_debugger_header_type_t type) /**< message type */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_type_t, message_type_p);
@@ -868,6 +876,7 @@ jerry_debugger_send_type (jerry_debugger_header_type_t type) /**< message type *
 bool
 jerry_debugger_send_configuration (uint8_t max_message_size) /**< maximum message size */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_configuration_t, configuration_p);
 
   /* Helper structure for endianness check. */
@@ -904,6 +913,7 @@ jerry_debugger_send_data (jerry_debugger_header_type_t type, /**< message type *
                           const void *data, /**< raw data */
                           size_t size) /**< size of data */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (size <= JERRY_DEBUGGER_SEND_MAX (uint8_t));
 
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_type_t, message_type_p);
@@ -926,6 +936,7 @@ jerry_debugger_send_string (uint8_t message_type, /**< message type */
                             const uint8_t *string_p, /**< string data */
                             size_t string_length) /**< length of string */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   const size_t max_byte_count = JERRY_DEBUGGER_SEND_MAX (uint8_t);
@@ -978,6 +989,7 @@ bool
 jerry_debugger_send_function_cp (jerry_debugger_header_type_t type, /**< message type */
                                  ecma_compiled_code_t *compiled_code_p) /**< byte code pointer */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_byte_code_cp_t, byte_code_cp_p);
@@ -1001,6 +1013,7 @@ bool
 jerry_debugger_send_parse_function (uint32_t line, /**< line */
                                     uint32_t column) /**< column */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_parse_function_t, message_parse_function_p);
@@ -1018,6 +1031,7 @@ jerry_debugger_send_parse_function (uint32_t line, /**< line */
 void
 jerry_debugger_send_memstats (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   JERRY_DEBUGGER_SEND_BUFFER_AS (jerry_debugger_send_memstats_t, memstats_p);
@@ -1153,6 +1167,7 @@ jerry_debugger_exception_object_to_string (ecma_value_t exception_obj_value) /**
 bool
 jerry_debugger_send_exception_string (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_string_t *string_p = NULL;
 
   ecma_value_t exception_value = JERRY_CONTEXT (error_value);

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -114,6 +114,7 @@ ecma_gc_set_object_visited (ecma_object_t *object_p) /**< object */
 inline void
 ecma_init_gc_info (ecma_object_t *object_p) /**< object */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (ecma_gc_objects_number)++;
   JERRY_CONTEXT (ecma_gc_new_objects)++;
 
@@ -507,6 +508,7 @@ ecma_gc_free_native_pointer (ecma_property_t *property_p) /**< property */
 static void
 ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (object_p != NULL
                 && !ecma_gc_is_object_visited (object_p)
                 && object_p->type_flags_refs < ECMA_OBJECT_REF_ONE);
@@ -818,6 +820,7 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 void
 ecma_gc_run (jmem_free_unused_memory_severity_t severity) /**< gc severity */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (ecma_gc_new_objects) = 0;
 
   ecma_object_t *white_gray_objects_p = JERRY_CONTEXT (ecma_gc_objects_p);
@@ -972,6 +975,7 @@ ecma_gc_run (jmem_free_unused_memory_severity_t severity) /**< gc severity */
 void
 ecma_free_unused_memory (jmem_free_unused_memory_severity_t severity) /**< severity of the request */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
 #ifdef JERRY_DEBUGGER
   while ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
          && JERRY_CONTEXT (debugger_byte_code_free_tail) != ECMA_NULL_POINTER)

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1390,6 +1390,7 @@ ecma_create_error_reference (ecma_value_t value, /**< referenced value */
 ecma_value_t
 ecma_create_error_reference_from_context (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return ecma_create_error_reference (JERRY_CONTEXT (error_value),
                                       (JERRY_CONTEXT (status_flags) & ECMA_STATUS_EXCEPTION) != 0);
 } /* ecma_create_error_reference_from_context */
@@ -1450,6 +1451,7 @@ ecma_value_t
 ecma_clear_error_reference (ecma_value_t value, /**< error reference */
                             bool set_abort_flag) /**< set abort flag */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_error_reference_t *error_ref_p = ecma_get_error_reference_from_value (value);
 
   if (set_abort_flag)
@@ -1549,6 +1551,7 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
     }
 
 #ifdef JERRY_DEBUGGER
+    JERRY_DEFINE_CURRENT_CONTEXT ();
     if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
         && !(bytecode_p->status_flags & CBC_CODE_FLAGS_DEBUGGER_IGNORE)
         && jerry_debugger_send_function_cp (JERRY_DEBUGGER_RELEASE_BYTE_CODE_CP, bytecode_p))

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -40,6 +40,7 @@ ecma_init (void)
   jmem_register_free_unused_memory_callback (ecma_free_unused_memory);
 
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) = ECMA_PROP_HASHMAP_ALLOC_ON;
   JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_HIGH_SEV_GC;
 #endif /* !CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE */

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -69,6 +69,7 @@ ecma_lcache_insert (ecma_object_t *object_p, /**< object */
                     jmem_cpointer_t name_cp, /**< property name */
                     ecma_property_t *prop_p) /**< property */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (object_p != NULL);
   JERRY_ASSERT (prop_p != NULL && !ecma_is_property_lcached (prop_p));
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (*prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA
@@ -124,6 +125,7 @@ inline ecma_property_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
                     const ecma_string_t *prop_name_p) /**< property's name */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (object_p != NULL);
   JERRY_ASSERT (prop_name_p != NULL);
 
@@ -193,6 +195,7 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
                         jmem_cpointer_t name_cp, /**< property name */
                         ecma_property_t *prop_p) /**< property */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (object_p != NULL);
   JERRY_ASSERT (prop_p != NULL && ecma_is_property_lcached (prop_p));
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (*prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA

--- a/jerry-core/ecma/base/ecma-literal-storage.c
+++ b/jerry-core/ecma/base/ecma-literal-storage.c
@@ -57,6 +57,7 @@ ecma_free_string_list (ecma_lit_storage_item_t *string_list_p) /**< string list 
 void
 ecma_finalize_lit_storage (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_free_string_list (JERRY_CONTEXT (string_list_first_p));
   ecma_free_string_list (JERRY_CONTEXT (number_list_first_p));
 } /* ecma_finalize_lit_storage */
@@ -77,6 +78,7 @@ ecma_find_or_create_literal_string (const lit_utf8_byte_t *chars_p, /**< string 
     return ecma_make_string_value (string_p);
   }
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_lit_storage_item_t *string_list_p = JERRY_CONTEXT (string_list_first_p);
   jmem_cpointer_t *empty_cpointer_p = NULL;
 
@@ -149,6 +151,7 @@ ecma_find_or_create_literal_number (ecma_number_t number_arg) /**< number to be 
 
   JERRY_ASSERT (ecma_is_value_float_number (num));
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_lit_storage_item_t *number_list_p = JERRY_CONTEXT (number_list_first_p);
   jmem_cpointer_t *empty_cpointer_p = NULL;
 

--- a/jerry-core/ecma/base/ecma-property-hashmap.c
+++ b/jerry-core/ecma/base/ecma-property-hashmap.c
@@ -75,6 +75,7 @@ void
 ecma_property_hashmap_create (ecma_object_t *object_p) /**< object */
 {
 #ifndef CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (ecma_prop_hashmap_alloc_state) != ECMA_PROP_HASHMAP_ALLOC_ON)
   {
     return;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
@@ -160,6 +160,7 @@ ecma_builtin_function_dispatch_construct (const ecma_value_t *arguments_list_p, 
   ECMA_STRING_TO_UTF8_STRING (function_body_str_p, function_body_buffer_p, function_body_buffer_size);
 
 #ifdef JERRY_ENABLE_LINE_INFO
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (resource_name) = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
 #endif /* JERRY_ENABLE_LINE_INFO */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -125,6 +125,7 @@ ecma_builtin_promise_reject_or_resolve (ecma_value_t this_arg, /**< "this" argum
 inline static ecma_value_t
 ecma_builtin_promise_reject_abrupt (ecma_value_t capability) /**< reject description */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_raise_type_error (ECMA_ERR_MSG ("Second argument is not an array."));
   ecma_value_t reason = JERRY_CONTEXT (error_value);
   ecma_string_t *reject_str_p = ecma_get_magic_string (LIT_INTERNAL_MAGIC_STRING_PROMISE_PROPERTY_REJECT);
@@ -563,6 +564,7 @@ ecma_builtin_promise_race_or_all (ecma_value_t this_arg, /**< 'this' argument */
                                   ecma_value_t array, /**< the items to be resolved */
                                   bool is_race) /**< indicates whether it is race function */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (!ecma_is_value_object (this_arg))
   {
     return ecma_raise_type_error (ECMA_ERR_MSG ("'this' is not an object."));

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1428,6 +1428,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
                                             ecma_value_t arg1, /**< separator */
                                             ecma_value_t arg2) /**< limit */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
 
   /* 1. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -177,6 +177,7 @@ bool
 ecma_builtin_is (ecma_object_t *obj_p, /**< pointer to an object */
                  ecma_builtin_id_t builtin_id) /**< id of built-in to check on */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (obj_p != NULL && !ecma_is_lexical_environment (obj_p));
   JERRY_ASSERT (builtin_id < ECMA_BUILTIN_ID__COUNT);
 
@@ -200,6 +201,7 @@ ecma_builtin_is (ecma_object_t *obj_p, /**< pointer to an object */
 ecma_object_t *
 ecma_builtin_get (ecma_builtin_id_t builtin_id) /**< id of built-in to check on */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (builtin_id < ECMA_BUILTIN_ID__COUNT);
 
   if (JERRY_UNLIKELY (JERRY_CONTEXT (ecma_builtin_objects)[builtin_id] == NULL))
@@ -223,6 +225,7 @@ ecma_builtin_get (ecma_builtin_id_t builtin_id) /**< id of built-in to check on 
 inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_get_global (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL] != NULL);
 
   return JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL];
@@ -410,6 +413,7 @@ ecma_instantiate_builtin_helper (ecma_builtin_id_t builtin_id, /**< built-in id 
                                  ecma_builtin_id_t object_prototype_builtin_id,  /**< built-in id of prototype */
                                  bool is_extensible) /**< value of object's [[Extensible]] property */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (ecma_builtin_objects)[builtin_id] == NULL);
 
   ecma_object_t *prototype_obj_p;
@@ -475,6 +479,7 @@ ecma_instantiate_builtin (ecma_builtin_id_t id) /**< built-in id */
 void
 ecma_finalize_builtins (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   for (ecma_builtin_id_t id = (ecma_builtin_id_t) 0;
        id < ECMA_BUILTIN_ID__COUNT;
        id = (ecma_builtin_id_t) (id + 1))

--- a/jerry-core/ecma/operations/ecma-eval.c
+++ b/jerry-core/ecma/operations/ecma-eval.c
@@ -80,6 +80,11 @@ ecma_op_eval_chars_buffer (const lit_utf8_byte_t *code_p, /**< code characters b
                            uint32_t parse_opts) /**< ecma_parse_opts_t option bits */
 {
 #ifndef JERRY_DISABLE_JS_PARSER
+
+#if defined (JERRY_ENABLE_LINE_INFO) || !defined (CONFIG_DISABLE_ES2015_CLASS)
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif /* !JERRY_ENABLE_LINE_INFO && CONFIG_DISABLE_ES2015_CLASS */
+
   JERRY_ASSERT (code_p != NULL);
 
   ecma_compiled_code_t *bytecode_data_p;

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -236,6 +236,7 @@ ecma_raise_standard_error (ecma_standard_error_t error_type, /**< error type */
     error_obj_p = ecma_new_standard_error (error_type);
   }
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (error_value) = ecma_make_object_value (error_obj_p);
   JERRY_CONTEXT (status_flags) |= ECMA_STATUS_EXCEPTION;
   return ECMA_VALUE_ERROR;
@@ -324,6 +325,7 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
   ecma_object_t *error_obj_p = ecma_new_standard_error_with_message (error_type, error_msg_p);
   ecma_deref_ecma_string (error_msg_p);
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (error_value) = ecma_make_object_value (error_obj_p);
   JERRY_CONTEXT (status_flags) |= ECMA_STATUS_EXCEPTION;
   return ECMA_VALUE_ERROR;

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -628,6 +628,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
                        const ecma_value_t *arguments_list_p, /**< arguments list */
                        ecma_length_t arguments_list_len) /**< length of arguments list */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (func_obj_p != NULL
                 && !ecma_is_lexical_environment (func_obj_p));
   JERRY_ASSERT (ecma_op_is_callable (ecma_make_object_value (func_obj_p)));
@@ -801,7 +802,6 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       return ret_value;
     }
 #endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
-
     JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
     JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_DIRECT_EVAL;
 

--- a/jerry-core/ecma/operations/ecma-jobqueue.c
+++ b/jerry-core/ecma/operations/ecma-jobqueue.c
@@ -54,6 +54,7 @@ typedef struct
  */
 void ecma_job_queue_init (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (job_queue_head_p) = NULL;
   JERRY_CONTEXT (job_queue_tail_p) = NULL;
 } /* ecma_job_queue_init */
@@ -179,6 +180,7 @@ ecma_process_promise_reaction_job (void *obj_p) /**< the job to be operated */
   {
     if (ECMA_IS_VALUE_ERROR (handler_result))
     {
+      JERRY_DEFINE_CURRENT_CONTEXT ();
       handler_result = JERRY_CONTEXT (error_value);
     }
 
@@ -253,6 +255,7 @@ ecma_process_promise_resolve_thenable_job (void *obj_p) /**< the job to be opera
 
   if (ECMA_IS_VALUE_ERROR (then_call_result))
   {
+    JERRY_DEFINE_CURRENT_CONTEXT ();
     then_call_result = JERRY_CONTEXT (error_value);
 
     ret = ecma_op_function_call (ecma_get_object_from_value (funcs->reject),
@@ -281,6 +284,7 @@ ecma_enqueue_job (ecma_job_handler_t handler, /**< the handler for the job */
   item_p->handler = handler;
   item_p->next_p = NULL;
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (job_queue_head_p) == NULL)
   {
     JERRY_CONTEXT (job_queue_head_p) = item_p;
@@ -330,6 +334,7 @@ ecma_process_all_enqueued_jobs (void)
 {
   ecma_value_t ret = ECMA_VALUE_UNDEFINED;
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   while (JERRY_CONTEXT (job_queue_head_p) != NULL && !ECMA_IS_VALUE_ERROR (ret))
   {
     ecma_job_queueitem_t *item_p = JERRY_CONTEXT (job_queue_head_p);
@@ -352,6 +357,7 @@ ecma_process_all_enqueued_jobs (void)
 void
 ecma_free_all_enqueued_jobs (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   while (JERRY_CONTEXT (job_queue_head_p) != NULL)
   {
     ecma_job_queueitem_t *item_p = JERRY_CONTEXT (job_queue_head_p);

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -39,6 +39,7 @@
 void
 ecma_init_global_lex_env (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_object_t *glob_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL);
 
   JERRY_CONTEXT (ecma_global_lex_env_p) = ecma_create_object_lex_env (NULL,
@@ -54,6 +55,7 @@ ecma_init_global_lex_env (void)
 void
 ecma_finalize_global_lex_env (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_deref_object (JERRY_CONTEXT (ecma_global_lex_env_p));
   JERRY_CONTEXT (ecma_global_lex_env_p) = NULL;
 } /* ecma_finalize_global_lex_env */
@@ -67,6 +69,7 @@ ecma_finalize_global_lex_env (void)
 ecma_object_t *
 ecma_get_global_environment (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return JERRY_CONTEXT (ecma_global_lex_env_p);
 } /* ecma_get_global_environment */
 

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -331,6 +331,7 @@ ecma_promise_resolve_handler (const ecma_value_t function, /**< the function its
   if (ECMA_IS_VALUE_ERROR (then))
   {
     /* 9. */
+    JERRY_DEFINE_CURRENT_CONTEXT ();
     then = JERRY_CONTEXT (error_value);
     ecma_reject_promise (promise, then);
   }
@@ -552,6 +553,7 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
   if (ECMA_IS_VALUE_ERROR (completion))
   {
     /* 10.a. */
+    JERRY_DEFINE_CURRENT_CONTEXT ();
     completion = JERRY_CONTEXT (error_value);
     status = ecma_op_function_call (ecma_get_object_from_value (funcs->reject),
                                     ECMA_VALUE_UNDEFINED,

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -894,6 +894,7 @@ ecma_op_typedarray_set_index_prop (ecma_object_t *obj_p, /**< a TypedArray objec
 
   if (ECMA_IS_VALUE_ERROR (error))
   {
+    JERRY_DEFINE_CURRENT_CONTEXT ();
     ecma_free_value (JERRY_CONTEXT (error_value));
     return false;
   }

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -170,7 +170,17 @@ struct jerry_context_t
  * This part is for JerryScript which uses external context.
  */
 
-#define JERRY_CONTEXT(field) (jerry_port_get_current_context ()->field)
+/**
+ * Declares the context before the usage. It must be called in the scope where the JERRY_CONTEXT macros
+ * are called (usually called at the beginning of a function which uses context).
+ */
+#define JERRY_DEFINE_CURRENT_CONTEXT() \
+  struct jerry_context_t  *jerry_current_context = jerry_port_get_current_context ()
+
+  /**
+   * Provides a reference to a field in the current context.
+   */
+#define JERRY_CONTEXT(field) (jerry_current_context->field)
 
 #ifndef JERRY_SYSTEM_ALLOCATOR
 
@@ -198,6 +208,11 @@ struct jmem_heap_t
  * Global context.
  */
 extern jerry_context_t jerry_global_context;
+
+/**
+ * If EXTERNAL_CONTEXT is not enabled then JERRY_DEFINE_CURRENT_CONTEXT is an empty macro to avoid errors
+ */
+#define JERRY_DEFINE_CURRENT_CONTEXT()
 
 /**
  * Provides a reference to a field in the current context.

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -31,6 +31,7 @@
 void
 jmem_stats_allocate_byte_code_bytes (size_t byte_code_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   heap_stats->byte_code_bytes += byte_code_size;
@@ -47,6 +48,7 @@ jmem_stats_allocate_byte_code_bytes (size_t byte_code_size)
 void
 jmem_stats_free_byte_code_bytes (size_t byte_code_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   JERRY_ASSERT (heap_stats->byte_code_bytes >= byte_code_size);
@@ -60,6 +62,7 @@ jmem_stats_free_byte_code_bytes (size_t byte_code_size)
 void
 jmem_stats_allocate_string_bytes (size_t string_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   heap_stats->string_bytes += string_size;
@@ -76,6 +79,7 @@ jmem_stats_allocate_string_bytes (size_t string_size)
 void
 jmem_stats_free_string_bytes (size_t string_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   JERRY_ASSERT (heap_stats->string_bytes >= string_size);
@@ -89,6 +93,7 @@ jmem_stats_free_string_bytes (size_t string_size)
 void
 jmem_stats_allocate_object_bytes (size_t object_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   heap_stats->object_bytes += object_size;
@@ -105,6 +110,7 @@ jmem_stats_allocate_object_bytes (size_t object_size)
 void
 jmem_stats_free_object_bytes (size_t object_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   JERRY_ASSERT (heap_stats->object_bytes >= object_size);
@@ -118,6 +124,7 @@ jmem_stats_free_object_bytes (size_t object_size)
 void
 jmem_stats_allocate_property_bytes (size_t property_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   heap_stats->property_bytes += property_size;
@@ -134,6 +141,7 @@ jmem_stats_allocate_property_bytes (size_t property_size)
 void
 jmem_stats_free_property_bytes (size_t property_size)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   JERRY_ASSERT (heap_stats->property_bytes >= property_size);
@@ -161,6 +169,7 @@ jmem_finalize (void)
   jmem_pools_finalize ();
 
 #ifdef JMEM_STATS
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (jerry_init_flags) & ECMA_INIT_MEM_STATS)
   {
     jmem_heap_stats_print ();
@@ -188,6 +197,9 @@ jmem_compress_pointer (const void *pointer_p) /**< pointer to compress */
 #if defined (ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY) && defined (JERRY_CPOINTER_32_BIT)
   JERRY_ASSERT (((jmem_cpointer_t) uint_ptr) == uint_ptr);
 #else /* !ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY || !JERRY_CPOINTER_32_BIT */
+#ifndef JERRY_SYSTEM_ALLOCATOR
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif /* JERRY_SYSTEM_ALLOCATOR */
   const uintptr_t heap_start = (uintptr_t) &JERRY_HEAP_CONTEXT (first);
 
   uint_ptr -= heap_start;
@@ -221,6 +233,9 @@ jmem_decompress_pointer (uintptr_t compressed_pointer) /**< pointer to decompres
 #if defined (ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY) && defined (JERRY_CPOINTER_32_BIT)
   JERRY_ASSERT (uint_ptr % JMEM_ALIGNMENT == 0);
 #else /* !ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY || !JERRY_CPOINTER_32_BIT */
+#ifndef JERRY_SYSTEM_ALLOCATOR
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif /* JERRY_SYSTEM_ALLOCATOR */
   const uintptr_t heap_start = (uintptr_t) &JERRY_HEAP_CONTEXT (first);
 
   uint_ptr <<= JMEM_ALIGNMENT_LOG;
@@ -238,6 +253,7 @@ jmem_decompress_pointer (uintptr_t compressed_pointer) /**< pointer to decompres
 void
 jmem_register_free_unused_memory_callback (jmem_free_unused_memory_callback_t callback) /**< callback routine */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   /* Currently only one callback is supported */
   JERRY_ASSERT (JERRY_CONTEXT (jmem_free_unused_memory_callback) == NULL);
 
@@ -250,6 +266,7 @@ jmem_register_free_unused_memory_callback (jmem_free_unused_memory_callback_t ca
 void
 jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t callback) /**< callback routine */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   /* Currently only one callback is supported */
   JERRY_ASSERT (JERRY_CONTEXT (jmem_free_unused_memory_callback) == callback);
 
@@ -262,6 +279,7 @@ jmem_unregister_free_unused_memory_callback (jmem_free_unused_memory_callback_t 
 void
 jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t severity) /**< severity of the request */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (jmem_free_unused_memory_callback) != NULL)
   {
     JERRY_CONTEXT (jmem_free_unused_memory_callback) (severity);

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -110,12 +110,12 @@ void
 jmem_heap_init (void)
 {
 #ifndef JERRY_SYSTEM_ALLOCATOR
+  JERRY_DEFINE_CURRENT_CONTEXT ();
 #ifndef JERRY_CPOINTER_32_BIT
   /* the maximum heap size for 16bit compressed pointers should be 512K */
   JERRY_ASSERT (((UINT16_MAX + 1) << JMEM_ALIGNMENT_LOG) >= JMEM_HEAP_SIZE);
 #endif /* !JERRY_CPOINTER_32_BIT */
   JERRY_ASSERT ((uintptr_t) JERRY_HEAP_CONTEXT (area) % JMEM_ALIGNMENT == 0);
-
   JERRY_CONTEXT (jmem_heap_limit) = CONFIG_MEM_HEAP_DESIRED_LIMIT;
 
   jmem_heap_free_t *const region_p = (jmem_heap_free_t *) JERRY_HEAP_CONTEXT (area);
@@ -140,6 +140,7 @@ jmem_heap_init (void)
 void
 jmem_heap_finalize (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (jmem_heap_allocated_size) == 0);
 #ifndef JERRY_SYSTEM_ALLOCATOR
   JMEM_VALGRIND_NOACCESS_SPACE (&JERRY_HEAP_CONTEXT (first), JMEM_HEAP_SIZE);
@@ -163,6 +164,7 @@ jmem_heap_alloc_block_internal (const size_t size) /**< size of requested block 
   const size_t required_size = ((size + JMEM_ALIGNMENT - 1) / JMEM_ALIGNMENT) * JMEM_ALIGNMENT;
   jmem_heap_free_t *data_space_p = NULL;
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JMEM_VALGRIND_DEFINED_SPACE (&JERRY_HEAP_CONTEXT (first), sizeof (jmem_heap_free_t));
 
   /* Fast path for 8 byte chunks, first region is guaranteed to be sufficient. */
@@ -303,6 +305,7 @@ jmem_heap_gc_and_alloc_block (const size_t size,      /**< required memory size 
                               bool ret_null_on_error) /**< indicates whether return null or terminate
                                                            with ERR_OUT_OF_MEMORY on out of memory */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_UNLIKELY (size == 0))
   {
     return NULL;
@@ -391,6 +394,7 @@ jmem_heap_free_block (void *ptr, /**< pointer to beginning of data space of the 
 {
 #ifndef JERRY_SYSTEM_ALLOCATOR
   /* checking that ptr points to the heap */
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (jmem_is_heap_pointer (ptr));
   JERRY_ASSERT (size > 0);
   JERRY_ASSERT (JERRY_CONTEXT (jmem_heap_limit) >= JERRY_CONTEXT (jmem_heap_allocated_size));
@@ -505,6 +509,7 @@ bool
 jmem_is_heap_pointer (const void *pointer) /**< pointer */
 {
 #ifndef JERRY_SYSTEM_ALLOCATOR
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return ((uint8_t *) pointer >= JERRY_HEAP_CONTEXT (area)
           && (uint8_t *) pointer <= (JERRY_HEAP_CONTEXT (area) + JMEM_HEAP_AREA_SIZE));
 #else /* JERRY_SYSTEM_ALLOCATOR */
@@ -521,6 +526,7 @@ jmem_is_heap_pointer (const void *pointer) /**< pointer */
 void
 jmem_heap_get_stats (jmem_heap_stats_t *out_heap_stats_p) /**< [out] heap stats */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (out_heap_stats_p != NULL);
 
   *out_heap_stats_p = JERRY_CONTEXT (jmem_heap_stats);
@@ -532,6 +538,7 @@ jmem_heap_get_stats (jmem_heap_stats_t *out_heap_stats_p) /**< [out] heap stats 
 void
 jmem_heap_stats_print (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
   JERRY_DEBUG_MSG ("Heap stats:\n");
@@ -583,6 +590,7 @@ static void
 jmem_heap_stat_init (void)
 {
 #ifndef JERRY_SYSTEM_ALLOCATOR
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (jmem_heap_stats).size = JMEM_HEAP_AREA_SIZE;
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
 } /* jmem_heap_stat_init */
@@ -593,6 +601,7 @@ jmem_heap_stat_init (void)
 static void
 jmem_heap_stat_alloc (size_t size) /**< Size of allocated block */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   const size_t aligned_size = (size + JMEM_ALIGNMENT - 1) / JMEM_ALIGNMENT * JMEM_ALIGNMENT;
   const size_t waste_bytes = aligned_size - size;
 
@@ -619,6 +628,7 @@ jmem_heap_stat_alloc (size_t size) /**< Size of allocated block */
 static void
 jmem_heap_stat_free (size_t size) /**< Size of freed block */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   const size_t aligned_size = (size + JMEM_ALIGNMENT - 1) / JMEM_ALIGNMENT * JMEM_ALIGNMENT;
   const size_t waste_bytes = aligned_size - size;
 
@@ -636,6 +646,7 @@ jmem_heap_stat_free (size_t size) /**< Size of freed block */
 static void
 jmem_heap_stat_skip (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (jmem_heap_stats).skip_count++;
 } /* jmem_heap_stat_skip  */
 
@@ -645,6 +656,7 @@ jmem_heap_stat_skip (void)
 static void
 jmem_heap_stat_nonskip (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (jmem_heap_stats).nonskip_count++;
 } /* jmem_heap_stat_nonskip */
 
@@ -654,6 +666,7 @@ jmem_heap_stat_nonskip (void)
 static void
 jmem_heap_stat_alloc_iter (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (jmem_heap_stats).alloc_iter_count++;
 } /* jmem_heap_stat_alloc_iter */
 
@@ -663,6 +676,7 @@ jmem_heap_stat_alloc_iter (void)
 static void
 jmem_heap_stat_free_iter (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_CONTEXT (jmem_heap_stats).free_iter_count++;
 } /* jmem_heap_stat_free_iter */
 #endif /* !JERRY_SYSTEM_ALLOCATOR */

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -39,6 +39,7 @@ jmem_pools_finalize (void)
 {
   jmem_pools_collect_empty ();
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (jmem_free_8_byte_chunk_p) == NULL);
 #ifdef JERRY_CPOINTER_32_BIT
   JERRY_ASSERT (JERRY_CONTEXT (jmem_free_16_byte_chunk_p) == NULL);
@@ -54,6 +55,7 @@ jmem_pools_finalize (void)
 inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_pools_alloc (size_t size) /**< size of the chunk */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
 #ifdef JMEM_GC_BEFORE_EACH_ALLOC
   jmem_run_free_unused_memory_callbacks (JMEM_FREE_UNUSED_MEMORY_SEVERITY_HIGH);
 #endif /* JMEM_GC_BEFORE_EACH_ALLOC */
@@ -113,6 +115,7 @@ inline void JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_pools_free (void *chunk_p, /**< pointer to the chunk */
                  size_t size) /**< size of the chunk */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (chunk_p != NULL);
 
   jmem_pools_chunk_t *const chunk_to_free_p = (jmem_pools_chunk_t *) chunk_p;
@@ -149,6 +152,7 @@ jmem_pools_free (void *chunk_p, /**< pointer to the chunk */
 void
 jmem_pools_collect_empty (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   jmem_pools_chunk_t *chunk_p = JERRY_CONTEXT (jmem_free_8_byte_chunk_p);
   JERRY_CONTEXT (jmem_free_8_byte_chunk_p) = NULL;
 

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -26,6 +26,7 @@
 inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 lit_get_magic_string_ex_count (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return JERRY_CONTEXT (lit_magic_string_ex_count);
 } /* lit_get_magic_string_ex_count */
 
@@ -114,6 +115,7 @@ lit_get_magic_string_size_block_start (lit_utf8_size_t size) /**< magic string s
 const lit_utf8_byte_t *
 lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id) /**< extern magic string id */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_array) && id < JERRY_CONTEXT (lit_magic_string_ex_count));
 
   return JERRY_CONTEXT (lit_magic_string_ex_array)[id];
@@ -127,6 +129,7 @@ lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id) /**< extern magic str
 lit_utf8_size_t
 lit_get_magic_string_ex_size (lit_magic_string_ex_id_t id) /**< external magic string id */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return JERRY_CONTEXT (lit_magic_string_ex_sizes)[id];
 } /* lit_get_magic_string_ex_size */
 
@@ -143,6 +146,7 @@ lit_magic_strings_ex_set (const lit_utf8_byte_t * const *ex_str_items, /**< char
   JERRY_ASSERT (count > 0);
   JERRY_ASSERT (ex_str_sizes != NULL);
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_array) == NULL);
   JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_count) == 0);
   JERRY_ASSERT (JERRY_CONTEXT (lit_magic_string_ex_sizes) == NULL);

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2181,6 +2181,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
 
   if (is_throw)
   {
+    JERRY_DEFINE_CURRENT_CONTEXT ();
     ecma_free_value (JERRY_CONTEXT (error_value));
     parser_raise_error (context_p, PARSER_ERR_INVALID_REGEXP);
   }

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -311,6 +311,9 @@ static void
 parser_parse_var_statement (parser_context_t *context_p) /**< context */
 {
   JERRY_ASSERT (context_p->token.type == LEXER_KEYW_VAR);
+#ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif /* !JERRY_DEBUGGER */
 
   while (true)
   {
@@ -331,6 +334,7 @@ parser_parse_var_statement (parser_context_t *context_p) /**< context */
     if (context_p->token.type == LEXER_ASSIGN)
     {
 #ifdef JERRY_DEBUGGER
+
       if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
           && ident_line_counter != context_p->last_breakpoint_line)
       {
@@ -414,6 +418,7 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
   }
 
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
   {
     jerry_debugger_send_string (JERRY_DEBUGGER_FUNCTION_NAME,
@@ -1713,6 +1718,10 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
   JERRY_ASSERT (context_p->last_statement.current_p == NULL);
   parser_stack_push_uint8 (context_p, PARSER_STATEMENT_START);
   parser_stack_iterator_init (context_p, &context_p->last_statement);
+
+#if defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO)
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif /* JERRY_DEBUGGER || JERRY_ENABLE_LINE_INFO */
 
 #ifdef JERRY_DEBUGGER
   /* Set lexical enviroment for the debugger. */

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -396,6 +396,7 @@ parser_emit_line_info (parser_context_t *context_p, /**< context */
                        uint32_t line, /**< current line */
                        bool flush_cbc) /**< flush last byte code */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if (JERRY_CONTEXT (resource_name) == ECMA_VALUE_UNDEFINED)
   {
     return;

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1382,6 +1382,7 @@ static void
 parser_send_breakpoints (parser_context_t *context_p, /**< context */
                          jerry_debugger_header_type_t type) /**< message type */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
   JERRY_ASSERT (context_p->breakpoint_info_count > 0);
 
@@ -1400,6 +1401,7 @@ parser_append_breakpoint_info (parser_context_t *context_p, /**< context */
                                jerry_debugger_header_type_t type, /**< message type */
                                uint32_t value) /**< line or offset of the breakpoint */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED);
 
   context_p->status_flags |= PARSER_DEBUGGER_BREAKPOINT_APPENDED;
@@ -1456,6 +1458,9 @@ parser_append_breakpoint_info (parser_context_t *context_p, /**< context */
 static ecma_compiled_code_t *
 parser_post_processing (parser_context_t *context_p) /**< context */
 {
+#if defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO)
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif  /* JERRY_DEBUGGER || JERRY_ENABLE_LINE_INFO */
   uint16_t literal_one_byte_limit;
   uint16_t ident_end;
   uint16_t uninitialized_var_end;
@@ -2288,6 +2293,10 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
                      uint32_t parse_opts, /**< ecma_parse_opts_t option bits */
                      parser_error_location_t *error_location_p) /**< error location */
 {
+#if defined (JERRY_DEBUGGER) || defined (PARSER_DUMP_BYTE_CODE)
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif /* JERRY_DEBUGGER || PARSER_DUMP_BYTE_CODE */
+
   parser_context_t context;
   ecma_compiled_code_t *compiled_code;
 
@@ -2466,6 +2475,7 @@ parser_save_context (parser_context_t *context_p, /**< context */
   JERRY_ASSERT (context_p->last_cbc_opcode == PARSER_CBC_UNAVAILABLE);
 
 #ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
       && context_p->breakpoint_info_count > 0)
   {
@@ -2556,6 +2566,9 @@ ecma_compiled_code_t *
 parser_parse_function (parser_context_t *context_p, /**< context */
                        uint32_t status_flags) /**< extra status flags */
 {
+#ifdef JERRY_DEBUGGER
+  JERRY_DEFINE_CURRENT_CONTEXT ();
+#endif /* JERRY_DEBUGGER */
   parser_saved_context_t saved_context;
   ecma_compiled_code_t *compiled_code_p;
 
@@ -2867,6 +2880,7 @@ parser_parse_script (const uint8_t *arg_list_p, /**< function argument list */
                      uint32_t parse_opts, /**< ecma_parse_opts_t option bits */
                      ecma_compiled_code_t **bytecode_data_p) /**< [out] JS bytecode */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
 #ifndef JERRY_DISABLE_JS_PARSER
   parser_error_location_t parser_error;
 

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -479,6 +479,7 @@ static uint8_t
 re_find_bytecode_in_cache (ecma_string_t *pattern_str_p, /**< pattern string */
                            uint16_t flags) /**< flags */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   uint8_t free_idx = RE_CACHE_SIZE;
 
   for (uint8_t idx = 0u; idx < RE_CACHE_SIZE; idx++)
@@ -513,6 +514,7 @@ re_find_bytecode_in_cache (ecma_string_t *pattern_str_p, /**< pattern string */
 void
 re_cache_gc_run (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   for (uint32_t i = 0u; i < RE_CACHE_SIZE; i++)
   {
     const re_compiled_code_t *cached_bytecode_p = JERRY_CONTEXT (re_cache)[i];
@@ -540,6 +542,7 @@ re_compile_bytecode (const re_compiled_code_t **out_bytecode_p, /**< [out] point
                      ecma_string_t *pattern_str_p, /**< pattern */
                      uint16_t flags) /**< flags */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
   uint8_t cache_idx = re_find_bytecode_in_cache (pattern_str_p, flags);
 

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -903,6 +903,7 @@ re_parse_next_token (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context *
       }
 
       JERRY_ASSERT (ECMA_IS_VALUE_ERROR (ret_value));
+      JERRY_DEFINE_CURRENT_CONTEXT ();
       ecma_free_value (JERRY_CONTEXT (error_value));
 
       parser_ctx_p->input_curr_p = input_curr_p;

--- a/jerry-core/vm/vm-utils.c
+++ b/jerry-core/vm/vm-utils.c
@@ -27,6 +27,7 @@
 bool
 vm_is_strict_mode (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   JERRY_ASSERT (JERRY_CONTEXT (vm_top_context_p) != NULL);
 
   return JERRY_CONTEXT (vm_top_context_p)->bytecode_header_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE;
@@ -47,6 +48,7 @@ vm_is_strict_mode (void)
 inline bool JERRY_ATTR_ALWAYS_INLINE
 vm_is_direct_eval_form_call (void)
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   return (JERRY_CONTEXT (status_flags) & ECMA_STATUS_DIRECT_EVAL) != 0;
 } /* vm_is_direct_eval_form_call */
 
@@ -68,6 +70,7 @@ vm_get_backtrace (uint32_t max_depth) /**< maximum backtrace depth, 0 = unlimite
     max_depth = UINT32_MAX;
   }
 
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   vm_frame_ctx_t *context_p = JERRY_CONTEXT (vm_top_context_p);
   ecma_object_t *array_p = ecma_get_object_from_value (result_array);
   uint32_t index = 0;

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -139,6 +139,7 @@ vm_op_set_value (ecma_value_t object, /**< base object */
     if (ECMA_IS_VALUE_ERROR (to_object))
     {
 #ifdef JERRY_ENABLE_ERROR_MESSAGES
+      JERRY_DEFINE_CURRENT_CONTEXT ();
       ecma_free_value (to_object);
       ecma_free_value (JERRY_CONTEXT (error_value));
 
@@ -244,6 +245,7 @@ ecma_value_t
 vm_run_eval (ecma_compiled_code_t *bytecode_data_p, /**< byte-code data */
              uint32_t parse_opts) /**< ecma_parse_opts_t option bits */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_value_t this_binding;
   ecma_object_t *lex_env_p;
 
@@ -443,6 +445,7 @@ vm_super_call (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 static void
 opfunc_call (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   uint8_t opcode = frame_ctx_p->byte_code_p[0];
   uint32_t arguments_list_len;
 
@@ -635,6 +638,7 @@ opfunc_construct (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 static void
 vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   const ecma_compiled_code_t *bytecode_header_p = frame_ctx_p->bytecode_header_p;
   uint8_t *byte_code_p = frame_ctx_p->byte_code_p;
   uint16_t encoding_limit;
@@ -806,6 +810,7 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 static ecma_value_t JERRY_ATTR_NOINLINE
 vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   const ecma_compiled_code_t *bytecode_header_p = frame_ctx_p->bytecode_header_p;
   uint8_t *byte_code_p = frame_ctx_p->byte_code_p;
   ecma_value_t *literal_start_p = frame_ctx_p->literal_start_p;
@@ -3359,6 +3364,7 @@ vm_execute (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
             const ecma_value_t *arg_p, /**< arguments list */
             ecma_length_t arg_list_len) /**< length of arguments list */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   const ecma_compiled_code_t *bytecode_header_p = frame_ctx_p->bytecode_header_p;
   ecma_value_t completion_value;
   uint16_t argument_end;
@@ -3467,6 +3473,7 @@ vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data heade
         const ecma_value_t *arg_list_p, /**< arguments list */
         ecma_length_t arg_list_len) /**< length of arguments list */
 {
+  JERRY_DEFINE_CURRENT_CONTEXT ();
   ecma_value_t *literal_p;
   vm_frame_ctx_t frame_ctx;
   uint32_t call_stack_size;


### PR DESCRIPTION
JERRY_INIT_CURRENT_CONTEXT macro has been added in the jerry-core/jcontext/jcontext.h
With this macro the number of external call of the jerry-port/default/default-external-context.c:40:jerry_port_get_current_context(void) has been decreased.


JerryScript-DCO-1.0-Signed-off-by : Bence Gabor Kis kisbg@inf.u-szeged.hu