### PR TITLE
Remove character pointer typedefs

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -143,18 +143,6 @@ Jerry's char value
 typedef uint8_t jerry_char_t;
 ```
 
-## jerry_char_ptr_t
-
-**Summary**
-
-Pointer to an array of character values
-
-**Prototype**
-
-```c
-typedef jerry_char_t *jerry_char_ptr_t;
-```
-
 ## jerry_size_t
 
 **Summary**
@@ -632,7 +620,7 @@ Registers an external magic string array.
 
 ```c
 void
-jerry_register_magic_strings  (const jerry_char_ptr_t *ex_str_items_p,
+jerry_register_magic_strings  (const jerry_char_t **ex_str_items_p,
                                uint32_t count,
                                const jerry_length_t *str_lengths_p);
 ```
@@ -655,12 +643,12 @@ main (void)
 
   // must be static, because 'jerry_register_magic_strings' does not copy
   // the items must be sorted by size at first, then lexicographically
-  static const jerry_char_ptr_t magic_string_items[] = {
-                                                         (const jerry_char_ptr_t) "magicstring1",
-                                                         (const jerry_char_ptr_t) "magicstring2",
-                                                         (const jerry_char_ptr_t) "magicstring3"
-                                                       };
-  uint32_t num_magic_string_items = (uint32_t) (sizeof (magic_string_items) / sizeof (jerry_char_ptr_t));
+  static const jerry_char_t *magic_string_items[] = {
+                                                      (const jerry_char_t *) "magicstring1",
+                                                      (const jerry_char_t *) "magicstring2",
+                                                      (const jerry_char_t *) "magicstring3"
+                                                    };
+  uint32_t num_magic_string_items = (uint32_t) (sizeof (magic_string_items) / sizeof (jerry_char_t *));
 
   // must be static, because 'jerry_register_magic_strings' does not copy
   static const jerry_length_t magic_string_lengths[] = {

--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -1705,7 +1705,7 @@ jerry_parse_and_save_literals (const jerry_char_t *source_p, /**< script source 
     /* Save the array of literals. */
     destination_p = jerry_append_chars_to_buffer (destination_p,
                                                   buffer_end_p,
-                                                  ";\n\njerry_char_ptr_t literals[",
+                                                  ";\n\njerry_char_t *literals[",
                                                   0);
 
     destination_p = jerry_append_number_to_buffer (destination_p, buffer_end_p, literal_count);

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -257,8 +257,8 @@ jerry_get_context_data (const jerry_context_data_manager_t *manager_p)
  * Register external magic string array
  */
 void
-jerry_register_magic_strings (const jerry_char_ptr_t *ex_str_items_p, /**< character arrays, representing
-                                                                       *   external magic strings' contents */
+jerry_register_magic_strings (const jerry_char_t **ex_str_items_p, /**< character arrays, representing
+                                                                    *   external magic strings' contents */
                               uint32_t count, /**< number of the strings */
                               const jerry_length_t *str_lengths_p) /**< lengths of all strings */
 {

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -121,11 +121,6 @@ typedef enum
 typedef uint8_t jerry_char_t;
 
 /**
- * Pointer to an array of character values.
- */
-typedef jerry_char_t *jerry_char_ptr_t;
-
-/**
  * Size type of JerryScript.
  */
 typedef uint32_t jerry_size_t;
@@ -313,7 +308,7 @@ typedef struct jerry_instance_t jerry_instance_t;
  */
 void jerry_init (jerry_init_flag_t flags);
 void jerry_cleanup (void);
-void jerry_register_magic_strings (const jerry_char_ptr_t *ex_str_items_p, uint32_t count,
+void jerry_register_magic_strings (const jerry_char_t **ex_str_items_p, uint32_t count,
                                    const jerry_length_t *str_lengths_p);
 void jerry_gc (jerry_gc_mode_t mode);
 void *jerry_get_context_data (const jerry_context_data_manager_t *manager_p);

--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -414,7 +414,7 @@ lit_char_get_utf8_length (ecma_char_t chr) /**< EcmaScript character */
 bool
 lit_read_code_unit_from_hex (const lit_utf8_byte_t *buf_p, /**< buffer with characters */
                              lit_utf8_size_t number_of_characters, /**< number of characters to be read */
-                             ecma_char_ptr_t out_code_unit_p) /**< [out] decoded result */
+                             ecma_char_t *out_code_unit_p) /**< [out] decoded result */
 {
   ecma_char_t code_unit = LIT_CHAR_NULL;
 

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -220,7 +220,7 @@ size_t lit_char_get_utf8_length (ecma_char_t chr);
 
 /* read a hex encoded code point from a zero terminated buffer */
 bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *buf_p, lit_utf8_size_t number_of_characters,
-                                  ecma_char_ptr_t out_code_unit_p);
+                                  ecma_char_t *out_code_unit_p);
 
 /**
  * Null character

--- a/jerry-core/lit/lit-globals.h
+++ b/jerry-core/lit/lit-globals.h
@@ -79,11 +79,6 @@ typedef uint16_t ecma_char_t;
 typedef uint32_t ecma_length_t;
 
 /**
- * Description of an ecma-character pointer
- */
-typedef ecma_char_t *ecma_char_ptr_t;
-
-/**
  * Max bytes needed to represent a code unit (utf-16 char) via utf-8 encoding
  */
 #define LIT_UTF8_MAX_BYTES_IN_CODE_UNIT (3)

--- a/jerry-main/main-unix-snapshot.c
+++ b/jerry-main/main-unix-snapshot.c
@@ -43,7 +43,7 @@ static uint8_t input_buffer[JERRY_BUFFER_SIZE];
 static uint32_t output_buffer[JERRY_BUFFER_SIZE / 4];
 static const char *output_file_name_p = "js.snapshot";
 static jerry_length_t magic_string_lengths[JERRY_LITERAL_LENGTH];
-static jerry_char_ptr_t magic_string_items[JERRY_LITERAL_LENGTH];
+static const jerry_char_t *magic_string_items[JERRY_LITERAL_LENGTH];
 
 /**
  * Check whether JerryScript has a requested feature enabled or not. If not,
@@ -337,7 +337,7 @@ process_generate (cli_state_t *cli_state_p, /**< cli state */
         jerry_length_t mstr_size = (jerry_length_t) strtol (sp_buffer_p, &sp_buffer_end_p, 10);
         if (mstr_size > 0)
         {
-          magic_string_items[num_of_lit] = (jerry_char_ptr_t) (sp_buffer_end_p + 1);
+          magic_string_items[num_of_lit] = (jerry_char_t *) (sp_buffer_end_p + 1);
           magic_string_lengths[num_of_lit] = mstr_size;
           num_of_lit++;
         }

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/setup.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/setup.cpp
@@ -21,7 +21,7 @@
 extern uint32_t jsmbed_js_magic_string_count;
 extern uint32_t jsmbed_js_magic_string_values[];
 
-extern const jerry_char_ptr_t jsmbed_js_magic_strings[];
+extern const jerry_char_t *jsmbed_js_magic_strings[];
 extern const jerry_length_t jsmbed_js_magic_string_lengths[];
 
 void jsmbed_js_load_magic_strings() {

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -191,10 +191,10 @@ const jerry_length_t magic_string_lengths[] =
 #undef JERRY_MAGIC_STRING_DEF
 };
 
-const jerry_char_ptr_t magic_string_items[] =
+const jerry_char_t *magic_string_items[] =
 {
 #define JERRY_MAGIC_STRING_DEF(NAME, STRING) \
-    (const jerry_char_ptr_t) jerry_magic_string_ex_ ## NAME,
+    (const jerry_char_t *) jerry_magic_string_ex_ ## NAME,
 
   JERRY_MAGIC_STRING_ITEMS
 
@@ -1126,7 +1126,7 @@ main (void)
   /* External Magic String */
   jerry_init (JERRY_INIT_SHOW_OPCODES);
 
-  uint32_t num_magic_string_items = (uint32_t) (sizeof (magic_string_items) / sizeof (jerry_char_ptr_t));
+  uint32_t num_magic_string_items = (uint32_t) (sizeof (magic_string_items) / sizeof (jerry_char_t *));
   jerry_register_magic_strings (magic_string_items,
                                 num_magic_string_items,
                                 magic_string_lengths);

--- a/tests/unit-core/test-snapshot.c
+++ b/tests/unit-core/test-snapshot.c
@@ -26,16 +26,16 @@
 /**
  * Magic strings
  */
-static const jerry_char_ptr_t magic_strings[] =
+static const jerry_char_t *magic_strings[] =
 {
-  (const jerry_char_ptr_t) " ",
-  (const jerry_char_ptr_t) "a",
-  (const jerry_char_ptr_t) "b",
-  (const jerry_char_ptr_t) "c",
-  (const jerry_char_ptr_t) "from",
-  (const jerry_char_ptr_t) "func",
-  (const jerry_char_ptr_t) "string",
-  (const jerry_char_ptr_t) "snapshot"
+  (const jerry_char_t *) " ",
+  (const jerry_char_t *) "a",
+  (const jerry_char_t *) "b",
+  (const jerry_char_t *) "c",
+  (const jerry_char_t *) "from",
+  (const jerry_char_t *) "func",
+  (const jerry_char_t *) "string",
+  (const jerry_char_t *) "snapshot"
 };
 
 /**
@@ -371,11 +371,11 @@ main (void)
                                                                    literal_buffer_c,
                                                                    SNAPSHOT_BUFFER_SIZE,
                                                                    true);
-    TEST_ASSERT (literal_sizes_c_format == 203);
+    TEST_ASSERT (literal_sizes_c_format == 200);
 
     static const char *expected_c_format = (
                                             "jerry_length_t literal_count = 4;\n\n"
-                                            "jerry_char_ptr_t literals[4] =\n"
+                                            "jerry_char_t *literals[4] =\n"
                                             "{\n"
                                             "  \"Bb\",\n"
                                             "  \"aa\",\n"


### PR DESCRIPTION
The `[jerry|ecma]_char_ptr_t` types are some old legacy that are
used quite inconsistently. Their `[jerry|ecma]_char_t *` variants
are used a lot more often, so it's better to stick to one form
throughout the code base.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu