### PR TITLE
Add a validation before evaluating the source code

### DIFF
--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -810,6 +810,12 @@ main (int argc,
 
       if (len > 0)
       {
+        if (!jerry_is_valid_utf8_string (buffer, (jerry_size_t) len))
+        {
+          jerry_port_log (JERRY_LOG_LEVEL_ERROR, "Error: Input must be a valid UTF-8 string.\n");
+          return JERRY_STANDALONE_EXIT_CODE_FAIL;
+        }
+
         /* Evaluate the line */
         jerry_value_t ret_val_eval = jerry_eval (buffer, len, JERRY_PARSE_NO_OPTS);
 


### PR DESCRIPTION
This patch checks whether the source code is a valid UTF-8 string before evaluating it in prompt mode.
Also fixes #2476.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu