### PR TITLE
Change `jerry_debugger_send_{output,log}` to take `const jerry_char_t *`

### DIFF
--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -375,7 +375,7 @@ Sends the program's output to the debugger client.
 
 ```c
 void
-jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t string_size)
+jerry_debugger_send_output (const jerry_char_t *buffer, jerry_size_t string_size)
 ```
 
 **Example**
@@ -412,7 +412,7 @@ Sends the program's log to the debugger client.
 
 ```c
 void
-jerry_debugger_send_log (jerry_log_level_t level, jerry_char_t buffer[], jerry_size_t string_size)
+jerry_debugger_send_log (jerry_log_level_t level, const jerry_char_t *buffer, jerry_size_t string_size)
 ```
 
 **Example**

--- a/jerry-core/api/jerry-debugger.c
+++ b/jerry-core/api/jerry-debugger.c
@@ -189,7 +189,7 @@ jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t
  * Currently only sends print output.
  */
 void
-jerry_debugger_send_output (jerry_char_t buffer[], /**< buffer */
+jerry_debugger_send_output (const jerry_char_t *buffer, /**< buffer */
                             jerry_size_t str_size) /**< string size */
 {
 #ifdef JERRY_DEBUGGER
@@ -211,7 +211,7 @@ jerry_debugger_send_output (jerry_char_t buffer[], /**< buffer */
  */
 void
 jerry_debugger_send_log (jerry_log_level_t level, /**< level of the diagnostics message */
-                         jerry_char_t buffer[], /**< buffer */
+                         const jerry_char_t *buffer, /**< buffer */
                          jerry_size_t str_size) /**< string size */
 {
 #ifdef JERRY_DEBUGGER

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -61,8 +61,8 @@ void jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint);
 jerry_debugger_wait_for_source_status_t
 jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t callback_p,
                                        void *user_p, jerry_value_t *return_value);
-void jerry_debugger_send_output (jerry_char_t buffer[], jerry_size_t str_size);
-void jerry_debugger_send_log (jerry_log_level_t level, jerry_char_t buffer[], jerry_size_t str_size);
+void jerry_debugger_send_output (const jerry_char_t *buffer, jerry_size_t str_size);
+void jerry_debugger_send_log (jerry_log_level_t level, const jerry_char_t *buffer, jerry_size_t str_size);
 
 /**
  * @}


### PR DESCRIPTION
... instead of `jerry_char_t []`, which is not used anywhere else
in the API.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu