### PR TITLE
Merge instance into context

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -238,32 +238,32 @@ typedef struct
 } jerry_context_data_manager_t;
 ```
 
-## jerry_instance_alloc_t
+## jerry_context_alloc_t
 
 **Summary**
 
-Function type for allocating buffer for JerryScript instance.
+Function type for allocating buffer for JerryScript context.
 
 **Prototype**
 
 ```c
-typedef void *(*jerry_instance_alloc_t) (size_t size, void *cb_data_p);
+typedef void *(*jerry_context_alloc_t) (size_t size, void *cb_data_p);
 ```
 
 - `size` - allocation size
 - `cb_data_p` - pointer to user data
 
 
-## jerry_instance_t
+## jerry_context_t
 
 **Summary**
 
-An opaque declaration of the JerryScript instance structure which is the header of the context space.
+An opaque declaration of the JerryScript context structure.
 
 **Prototype**
 
 ```c
-typedef struct jerry_instance_t jerry_instance_t;
+typedef struct jerry_context_t jerry_context_t;
 ```
 
 ## jerry_property_descriptor_t
@@ -4877,26 +4877,26 @@ main (void)
 
 # External context functions
 
-## jerry_create_instance
+## jerry_create_context
 
 **Summary**
 
-Creates a JerryScript instance for external context.
+Create an external JerryScript engine context.
 
 **Prototype**
 
 ```c
-jerry_instance_t *
-jerry_create_instance (uint32_t heap_size,
-                       jerry_instance_alloc_t alloc,
-                       void *cb_data_p);
+jerry_context_t *
+jerry_create_context (uint32_t heap_size,
+                      jerry_context_alloc_t alloc,
+                      void *cb_data_p);
 ```
 
-- `heap_size` - requested heap size of the JerryScript instance
+- `heap_size` - requested heap size of the JerryScript context
 - `alloc` - function for allocation
 - `cb_data_p` - user data
 - return value
-  - pointer to the newly created JerryScript instance if success
+  - pointer to the newly created JerryScript context if success
   - NULL otherwise.
 
 **Example**
@@ -4910,19 +4910,19 @@ jerry_create_instance (uint32_t heap_size,
 #include "jerryscript.h"
 #include "jerryscript-port.h"
 
-/* A different Thread Local Storage variable for each jerry instance. */
-__thread jerry_instance_t *tls_instance;
+/* A different Thread Local Storage variable for each jerry context. */
+__thread jerry_context_t *tls_context;
 
-jerry_instance_t *
-jerry_port_get_current_instance (void)
+jerry_context_t *
+jerry_port_get_current_context (void)
 {
-  /* Returns the instance assigned to the thread. */
-  return tls_instance;
+  /* Returns the context assigned to the thread. */
+  return tls_context;
 }
 
 /* Allocate JerryScript heap for each thread. */
 static void *
-instance_alloc_fn (size_t size, void *cb_data)
+context_alloc_fn (size_t size, void *cb_data)
 {
   (void) cb_data;
   return malloc (size);
@@ -4931,15 +4931,15 @@ instance_alloc_fn (size_t size, void *cb_data)
 static void *
 thread_function (void *param)
 {
-  tls_instance = jerry_create_instance (512 * 1024,
-                                        instance_alloc_fn,
-                                        NULL);
+  tls_context = jerry_create_context (512 * 1024,
+                                      context_alloc_fn,
+                                      NULL);
   jerry_init (JERRY_INIT_EMPTY);
-  /* Run the JerryScript instance (e.g.: jerry_parse & jerry_run) */
+  /* Run JerryScript in the context (e.g.: jerry_parse & jerry_run) */
   jerry_cleanup ();
 
-  /* Deallocate JerryScript instance */
-  free (tls_instance);
+  /* Deallocate JerryScript context */
+  free (tls_context);
 
   return NULL;
 }
@@ -4969,9 +4969,9 @@ main (void)
 
 **See also**
 
-- [jerry_instance_t](#jerry_instance_t)
-- [jerry_instance_alloc_t](#jerry_instance_alloc_t)
-- [jerry_port_get_current_instance](05.PORT-API.md#jerry_port_get_current_instance)
+- [jerry_context_t](#jerry_context_t)
+- [jerry_context_alloc_t](#jerry_context_alloc_t)
+- [jerry_port_get_current_context](05.PORT-API.md#jerry_port_get_current_context)
 
 
 # Snapshot functions

--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -112,23 +112,25 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p);
 double jerry_port_get_current_time (void);
 ```
 
-## External instance
+## External context
 
-Allow user to provide external buffer for jerry instance (which includes an isolated context and heap with other instances), so that user can config the heap size in runtime and run multiple JS apps simultaneously.
+Allow user to provide external buffer for isolated engine contexts, so that user
+can configure the heap size at runtime and run multiple JS applications
+simultaneously.
 
 ```c
 /**
- * Get the current instance which contains the current context, heap and other
- * structures. Each port should provide its own implementation of this interface.
+ * Get the current context of the engine. Each port should provide its own
+ * implementation of this interface.
  *
  * Note:
  *      This port function is called by jerry-core when
  *      JERRY_ENABLE_EXTERNAL_CONTEXT is defined. Otherwise this function is not
  *      used.
  *
- * @return the pointer to the jerry instance.
+ * @return the pointer to the engine context.
  */
-struct jerry_instance_t *jerry_port_get_current_instance (void);
+struct jerry_context_t *jerry_port_get_current_context (void);
 ```
 
 ## Sleep
@@ -233,37 +235,38 @@ double jerry_port_get_current_time (void)
   return ((double) tv.tv_sec) * 1000.0 + ((double) tv.tv_usec) / 1000.0;
 } /* jerry_port_get_current_time */
 ```
-## External instance
+
+## External context
 
 ```c
 #include "jerryscript-port.h"
 #include "jerryscript-port-default.h"
 
 /**
- * Pointer to the current instance.
+ * Pointer to the current context.
  * Note that it is a global variable, and is not a thread safe implementation.
  */
-static jerry_instance_t *current_instance_p = NULL;
+static jerry_context_t *current_context_p = NULL;
 
 /**
- * Set the current_instance_p as the passed pointer.
+ * Set the current_context_p as the passed pointer.
  */
 void
-jerry_port_default_set_instance (jerry_instance_t *instance_p) /**< points to the created instance */
+jerry_port_default_set_context (jerry_context_t *context_p) /**< points to the created context */
 {
-  current_instance_p = instance_p;
-} /* jerry_port_default_set_instance */
+  current_context_p = context_p;
+} /* jerry_port_default_set_context */
 
 /**
- * Get the current instance.
+ * Get the current context.
  *
- * @return the pointer to the current instance
+ * @return the pointer to the current context
  */
-jerry_instance_t *
-jerry_port_get_current_instance (void)
+jerry_context_t *
+jerry_port_get_current_context (void)
 {
-  return current_instance_p;
-} /* jerry_port_get_current_instance */
+  return current_context_p;
+} /* jerry_port_get_current_context */
 ```
 
 ## Sleep

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -281,9 +281,9 @@ typedef struct
 } jerry_context_data_manager_t;
 
 /**
- * Function type for allocating buffer for JerryScript instance.
+ * Function type for allocating buffer for JerryScript context.
  */
-typedef void *(*jerry_instance_alloc_t) (size_t size, void *cb_data_p);
+typedef void *(*jerry_context_alloc_t) (size_t size, void *cb_data_p);
 
 /**
  * Type information of a native pointer.
@@ -294,9 +294,9 @@ typedef struct
 } jerry_object_native_info_t;
 
 /**
- * An opaque declaration of the JerryScript instance structure.
+ * An opaque declaration of the JerryScript context structure.
  */
-typedef struct jerry_instance_t jerry_instance_t;
+typedef struct jerry_context_t jerry_context_t;
 
 /**
  * General engine functions.
@@ -517,7 +517,7 @@ bool jerry_is_valid_cesu8_string (const jerry_char_t *cesu8_buf_p, jerry_size_t 
 /*
  * External context functions.
  */
-jerry_instance_t *jerry_create_instance (uint32_t heap_size, jerry_instance_alloc_t alloc, void *cb_data_p);
+jerry_context_t *jerry_create_context (uint32_t heap_size, jerry_context_alloc_t alloc, void *cb_data_p);
 
 /**
  * Miscellaneous functions.

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -147,17 +147,17 @@ bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p);
 double jerry_port_get_current_time (void);
 
 /**
- * Get the current instance which contains the current context, heap and other
- * structures. Each port should provide its own implementation of this interface.
+ * Get the current context of the engine. Each port should provide its own
+ * implementation of this interface.
  *
  * Note:
  *      This port function is called by jerry-core when
  *      JERRY_ENABLE_EXTERNAL_CONTEXT is defined. Otherwise this function is not
  *      used.
  *
- * @return the pointer to the jerry instance.
+ * @return the pointer to the engine context.
  */
-struct jerry_instance_t *jerry_port_get_current_instance (void);
+struct jerry_context_t *jerry_port_get_current_context (void);
 
 /**
  * Makes the process sleep for a given time.

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -401,15 +401,15 @@ check_usage (bool condition, /**< the condition that must hold */
 #ifdef JERRY_ENABLE_EXTERNAL_CONTEXT
 
 /**
- * The alloc function passed to jerry_create_instance
+ * The alloc function passed to jerry_create_context
  */
 static void *
-instance_alloc (size_t size,
-                void *cb_data_p)
+context_alloc (size_t size,
+               void *cb_data_p)
 {
   (void) cb_data_p; /* unused */
   return malloc (size);
-} /* instance_alloc */
+} /* context_alloc */
 
 #endif /* JERRY_ENABLE_EXTERNAL_CONTEXT */
 
@@ -607,8 +607,8 @@ main (int argc,
 
 #ifdef JERRY_ENABLE_EXTERNAL_CONTEXT
 
-  jerry_instance_t *instance_p = jerry_create_instance (512*1024, instance_alloc, NULL);
-  jerry_port_default_set_instance (instance_p);
+  jerry_context_t *context_p = jerry_create_context (512*1024, context_alloc, NULL);
+  jerry_port_default_set_context (context_p);
 
 #endif /* JERRY_ENABLE_EXTERNAL_CONTEXT */
 
@@ -873,7 +873,7 @@ main (int argc,
 
   jerry_cleanup ();
 #ifdef JERRY_ENABLE_EXTERNAL_CONTEXT
-  free (instance_p);
+  free (context_p);
 #endif /* JERRY_ENABLE_EXTERNAL_CONTEXT */
   return ret_code;
 } /* main */

--- a/jerry-port/default/default-external-context.c
+++ b/jerry-port/default/default-external-context.c
@@ -17,27 +17,27 @@
 #include "jerryscript-port-default.h"
 
 /**
- * Pointer to the current instance.
+ * Pointer to the current context.
  * Note that it is a global variable, and is not a thread safe implementation.
  */
-static jerry_instance_t *current_instance_p = NULL;
+static jerry_context_t *current_context_p = NULL;
 
 /**
- * Set the current_instance_p as the passed pointer.
+ * Set the current_context_p as the passed pointer.
  */
 void
-jerry_port_default_set_instance (jerry_instance_t *instance_p) /**< points to the created instance */
+jerry_port_default_set_context (jerry_context_t *context_p) /**< points to the created context */
 {
-  current_instance_p = instance_p;
-} /* jerry_port_default_set_instance */
+  current_context_p = context_p;
+} /* jerry_port_default_set_context */
 
 /**
- * Get the current instance.
+ * Get the current context.
  *
- * @return the pointer to the current instance
+ * @return the pointer to the current context
  */
-jerry_instance_t *
-jerry_port_get_current_instance (void)
+jerry_context_t *
+jerry_port_get_current_context (void)
 {
-  return current_instance_p;
-} /* jerry_port_get_current_instance */
+  return current_context_p;
+} /* jerry_port_get_current_context */

--- a/jerry-port/default/include/jerryscript-port-default.h
+++ b/jerry-port/default/include/jerryscript-port-default.h
@@ -37,7 +37,7 @@ bool jerry_port_default_is_abort_on_fail (void);
 jerry_log_level_t jerry_port_default_get_log_level (void);
 void jerry_port_default_set_log_level (jerry_log_level_t level);
 
-void jerry_port_default_set_instance (jerry_instance_t *instance_p);
+void jerry_port_default_set_context (jerry_context_t *context_p);
 
 /**
  * @}


### PR DESCRIPTION
There was quite some confusion about terminology around instances
and contexts. All the docs mentioned external contexts but
functions and types were referring to instances, and the relation
between these two concepts were not clear. This commit keeps
(external) context as the only surviving concept.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu