### PR TITLE
[RfC] External context creation without callbacks

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -11,6 +11,30 @@ Enum that contains the following elements:
  - JERRY_INIT_MEM_STATS_SEPARATE - dump memory statistics and reset peak values after parse
  - JERRY_INIT_DEBUGGER - deprecated, an unused placeholder now
 
+## jerry_init_t
+
+**Summary**
+
+JerryScript initialization data.
+
+**Prototype**
+
+```c
+typedef struct
+{
+  jerry_init_flag_t flags; /**< combination of engine initialization flags */
+
+  /* The following fields are unused if engine is configured to use global context or system allocator. */
+  void *heap_p; /**< beginning of heap memory */
+  uint32_t heap_size; /**< size of heap memory */
+} jerry_init_t;
+```
+
+**See also**
+
+- [jerry_init_flag_t](#jerry_init_flag_t)
+- [jerry_init](#jerry_init)
+
 ## jerry_type_t
 
 Enum that contains JerryScript API value types:
@@ -237,22 +261,6 @@ typedef struct
   size_t bytes_needed;
 } jerry_context_data_manager_t;
 ```
-
-## jerry_context_alloc_t
-
-**Summary**
-
-Function type for allocating buffer for JerryScript context.
-
-**Prototype**
-
-```c
-typedef void *(*jerry_context_alloc_t) (size_t size, void *cb_data_p);
-```
-
-- `size` - allocation size
-- `cb_data_p` - pointer to user data
-
 
 ## jerry_context_t
 
@@ -488,17 +496,10 @@ on JavaScript values.
 
 ```c
 void
-jerry_init (jerry_init_flag_t flags)
+jerry_init (jerry_init_t init_data)
 ```
 
-`flags` - combination of various engine configuration flags:
-
-- `JERRY_INIT_EMPTY` - no flags, just initialize in default configuration.
-- `JERRY_INIT_SHOW_OPCODES` - print compiled byte-code.
-- `JERRY_INIT_SHOW_REGEXP_OPCODES` - print compiled regexp byte-code.
-- `JERRY_INIT_MEM_STATS` - dump memory statistics.
-- `JERRY_INIT_MEM_STATS_SEPARATE` - dump memory statistics and reset peak values after parse.
-- `JERRY_INIT_DEBUGGER` - deprecated, an unused placeholder now
+- `init_data` - engine initialization data
 
 **Example**
 
@@ -510,7 +511,7 @@ jerry_init (jerry_init_flag_t flags)
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_SHOW_OPCODES | JERRY_INIT_SHOW_REGEXP_OPCODES);
+  jerry_init (JERRY_INIT_FLAGS (JERRY_INIT_SHOW_OPCODES | JERRY_INIT_SHOW_REGEXP_OPCODES));
 
   // ...
 
@@ -520,6 +521,7 @@ main (void)
 
 **See also**
 
+- [jerry_init_t](#jerry_init_t)
 - [jerry_cleanup](#jerry_cleanup)
 
 
@@ -653,7 +655,7 @@ jerry_register_magic_strings  (const jerry_char_t **ex_str_items_p,
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   // must be static, because 'jerry_register_magic_strings' does not copy
   // the items must be sorted by size at first, then lexicographically
@@ -736,7 +738,7 @@ jerry_gc (jerry_gc_mode_t mode);
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t object_value = jerry_create_object ();
   jerry_release_value (object_value);
@@ -768,12 +770,12 @@ The simplest way to run JavaScript.
 bool
 jerry_run_simple (const jerry_char_t *script_source_p,
                   size_t script_source_size,
-                  jerry_init_flag_t flags);
+                  jerry_init_t init_data);
 ```
 
 - `script_source_p` - source code, it must be a valid utf8 string.
 - `script_source_size` - size of source code buffer, in bytes.
-- `jerry_init_flag_t` - combination of various engine configuration flags
+- `init_data` - engine initialization data
 - return value
   - true, if run was successful
   - false, otherwise
@@ -791,7 +793,7 @@ main (void)
 {
   const jerry_char_t *script = (const jerry_char_t *) "print ('Hello, World!');";
 
-  jerry_run_simple (script, strlen ((const char *) script), JERRY_INIT_EMPTY);
+  jerry_run_simple (script, strlen ((const char *) script), JERRY_INIT_DEFAULT);
 }
 ```
 
@@ -845,7 +847,7 @@ jerry_parse (const jerry_char_t *resource_name_p, /**< resource name (usually a 
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   const jerry_char_t script[] = "print ('Hello, World!');";
   size_t script_size = strlen ((const char *) script);
@@ -934,7 +936,7 @@ main (void)
   size_t script_size = strlen ((const char *) script);
 
   /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Setup Global scope code */
   jerry_value_t parsed_code = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
@@ -1022,7 +1024,7 @@ jerry_run_all_enqueued_jobs (void)
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   const jerry_char_t script[] = "new Promise(function(f,r) { f('Hello, World!'); }).then(function(x) { print(x); });";
   size_t script_size = strlen ((const char *) script);
@@ -4803,7 +4805,7 @@ main (void)
 
   if (jerry_is_valid_utf8_string (script, (jerry_size_t) script_size))
   {
-    jerry_run_simple (script, script_size, JERRY_INIT_EMPTY);
+    jerry_run_simple (script, script_size, JERRY_INIT_DEFAULT);
   }
 }
 ```
@@ -4846,7 +4848,7 @@ jerry_is_valid_cesu8_string (const jerry_char_t *cesu8_buf_p, /**< CESU-8 string
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   const jerry_char_t script[] = "Hello, World!";
   size_t script_size = strlen ((const char *) script);
@@ -4923,27 +4925,22 @@ void jerry_heap_free (void *mem_p, size_t size);
 
 # External context functions
 
-## jerry_create_context
+## jerry_context_size
 
 **Summary**
 
-Create an external JerryScript engine context.
+The size of an engine context, which may be used for external context
+allocation.
 
 **Prototype**
 
 ```c
-jerry_context_t *
-jerry_create_context (uint32_t heap_size,
-                      jerry_context_alloc_t alloc,
-                      void *cb_data_p);
+size_t
+jerry_context_size (void)
 ```
 
-- `heap_size` - requested heap size of the JerryScript context
-- `alloc` - function for allocation
-- `cb_data_p` - user data
 - return value
-  - pointer to the newly created JerryScript context if success
-  - NULL otherwise.
+  - number of bytes needed to represent a context
 
 **Example**
 
@@ -4951,6 +4948,7 @@ jerry_create_context (uint32_t heap_size,
 
 ```c
 #include <stdlib.h>
+#include <string.h>
 #include <pthread.h>
 
 #include "jerryscript.h"
@@ -4966,26 +4964,22 @@ jerry_port_get_current_context (void)
   return tls_context;
 }
 
-/* Allocate JerryScript heap for each thread. */
-static void *
-context_alloc_fn (size_t size, void *cb_data)
-{
-  (void) cb_data;
-  return malloc (size);
-}
-
 static void *
 thread_function (void *param)
 {
-  tls_context = jerry_create_context (512 * 1024,
-                                      context_alloc_fn,
-                                      NULL);
-  jerry_init (JERRY_INIT_EMPTY);
+  tls_context = malloc (jerry_context_size ());
+  memset (tls_context, 0, jerry_context_size ());
+
+  uint32_t heap_size = 512 * 1024;
+  void *heap_p = malloc (heap_size);
+
+  jerry_init (JERRY_INIT_DATA (JERRY_INIT_EMPTY, heap_p, heap_size));
   /* Run JerryScript in the context (e.g.: jerry_parse & jerry_run) */
   jerry_cleanup ();
 
-  /* Deallocate JerryScript context */
+  /* Deallocate JerryScript context and heap */
   free (tls_context);
+  free (heap_p);
 
   return NULL;
 }
@@ -5016,7 +5010,6 @@ main (void)
 **See also**
 
 - [jerry_context_t](#jerry_context_t)
-- [jerry_context_alloc_t](#jerry_context_alloc_t)
 - [jerry_port_get_current_context](05.PORT-API.md#jerry_port_get_current_context)
 
 
@@ -5065,7 +5058,7 @@ jerry_generate_snapshot (const jerry_char_t *resource_name_p,
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   static uint32_t global_mode_snapshot_buffer[256];
   const jerry_char_t *code_to_snapshot_p = (const jerry_char_t *) "(function () { return 'string from snapshot'; }) ();";
@@ -5145,7 +5138,7 @@ jerry_generate_function_snapshot (const jerry_char_t *resource_name_p,
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   static uint32_t func_snapshot_buffer[256];
   const jerry_char_t *args_p = (const jerry_char_t *) "a, b";
@@ -5218,7 +5211,7 @@ main (void)
   static uint32_t global_mode_snapshot_buffer[256];
   const jerry_char_t *code_to_snapshot_p = (const jerry_char_t *) "(function () { return 'string from snapshot'; }) ();";
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t generate_result;
   generate_result = jerry_generate_snapshot (NULL,
@@ -5234,7 +5227,7 @@ main (void)
 
   jerry_cleanup ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t res = jerry_exec_snapshot (global_mode_snapshot_buffer,
                                            global_mode_snapshot_size,
@@ -5297,7 +5290,7 @@ main (void)
   const jerry_char_t *args_p = (const jerry_char_t *)"a, b";
   const jerry_char_t *src_p = (const jerry_char_t *) "return a + b;";
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t generate_result;
   generate_result = jerry_generate_function_snapshot (NULL,
@@ -5315,7 +5308,7 @@ main (void)
 
   jerry_cleanup ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t func = jerry_load_function_snapshot (snapshot_buffer,
                                                      snapshot_size,
@@ -5391,7 +5384,7 @@ jerry_parse_and_save_literals (const jerry_char_t *source_p,
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   static uint32_t save_literal_buffer[256];
   const jerry_char_t *code_for_literal_save_p = (const jerry_char_t *) "var obj = { a:'aa', bb:'Bb' }";
@@ -5483,7 +5476,7 @@ vm_exec_stop_callback (void *user_p)
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_set_vm_exec_stop_callback (vm_exec_stop_callback, &countdown, 16);
 

--- a/docs/03.API-EXAMPLE.md
+++ b/docs/03.API-EXAMPLE.md
@@ -16,7 +16,7 @@ main (void)
   const jerry_char_t script[] = "var str = 'Hello, World!';";
   size_t script_size = strlen ((const char *) script);
 
-  bool ret_value = jerry_run_simple (script, script_size, JERRY_INIT_EMPTY);
+  bool ret_value = jerry_run_simple (script, script_size, JERRY_INIT_DEFAULT);
 
   return (ret_value ? 0 : 1);
 }
@@ -48,7 +48,7 @@ main (void)
   size_t script_size = strlen ((const char *) script);
 
   /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register 'print' function from the extensions */
   jerryx_handler_register_global ((const jerry_char_t *) "print",
@@ -94,7 +94,7 @@ main (void)
   const jerry_char_t script_2[] = "print (s);";
 
   /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register 'print' function from the extensions */
   jerryx_handler_register_global ((const jerry_char_t *) "print",
@@ -143,7 +143,7 @@ main (void)
   const jerry_char_t script[] = "print (s);";
 
   /* Initializing JavaScript environment */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register 'print' function from the extensions */
   jerryx_handler_register_global ((const jerry_char_t *) "print",
@@ -280,7 +280,7 @@ main (void)
   bool is_done = false;
 
   /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register 'print' function from the extensions */
   jerryx_handler_register_global ((const jerry_char_t *) "print",
@@ -377,7 +377,7 @@ int
 main (void)
 {
   /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register 'print' function from the extensions */
   jerryx_handler_register_global ((const jerry_char_t *) "print",
@@ -486,7 +486,7 @@ int
 main (void)
 {
   /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register 'print' function from the extensions */
   jerryx_handler_register_global ((const jerry_char_t *) "print",
@@ -576,7 +576,7 @@ main (void)
   size_t script_size = strlen ((const char *) script);
 
   /* Initialize the engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register the print function */
   jerryx_handler_register_global ((const jerry_char_t *) "print",

--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -133,7 +133,7 @@ jerry_debugger_is_connected (void);
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 
@@ -173,7 +173,7 @@ jerry_debugger_stop (void)
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 
@@ -215,7 +215,7 @@ jerry_debugger_continue (void)
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 
@@ -258,7 +258,7 @@ jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint)
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 
@@ -337,7 +337,7 @@ main (void)
     /* Create a new JerryScript instance when a context reset is
      * received. Applications usually registers their core bindings
      * here as well (e.g. print, setTimeout). */
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
     jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                    && jerryx_debugger_ws_create ());
 
@@ -389,7 +389,7 @@ jerry_debugger_send_output (const jerry_char_t *buffer, jerry_size_t string_size
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 
@@ -426,7 +426,7 @@ jerry_debugger_send_log (jerry_log_level_t level, const jerry_char_t *buffer, je
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerryx_debugger_after_connect (jerryx_debugger_tcp_create (5001)
                                  && jerryx_debugger_ws_create ());
 

--- a/docs/12.EXT-REFERENCE-MODULE.md
+++ b/docs/12.EXT-REFERENCE-MODULE.md
@@ -299,7 +299,7 @@ main (int argc, char **argv)
   /* This plays the role of the library constructor. */
   my_module_register ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   ...
   jerry_value_t my_module = jerryx_module_resolve ("my_module", resolvers, 1);
   ...

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -55,6 +55,35 @@ typedef enum
 } jerry_init_flag_t;
 
 /**
+ * JerryScript initialization data.
+ */
+typedef struct
+{
+  jerry_init_flag_t flags; /**< combination of engine initialization flags */
+
+  /* The following fields are unused if engine is configured to use global context or system allocator. */
+  void *heap_p; /**< beginning of heap memory */
+  uint32_t heap_size; /**< size of heap memory */
+} jerry_init_t;
+
+/**
+ * Convenience macro to help create a jerry_init_t structure.
+ */
+#define JERRY_INIT_DATA(flags, heap_p, heap_size) ((jerry_init_t) { flags, heap_p, heap_size })
+
+/**
+ * Convenience macro to help create a jerry_init_t structure with flags only.
+ * Useful if engine is configured to use global context or system allocator.
+ */
+#define JERRY_INIT_FLAGS(flags) (JERRY_INIT_DATA (flags, NULL, 0))
+
+/**
+ * Convenience macro to help create a default jerry_init_t structure with empty
+ * flag set.
+ */
+#define JERRY_INIT_DEFAULT (JERRY_INIT_FLAGS (JERRY_INIT_EMPTY))
+
+/**
  * JerryScript API Error object types.
  */
 typedef enum
@@ -281,11 +310,6 @@ typedef struct
 } jerry_context_data_manager_t;
 
 /**
- * Function type for allocating buffer for JerryScript context.
- */
-typedef void *(*jerry_context_alloc_t) (size_t size, void *cb_data_p);
-
-/**
  * Type information of a native pointer.
  */
 typedef struct
@@ -301,7 +325,7 @@ typedef struct jerry_context_t jerry_context_t;
 /**
  * General engine functions.
  */
-void jerry_init (jerry_init_flag_t flags);
+void jerry_init (jerry_init_t init_data);
 void jerry_cleanup (void);
 void jerry_register_magic_strings (const jerry_char_t **ex_str_items_p, uint32_t count,
                                    const jerry_length_t *str_lengths_p);
@@ -313,7 +337,7 @@ bool jerry_get_memory_stats (jerry_heap_stats_t *out_stats_p);
 /**
  * Parser and executor functions.
  */
-bool jerry_run_simple (const jerry_char_t *script_source_p, size_t script_source_size, jerry_init_flag_t flags);
+bool jerry_run_simple (const jerry_char_t *script_source_p, size_t script_source_size, jerry_init_t init_data);
 jerry_value_t jerry_parse (const jerry_char_t *resource_name_p, size_t resource_name_length,
                            const jerry_char_t *source_p, size_t source_size, uint32_t parse_opts);
 jerry_value_t jerry_parse_function (const jerry_char_t *resource_name_p, size_t resource_name_length,
@@ -523,7 +547,7 @@ void jerry_heap_free (void *mem_p, size_t size);
 /*
  * External context functions.
  */
-jerry_context_t *jerry_create_context (uint32_t heap_size, jerry_context_alloc_t alloc, void *cb_data_p);
+size_t jerry_context_size (void);
 
 /**
  * Miscellaneous functions.

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -62,7 +62,7 @@ typedef struct jerry_context_data_header
   ((uint8_t *) (item_p + 1))
 
 /**
- * First non-external member of the jerry context
+ * First member of the jerry context
  */
 #define JERRY_CONTEXT_FIRST_MEMBER ecma_builtin_objects
 
@@ -74,15 +74,7 @@ typedef struct jerry_context_data_header
  */
 struct jerry_context_t
 {
-  /* The value of external context members must be preserved across initializations and cleanups. */
-#ifdef JERRY_ENABLE_EXTERNAL_CONTEXT
-#ifndef JERRY_SYSTEM_ALLOCATOR
-  jmem_heap_t *heap_p; /**< point to the heap aligned to JMEM_ALIGNMENT. */
-  uint32_t heap_size; /**< size of the heap */
-#endif /* !JERRY_SYSTEM_ALLOCATOR */
-#endif /* JERRY_ENABLE_EXTERNAL_CONTEXT */
-
-  /* Update JERRY_CONTEXT_FIRST_MEMBER if the first non-external member changes */
+  /* Update JERRY_CONTEXT_FIRST_MEMBER if the first member changes */
   ecma_object_t *ecma_builtin_objects[ECMA_BUILTIN_ID__COUNT]; /**< pointer to instances of built-in objects */
 #ifndef CONFIG_DISABLE_REGEXP_BUILTIN
   const re_compiled_code_t *re_cache[RE_CACHE_SIZE]; /**< regex cache */
@@ -155,6 +147,13 @@ struct jerry_context_t
 #ifdef JMEM_STATS
   jmem_heap_stats_t jmem_heap_stats; /**< heap's memory usage statistics */
 #endif /* JMEM_STATS */
+
+#ifdef JERRY_ENABLE_EXTERNAL_CONTEXT
+#ifndef JERRY_SYSTEM_ALLOCATOR
+  jmem_heap_t *heap_p; /**< pointer to the heap aligned to JMEM_ALIGNMENT */
+  uint32_t heap_size; /**< size of the heap */
+#endif /* !JERRY_SYSTEM_ALLOCATOR */
+#endif /* JERRY_ENABLE_EXTERNAL_CONTEXT */
 
   /* This must be at the end of the context for performance reasons */
 #ifndef CONFIG_ECMA_LCACHE_DISABLE

--- a/jerry-main/main-unix-snapshot.c
+++ b/jerry-main/main-unix-snapshot.c
@@ -313,7 +313,7 @@ process_generate (cli_state_t *cli_state_p, /**< cli state */
     return JERRY_STANDALONE_EXIT_CODE_FAIL;
   }
 
-  jerry_init (flags);
+  jerry_init (JERRY_INIT_FLAGS (flags));
 
   if (!jerry_is_valid_utf8_string (source_p, (jerry_size_t) source_length))
   {
@@ -452,7 +452,7 @@ process_merge (cli_state_t *cli_state_p, /**< cli state */
                int argc, /**< number of arguments */
                char *prog_name_p) /**< program name */
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   uint8_t *input_pos_p = input_buffer;
 

--- a/jerry-main/main-unix-test.c
+++ b/jerry-main/main-unix-test.c
@@ -79,7 +79,7 @@ main (int argc,
     return JERRY_STANDALONE_EXIT_CODE_OK;
   }
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerry_value_t ret_value = jerry_create_undefined ();
 
   for (int i = 1; i < argc; i++)

--- a/targets/curie_bsp/jerry_app/quark/main.c
+++ b/targets/curie_bsp/jerry_app/quark/main.c
@@ -137,7 +137,7 @@ void eval_jerry_script (int argc, char *argv[], struct tcmd_handler_ctx *ctx)
 void jerry_start ()
 {
   srand ((unsigned) jerry_port_get_current_time ());
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerry_value_t global_obj_val = jerry_get_global_object ();
   jerry_value_t print_func_name_val = jerry_create_string ((jerry_char_t *) "print");
   print_function = jerry_get_property (global_obj_val, print_func_name_val);

--- a/targets/esp8266/user/jerry_run.c
+++ b/targets/esp8266/user/jerry_run.c
@@ -28,7 +28,7 @@ void js_entry ()
 {
   srand ((unsigned) jerry_port_get_current_time ());
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   js_register_functions ();
 }
 

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-launcher/source/launcher.cpp
@@ -70,7 +70,7 @@ static int load_javascript() {
 int jsmbed_js_init() {
     srand ((unsigned) jerry_port_get_current_time());
     jerry_init_flag_t flags = JERRY_INIT_EMPTY;
-    jerry_init(flags);
+    jerry_init(JERRY_INIT_FLAGS (flags));
 
     jsmbed_js_load_magic_strings();
     mbed::js::LibraryRegistry::getInstance().register_all();

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -377,7 +377,7 @@ int jerry_main (int argc, char *argv[])
     }
   }
 
-  jerry_init (flags);
+  jerry_init (JERRY_INIT_FLAGS (flags));
 
   if (start_debug_server)
   {

--- a/targets/particle/source/main.cpp
+++ b/targets/particle/source/main.cpp
@@ -70,7 +70,7 @@ js_delay (const jerry_value_t func_value, /**< function object */
 static void
 init_jerry ()
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Create an empty JS object */
   jerry_value_t object = jerry_create_object ();

--- a/targets/riot-stm32f4/source/main-riotos.c
+++ b/targets/riot-stm32f4/source/main-riotos.c
@@ -60,7 +60,7 @@ int test_jerry (int argc, char **argv)
   printf ("This test run the following script code: [%s]\n\n", script);
 
   /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Register the print function in the global object. */
   register_js_function ("print", jerryx_handler_print);

--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
@@ -353,7 +353,7 @@ jerry_cmd_main (int argc, char *argv[])
     }
   }
 
-  jerry_init (flags);
+  jerry_init (JERRY_INIT_FLAGS (flags));
 
   if (start_debug_server)
   {

--- a/targets/zephyr/src/main-zephyr.c
+++ b/targets/zephyr/src/main-zephyr.c
@@ -88,7 +88,7 @@ void main (void)
     (int)SYS_KERNEL_VER_PATCHLEVEL (zephyr_ver));
 
   zephyr_getline_init ();
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   register_js_function ("print", jerryx_handler_print);
   jerry_value_t global_obj_val = jerry_get_global_object ();
 

--- a/tests/unit-core/test-abort.c
+++ b/tests/unit-core/test-abort.c
@@ -39,7 +39,7 @@ main (void)
 {
   TEST_INIT ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t global = jerry_get_global_object ();
   jerry_value_t callback_name = jerry_create_string ((jerry_char_t *) "callback");

--- a/tests/unit-core/test-api-errortype.c
+++ b/tests/unit-core/test-api-errortype.c
@@ -21,7 +21,7 @@ main (void)
 {
   TEST_INIT ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_error_t errors[] =
   {

--- a/tests/unit-core/test-api-set-and-clear-error-flag.c
+++ b/tests/unit-core/test-api-set-and-clear-error-flag.c
@@ -31,7 +31,7 @@ main (void)
 {
   TEST_INIT ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t obj_val = jerry_create_object ();
   obj_val = jerry_create_error_from_value (obj_val, true);

--- a/tests/unit-core/test-api-value-type.c
+++ b/tests/unit-core/test-api-value-type.c
@@ -44,7 +44,7 @@ main (void)
 {
   TEST_INIT ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_char_t test_eval_function[] = "function demo(a) { return a + 1; }; demo";
 

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -315,7 +315,7 @@ test_run_simple (const char *script_p) /**< source code to run */
 {
   size_t script_size = strlen (script_p);
 
-  return jerry_run_simple ((const jerry_char_t *) script_p, script_size, JERRY_INIT_EMPTY);
+  return jerry_run_simple ((const jerry_char_t *) script_p, script_size, JERRY_INIT_DEFAULT);
 } /* test_run_simple */
 
 static bool
@@ -363,7 +363,7 @@ main (void)
   is_ok = test_run_simple ("throw 'Hello World';");
   TEST_ASSERT (!is_ok);
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   parsed_code_val = jerry_parse (NULL,
                                  0,
@@ -1079,7 +1079,7 @@ main (void)
 
   /* Test: jerry_get_value_from_error */
   {
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
     jerry_value_t num_val = jerry_create_number (123);
     num_val = jerry_create_error_from_value (num_val, true);
     TEST_ASSERT (jerry_value_is_error (num_val));
@@ -1099,7 +1099,7 @@ main (void)
   /* Test: parser error location */
   if (jerry_is_feature_enabled (JERRY_FEATURE_ERROR_MESSAGES))
   {
-    jerry_init (JERRY_INIT_SHOW_OPCODES);
+    jerry_init (JERRY_INIT_FLAGS (JERRY_INIT_SHOW_OPCODES));
 
     const char *parser_err_src_p = "b = 'hello';\nvar a = (;";
     parsed_code_val = jerry_parse (NULL,
@@ -1124,7 +1124,7 @@ main (void)
   }
 
   /* External Magic String */
-  jerry_init (JERRY_INIT_SHOW_OPCODES);
+  jerry_init (JERRY_INIT_FLAGS (JERRY_INIT_SHOW_OPCODES));
 
   uint32_t num_magic_string_items = (uint32_t) (sizeof (magic_string_items) / sizeof (jerry_char_t *));
   jerry_register_magic_strings (magic_string_items,

--- a/tests/unit-core/test-arraybuffer.c
+++ b/tests/unit-core/test-arraybuffer.c
@@ -161,7 +161,7 @@ static void test_free_cb (void *buffer) /**< buffer to free (if needed) */
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   if (!jerry_is_feature_enabled (JERRY_FEATURE_TYPEDARRAY))
   {

--- a/tests/unit-core/test-backtrace.c
+++ b/tests/unit-core/test-backtrace.c
@@ -82,7 +82,7 @@ compare (jerry_value_t array, /**< array */
 static void
 test_get_backtrace_api_call (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t global = jerry_get_global_object ();
 
@@ -159,7 +159,7 @@ test_get_backtrace_api_call (void)
 static void
 test_exception_backtrace (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   const char *source = ("function f() {\n"
                         "  undef_reference;\n"
@@ -202,7 +202,7 @@ test_exception_backtrace (void)
 static void
 test_large_line_count (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   const char *source = ("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
                         "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"

--- a/tests/unit-core/test-context-data.c
+++ b/tests/unit-core/test-context-data.c
@@ -107,7 +107,7 @@ main (void)
 {
   TEST_INIT ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   TEST_ASSERT (!strcmp (*((const char **) jerry_get_context_data (&manager1)), "item1"));
   TEST_ASSERT (!strcmp (*((const char **) jerry_get_context_data (&manager2)), "item2"));

--- a/tests/unit-core/test-exec-stop.c
+++ b/tests/unit-core/test-exec-stop.c
@@ -44,7 +44,7 @@ main (void)
     return 0;
   }
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   int countdown = 6;
   jerry_set_vm_exec_stop_callback (vm_exec_stop_callback, &countdown, 16);

--- a/tests/unit-core/test-has-property.c
+++ b/tests/unit-core/test-has-property.c
@@ -30,7 +30,7 @@ main (void)
 {
   TEST_INIT ();
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t object = jerry_create_object ();
   jerry_value_t prop_name = jerry_create_string_from_utf8 ((jerry_char_t *) "something");

--- a/tests/unit-core/test-mem-stats.c
+++ b/tests/unit-core/test-mem-stats.c
@@ -29,7 +29,7 @@ int main (void)
                          "var c = a + ' ' + b;"
                          );
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerry_value_t parsed_code_val = jerry_parse (NULL,
                                                0,
                                                (jerry_char_t *) test_source,

--- a/tests/unit-core/test-objects-foreach.c
+++ b/tests/unit-core/test-objects-foreach.c
@@ -67,7 +67,7 @@ find_test_object_by_property (const jerry_value_t candidate,
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Render strict-equal as a function. */
   jerry_value_t parse_result = jerry_parse (NULL,

--- a/tests/unit-core/test-promise.c
+++ b/tests/unit-core/test-promise.c
@@ -116,7 +116,7 @@ register_js_function (const char *name_p, /**< name of the function */
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   if (!jerry_is_feature_enabled (JERRY_FEATURE_PROMISE))
   {

--- a/tests/unit-core/test-snapshot.c
+++ b/tests/unit-core/test-snapshot.c
@@ -61,7 +61,7 @@ static void test_function_snapshot (void)
   const char *args_p = "a, b";
   const char *code_to_snapshot_p = "return a + b";
 
-  jerry_init (flags);
+  jerry_init (JERRY_INIT_FLAGS (flags));
   jerry_value_t generate_result;
   generate_result = jerry_generate_function_snapshot (NULL,
                                                       0,
@@ -80,7 +80,7 @@ static void test_function_snapshot (void)
 
   jerry_cleanup ();
 
-  jerry_init (flags);
+  jerry_init (JERRY_INIT_FLAGS (flags));
 
   jerry_value_t function_obj = jerry_load_function_snapshot (function_snapshot_buffer,
                                                              function_snapshot_size,
@@ -112,7 +112,7 @@ static void test_function_snapshot (void)
 
 static void arguments_test_exec_snapshot (uint32_t *snapshot_p, size_t snapshot_size, uint32_t exec_snapshot_flags)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
   jerry_value_t res = jerry_exec_snapshot (snapshot_p, snapshot_size, 0, exec_snapshot_flags);
   TEST_ASSERT (!jerry_value_is_error (res));
   TEST_ASSERT (jerry_value_is_number (res));
@@ -137,7 +137,7 @@ static void test_function_arguments_snapshot (void)
                                       "  return a + b + c;"
                                       "}"
                                       "f(3,4,5);");
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
 
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
@@ -165,7 +165,7 @@ static void test_exec_snapshot (uint32_t *snapshot_p, size_t snapshot_size, uint
 {
   char string_data[32];
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_register_magic_strings (magic_strings,
                                 sizeof (magic_string_lengths) / sizeof (jerry_length_t),
@@ -198,7 +198,7 @@ main (void)
   {
     const char *code_to_snapshot_p = "(function () { return 'string from snapshot'; }) ();";
 
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
@@ -248,7 +248,7 @@ main (void)
                                       "};"
                                       "func('string', 'from');");
 
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
     jerry_register_magic_strings (magic_strings,
                                   sizeof (magic_string_lengths) / sizeof (jerry_length_t),
                                   magic_string_lengths);
@@ -288,7 +288,7 @@ main (void)
 
     const char *code_to_snapshot_p = "var a = 'hello'; 123";
 
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
@@ -307,7 +307,7 @@ main (void)
 
     code_to_snapshot_p = "var b = 'hello'; 456";
 
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
                                                (const jerry_char_t *) code_to_snapshot_p,
@@ -323,7 +323,7 @@ main (void)
 
     jerry_cleanup ();
 
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
 
     const char *error_p;
     const uint32_t *snapshot_buffers[2];
@@ -349,7 +349,7 @@ main (void)
     TEST_ASSERT (0 == memcmp (snapshot_buffer_0_bck, snapshot_buffer_0, SNAPSHOT_BUFFER_SIZE));
     TEST_ASSERT (0 == memcmp (snapshot_buffer_1_bck, snapshot_buffer_1, SNAPSHOT_BUFFER_SIZE));
 
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
 
     jerry_value_t res = jerry_exec_snapshot (merged_snapshot_buffer, merged_size, 0, 0);
     TEST_ASSERT (!jerry_value_is_error (res));
@@ -368,7 +368,7 @@ main (void)
   if (jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_SAVE))
   {
     /* C format generation */
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
 
     static uint32_t literal_buffer_c[SNAPSHOT_BUFFER_SIZE];
     static const char *code_for_c_format_p = "var object = { aa:'fo o', Bb:'max', aaa:'xzy0' };";
@@ -403,7 +403,7 @@ main (void)
     jerry_cleanup ();
 
     /* List format generation */
-    jerry_init (JERRY_INIT_EMPTY);
+    jerry_init (JERRY_INIT_DEFAULT);
 
     static uint32_t literal_buffer_list[SNAPSHOT_BUFFER_SIZE];
     static const char *code_for_list_format_p = "var obj = { a:'aa', bb:'Bb' };";

--- a/tests/unit-core/test-typedarray.c
+++ b/tests/unit-core/test-typedarray.c
@@ -402,7 +402,7 @@ static void test_property_by_index (test_entry_t test_entries[])
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   if (!jerry_is_feature_enabled (JERRY_FEATURE_TYPEDARRAY))
   {

--- a/tests/unit-ext/module/jerry-module-test.c
+++ b/tests/unit-ext/module/jerry-module-test.c
@@ -205,7 +205,7 @@ main (int argc, char **argv)
   my_custom_module_register ();
 #endif /* !ENABLE_INIT_FINI */
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   js_global = jerry_get_global_object ();
 

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -643,7 +643,7 @@ register_js_function (const char *name_p, /**< name of the function */
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   test_utf8_string ();
 

--- a/tests/unit-ext/test-ext-autorelease.c
+++ b/tests/unit-ext/test-ext-autorelease.c
@@ -53,7 +53,7 @@ test_autorelease_val (void)
 int
 main (void)
 {
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   native_free_cb_call_count = 0;
   test_autorelease_val ();

--- a/tests/unit-ext/test-ext-module-canonical.c
+++ b/tests/unit-ext/test-ext-module-canonical.c
@@ -76,7 +76,7 @@ main (int argc, char **argv)
 
   const jerryx_module_resolver_t *resolver = &canonical_test;
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   jerry_value_t actual_name = jerry_create_string ((jerry_char_t *) ACTUAL_NAME);
   jerry_value_t alias_name = jerry_create_string ((jerry_char_t *) ALIAS_NAME);

--- a/tests/unit-ext/test-ext-module-empty.c
+++ b/tests/unit-ext/test-ext-module-empty.c
@@ -29,7 +29,7 @@ main (int argc, char **argv)
   const jerryx_module_resolver_t *resolver = &jerryx_module_native_resolver;
   jerry_value_t module_name;
 
-  jerry_init (JERRY_INIT_EMPTY);
+  jerry_init (JERRY_INIT_DEFAULT);
 
   /* Attempt to load a non-existing module. */
   module_name = jerry_create_string ((jerry_char_t *) "some-unknown-module-name");


### PR DESCRIPTION
This change separates the concept of the external heap from the
external context, i.e., the context and the heap may be allocated
in separate memory regions by the user, and what's more, it puts
the allocation under the direct control of the user without any
need for a callback mechanism (opposed to the existing approach
based on `jerry_context_alloc_t` callbacks).

The here-implemented approach
- enables the same context/heap separation in the external case
  that is already available in the global internal context
  configuration, and
- enables statically allocated external heaps.

However, as this change gives allocation in the hands of the user,
the binding of the heap to the context can only happen when the
engine is initialised. This necessitates the change of the
arguments of `jerry_init`, which is a major API break (as that
function cannot be avoided in any scenario involving the engine.)

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu