### PR TITLE
Reorganize heap context related elements

### DIFF
--- a/jerry-core/jcontext/jcontext.c
+++ b/jerry-core/jcontext/jcontext.c
@@ -20,10 +20,19 @@
  */
 
 #ifndef JERRY_ENABLE_EXTERNAL_CONTEXT
+
 /**
  * Global context.
  */
 jerry_context_t jerry_global_context;
+
+#ifndef JERRY_SYSTEM_ALLOCATOR
+
+/**
+ * Check size of heap is corresponding to configuration
+ */
+JERRY_STATIC_ASSERT (sizeof (jmem_heap_t) <= JMEM_HEAP_SIZE,
+                     size_of_mem_heap_must_be_less_than_or_equal_to_JMEM_HEAP_SIZE);
 
 /**
  * Jerry global heap section attribute.
@@ -34,11 +43,11 @@ jerry_context_t jerry_global_context;
 #define JERRY_GLOBAL_HEAP_SECTION JERRY_ATTR_SECTION (JERRY_HEAP_SECTION_ATTR)
 #endif /* !JERRY_HEAP_SECTION_ATTR */
 
-#ifndef JERRY_SYSTEM_ALLOCATOR
 /**
  * Global heap.
  */
 jmem_heap_t jerry_global_heap JERRY_ATTR_ALIGNED (JMEM_ALIGNMENT) JERRY_GLOBAL_HEAP_SECTION;
+
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
 
 #endif /* !JERRY_ENABLE_EXTERNAL_CONTEXT */

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -32,6 +32,7 @@
  * @{
  */
 
+#ifndef JERRY_SYSTEM_ALLOCATOR
 /**
  * End of list marker.
  */
@@ -52,7 +53,6 @@
  * @}
  */
 
-#ifndef JERRY_SYSTEM_ALLOCATOR
 /**
  * Get end of region
  *
@@ -64,14 +64,6 @@ jmem_heap_get_region_end (jmem_heap_free_t *curr_p) /**< current region */
   return (jmem_heap_free_t *)((uint8_t *) curr_p + curr_p->size);
 } /* jmem_heap_get_region_end */
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
-
-#ifndef JERRY_ENABLE_EXTERNAL_CONTEXT
-/**
- * Check size of heap is corresponding to configuration
- */
-JERRY_STATIC_ASSERT (sizeof (jmem_heap_t) <= JMEM_HEAP_SIZE,
-                     size_of_mem_heap_must_be_less_than_or_equal_to_MEM_HEAP_SIZE);
-#endif /* !JERRY_ENABLE_EXTERNAL_CONTEXT */
 
 #ifdef JMEM_STATS
 static void jmem_heap_stat_init (void);
@@ -117,12 +109,11 @@ static void jmem_heap_stat_free_iter (void);
 void
 jmem_heap_init (void)
 {
+#ifndef JERRY_SYSTEM_ALLOCATOR
 #ifndef JERRY_CPOINTER_32_BIT
   /* the maximum heap size for 16bit compressed pointers should be 512K */
   JERRY_ASSERT (((UINT16_MAX + 1) << JMEM_ALIGNMENT_LOG) >= JMEM_HEAP_SIZE);
 #endif /* !JERRY_CPOINTER_32_BIT */
-
-#ifndef JERRY_SYSTEM_ALLOCATOR
   JERRY_ASSERT ((uintptr_t) JERRY_HEAP_CONTEXT (area) % JMEM_ALIGNMENT == 0);
 
   JERRY_CONTEXT (jmem_heap_limit) = CONFIG_MEM_HEAP_DESIRED_LIMIT;
@@ -547,9 +538,12 @@ jmem_heap_stats_print (void)
 {
   jmem_heap_stats_t *heap_stats = &JERRY_CONTEXT (jmem_heap_stats);
 
-  JERRY_DEBUG_MSG ("Heap stats:\n"
-                   "  Heap size = %zu bytes\n"
-                   "  Allocated = %zu bytes\n"
+  JERRY_DEBUG_MSG ("Heap stats:\n");
+#ifndef JERRY_SYSTEM_ALLOCATOR
+  JERRY_DEBUG_MSG ("  Heap size = %zu bytes\n",
+                   heap_stats->size);
+#endif /* !JERRY_SYSTEM_ALLOCATOR */
+  JERRY_DEBUG_MSG ("  Allocated = %zu bytes\n"
                    "  Peak allocated = %zu bytes\n"
                    "  Waste = %zu bytes\n"
                    "  Peak waste = %zu bytes\n"
@@ -561,7 +555,6 @@ jmem_heap_stats_print (void)
                    "  Peak allocated object data = %zu bytes\n"
                    "  Allocated property data = %zu bytes\n"
                    "  Peak allocated property data = %zu bytes\n",
-                   heap_stats->size,
                    heap_stats->allocated_bytes,
                    heap_stats->peak_allocated_bytes,
                    heap_stats->waste_bytes,
@@ -593,7 +586,9 @@ jmem_heap_stats_print (void)
 static void
 jmem_heap_stat_init (void)
 {
+#ifndef JERRY_SYSTEM_ALLOCATOR
   JERRY_CONTEXT (jmem_heap_stats).size = JMEM_HEAP_AREA_SIZE;
+#endif /* !JERRY_SYSTEM_ALLOCATOR */
 } /* jmem_heap_stat_init */
 
 /**

--- a/jerry-core/jmem/jmem.h
+++ b/jerry-core/jmem/jmem.h
@@ -25,13 +25,6 @@
  * @{
  */
 
-#ifndef JERRY_ENABLE_EXTERNAL_CONTEXT
-/**
- * Size of heap
- */
-#define JMEM_HEAP_SIZE ((size_t) (CONFIG_MEM_HEAP_AREA_SIZE))
-#endif /* !JERRY_ENABLE_EXTERNAL_CONTEXT */
-
 /**
  * Logarithm of required alignment for allocated units/blocks
  */


### PR DESCRIPTION
- Moved global context's `JMEM_HEAP_SIZE` to jcontext.h as external
  context's heap size is declared there, too.
- Moved the assert on `jmem_heap_t` vs `JMEM_HEAP_SIZE` to jcontext.c,
  as both entities are declared in the corresponding header.
- Removed superfluous checks on `JMEM_HEAP_SIZE` as it is not a
  publicly configurable macro (opposed to `CONFIG_MEM_HEAP_AREA_SIZE`).
- Ensured that all definitions of and references to `jmem_heap_t`,
  `JERRY_HEAP_CONTEXT`, `JERRY_HEAP_SIZE`, and `JERRY_HEAP_AREA_SIZE`
  are guarded by `#ifndef JERRY_SYSTEM_ALLOCATOR`, as they are
  meaningless if the system allocator is used.

The commit also contains some stylistic changes in jcontext.h

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu