### PR TITLE
Send print output to debugger client from the port implementation

### DIFF
--- a/jerry-ext/handler/handler-print.c
+++ b/jerry-ext/handler/handler-print.c
@@ -88,10 +88,6 @@ jerryx_handler_print (const jerry_value_t func_obj_val, /**< function object */
         *buf_end_p++ = (arg_index < args_cnt - 1) ? ' ' : '\n';
       }
 
-#ifdef JERRY_DEBUGGER
-      jerry_char_t *debugger_start_p = substr_buf;
-#endif /* JERRY_DEBUGGER */
-
       for (jerry_char_t *buf_p = substr_buf; buf_p < buf_end_p; buf_p++)
       {
         char chr = (char) *buf_p;
@@ -106,24 +102,7 @@ jerryx_handler_print (const jerry_value_t func_obj_val, /**< function object */
         {
           jerryx_port_handler_print_char (null_str[null_index]);
         }
-
-#ifdef JERRY_DEBUGGER
-        if (debugger_start_p < buf_p)
-        {
-          jerry_debugger_send_output (debugger_start_p, (jerry_size_t) (buf_p - debugger_start_p));
-        }
-
-        jerry_debugger_send_output ((jerry_char_t *) null_str, 6);
-        debugger_start_p = buf_p + 1;
-#endif /* JERRY_DEBUGGER */
       }
-
-#ifdef JERRY_DEBUGGER
-      if (debugger_start_p < buf_end_p)
-      {
-        jerry_debugger_send_output (debugger_start_p, (jerry_size_t) (buf_end_p - debugger_start_p));
-      }
-#endif /* JERRY_DEBUGGER */
     }
     while (substr_pos < length);
 
@@ -133,9 +112,6 @@ jerryx_handler_print (const jerry_value_t func_obj_val, /**< function object */
   if (args_cnt == 0 || jerry_value_is_error (ret_val))
   {
     jerryx_port_handler_print_char ('\n');
-#ifdef JERRY_DEBUGGER
-    jerry_debugger_send_output ((jerry_char_t *) "\n", 1);
-#endif /* JERRY_DEBUGGER */
   }
 
   return ret_val;

--- a/jerry-port/default/defaultx-handler.c
+++ b/jerry-port/default/defaultx-handler.c
@@ -17,6 +17,14 @@
 
 #include "jerryscript-ext/handler.h"
 
+#ifdef JERRY_DEBUGGER
+
+#define DEBUG_BUFFER_SIZE (256)
+static char debug_buffer[DEBUG_BUFFER_SIZE];
+static int debug_buffer_index = 0;
+
+#endif /* JERRY_DEBUGGER */
+
 /**
  * Default implementation of jerryx_port_handler_print_char. Uses 'printf' to
  * print a single character to standard output.
@@ -25,4 +33,14 @@ void
 jerryx_port_handler_print_char (char c) /**< the character to print */
 {
   printf ("%c", c);
+
+#ifdef JERRY_DEBUGGER
+  debug_buffer[debug_buffer_index++] = c;
+
+  if ((debug_buffer_index == DEBUG_BUFFER_SIZE) || (c == '\n'))
+  {
+    jerry_debugger_send_output ((jerry_char_t *) debug_buffer, (jerry_size_t) debug_buffer_index);
+    debug_buffer_index = 0;
+  }
+#endif /* JERRY_DEBUGGER */
 } /* jerryx_port_handler_print_char */


### PR DESCRIPTION
... not from the print handler extension. The sending of logs is
already in the port implementation.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu