### PR TITLE
Promote dynamic memory management from debugger transport to core API

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -4875,6 +4875,52 @@ main (void)
 - [jerry_substring_to_char_buffer](#jerry_substring_to_char_buffer)
 
 
+# Dynamic memory management functions
+
+## jerry_heap_alloc
+
+**Summary**
+
+Allocate memory on the engine's heap.
+
+*Note*: This function may take away memory from the executed JavaScript code.
+If any other dynamic memory allocation API is available (e.g., libc malloc), it
+should be used instead.
+
+**Prototype**
+
+```c
+void *jerry_heap_alloc (size_t size);
+```
+
+- `size`: size of the memory block.
+- return value: non-NULL pointer, if the memory is successfully allocated,
+                NULL otherwise.
+
+**See also**
+
+- [jerry_heap_free](#jerry_heap_free)
+
+## jerry_heap_free
+
+**Summary**
+
+Free memory allocated on the engine's heap.
+
+**Prototype**
+
+```c
+void jerry_heap_free (void *mem_p, size_t size);
+```
+
+- `mem_p`: value returned by `jerry_heap_alloc`.
+- `size`: same size as passed to `jerry_heap_alloc`.
+
+**See also**
+
+- [jerry_heap_alloc](#jerry_heap_alloc)
+
+
 # External context functions
 
 ## jerry_create_context

--- a/docs/13.DEBUGGER-TRANSPORT.md
+++ b/docs/13.DEBUGGER-TRANSPORT.md
@@ -96,37 +96,6 @@ typedef bool (*jerry_debugger_transport_receive_t) (struct jerry_debugger_transp
 
 # Transport interface API functions
 
-## jerry_debugger_transport_malloc
-
-**Summary**
-
-Allocates memory for the transport interface.
-
-**Prototype**
-
-```c
-void * jerry_debugger_transport_malloc (size_t size);
-```
-
-- `size`: size of the memory block.
-- return value: non-NULL pointer, if the memory is successfully allocated,
-                NULL otherwise.
-
-## jerry_debugger_transport_free
-
-**Summary**
-
-Free memory allocated by [jerry_debugger_transport_malloc](#jerry_debugger_transport_malloc)
-
-**Prototype**
-
-```c
-void jerry_debugger_transport_free (void *mem_p, size_t size);
-```
-
-- `header_p`: header of a transporation interface.
-- `size`: total size of the transportation interface.
-
 ## jerry_debugger_transport_add
 
 **Summary**
@@ -180,7 +149,7 @@ bool jerry_debugger_transport_is_connected (void);
 **Summary**
 
 Disconnect from the current debugger client. It does nothing if a client is
-not connected, 
+not connected.
 
 **Prototype**
 

--- a/jerry-core/api/jerry-debugger-transport.c
+++ b/jerry-core/api/jerry-debugger-transport.c
@@ -30,28 +30,6 @@
 #define JERRY_DEBUGGER_TRANSPORT_TIMEOUT 100
 
 /**
- * Allocate memory for a connection.
- *
- * @return allocated memory on success
- *         NULL otherwise
- */
-void *
-jerry_debugger_transport_malloc (size_t size) /**< size of the memory block */
-{
-  return jmem_heap_alloc_block_null_on_error (size);
-} /* jerry_debugger_transport_malloc */
-
-/**
- * Free memory allocated for a connection.
- */
-void
-jerry_debugger_transport_free (void *mem_p, /**< value returned by jerry_debugger_transport_malloc() */
-                               size_t size) /**< same size passed to jerry_debugger_transport_malloc() */
-{
-  jmem_heap_free_block (mem_p, size);
-} /* jerry_debugger_transport_free */
-
-/**
  * Add a new transport layer.
  */
 void

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2622,6 +2622,37 @@ jerry_is_valid_cesu8_string (const jerry_char_t *cesu8_buf_p, /**< CESU-8 string
 } /* jerry_is_valid_cesu8_string */
 
 /**
+ * Allocate memory on the engine's heap.
+ *
+ * Note:
+ *      This function may take away memory from the executed JavaScript code.
+ *      If any other dynamic memory allocation API is available (e.g., libc
+ *      malloc), it should be used instead.
+ *
+ * @return allocated memory on success
+ *         NULL otherwise
+ */
+void *
+jerry_heap_alloc (size_t size) /**< size of the memory block */
+{
+  jerry_assert_api_available ();
+
+  return jmem_heap_alloc_block_null_on_error (size);
+} /* jerry_heap_alloc */
+
+/**
+ * Free memory allocated on the engine's heap.
+ */
+void
+jerry_heap_free (void *mem_p, /**< value returned by jerry_heap_alloc */
+                 size_t size) /**< same size as passed to jerry_heap_alloc */
+{
+  jerry_assert_api_available ();
+
+  jmem_heap_free_block (mem_p, size);
+} /* jerry_heap_free */
+
+/**
  * Create an external engine context.
  *
  * @return the pointer to the context.

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -515,6 +515,12 @@ bool jerry_is_valid_utf8_string (const jerry_char_t *utf8_buf_p, jerry_size_t bu
 bool jerry_is_valid_cesu8_string (const jerry_char_t *cesu8_buf_p, jerry_size_t buf_size);
 
 /*
+ * Dynamic memory management functions.
+ */
+void *jerry_heap_alloc (size_t size);
+void jerry_heap_free (void *mem_p, size_t size);
+
+/*
  * External context functions.
  */
 jerry_context_t *jerry_create_context (uint32_t heap_size, jerry_context_alloc_t alloc, void *cb_data_p);

--- a/jerry-core/include/jerryscript-debugger-transport.h
+++ b/jerry-core/include/jerryscript-debugger-transport.h
@@ -83,8 +83,6 @@ typedef struct jerry_debugger_transport_interface_t
   struct jerry_debugger_transport_interface_t *next_p; /**< next transport layer */
 } jerry_debugger_transport_header_t;
 
-void * jerry_debugger_transport_malloc (size_t size);
-void jerry_debugger_transport_free (void *mem_p, size_t size);
 void jerry_debugger_transport_add (jerry_debugger_transport_header_t *header_p,
                                    size_t send_message_header_size, size_t max_send_message_size,
                                    size_t receive_message_header_size, size_t max_receive_message_size);

--- a/jerry-ext/debugger/debugger-tcp.c
+++ b/jerry-ext/debugger/debugger-tcp.c
@@ -56,7 +56,7 @@ jerryx_debugger_tcp_close (jerry_debugger_transport_header_t *header_p) /**< tcp
 
   close (tcp_p->tcp_socket);
 
-  jerry_debugger_transport_free ((void *) header_p, sizeof (jerryx_debugger_transport_tcp_t));
+  jerry_heap_free ((void *) header_p, sizeof (jerryx_debugger_transport_tcp_t));
 } /* jerryx_debugger_tcp_close */
 
 /**
@@ -223,7 +223,7 @@ jerryx_debugger_tcp_create (uint16_t port) /**< listening port */
   size_t size = sizeof (jerryx_debugger_transport_tcp_t);
 
   jerry_debugger_transport_header_t *header_p;
-  header_p = (jerry_debugger_transport_header_t *) jerry_debugger_transport_malloc (size);
+  header_p = (jerry_debugger_transport_header_t *) jerry_heap_alloc (size);
 
   if (!header_p)
   {

--- a/jerry-ext/debugger/debugger-ws.c
+++ b/jerry-ext/debugger/debugger-ws.c
@@ -277,7 +277,7 @@ jerryx_debugger_ws_close (jerry_debugger_transport_header_t *header_p) /**< tcp 
 {
   JERRYX_ASSERT (!jerry_debugger_transport_is_connected ());
 
-  jerry_debugger_transport_free ((void *) header_p, sizeof (jerry_debugger_transport_header_t));
+  jerry_heap_free ((void *) header_p, sizeof (jerry_debugger_transport_header_t));
 } /* jerryx_debugger_ws_close */
 
 /**
@@ -411,7 +411,7 @@ jerryx_debugger_ws_create (void)
   bool is_handshake_ok = false;
 
   const size_t buffer_size = 1024;
-  uint8_t *request_buffer_p = (uint8_t *) jerry_debugger_transport_malloc (buffer_size);
+  uint8_t *request_buffer_p = (uint8_t *) jerry_heap_alloc (buffer_size);
 
   if (!request_buffer_p)
   {
@@ -420,7 +420,7 @@ jerryx_debugger_ws_create (void)
 
   is_handshake_ok = jerryx_process_handshake (request_buffer_p);
 
-  jerry_debugger_transport_free ((void *) request_buffer_p, buffer_size);
+  jerry_heap_free ((void *) request_buffer_p, buffer_size);
 
   if (!is_handshake_ok && jerry_debugger_transport_is_connected ())
   {
@@ -429,7 +429,7 @@ jerryx_debugger_ws_create (void)
 
   const size_t interface_size = sizeof (jerry_debugger_transport_header_t);
   jerry_debugger_transport_header_t *header_p;
-  header_p = (jerry_debugger_transport_header_t *) jerry_debugger_transport_malloc (interface_size);
+  header_p = (jerry_debugger_transport_header_t *) jerry_heap_alloc (interface_size);
 
   if (!header_p)
   {


### PR DESCRIPTION
Under the cover of the debugger transport layer, allocation on the
engine's heap has been made available to the public. As there are
actually no restrictions on what the allocated memory can be used
for, the memory management functions better fit in the core part
of the API.

Closes #1805

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu