### PR TITLE
Fix syntax error when closing a block after a return statement

### DIFF
--- a/jerry-core/parser/js/js-parser-scanner.c
+++ b/jerry-core/parser/js/js-parser-scanner.c
@@ -463,7 +463,8 @@ parser_scan_statement (parser_context_t *context_p, /**< context */
     {
       lexer_next_token (context_p);
       if (!(context_p->token.flags & LEXER_WAS_NEWLINE)
-          && context_p->token.type != LEXER_SEMICOLON)
+          && context_p->token.type != LEXER_SEMICOLON
+          && context_p->token.type != LEXER_RIGHT_BRACE)
       {
         *mode = SCAN_MODE_PRIMARY_EXPRESSION;
       }

--- a/tests/jerry/regression-test-issue-2478.js
+++ b/tests/jerry/regression-test-issue-2478.js
@@ -1,0 +1,21 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+function fn(x) {
+  switch (x) {
+    case 1: { return }
+  }
+}
+
+new Function("switch(1) { default: { return }}")


### PR DESCRIPTION
Fix for #2478. This adds a right brace to the list of tokens that will end a return statement.

JerryScript-DCO-1.0-Signed-off-by: Marc Jessome marc.jessome@fitbit.com