### PR TITLE
Clean up memory statistics printing functions

### DIFF
--- a/jerry-core/jmem/jmem-allocator-internal.h
+++ b/jerry-core/jmem/jmem-allocator-internal.h
@@ -60,9 +60,6 @@ void jmem_run_free_unused_memory_callbacks (jmem_free_unused_memory_severity_t s
  * \addtogroup poolman Memory pool manager
  * @{
  */
-#ifdef JMEM_STATS
-void jmem_pools_stats_print (void);
-#endif /* JMEM_STATS */
 
 void jmem_pools_finalize (void);
 void jmem_pools_collect_empty (void);

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -26,15 +26,6 @@
 
 #ifdef JMEM_STATS
 /**
- * Print memory usage statistics
- */
-static void
-jmem_stats_print (void)
-{
-  jmem_heap_stats_print ();
-} /* jmem_stats_print */
-
-/**
  * Register byte code allocation.
  */
 void
@@ -172,7 +163,7 @@ jmem_finalize (void)
 #ifdef JMEM_STATS
   if (JERRY_CONTEXT (jerry_init_flags) & ECMA_INIT_MEM_STATS)
   {
-    jmem_stats_print ();
+    jmem_heap_stats_print ();
   }
 #endif /* JMEM_STATS */
 


### PR DESCRIPTION
- Remove leftover declaration of `jmem_pools_stats_print`.
- Remove unnecessary trampoline function `jmem_stats_print`.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu