### PR TITLE
Merge lcache into context

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2648,10 +2648,6 @@ jerry_create_instance (uint32_t heap_size, /**< the size of heap */
   total_size += heap_size;
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
 
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-  total_size += sizeof (jerry_hash_table_t);
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
-
   total_size = JERRY_ALIGNUP (total_size, JMEM_ALIGNMENT);
 
   jerry_instance_t *instance_p = (jerry_instance_t *) alloc (total_size, cb_data_p);
@@ -2672,11 +2668,6 @@ jerry_create_instance (uint32_t heap_size, /**< the size of heap */
   instance_p->heap_p = (jmem_heap_t *) byte_p;
   instance_p->heap_size = heap_size;
   byte_p += heap_size;
-#endif /* !JERRY_SYSTEM_ALLOCATOR */
-
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-  instance_p->lcache_p = byte_p;
-  byte_p += sizeof (jerry_hash_table_t);
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
 
   JERRY_ASSERT (byte_p <= ((uint8_t *) instance_p) + total_size);

--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -16,7 +16,6 @@
 #include "ecma-alloc.h"
 #include "ecma-globals.h"
 #include "ecma-gc.h"
-#include "ecma-lcache.h"
 #include "jrt.h"
 #include "jmem.h"
 

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -21,7 +21,6 @@
 #include "ecma-globals.h"
 #include "ecma-gc.h"
 #include "ecma-helpers.h"
-#include "ecma-lcache.h"
 #include "ecma-property-hashmap.h"
 #include "jcontext.h"
 #include "jrt.h"

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -17,7 +17,6 @@
 #include "ecma-gc.h"
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
-#include "ecma-lcache.h"
 #include "jrt.h"
 #include "jrt-libc-includes.h"
 #include "lit-char-helpers.h"

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -17,7 +17,6 @@
 #include "ecma-gc.h"
 #include "ecma-helpers.h"
 #include "ecma-init-finalize.h"
-#include "ecma-lcache.h"
 #include "ecma-lex-env.h"
 #include "ecma-literal-storage.h"
 #include "jmem.h"
@@ -36,7 +35,6 @@
 void
 ecma_init (void)
 {
-  ecma_lcache_init ();
   ecma_init_global_lex_env ();
 
   jmem_register_free_unused_memory_callback (ecma_free_unused_memory);

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -33,20 +33,6 @@
  */
 #define ECMA_LCACHE_HASH_MASK (ECMA_LCACHE_HASH_ROWS_COUNT - 1)
 
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
-
-/**
- * Initialize LCache
- */
-void
-ecma_lcache_init (void)
-{
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-  memset (JERRY_HASH_TABLE_CONTEXT (table), 0, sizeof (jerry_hash_table_t));
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
-} /* ecma_lcache_init */
-
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
 /**
  * Invalidate specified LCache entry
  */
@@ -74,6 +60,7 @@ ecma_lcache_row_index (jmem_cpointer_t object_cp, /**< compressed pointer to obj
    * so properties of different objects with the same name can be cached effectively. */
   return (size_t) ((name_hash ^ object_cp) & ECMA_LCACHE_HASH_MASK);
 } /* ecma_lcache_row_index */
+
 #endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 
 /**
@@ -96,7 +83,7 @@ ecma_lcache_insert (ecma_object_t *object_p, /**< object */
 
   lit_string_hash_t name_hash = ecma_string_get_property_name_hash (*prop_p, name_cp);
   size_t row_index = ecma_lcache_row_index (object_cp, name_hash);
-  ecma_lcache_hash_entry_t *entries_p = JERRY_HASH_TABLE_CONTEXT (table)[row_index];
+  ecma_lcache_hash_entry_t *entries_p = JERRY_CONTEXT (lcache) [row_index];
 
   uint32_t entry_index;
   for (entry_index = 0; entry_index < ECMA_LCACHE_HASH_ROW_LENGTH; entry_index++)
@@ -131,12 +118,6 @@ ecma_lcache_insert (ecma_object_t *object_p, /**< object */
   JERRY_UNUSED (name_cp);
 #endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 } /* ecma_lcache_insert */
-
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-
-
-
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 
 /**
  * Lookup property in the LCache
@@ -182,7 +163,7 @@ ecma_lcache_lookup (ecma_object_t *object_p, /**< object */
 
   size_t row_index = ecma_lcache_row_index (object_cp, name_hash);
 
-  ecma_lcache_hash_entry_t *entry_p = JERRY_HASH_TABLE_CONTEXT (table) [row_index];
+  ecma_lcache_hash_entry_t *entry_p = JERRY_CONTEXT (lcache) [row_index];
   ecma_lcache_hash_entry_t *entry_end_p = entry_p + ECMA_LCACHE_HASH_ROW_LENGTH;
 
   while (entry_p < entry_end_p)
@@ -230,12 +211,12 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
 
   lit_string_hash_t name_hash = ecma_string_get_property_name_hash (*prop_p, name_cp);
   size_t row_index = ecma_lcache_row_index (object_cp, name_hash);
-  ecma_lcache_hash_entry_t *entry_p = JERRY_HASH_TABLE_CONTEXT (table) [row_index];
+  ecma_lcache_hash_entry_t *entry_p = JERRY_CONTEXT (lcache) [row_index];
 
   while (true)
   {
     /* The property must be present. */
-    JERRY_ASSERT (entry_p - JERRY_HASH_TABLE_CONTEXT (table) [row_index] < ECMA_LCACHE_HASH_ROW_LENGTH);
+    JERRY_ASSERT (entry_p - JERRY_CONTEXT (lcache) [row_index] < ECMA_LCACHE_HASH_ROW_LENGTH);
 
     if (entry_p->object_cp != ECMA_NULL_POINTER && entry_p->prop_p == prop_p)
     {

--- a/jerry-core/ecma/base/ecma-lcache.h
+++ b/jerry-core/ecma/base/ecma-lcache.h
@@ -23,7 +23,6 @@
  * @{
  */
 
-void ecma_lcache_init (void);
 void ecma_lcache_insert (ecma_object_t *object_p, jmem_cpointer_t name_cp, ecma_property_t *prop_p);
 ecma_property_t *ecma_lcache_lookup (ecma_object_t *object_p, const ecma_string_t *prop_name_p);
 void ecma_lcache_invalidate (ecma_object_t *object_p, jmem_cpointer_t name_cp, ecma_property_t *prop_p);

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -20,7 +20,6 @@
 #include "ecma-gc.h"
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
-#include "ecma-lcache.h"
 #include "ecma-lex-env.h"
 #include "ecma-objects.h"
 #include "ecma-objects-arguments.h"

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -20,7 +20,6 @@
 #include "ecma-gc.h"
 #include "ecma-globals.h"
 #include "ecma-function-object.h"
-#include "ecma-lcache.h"
 #include "ecma-lex-env.h"
 #include "ecma-string-object.h"
 #include "ecma-objects-arguments.h"

--- a/jerry-core/jcontext/jcontext.c
+++ b/jerry-core/jcontext/jcontext.c
@@ -41,14 +41,6 @@ jerry_context_t jerry_global_context;
 jmem_heap_t jerry_global_heap JERRY_ATTR_ALIGNED (JMEM_ALIGNMENT) JERRY_GLOBAL_HEAP_SECTION;
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
 
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-
-/**
- * Global hash table.
- */
-jerry_hash_table_t jerry_global_hash_table;
-
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 #endif /* !JERRY_ENABLE_EXTERNAL_CONTEXT */
 
 /**

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -131,17 +131,13 @@ typedef struct
 #ifdef JMEM_STATS
   jmem_heap_stats_t jmem_heap_stats; /**< heap's memory usage statistics */
 #endif /* JMEM_STATS */
-} jerry_context_t;
 
+  /* This must be at the end of the context for performance reasons */
 #ifndef CONFIG_ECMA_LCACHE_DISABLE
-/**
- * Hash table for caching the last access of properties.
- */
-typedef struct
-{
-  ecma_lcache_hash_entry_t table[ECMA_LCACHE_HASH_ROWS_COUNT][ECMA_LCACHE_HASH_ROW_LENGTH];
-} jerry_hash_table_t;
+  /** hash table for caching the last access of properties */
+  ecma_lcache_hash_entry_t lcache[ECMA_LCACHE_HASH_ROWS_COUNT][ECMA_LCACHE_HASH_ROW_LENGTH];
 #endif /* !CONFIG_ECMA_LCACHE_DISABLE */
+} jerry_context_t;
 
 #ifdef JERRY_ENABLE_EXTERNAL_CONTEXT
 
@@ -173,9 +169,6 @@ struct jerry_instance_t
   jmem_heap_t *heap_p; /**< point to the heap aligned to JMEM_ALIGNMENT. */
   uint32_t heap_size; /**< size of the heap */
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-  uint8_t *lcache_p; /**< point to the entrance of the lcache in buffer */
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 };
 
 #define JERRY_CONTEXT(field) (JERRY_GET_CURRENT_INSTANCE ()->context.field)
@@ -199,18 +192,6 @@ jerry_context_get_current_heap (void)
 #define JMEM_HEAP_AREA_SIZE (JERRY_GET_CURRENT_INSTANCE ()->heap_size - JMEM_ALIGNMENT)
 
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
-
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-
-static inline jerry_hash_table_t * JERRY_ATTR_ALWAYS_INLINE
-jerry_context_get_current_lcache (void)
-{
-  return (jerry_hash_table_t *) (JERRY_GET_CURRENT_INSTANCE ()->lcache_p);
-} /* jerry_context_get_current_lcache */
-
-#define JERRY_HASH_TABLE_CONTEXT(field) (jerry_context_get_current_lcache ()->field)
-
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 
 #else /* !JERRY_ENABLE_EXTERNAL_CONTEXT */
 
@@ -253,15 +234,6 @@ extern jerry_context_t jerry_global_context;
 extern jmem_heap_t jerry_global_heap;
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
 
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-
-/**
- * Global hash table.
- */
-extern jerry_hash_table_t jerry_global_hash_table;
-
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
-
 /**
  * Provides a reference to a field in the current context.
  */
@@ -274,15 +246,6 @@ extern jerry_hash_table_t jerry_global_hash_table;
 #define JERRY_HEAP_CONTEXT(field) (jerry_global_heap.field)
 
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
-
-#ifndef CONFIG_ECMA_LCACHE_DISABLE
-
-/**
- * Provides a reference to the global hash table.
- */
-#define JERRY_HASH_TABLE_CONTEXT(field) (jerry_global_hash_table.field)
-
-#endif /* !CONFIG_ECMA_LCACHE_DISABLE */
 
 #endif /* JERRY_ENABLE_EXTERNAL_CONTEXT */
 


### PR DESCRIPTION
It is superfluous to maintain multiple globals when the whole
reason of context is to keep them in a single place. It also
simplifies initialization and external context creation a bit.

Also removed unused lcache header includes.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu