### PR TITLE
Align the RIOT target with the clang build of RIOT OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,9 +149,12 @@ matrix:
     - env: JOBNAME="RIOT/STM32F4 Build Test"
       install: make -f ./targets/riot-stm32f4/Makefile.travis install-noapt
       script: make -f ./targets/riot-stm32f4/Makefile.travis script
+      compiler: clang-3.9
       addons:
         apt:
-          packages: [gcc-arm-none-eabi, libnewlib-arm-none-eabi]
+          sources:
+            - sourceline: ppa:team-gcc-arm-embedded/ppa
+          packages: [clang-3.9, gcc-arm-embedded, gcc-multilib]
 
     - env: JOBNAME="Tizen RT/Artik053 Build Test"
       addons:

--- a/targets/riot-stm32f4/Makefile
+++ b/targets/riot-stm32f4/Makefile
@@ -18,6 +18,9 @@ APPLICATION = riot_jerry
 # default BOARD enviroment
 BOARD ?= stm32f4discovery
 
+# LLVM/Clang-based toolchain
+TOOLCHAIN ?= llvm
+
 # path to the RIOT base directory
 RIOTBASE ?= $(CURDIR)/../RIOT
 # path to the JERRYSCRIPT directory
@@ -29,11 +32,6 @@ APPDIR ?= $(JERRYDIR)/targets/riot-stm32f4/source
 # path to the binary directory
 BINDIR ?= $(JERRYDIR)/targets/riot-stm32f4/bin/
 
-# Comment this out to disable code in RIOT that does safety checking
-# which is not needed in a production environment but helps in the
-# development process:
-CFLAGS += -DDEVELHELP
-
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
@@ -44,7 +42,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 
 # Add the jerry libs
-USEMODULE += libjerrycore libjerryport-minimal libjerryext
+USEMODULE += libjerry-core libjerry-port-default-minimal libjerry-ext
 
 
 include $(RIOTBASE)/Makefile.include

--- a/targets/riot-stm32f4/Makefile.riot
+++ b/targets/riot-stm32f4/Makefile.riot
@@ -12,14 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Build and output directories
 BUILD_DIR  ?= build/riotstm32f4
 COPYTARGET ?= targets/riot-stm32f4/bin
 
+# JerryScript configuration
 JERRYHEAP  ?= 16
 
-EXT_CFLAGS := -D__TARGET_RIOT_STM32F4
+# To be defined on the command line of make if Clang is available via a
+# different name (e.g., clang-N.M)
+CC ?= clang
+
+# Cross-compilation settings for Clang
+EXT_CFLAGS := -target arm-none-eabi
 EXT_CFLAGS += -mlittle-endian -mthumb -mcpu=cortex-m4
-EXT_CFLAGS += -Wno-error=format=
+EXT_CFLAGS += -isystem /usr/arm-none-eabi/include
+EXT_CFLAGS += $(addprefix -isystem $(lastword $(sort $(wildcard /usr/lib/gcc/arm-none-eabi/*/))), include include-fixed)
+EXT_CFLAGS += -nostdinc
+
+# For ABI compatibility with RIOT-OS
+EXT_CFLAGS += -fshort-enums
+
 
 .PHONY: libjerry riot-jerry flash clean
 
@@ -27,11 +40,10 @@ all: libjerry riot-jerry
 
 libjerry:
 	mkdir -p $(BUILD_DIR)
-	mkdir -p $(COPYTARGET)
 	cmake -B$(BUILD_DIR) -H./ \
 	 -DCMAKE_SYSTEM_NAME=RIOT \
 	 -DCMAKE_SYSTEM_PROCESSOR=armv7l \
-	 -DCMAKE_C_COMPILER=arm-none-eabi-gcc \
+	 -DCMAKE_C_COMPILER=$(CC) \
 	 -DCMAKE_C_COMPILER_WORKS=TRUE \
 	 -DENABLE_LTO=OFF \
 	 -DENABLE_ALL_IN_ONE=OFF \
@@ -39,12 +51,12 @@ libjerry:
 	 -DJERRY_CMDLINE=OFF \
 	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
-
 	make -C$(BUILD_DIR) jerry-core jerry-port-default-minimal jerry-ext
-	cp $(BUILD_DIR)/lib/libjerry-core.a $(COPYTARGET)/libjerrycore.a
-	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(COPYTARGET)/libjerryport-minimal.a
-	cp $(BUILD_DIR)/lib/libjerry-ext.a $(COPYTARGET)/libjerryext.a
 
+	mkdir -p $(COPYTARGET)
+	cp $(BUILD_DIR)/lib/libjerry-core.a $(COPYTARGET)
+	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(COPYTARGET)
+	cp $(BUILD_DIR)/lib/libjerry-ext.a $(COPYTARGET)
 
 riot-jerry: libjerry
 	make -f ./targets/riot-stm32f4/Makefile

--- a/targets/riot-stm32f4/Makefile.travis
+++ b/targets/riot-stm32f4/Makefile.travis
@@ -23,11 +23,11 @@ all:
 
 # Install cross-compiler via apt.
 install-apt-get-deps:
-	sudo apt-get install -q -y gcc-arm-none-eabi
+	sudo apt-get install -q -y clang-3.9 gcc-arm-embedded gcc-multilib
 
 # Fetch RIOT OS repository.
 install-clone-riot:
-	git clone git://github.com/RIOT-OS/RIOT.git ../RIOT -b 2017.10
+	git clone git://github.com/RIOT-OS/RIOT.git ../RIOT -b 2018.07
 
 # Perform all the necessary (JerryScript-independent) installation steps.
 install-noapt: install-clone-riot


### PR DESCRIPTION
This means cross building with clang and using short enums. Also
bump RIOT OS version to latest 2018.07.

Note: On Travis CI, clang-3.9 is used for testing. That version is
widely available, from Ubuntu 14.04 to 18.04.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu