### PR TITLE
Doctest debugger examples and fix revealed issues

### DIFF
--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -126,7 +126,14 @@ jerry_debugger_is_connected (void);
 
 **Example**
 
+[doctest]: # (test="link")
+
 ```c
+#include "jerryscript.h"
+#include "jerryscript-ext/debugger.h"
+
+int
+main (void)
 {
   jerry_init (JERRY_INIT_EMPTY);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
@@ -159,7 +166,14 @@ jerry_debugger_stop (void)
 
 **Example**
 
+[doctest]: # (test="link")
+
 ```c
+#include "jerryscript.h"
+#include "jerryscript-ext/debugger.h"
+
+int
+main (void)
 {
   jerry_init (JERRY_INIT_EMPTY);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
@@ -194,7 +208,14 @@ jerry_debugger_continue (void)
 
 **Example**
 
+[doctest]: # (test="link")
+
 ```c
+#include "jerryscript.h"
+#include "jerryscript-ext/debugger.h"
+
+int
+main (void)
 {
   jerry_init (JERRY_INIT_EMPTY);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
@@ -229,7 +250,15 @@ jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint)
 
 **Example**
 
+[doctest]: # (test="link")
+
 ```c
+#include <string.h>
+#include "jerryscript.h"
+#include "jerryscript-ext/debugger.h"
+
+int
+main (void)
 {
   jerry_init (JERRY_INIT_EMPTY);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
@@ -238,7 +267,9 @@ jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint)
   jerry_debugger_stop_at_breakpoint (true);
 
   // Protected execution of JavaScript code.
-  jerry_eval (...);
+  const jerry_char_t script[] = "42";
+  size_t script_size = strlen ((const char *) script);
+  jerry_eval (script, script_size, JERRY_PARSE_NO_OPTS);
 
   jerry_debugger_stop_at_breakpoint (false);
 
@@ -266,7 +297,12 @@ jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t
 
 **Example**
 
+[doctest]: # (test="link")
+
 ```c
+#include "jerryscript.h"
+#include "jerryscript-ext/debugger.h"
+
 /**
  * Runs the source code received by jerry_debugger_wait_for_client_source.
  */
@@ -293,8 +329,11 @@ wait_for_source_callback (const jerry_char_t *resource_name_p, /**< resource nam
   return ret_val;
 } /* wait_for_source_callback */
 
-int main ()
+int
+main (void)
 {
+  jerry_debugger_wait_for_source_status_t receive_status;
+
   do
   {
     /* Create a new JerryScript instance when a context reset is
@@ -307,7 +346,6 @@ int main ()
     do
     {
       jerry_value_t run_result;
-      jerry_debugger_wait_for_source_status_t receive_status;
 
       receive_status = jerry_debugger_wait_for_client_source (wait_for_source_callback,
                                                               NULL,
@@ -344,13 +382,20 @@ jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t string_size)
 
 **Example**
 
+[doctest]: # (test="link")
+
 ```c
+#include "jerryscript.h"
+#include "jerryscript-ext/debugger.h"
+
+int
+main (void)
 {
   jerry_init (JERRY_INIT_EMPTY);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 
-  jerry_char_t my_output = "Hey, this should be sent too!";
+  jerry_char_t my_output[] = "Hey, this should be sent too!";
   jerry_size_t my_output_size = sizeof (my_output);
 
   jerry_debugger_send_output (my_output, my_output_size);
@@ -374,13 +419,20 @@ jerry_debugger_send_log (jerry_log_level_t level, jerry_char_t buffer[], jerry_s
 
 **Example**
 
+[doctest]: # (test="link")
+
 ```c
+#include "jerryscript.h"
+#include "jerryscript-ext/debugger.h"
+
+int
+main (void)
 {
   jerry_init (JERRY_INIT_EMPTY);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 
-  jerry_char_t my_log = "Custom diagnostics";
+  jerry_char_t my_log[] = "Custom diagnostics";
   jerry_size_t my_log_size = sizeof (my_log);
 
   jerry_debugger_send_log (JERRY_LOG_LEVEL_DEBUG, my_log, my_log_size);


### PR DESCRIPTION
This will help to keep the debugger documentation up to date.
(Note: only compilation & linking is possible as execution would
require a connecting debugger client, which is not supported for
unit/doctests.)

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu