### PR TITLE
Remove the JERRY_GET_CURRENT_CONTEXT macro

### DIFF
--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -170,14 +170,7 @@ struct jerry_context_t
  * This part is for JerryScript which uses external context.
  */
 
-#ifndef JERRY_GET_CURRENT_CONTEXT
-/**
- * Default function if JERRY_GET_CURRENT_CONTEXT is not defined.
- */
-#define JERRY_GET_CURRENT_CONTEXT() (jerry_port_get_current_context ())
-#endif /* !JERRY_GET_CURRENT_CONTEXT */
-
-#define JERRY_CONTEXT(field) (JERRY_GET_CURRENT_CONTEXT ()->field)
+#define JERRY_CONTEXT(field) (jerry_port_get_current_context ()->field)
 
 #ifndef JERRY_SYSTEM_ALLOCATOR
 


### PR DESCRIPTION
It was an unused and undocumented macro that enabled diverting the
`jerry_port_get_current_context` calls, an approach that was not
used anywhere else in the Port API.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu