### PR TITLE
Move the 'init/fini arrays' build option to jerry-ext

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,6 @@ set(BUILD_SHARED_LIBS  OFF CACHE BOOL "Build shared libraries?")
 set(ENABLE_LTO         ON  CACHE BOOL "Enable LTO build?")
 set(ENABLE_STRIP       ON  CACHE BOOL "Enable stripping all symbols from release binary?")
 
-# Optional features
-set(FEATURE_INIT_FINI OFF CACHE BOOL "Enable init/fini arrays?")
-
 # Option overrides
 if(JERRY_CMDLINE OR JERRY_CMDLINE_TEST OR JERRY_CMDLINE_SNAPSHOT OR UNITTESTS OR DOCTESTS)
   set(JERRY_PORT_DEFAULT ON)
@@ -112,7 +109,6 @@ message(STATUS "JERRY_EXT                   " ${JERRY_EXT} ${JERRY_EXT_MESSAGE})
 message(STATUS "JERRY_LIBM                  " ${JERRY_LIBM} ${JERRY_LIBM_MESSAGE})
 message(STATUS "UNITTESTS                   " ${UNITTESTS})
 message(STATUS "DOCTESTS                    " ${DOCTESTS})
-message(STATUS "FEATURE_INIT_FINI           " ${FEATURE_INIT_FINI})
 
 # Setup directories
 # Note: This mimics a conventional file system layout in the build directory for

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -16,6 +16,12 @@ cmake_minimum_required (VERSION 2.8.12)
 set(JERRY_EXT_NAME jerry-ext)
 project (${JERRY_EXT_NAME} C)
 
+# Optional features
+set(FEATURE_INIT_FINI OFF CACHE BOOL "Enable init/fini arrays?")
+
+# Status messages
+message(STATUS "FEATURE_INIT_FINI           " ${FEATURE_INIT_FINI})
+
 # Include directories
 set(INCLUDE_EXT_PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(INCLUDE_EXT_PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/common")


### PR DESCRIPTION
Since the removal of jerry-libc, only jerry-ext uses the
`FEATURE_INIT_FINI` optional feature. Thus, it's better to move it
from the global cmakelists to that of jerry-ext.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu