### PR TITLE
Don't use `strlen` for string literals

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -783,15 +783,14 @@ jerry_run_simple (const jerry_char_t *script_source_p,
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
 main (void)
 {
-  const jerry_char_t *script = (const jerry_char_t *) "print ('Hello, World!');";
+  const jerry_char_t script[] = "print ('Hello, World!');";
 
-  jerry_run_simple (script, strlen ((const char *) script), JERRY_INIT_EMPTY);
+  jerry_run_simple (script, sizeof (script) - 1, JERRY_INIT_EMPTY);
 }
 ```
 
@@ -839,7 +838,6 @@ jerry_parse (const jerry_char_t *resource_name_p, /**< resource name (usually a 
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
@@ -848,9 +846,8 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "print ('Hello, World!');";
-  size_t script_size = strlen ((const char *) script);
 
-  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
   jerry_release_value (parsed_code);
 
   jerry_cleanup ();
@@ -924,20 +921,18 @@ jerry_run (const jerry_value_t func_val);
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
 main (void)
 {
   const jerry_char_t script[] = "print ('Hello, World!');";
-  size_t script_size = strlen ((const char *) script);
 
   /* Initialize engine */
   jerry_init (JERRY_INIT_EMPTY);
 
   /* Setup Global scope code */
-  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   if (!jerry_value_is_error (parsed_code))
   {
@@ -1016,7 +1011,6 @@ jerry_run_all_enqueued_jobs (void)
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
@@ -1025,9 +1019,8 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "new Promise(function(f,r) { f('Hello, World!'); }).then(function(x) { print(x); });";
-  size_t script_size = strlen ((const char *) script);
 
-  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
   jerry_value_t script_value = jerry_run (parsed_code);
   jerry_value_t job_value = jerry_run_all_enqueued_jobs ();
 
@@ -2989,10 +2982,10 @@ jerry_create_error_sz (jerry_error_t error_type,
 
 ```c
 {
-  const jerry_char_t *message = "error";
+  const jerry_char_t message[] = "error";
   jerry_value_t error_obj = jerry_create_error_sz (JERRY_ERROR_COMMON,
                                                    message,
-                                                   strlen ((const char *) message));
+                                                   sizeof (message) - 1);
 
   ... // usage of error_obj
 
@@ -3320,7 +3313,7 @@ jerry_create_string_sz (const jerry_char_t *str_p,
 {
   const jerry_char_t char_array[] = "a string";
   jerry_value_t string_value  = jerry_create_string_sz (char_array,
-                                                        strlen ((const char *) char_array));
+                                                        sizeof (char_array) - 1);
 
   ... // usage of string_value
 
@@ -3398,7 +3391,7 @@ jerry_create_string_sz (const jerry_char_t *str_p,
 {
   const jerry_char_t char_array[] = "a string";
   jerry_value_t string_value  = jerry_create_string_sz_from_utf8 (char_array,
-                                                                  strlen ((const char *) char_array));
+                                                                  sizeof (char_array) - 1);
 
   ... // usage of string_value
 
@@ -4792,16 +4785,15 @@ jerry_is_valid_utf8_string (const jerry_char_t *utf8_buf_p, /**< UTF-8 string */
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
 main (void)
 {
   const jerry_char_t script[] = "print ('Hello, World!');";
-  size_t script_size = strlen ((const char *) script);
+  const jerry_size_t script_size = sizeof (script) - 1;
 
-  if (jerry_is_valid_utf8_string (script, (jerry_size_t) script_size))
+  if (jerry_is_valid_utf8_string (script, script_size))
   {
     jerry_run_simple (script, script_size, JERRY_INIT_EMPTY);
   }
@@ -4840,7 +4832,6 @@ jerry_is_valid_cesu8_string (const jerry_char_t *cesu8_buf_p, /**< CESU-8 string
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
@@ -4849,12 +4840,12 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "Hello, World!";
-  size_t script_size = strlen ((const char *) script);
+  const jerry_size_t script_size = sizeof (script) - 1;
 
-  if (jerry_is_valid_cesu8_string (script, (jerry_size_t) script_size))
+  if (jerry_is_valid_cesu8_string (script, script_size))
   {
     jerry_value_t string_value = jerry_create_string_sz (script,
-                                                         (jerry_size_t) script_size);
+                                                         script_size);
 
     // usage of string_value
 
@@ -5059,7 +5050,6 @@ jerry_generate_snapshot (const jerry_char_t *resource_name_p,
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
@@ -5068,13 +5058,13 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   static uint32_t global_mode_snapshot_buffer[256];
-  const jerry_char_t *code_to_snapshot_p = (const jerry_char_t *) "(function () { return 'string from snapshot'; }) ();";
+  const jerry_char_t script_to_snapshot[] = "(function () { return 'string from snapshot'; }) ();";
 
   jerry_value_t generate_result;
   generate_result = jerry_generate_snapshot (NULL,
                                              0,
-                                             code_to_snapshot_p,
-                                             strlen ((const char *) code_to_snapshot_p),
+                                             script_to_snapshot,
+                                             sizeof (script_to_snapshot) - 1,
                                              0,
                                              global_mode_snapshot_buffer,
                                              sizeof (global_mode_snapshot_buffer) / sizeof (uint32_t));
@@ -5139,7 +5129,6 @@ jerry_generate_function_snapshot (const jerry_char_t *resource_name_p,
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
@@ -5148,16 +5137,16 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   static uint32_t func_snapshot_buffer[256];
-  const jerry_char_t *args_p = (const jerry_char_t *) "a, b";
-  const jerry_char_t *src_p = (const jerry_char_t *) "return a + b;";
+  const jerry_char_t args[] = "a, b";
+  const jerry_char_t src[] = "return a + b;";
 
   jerry_value_t generate_result;
   generate_result = jerry_generate_function_snapshot (NULL,
                                                       0,
-                                                      src_p,
-                                                      strlen ((const char *) src_p),
-                                                      args_p,
-                                                      strlen ((const char *) args_p),
+                                                      src,
+                                                      sizeof (src) - 1,
+                                                      args,
+                                                      sizeof (args) - 1,
                                                       0,
                                                       func_snapshot_buffer,
                                                       sizeof (func_snapshot_buffer) / sizeof (uint32_t));
@@ -5209,22 +5198,21 @@ jerry_exec_snapshot (const uint32_t *snapshot_p,
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
 main (void)
 {
   static uint32_t global_mode_snapshot_buffer[256];
-  const jerry_char_t *code_to_snapshot_p = (const jerry_char_t *) "(function () { return 'string from snapshot'; }) ();";
+  const jerry_char_t script_to_snapshot[] = "(function () { return 'string from snapshot'; }) ();";
 
   jerry_init (JERRY_INIT_EMPTY);
 
   jerry_value_t generate_result;
   generate_result = jerry_generate_snapshot (NULL,
                                              0,
-                                             code_to_snapshot_p,
-                                             strlen ((const char *) code_to_snapshot_p),
+                                             script_to_snapshot,
+                                             sizeof (script_to_snapshot) - 1,
                                              0,
                                              global_mode_snapshot_buffer,
                                              sizeof (global_mode_snapshot_buffer) / sizeof (uint32_t));
@@ -5287,25 +5275,24 @@ jerry_load_function_snapshot (const uint32_t *snapshot_p,
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
 main (void)
 {
   static uint32_t snapshot_buffer[256];
-  const jerry_char_t *args_p = (const jerry_char_t *)"a, b";
-  const jerry_char_t *src_p = (const jerry_char_t *) "return a + b;";
+  const jerry_char_t func_args[] = "a, b";
+  const jerry_char_t func_src[] = "return a + b;";
 
   jerry_init (JERRY_INIT_EMPTY);
 
   jerry_value_t generate_result;
   generate_result = jerry_generate_function_snapshot (NULL,
                                                       0,
-                                                      src_p,
-                                                      strlen ((const char *) src_p),
-                                                      args_p,
-                                                      strlen ((const char *) args_p),
+                                                      func_src,
+                                                      sizeof (func_src) - 1,
+                                                      func_args,
+                                                      sizeof (func_args) - 1,
                                                       false,
                                                       snapshot_buffer,
                                                       sizeof (snapshot_buffer) / sizeof (uint32_t));
@@ -5383,7 +5370,6 @@ jerry_get_literals_from_snapshot (const uint32_t *snapshot_p,
 
 ```c
 #include <stdio.h>
-#include <string.h>
 #include "jerryscript.h"
 
 int
@@ -5393,13 +5379,12 @@ main (void)
 
   static jerry_char_t literal_buffer[256];
   static uint32_t snapshot_buffer[256];
-  const jerry_char_t *code_for_literal_save_p = (const jerry_char_t *) "var obj = { a:'aa', bb:'Bb' }";
-  size_t code_for_literal_save_size = strlen ((const char *) code_for_literal_save_p);
+  const jerry_char_t script_for_literal_save[] = "var obj = { a:'aa', bb:'Bb' }";
 
   jerry_value_t generate_result = jerry_generate_snapshot (NULL,
                                                            0,
-                                                           code_for_literal_save_p,
-                                                           code_for_literal_save_size,
+                                                           script_for_literal_save,
+                                                           sizeof (script_for_literal_save) - 1,
                                                            0,
                                                            snapshot_buffer,
                                                            256);
@@ -5471,7 +5456,6 @@ jerry_set_vm_exec_stop_callback (jerry_vm_exec_stop_callback_t stop_cb,
 [doctest]: # (test="link")
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 static int countdown = 10;
@@ -5497,11 +5481,11 @@ main (void)
   jerry_set_vm_exec_stop_callback (vm_exec_stop_callback, &countdown, 16);
 
   // Inifinte loop.
-  const char *src_p = "while(true) {}";
+  const jerry_char_t script[] = "while(true) {}";
 
-  jerry_value_t src = jerry_parse (NULL, 0, (jerry_char_t *) src_p, strlen (src_p), JERRY_PARSE_NO_OPTS);
-  jerry_release_value (jerry_run (src));
-  jerry_release_value (src);
+  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
+  jerry_release_value (jerry_run (parsed_code));
+  jerry_release_value (parsed_code);
   jerry_cleanup ();
 }
 ```
@@ -5920,9 +5904,8 @@ jerry_value_t jerry_json_parse (const jerry_char_t *string_p, jerry_size_t strin
 
 ```c
 {
-  const char *data = "{\"name\": \"John\", \"age\": 5}";
-  jerry_size_t str_length = (jerry_size_t)strlen (data);
-  jerry_value_t parsed_json = jerry_json_parse ((jerry_char_t*)data, str_length);
+  const jerry_char_t data[] = "{\"name\": \"John\", \"age\": 5}";
+  jerry_value_t parsed_json = jerry_json_parse (data, sizeof (data) - 1);
 
   // parsed_json now conatins all data stored in data_in_json
 

--- a/docs/03.API-EXAMPLE.md
+++ b/docs/03.API-EXAMPLE.md
@@ -7,16 +7,14 @@ This guide is intended to introduce you to JerryScript embedding API through cre
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 
 int
 main (void)
 {
   const jerry_char_t script[] = "var str = 'Hello, World!';";
-  size_t script_size = strlen ((const char *) script);
 
-  bool ret_value = jerry_run_simple (script, script_size, JERRY_INIT_EMPTY);
+  bool ret_value = jerry_run_simple (script, sizeof (script) - 1, JERRY_INIT_EMPTY);
 
   return (ret_value ? 0 : 1);
 }
@@ -37,7 +35,6 @@ Here we perform the same actions, as `jerry_run_simple`, while splitting into se
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
 
@@ -45,7 +42,6 @@ int
 main (void)
 {
   const jerry_char_t script[] = "print ('Hello, World!');";
-  size_t script_size = strlen ((const char *) script);
 
   /* Initialize engine */
   jerry_init (JERRY_INIT_EMPTY);
@@ -55,7 +51,7 @@ main (void)
                                   jerryx_handler_print);
 
   /* Setup Global scope code */
-  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t parsed_code = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   if (!jerry_value_is_error (parsed_code))
   {
@@ -83,7 +79,6 @@ Our code is more complex now, but it introduces possibilities to interact with J
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
 
@@ -104,7 +99,7 @@ main (void)
 
   /* Evaluate script1 */
   eval_ret = jerry_eval (script_1,
-                         strlen ((const char *) script_1),
+                         sizeof (script_1) - 1,
                          JERRY_PARSE_NO_OPTS);
 
   /* Free JavaScript value, returned by eval */
@@ -112,7 +107,7 @@ main (void)
 
   /* Evaluate script2 */
   eval_ret = jerry_eval (script_2,
-                         strlen ((const char *) script_2),
+                         sizeof (script_2) - 1,
                          JERRY_PARSE_NO_OPTS);
 
   /* Free JavaScript value, returned by eval */
@@ -132,7 +127,6 @@ This way, we execute two independent script parts in one execution environment. 
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
 
@@ -168,7 +162,7 @@ main (void)
 
   /* Now starting script that would output value of just initialized field */
   jerry_value_t eval_ret = jerry_eval (script,
-                                       strlen ((const char *) script),
+                                       sizeof (script) - 1,
                                        JERRY_PARSE_NO_OPTS);
 
   /* Free JavaScript value, returned by eval */
@@ -197,7 +191,6 @@ The following example function will output a JavaScript value:
 ```c
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include "jerryscript.h"
 
 static void
@@ -312,7 +305,7 @@ main (void)
     }
 
     /* If the command is "quit", break the loop */
-    if (!strncmp (cmd, "quit\n", strlen ("quit\n")))
+    if (!strncmp (cmd, "quit\n", sizeof ("quit\n") - 1))
     {
       break;
     }
@@ -352,7 +345,6 @@ In this example we demonstrate how to use native function and structures in Java
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
 
@@ -417,10 +409,9 @@ main (void)
     var str = MyObject.myFunc (); \
     print (str); \
   ";
-  size_t script_size = strlen ((const char *) script);
 
   /* Evaluate script */
-  jerry_value_t eval_ret = jerry_eval (script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t eval_ret = jerry_eval (script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   /* Free JavaScript value, returned by eval */
   jerry_release_value (eval_ret);
@@ -445,7 +436,6 @@ Here we create a JS Object with `jerry_eval`, then extend it with a native funct
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 #include "jerryscript-ext/handler.h"
 
@@ -508,7 +498,7 @@ main (void)
 
   /* Evaluate script */
   my_js_obj_val = jerry_eval (my_js_object,
-                              strlen ((const char *) my_js_object),
+                              sizeof (my_js_object) - 1,
                               JERRY_PARSE_NO_OPTS);
 
   /* Create a JS function object and wrap into a jerry value */
@@ -529,10 +519,9 @@ main (void)
     MyObject.add2x (5); \
     print (MyObject.foo ()); \
   ";
-  size_t script_size = strlen ((const char *) script);
 
   /* Evaluate script */
-  jerry_value_t eval_ret = jerry_eval (script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t eval_ret = jerry_eval (script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   /* Free JavaScript value, returned by eval */
   jerry_release_value (eval_ret);
@@ -559,7 +548,6 @@ A recommended method is using `jerry_port_get_current_time()` or something based
 [doctest]: # ()
 
 ```c
-#include <string.h>
 #include <stdlib.h>
 #include "jerryscript.h"
 #include "jerryscript-port.h"
@@ -573,7 +561,6 @@ main (void)
 
   /* Generate a random number, and print it */
   const jerry_char_t script[] = "var a = Math.random (); print(a)";
-  size_t script_size = strlen ((const char *) script);
 
   /* Initialize the engine */
   jerry_init (JERRY_INIT_EMPTY);
@@ -583,7 +570,7 @@ main (void)
                                   jerryx_handler_print);
 
   /* Evaluate the script */
-  jerry_value_t eval_ret = jerry_eval (script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t eval_ret = jerry_eval (script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   /* Free the JavaScript value returned by eval */
   jerry_release_value (eval_ret);

--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -251,7 +251,6 @@ jerry_debugger_stop_at_breakpoint (bool enable_stop_at_breakpoint)
 [doctest]: # (test="link")
 
 ```c
-#include <string.h>
 #include "jerryscript.h"
 #include "jerryscript-ext/debugger.h"
 
@@ -266,8 +265,7 @@ main (void)
 
   // Protected execution of JavaScript code.
   const jerry_char_t script[] = "42";
-  size_t script_size = strlen ((const char *) script);
-  jerry_eval (script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_eval (script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   jerry_debugger_stop_at_breakpoint (false);
 

--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -291,10 +291,9 @@ static void
 static_snapshot_error_unsupported_literal (snapshot_globals_t *globals_p, /**< snapshot globals */
                                            ecma_value_t literal) /**< literal form the literal pool */
 {
-  const char * const error_prefix_p = "Unsupported static snapshot literal: ";
+  const lit_utf8_byte_t error_prefix[] = "Unsupported static snapshot literal: ";
 
-  ecma_string_t *error_message_p = ecma_new_ecma_string_from_utf8 ((const lit_utf8_byte_t *) error_prefix_p,
-                                                                   (lit_utf8_size_t) strlen (error_prefix_p));
+  ecma_string_t *error_message_p = ecma_new_ecma_string_from_utf8 (error_prefix, sizeof (error_prefix) - 1);
 
   literal = ecma_op_to_string (literal);
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (literal));

--- a/jerry-core/vm/vm-utils.c
+++ b/jerry-core/vm/vm-utils.c
@@ -84,9 +84,8 @@ vm_get_backtrace (uint32_t max_depth) /**< maximum backtrace depth, 0 = unlimite
 
     if (ecma_string_is_empty (str_p))
     {
-      const char * const unknown_str_p = "<unknown>:";
-      str_p = ecma_new_ecma_string_from_utf8 ((const lit_utf8_byte_t *) unknown_str_p,
-                                              (lit_utf8_size_t) strlen (unknown_str_p));
+      const lit_utf8_byte_t unknown_str[] = "<unknown>:";
+      str_p = ecma_new_ecma_string_from_utf8 (unknown_str, sizeof (unknown_str) - 1);
     }
     else
     {

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -395,9 +395,8 @@ int jerry_main (int argc, char *argv[])
   {
     printf ("No input files, running a hello world demo:\n");
     const jerry_char_t script[] = "var str = 'Hello World'; print(str + ' from JerryScript')";
-    size_t script_size = strlen ((const char *) script);
 
-    ret_value = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
+    ret_value = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
     if (!jerry_value_is_error (ret_value))
     {

--- a/targets/particle/source/main.cpp
+++ b/targets/particle/source/main.cpp
@@ -114,9 +114,7 @@ test_jerry ()
     test.delay(250); \
   ";
 
-  size_t script_size = strlen ((const char *) script);
-
-  jerry_value_t eval_ret = jerry_eval (script, script_size, JERRY_PARSE_NO_OPTS);
+  jerry_value_t eval_ret = jerry_eval (script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   /* Free JavaScript value, returned by eval */
   jerry_release_value (eval_ret);

--- a/targets/riot-stm32f4/source/main-riotos.c
+++ b/targets/riot-stm32f4/source/main-riotos.c
@@ -56,7 +56,6 @@ int test_jerry (int argc, char **argv)
   jerry_value_t ret_value = jerry_create_undefined ();
 
   const jerry_char_t script[] = "print ('Hello, World!');";
-  size_t script_size = strlen ((const char *) script);
   printf ("This test run the following script code: [%s]\n\n", script);
 
   /* Initialize engine */
@@ -66,7 +65,7 @@ int test_jerry (int argc, char **argv)
   register_js_function ("print", jerryx_handler_print);
 
   /* Setup Global scope code */
-  ret_value = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
+  ret_value = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
   if (!jerry_value_is_error (ret_value))
   {

--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
@@ -371,9 +371,8 @@ jerry_cmd_main (int argc, char *argv[])
   {
     printf ("No input files, running a hello world demo:\n");
     const jerry_char_t script[] = "var str = 'Hello World'; print(str + ' from JerryScript')";
-    size_t script_size = strlen ((const char *) script);
 
-    ret_value = jerry_parse (NULL, 0, script, script_size, JERRY_PARSE_NO_OPTS);
+    ret_value = jerry_parse (NULL, 0, script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
 
     if (!jerry_value_is_error (ret_value))
     {

--- a/tests/unit-core/test-abort.c
+++ b/tests/unit-core/test-abort.c
@@ -52,20 +52,22 @@ main (void)
   jerry_release_value (callback_name);
   jerry_release_value (global);
 
-  const char *inf_loop_code_src_p = ("while(true) {\n"
-                                     "  with ({}) {\n"
-                                     "    try {\n"
-                                     "      callback();\n"
-                                     "    } catch (e) {\n"
-                                     "    } finally {\n"
-                                     "    }\n"
-                                     "  }\n"
-                                     "}");
+  const jerry_char_t inf_loop_code_src1[] = TEST_STRING_LITERAL (
+    "while(true) {\n"
+    "  with ({}) {\n"
+    "    try {\n"
+    "      callback();\n"
+    "    } catch (e) {\n"
+    "    } finally {\n"
+    "    }\n"
+    "  }\n"
+    "}"
+  );
 
   jerry_value_t parsed_code_val = jerry_parse (NULL,
                                                0,
-                                               (jerry_char_t *) inf_loop_code_src_p,
-                                               strlen (inf_loop_code_src_p),
+                                               inf_loop_code_src1,
+                                               sizeof (inf_loop_code_src1) - 1,
                                                JERRY_PARSE_NO_OPTS);
 
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
@@ -76,29 +78,31 @@ main (void)
   jerry_release_value (res);
   jerry_release_value (parsed_code_val);
 
-  inf_loop_code_src_p = ("function f() {"
-                         "  while(true) {\n"
-                         "    with ({}) {\n"
-                         "      try {\n"
-                         "        callback();\n"
-                         "      } catch (e) {\n"
-                         "      } finally {\n"
-                         "      }\n"
-                         "    }\n"
-                         "  }"
-                         "}\n"
-                         "function g() {\n"
-                         "  for (a in { x:5 })\n"
-                         "    f();\n"
-                         "}\n"
-                          "\n"
-                         "with({})\n"
-                         " f();\n");
+  const jerry_char_t inf_loop_code_src2[] = TEST_STRING_LITERAL (
+    "function f() {"
+    "  while(true) {\n"
+    "    with ({}) {\n"
+    "      try {\n"
+    "        callback();\n"
+    "      } catch (e) {\n"
+    "      } finally {\n"
+    "      }\n"
+    "    }\n"
+    "  }"
+    "}\n"
+    "function g() {\n"
+    "  for (a in { x:5 })\n"
+    "    f();\n"
+    "}\n"
+    "\n"
+    "with({})\n"
+    " f();\n"
+  );
 
   parsed_code_val = jerry_parse (NULL,
                                  0,
-                                 (jerry_char_t *) inf_loop_code_src_p,
-                                 strlen (inf_loop_code_src_p),
+                                 inf_loop_code_src2,
+                                 sizeof (inf_loop_code_src2) - 1,
                                  JERRY_PARSE_NO_OPTS);
 
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));

--- a/tests/unit-core/test-api-set-and-clear-error-flag.c
+++ b/tests/unit-core/test-api-set-and-clear-error-flag.c
@@ -17,7 +17,7 @@
 #include "test-common.h"
 
 static void
-compare_str (jerry_value_t value, const char *str_p, size_t str_len)
+compare_str (jerry_value_t value, const jerry_char_t *str_p, size_t str_len)
 {
   jerry_size_t size = jerry_get_string_size (value);
   JERRY_ASSERT (str_len == size);
@@ -43,56 +43,56 @@ main (void)
   jerry_release_value (err_val);
   jerry_release_value (obj_val);
 
-  const char *pterodactylus_p = "Pterodactylus";
-  const size_t pterodactylus_size = strlen (pterodactylus_p);
+  const jerry_char_t pterodactylus[] = "Pterodactylus";
+  const size_t pterodactylus_size = sizeof (pterodactylus) - 1;
 
-  jerry_value_t str = jerry_create_string ((jerry_char_t *) pterodactylus_p);
+  jerry_value_t str = jerry_create_string (pterodactylus);
   jerry_value_t error = jerry_create_error_from_value (str, true);
   str = jerry_get_value_from_error (error, true);
 
-  compare_str (str, pterodactylus_p, pterodactylus_size);
+  compare_str (str, pterodactylus, pterodactylus_size);
   jerry_release_value (str);
 
-  str = jerry_create_string ((jerry_char_t *) pterodactylus_p);
+  str = jerry_create_string (pterodactylus);
   error = jerry_create_error_from_value (str, false);
   jerry_release_value (str);
   str = jerry_get_value_from_error (error, true);
 
-  compare_str (str, pterodactylus_p, pterodactylus_size);
+  compare_str (str, pterodactylus, pterodactylus_size);
   jerry_release_value (str);
 
-  str = jerry_create_string ((jerry_char_t *) pterodactylus_p);
+  str = jerry_create_string (pterodactylus);
   error = jerry_create_abort_from_value (str, true);
   str = jerry_get_value_from_error (error, true);
 
-  compare_str (str, pterodactylus_p, pterodactylus_size);
+  compare_str (str, pterodactylus, pterodactylus_size);
   jerry_release_value (str);
 
-  str = jerry_create_string ((jerry_char_t *) pterodactylus_p);
+  str = jerry_create_string (pterodactylus);
   error = jerry_create_abort_from_value (str, false);
   jerry_release_value (str);
   str = jerry_get_value_from_error (error, true);
 
-  compare_str (str, pterodactylus_p, pterodactylus_size);
+  compare_str (str, pterodactylus, pterodactylus_size);
   jerry_release_value (str);
 
-  str = jerry_create_string ((jerry_char_t *) pterodactylus_p);
+  str = jerry_create_string (pterodactylus);
   error = jerry_create_error_from_value (str, true);
   error = jerry_create_abort_from_value (error, true);
   JERRY_ASSERT (jerry_value_is_abort (error));
   str = jerry_get_value_from_error (error, true);
 
-  compare_str (str, pterodactylus_p, pterodactylus_size);
+  compare_str (str, pterodactylus, pterodactylus_size);
   jerry_release_value (str);
 
-  str = jerry_create_string ((jerry_char_t *) pterodactylus_p);
+  str = jerry_create_string (pterodactylus);
   error = jerry_create_error_from_value (str, true);
   jerry_value_t error2 = jerry_create_abort_from_value (error, false);
   JERRY_ASSERT (jerry_value_is_abort (error2));
   jerry_release_value (error);
   str = jerry_get_value_from_error (error2, true);
 
-  compare_str (str, pterodactylus_p, pterodactylus_size);
+  compare_str (str, pterodactylus, pterodactylus_size);
   jerry_release_value (str);
 
   double test_num = 3.1415926;

--- a/tests/unit-core/test-api-value-type.c
+++ b/tests/unit-core/test-api-value-type.c
@@ -46,7 +46,7 @@ main (void)
 
   jerry_init (JERRY_INIT_EMPTY);
 
-  jerry_char_t test_eval_function[] = "function demo(a) { return a + 1; }; demo";
+  const jerry_char_t test_eval_function[] = "function demo(a) { return a + 1; }; demo";
 
   test_entry_t entries[] =
   {
@@ -68,7 +68,7 @@ main (void)
     ENTRY (JERRY_TYPE_NULL, jerry_create_null ()),
 
     ENTRY (JERRY_TYPE_FUNCTION, jerry_eval (test_eval_function,
-                                            strlen ((char *) test_eval_function),
+                                            sizeof (test_eval_function) - 1,
                                             JERRY_PARSE_NO_OPTS)),
     ENTRY (JERRY_TYPE_FUNCTION, jerry_create_external_function (test_ext_function)),
 

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -18,46 +18,46 @@
 
 #include "test-common.h"
 
-const char *test_source = (
-                           "function assert (arg) { "
-                           "  if (!arg) { "
-                           "    throw Error('Assert failed');"
-                           "  } "
-                           "} "
-                           "this.t = 1; "
-                           "function f () { "
-                           "return this.t; "
-                           "} "
-                           "this.foo = f; "
-                           "this.bar = function (a) { "
-                           "return a + t; "
-                           "}; "
-                           "function A () { "
-                           "this.t = 12; "
-                           "} "
-                           "this.A = A; "
-                           "this.a = new A (); "
-                           "function call_external () { "
-                           "  return this.external ('1', true); "
-                           "} "
-                           "function call_throw_test() { "
-                           "  var catched = false; "
-                           "  try { "
-                           "    this.throw_test(); "
-                           "  } catch (e) { "
-                           "    catched = true; "
-                           "    assert(e.name == 'TypeError'); "
-                           "    assert(e.message == 'error'); "
-                           "  } "
-                           "  assert(catched); "
-                           "} "
-                           "function throw_reference_error() { "
-                           " throw new ReferenceError ();"
-                           "} "
-                           "p = {'alpha':32, 'bravo':false, 'charlie':{}, 'delta':123.45, 'echo':'foobar'};"
-                           "np = {}; Object.defineProperty (np, 'foxtrot', { "
-                           "get: function() { throw 'error'; }, enumerable: true }) "
-                           );
+const jerry_char_t test_source[] = TEST_STRING_LITERAL (
+  "function assert (arg) { "
+  "  if (!arg) { "
+  "    throw Error('Assert failed');"
+  "  } "
+  "} "
+  "this.t = 1; "
+  "function f () { "
+  "return this.t; "
+  "} "
+  "this.foo = f; "
+  "this.bar = function (a) { "
+  "return a + t; "
+  "}; "
+  "function A () { "
+  "this.t = 12; "
+  "} "
+  "this.A = A; "
+  "this.a = new A (); "
+  "function call_external () { "
+  "  return this.external ('1', true); "
+  "} "
+  "function call_throw_test() { "
+  "  var catched = false; "
+  "  try { "
+  "    this.throw_test(); "
+  "  } catch (e) { "
+  "    catched = true; "
+  "    assert(e.name == 'TypeError'); "
+  "    assert(e.message == 'error'); "
+  "  } "
+  "  assert(catched); "
+  "} "
+  "function throw_reference_error() { "
+  " throw new ReferenceError ();"
+  "} "
+  "p = {'alpha':32, 'bravo':false, 'charlie':{}, 'delta':123.45, 'echo':'foobar'};"
+  "np = {}; Object.defineProperty (np, 'foxtrot', { "
+  "get: function() { throw 'error'; }, enumerable: true }) "
+);
 
 bool test_api_is_free_callback_was_called = false;
 
@@ -322,21 +322,14 @@ static bool
 strict_equals (jerry_value_t a,
                jerry_value_t b)
 {
-  bool is_strict_equal;
-  const char *is_equal_src;
-  jerry_value_t args[2];
-  jerry_value_t is_equal_fn_val;
-  jerry_value_t res;
-
-  is_equal_src = "var isEqual = function(a, b) { return (a === b); }; isEqual";
-  is_equal_fn_val = jerry_eval ((jerry_char_t *) is_equal_src, strlen (is_equal_src), JERRY_PARSE_NO_OPTS);
+  const jerry_char_t is_equal_src[] = "var isEqual = function(a, b) { return (a === b); }; isEqual";
+  jerry_value_t is_equal_fn_val = jerry_eval (is_equal_src, sizeof (is_equal_src) - 1, JERRY_PARSE_NO_OPTS);
   TEST_ASSERT (!jerry_value_is_error (is_equal_fn_val));
-  args[0] = a;
-  args[1] = b;
-  res = jerry_call_function (is_equal_fn_val, jerry_create_undefined (), args, 2);
+  jerry_value_t args[2] = {a, b};
+  jerry_value_t res = jerry_call_function (is_equal_fn_val, jerry_create_undefined (), args, 2);
   TEST_ASSERT (!jerry_value_is_error (res));
   TEST_ASSERT (jerry_value_is_boolean (res));
-  is_strict_equal = jerry_get_boolean_value (res);
+  bool is_strict_equal = jerry_get_boolean_value (res);
   jerry_release_value (res);
   jerry_release_value (is_equal_fn_val);
   return is_strict_equal;
@@ -367,8 +360,8 @@ main (void)
 
   parsed_code_val = jerry_parse (NULL,
                                  0,
-                                 (jerry_char_t *) test_source,
-                                 strlen (test_source),
+                                 test_source,
+                                 sizeof (test_source) - 1,
                                  JERRY_PARSE_NO_OPTS);
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
 
@@ -1000,8 +993,8 @@ main (void)
   jerry_release_value (obj_val);
 
   /* Test: eval */
-  const char *eval_code_src_p = "(function () { return 123; })";
-  val_t = jerry_eval ((jerry_char_t *) eval_code_src_p, strlen (eval_code_src_p), JERRY_PARSE_STRICT_MODE);
+  const jerry_char_t eval_code_src1[] = "(function () { return 123; })";
+  val_t = jerry_eval (eval_code_src1, sizeof (eval_code_src1) - 1, JERRY_PARSE_STRICT_MODE);
   TEST_ASSERT (!jerry_value_is_error (val_t));
   TEST_ASSERT (jerry_value_is_object (val_t));
   TEST_ASSERT (jerry_value_is_function (val_t));
@@ -1021,8 +1014,8 @@ main (void)
   jerry_gc (JERRY_GC_SEVERITY_LOW);
 
   /* Test: spaces */
-  eval_code_src_p = "\x0a \x0b \x0c \xc2\xa0 \xe2\x80\xa8 \xe2\x80\xa9 \xef\xbb\xbf 4321";
-  val_t = jerry_eval ((jerry_char_t *) eval_code_src_p, strlen (eval_code_src_p), JERRY_PARSE_STRICT_MODE);
+  const jerry_char_t eval_code_src2[] = "\x0a \x0b \x0c \xc2\xa0 \xe2\x80\xa8 \xe2\x80\xa9 \xef\xbb\xbf 4321";
+  val_t = jerry_eval (eval_code_src2, sizeof (eval_code_src2) - 1, JERRY_PARSE_STRICT_MODE);
   TEST_ASSERT (!jerry_value_is_error (val_t));
   TEST_ASSERT (jerry_value_is_number (val_t)
                && jerry_get_number_value (val_t) == 4321.0);
@@ -1045,16 +1038,16 @@ main (void)
   jerry_release_value (val_t);
 
   /* Test: create function */
-  const char *func_resource = "unknown";
-  const char *func_arg_list = "a , b,c";
-  const char *func_src = "  return 5 +  a+\nb+c";
+  const jerry_char_t func_resource[] = "unknown";
+  const jerry_char_t func_arg_list[] = "a , b,c";
+  const jerry_char_t func_src[] = "  return 5 +  a+\nb+c";
 
-  jerry_value_t func_val = jerry_parse_function ((const jerry_char_t *) func_resource,
-                                                 strlen (func_resource),
-                                                 (const jerry_char_t *) func_arg_list,
-                                                 strlen (func_arg_list),
-                                                 (const jerry_char_t *) func_src,
-                                                 strlen (func_src),
+  jerry_value_t func_val = jerry_parse_function (func_resource,
+                                                 sizeof (func_resource) - 1,
+                                                 func_arg_list,
+                                                 sizeof (func_arg_list) - 1,
+                                                 func_src,
+                                                 sizeof (func_src) - 1,
                                                  JERRY_PARSE_NO_OPTS);
 
   TEST_ASSERT (!jerry_value_is_error (func_val));
@@ -1101,11 +1094,11 @@ main (void)
   {
     jerry_init (JERRY_INIT_SHOW_OPCODES);
 
-    const char *parser_err_src_p = "b = 'hello';\nvar a = (;";
+    const jerry_char_t parser_err_src[] = "b = 'hello';\nvar a = (;";
     parsed_code_val = jerry_parse (NULL,
                                    0,
-                                   (jerry_char_t *) parser_err_src_p,
-                                   strlen (parser_err_src_p),
+                                   parser_err_src,
+                                   sizeof (parser_err_src) - 1,
                                    JERRY_PARSE_NO_OPTS);
     TEST_ASSERT (jerry_value_is_error (parsed_code_val));
     parsed_code_val = jerry_get_value_from_error (parsed_code_val, true);
@@ -1131,11 +1124,11 @@ main (void)
                                 num_magic_string_items,
                                 magic_string_lengths);
 
-  const char *ms_code_src_p = "var global = {}; var console = [1]; var process = 1;";
+  const jerry_char_t ms_code_src[] = "var global = {}; var console = [1]; var process = 1;";
   parsed_code_val = jerry_parse (NULL,
                                  0,
-                                 (jerry_char_t *) ms_code_src_p,
-                                 strlen (ms_code_src_p),
+                                 ms_code_src,
+                                 sizeof (ms_code_src) - 1,
                                  JERRY_PARSE_NO_OPTS);
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
 
@@ -1160,9 +1153,9 @@ main (void)
 
   jerry_release_value (args[0]);
 
-  const char *test_magic_str_access_src_p = "'console'.charAt(6) == 'e'";
-  res = jerry_eval ((const jerry_char_t *) test_magic_str_access_src_p,
-                    strlen (test_magic_str_access_src_p),
+  const jerry_char_t test_magic_str_access_src[] = "'console'.charAt(6) == 'e'";
+  res = jerry_eval (test_magic_str_access_src,
+                    sizeof (test_magic_str_access_src) - 1,
                     JERRY_PARSE_NO_OPTS);
   TEST_ASSERT (jerry_value_is_boolean (res));
   TEST_ASSERT (jerry_get_boolean_value (res) == true);
@@ -1183,22 +1176,20 @@ main (void)
 
   {
     /*json parser check*/
-    char data_check[]="John";
+    const char data_check[]="John";
     jerry_value_t key = jerry_create_string ((const jerry_char_t *) "name");
-    const char *data = "{\"name\": \"John\", \"age\": 5}";
-    jerry_size_t str_length = (jerry_size_t) strlen (data);
-    jerry_value_t parsed_json = jerry_json_parse ((jerry_char_t *) data, str_length);
+    const jerry_char_t data[] = "{\"name\": \"John\", \"age\": 5}";
+    jerry_value_t parsed_json = jerry_json_parse (data, sizeof (data) - 1);
     jerry_value_t has_prop_js = jerry_has_property (parsed_json, key);
     TEST_ASSERT (jerry_get_boolean_value (has_prop_js));
     jerry_release_value (has_prop_js);
     jerry_value_t parsed_data = jerry_get_property (parsed_json, key);
     TEST_ASSERT (jerry_value_is_string (parsed_data)== true);
-    jerry_size_t buff_size = (jerry_size_t) jerry_get_string_length (parsed_data);
     char buff[jerry_get_string_length (parsed_data)];
-    jerry_char_t *buff_p = (jerry_char_t *) buff;
-    jerry_string_to_char_buffer (parsed_data, buff_p, buff_size);
+    jerry_size_t buff_size = (jerry_size_t) jerry_get_string_length (parsed_data);
+    jerry_string_to_char_buffer (parsed_data, (jerry_char_t *) buff, buff_size);
     buff[buff_size] = '\0';
-    TEST_ASSERT (strcmp ((const char *) data_check, (const char *) buff) == false);
+    TEST_ASSERT (strcmp (data_check, buff) == false);
     jerry_release_value (parsed_json);
     jerry_release_value (key);
     jerry_release_value (parsed_data);

--- a/tests/unit-core/test-arraybuffer.c
+++ b/tests/unit-core/test-arraybuffer.c
@@ -74,11 +74,13 @@ assert_handler (const jerry_value_t func_obj_val, /**< function object */
 static void
 test_read_with_offset (uint8_t offset) /**< offset for buffer read. */
 {
-  const char *eval_arraybuffer_src_p = ("var array = new Uint8Array (15);"
-                                        "for (var i = 0; i < array.length; i++) { array[i] = i * 2; };"
-                                        "array.buffer");
-  jerry_value_t arraybuffer = jerry_eval ((jerry_char_t *) eval_arraybuffer_src_p,
-                                          strlen (eval_arraybuffer_src_p),
+  const jerry_char_t eval_arraybuffer_src[] = TEST_STRING_LITERAL (
+    "var array = new Uint8Array (15);"
+    "for (var i = 0; i < array.length; i++) { array[i] = i * 2; };"
+    "array.buffer"
+  );
+  jerry_value_t arraybuffer = jerry_eval (eval_arraybuffer_src,
+                                          sizeof (eval_arraybuffer_src) - 1,
                                           JERRY_PARSE_STRICT_MODE);
 
   TEST_ASSERT (!jerry_value_is_error (arraybuffer));
@@ -112,9 +114,9 @@ static void test_write_with_offset (uint8_t offset) /**< offset for buffer write
     jerry_release_value (offset_val);
   }
 
-  const char *eval_arraybuffer_src_p = "var array = new Uint8Array (15); array.buffer";
-  jerry_value_t arraybuffer = jerry_eval ((jerry_char_t *) eval_arraybuffer_src_p,
-                                          strlen (eval_arraybuffer_src_p),
+  const jerry_char_t eval_arraybuffer_src[] = "var array = new Uint8Array (15); array.buffer";
+  jerry_value_t arraybuffer = jerry_eval (eval_arraybuffer_src,
+                                          sizeof (eval_arraybuffer_src) - 1,
                                           JERRY_PARSE_STRICT_MODE);
 
   TEST_ASSERT (!jerry_value_is_error (arraybuffer));
@@ -132,19 +134,20 @@ static void test_write_with_offset (uint8_t offset) /**< offset for buffer write
   jerry_length_t copied = jerry_arraybuffer_write (arraybuffer, offset, buffer, 20);
   TEST_ASSERT (copied == (jerry_length_t)(15 - offset));
 
-  const char *eval_test_arraybuffer_p = (
-      "for (var i = 0; i < offset; i++)"
-      "{"
-      "  assert (array[i] == 0, 'offset check for: ' + i + ' was: ' + array[i] + ' should be: 0');"
-      "};"
-      "for (var i = offset; i < array.length; i++)"
-      "{"
-      "  var expected = (i - offset) * 3;"
-      "  assert (array[i] == expected, 'calc check for: ' + i + ' was: ' + array[i] + ' should be: ' + expected);"
-      "};"
-      "assert (array[15] === undefined, 'ArrayBuffer out of bounds index should return undefined value');");
-  jerry_value_t res = jerry_eval ((jerry_char_t *) eval_test_arraybuffer_p,
-                                  strlen (eval_test_arraybuffer_p),
+  const jerry_char_t eval_test_arraybuffer[] = TEST_STRING_LITERAL (
+    "for (var i = 0; i < offset; i++)"
+    "{"
+    "  assert (array[i] == 0, 'offset check for: ' + i + ' was: ' + array[i] + ' should be: 0');"
+    "};"
+    "for (var i = offset; i < array.length; i++)"
+    "{"
+    "  var expected = (i - offset) * 3;"
+    "  assert (array[i] == expected, 'calc check for: ' + i + ' was: ' + array[i] + ' should be: ' + expected);"
+    "};"
+    "assert (array[15] === undefined, 'ArrayBuffer out of bounds index should return undefined value');"
+  );
+  jerry_value_t res = jerry_eval (eval_test_arraybuffer,
+                                  sizeof (eval_test_arraybuffer) - 1,
                                   JERRY_PARSE_STRICT_MODE);
   jerry_release_value (res);
   jerry_release_value (arraybuffer);
@@ -176,9 +179,9 @@ main (void)
 
   /* Test array buffer queries */
   {
-    const char *eval_arraybuffer_src_p = "new ArrayBuffer (10)";
-    jerry_value_t eval_arraybuffer = jerry_eval ((jerry_char_t *) eval_arraybuffer_src_p,
-                                                 strlen (eval_arraybuffer_src_p),
+    const jerry_char_t eval_arraybuffer_src[] = "new ArrayBuffer (10)";
+    jerry_value_t eval_arraybuffer = jerry_eval (eval_arraybuffer_src,
+                                                 sizeof (eval_arraybuffer_src) - 1,
                                                  JERRY_PARSE_STRICT_MODE);
     TEST_ASSERT (!jerry_value_is_error (eval_arraybuffer));
     TEST_ASSERT (jerry_value_is_arraybuffer (eval_arraybuffer));
@@ -291,16 +294,17 @@ main (void)
       jerry_release_value (input_buffer);
     }
 
-    const char *eval_arraybuffer_src_p = (
+    const jerry_char_t eval_arraybuffer_src[] = TEST_STRING_LITERAL (
       "var array = new Uint8Array(input_buffer);"
       "for (var i = 0; i < array.length; i++)"
       "{"
       "  array[i] = i * 2;"
       "};"
-      "array.buffer");
-    jerry_value_t buffer = jerry_eval ((jerry_char_t *) eval_arraybuffer_src_p,
-                                        strlen (eval_arraybuffer_src_p),
-                                        JERRY_PARSE_STRICT_MODE);
+      "array.buffer"
+    );
+    jerry_value_t buffer = jerry_eval (eval_arraybuffer_src,
+                                       sizeof (eval_arraybuffer_src) - 1,
+                                       JERRY_PARSE_STRICT_MODE);
 
     TEST_ASSERT (!jerry_value_is_error (buffer));
     TEST_ASSERT (jerry_value_is_arraybuffer (buffer));
@@ -324,7 +328,7 @@ main (void)
 
     jerry_release_value (buffer);
 
-    const char *eval_test_arraybuffer_p = (
+    const jerry_char_t eval_test_arraybuffer[] = TEST_STRING_LITERAL (
       "var sum = 0;"
       "for (var i = 0; i < array.length; i++)"
       "{"
@@ -332,9 +336,10 @@ main (void)
       "  assert(array[i] == expected, 'Array at index ' + i + ' was: ' + array[i] + ' should be: ' + expected);"
       "  sum += array[i]"
       "};"
-      "sum");
-    jerry_value_t res = jerry_eval ((jerry_char_t *) eval_test_arraybuffer_p,
-                                    strlen (eval_test_arraybuffer_p),
+      "sum"
+    );
+    jerry_value_t res = jerry_eval (eval_test_arraybuffer,
+                                    sizeof (eval_test_arraybuffer) - 1,
                                     JERRY_PARSE_STRICT_MODE);
     TEST_ASSERT (jerry_value_is_number (res));
     TEST_ASSERT (jerry_get_number_value (res) == sum);

--- a/tests/unit-core/test-common.h
+++ b/tests/unit-core/test-common.h
@@ -50,4 +50,12 @@ do \
   srand ((unsigned) jerry_port_get_current_time ()); \
 } while (0)
 
+/**
+ * Dummy macro to enable the breaking of long string literals into multiple
+ * substrings on separate lines. (Style checker doesn't allow it without putting
+ * the whole literal into parentheses but the compiler warns about parenthesized
+ * string constants.)
+ */
+#define TEST_STRING_LITERAL(x) x
+
 #endif /* !TEST_COMMON_H */

--- a/tests/unit-core/test-exec-stop.c
+++ b/tests/unit-core/test-exec-stop.c
@@ -49,11 +49,11 @@ main (void)
   int countdown = 6;
   jerry_set_vm_exec_stop_callback (vm_exec_stop_callback, &countdown, 16);
 
-  const char *inf_loop_code_src_p = "while(true) {}";
+  const jerry_char_t inf_loop_code_src1[] = "while(true) {}";
   jerry_value_t parsed_code_val = jerry_parse (NULL,
                                                0,
-                                               (jerry_char_t *) inf_loop_code_src_p,
-                                               strlen (inf_loop_code_src_p),
+                                               inf_loop_code_src1,
+                                               sizeof (inf_loop_code_src1) - 1,
                                                JERRY_PARSE_NO_OPTS);
 
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
@@ -71,13 +71,15 @@ main (void)
   /* We keep the callback function, only the countdown is reset. */
   countdown = 6;
 
-  inf_loop_code_src_p = ("function f() { while (true) ; }\n"
-                         "try { f(); } catch(e) {}");
+  const jerry_char_t inf_loop_code_src2[] = TEST_STRING_LITERAL (
+    "function f() { while (true) ; }\n"
+    "try { f(); } catch(e) {}"
+  );
 
   parsed_code_val = jerry_parse (NULL,
                                  0,
-                                 (jerry_char_t *) inf_loop_code_src_p,
-                                 strlen (inf_loop_code_src_p),
+                                 inf_loop_code_src2,
+                                 sizeof (inf_loop_code_src2) - 1,
                                  JERRY_PARSE_NO_OPTS);
 
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));

--- a/tests/unit-core/test-mem-stats.c
+++ b/tests/unit-core/test-mem-stats.c
@@ -23,17 +23,17 @@ int main (void)
   {
     return 0;
   }
-  const char *test_source = (
-                         "var a = 'hello';"
-                         "var b = 'world';"
-                         "var c = a + ' ' + b;"
-                         );
+  const jerry_char_t test_source[] = TEST_STRING_LITERAL (
+    "var a = 'hello';"
+    "var b = 'world';"
+    "var c = a + ' ' + b;"
+  );
 
   jerry_init (JERRY_INIT_EMPTY);
   jerry_value_t parsed_code_val = jerry_parse (NULL,
                                                0,
-                                               (jerry_char_t *) test_source,
-                                               strlen (test_source),
+                                               test_source,
+                                               sizeof (test_source) - 1,
                                                JERRY_PARSE_NO_OPTS);
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
 

--- a/tests/unit-core/test-objects-foreach.c
+++ b/tests/unit-core/test-objects-foreach.c
@@ -28,7 +28,7 @@ static const jerry_object_native_info_t test_info =
   .free_cb = free_test_data
 };
 
-static const char *strict_equal_source = "var x = function(a, b) {return a === b;}; x";
+static const jerry_char_t strict_equal_source[] = "var x = function(a, b) {return a === b;}; x";
 
 static bool
 find_test_object_by_data (const jerry_value_t candidate,
@@ -72,8 +72,8 @@ main (void)
   /* Render strict-equal as a function. */
   jerry_value_t parse_result = jerry_parse (NULL,
                                             0,
-                                            (jerry_char_t *) strict_equal_source,
-                                            strlen (strict_equal_source),
+                                            strict_equal_source,
+                                            sizeof (strict_equal_source) - 1,
                                             JERRY_PARSE_STRICT_MODE);
   TEST_ASSERT (!jerry_value_is_error (parse_result));
   jerry_value_t strict_equal = jerry_run (parse_result);

--- a/tests/unit-core/test-promise.c
+++ b/tests/unit-core/test-promise.c
@@ -19,22 +19,22 @@
 #include "test-common.h"
 
 
-const char *test_source = (
-                           "var p1 = create_promise1();"
-                           "var p2 = create_promise2();"
-                           "p1.then(function(x) { "
-                           "  assert(x==='resolved'); "
-                           "}); "
-                           "p2.catch(function(x) { "
-                           "  assert(x==='rejected'); "
-                           "}); "
-                           );
+static const jerry_char_t test_source[] = TEST_STRING_LITERAL (
+  "var p1 = create_promise1();"
+  "var p2 = create_promise2();"
+  "p1.then(function(x) { "
+  "  assert(x==='resolved'); "
+  "}); "
+  "p2.catch(function(x) { "
+  "  assert(x==='rejected'); "
+  "}); "
+);
 
 static int count_in_assert = 0;
 static jerry_value_t my_promise1;
 static jerry_value_t my_promise2;
-const jerry_char_t s1[] = "resolved";
-const jerry_char_t s2[] = "rejected";
+static const jerry_char_t s1[] = "resolved";
+static const jerry_char_t s2[] = "rejected";
 
 static jerry_value_t
 create_promise1_handler (const jerry_value_t func_obj_val, /**< function object */
@@ -131,8 +131,8 @@ main (void)
 
   jerry_value_t parsed_code_val = jerry_parse (NULL,
                                                0,
-                                               (jerry_char_t *) test_source,
-                                               strlen (test_source),
+                                               test_source,
+                                               sizeof (test_source) - 1,
                                                JERRY_PARSE_NO_OPTS);
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
 

--- a/tests/unit-core/test-snapshot.c
+++ b/tests/unit-core/test-snapshot.c
@@ -63,17 +63,17 @@ static void test_function_snapshot (void)
   const jerry_init_flag_t flags = JERRY_INIT_EMPTY;
   static uint32_t function_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
 
-  const char *args_p = "a, b";
-  const char *code_to_snapshot_p = "return a + b";
+  const jerry_char_t func_args[] = "a, b";
+  const jerry_char_t code_to_snapshot[] = "return a + b";
 
   jerry_init (flags);
   jerry_value_t generate_result;
   generate_result = jerry_generate_function_snapshot (NULL,
                                                       0,
-                                                      (const jerry_char_t *) code_to_snapshot_p,
-                                                      strlen (code_to_snapshot_p),
-                                                      (jerry_char_t *) args_p,
-                                                      strlen (args_p),
+                                                      code_to_snapshot,
+                                                      sizeof (code_to_snapshot) - 1,
+                                                      func_args,
+                                                      sizeof (func_args) - 1,
                                                       0,
                                                       function_snapshot_buffer,
                                                       SNAPSHOT_BUFFER_SIZE);
@@ -135,20 +135,22 @@ static void test_function_arguments_snapshot (void)
   {
     static uint32_t arguments_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
 
-    const char *code_to_snapshot_p = ("function f(a,b,c) {"
-                                      "  arguments[0]++;"
-                                      "  arguments[1]++;"
-                                      "  arguments[2]++;"
-                                      "  return a + b + c;"
-                                      "}"
-                                      "f(3,4,5);");
+    const jerry_char_t code_to_snapshot[] = TEST_STRING_LITERAL (
+      "function f(a,b,c) {"
+      "  arguments[0]++;"
+      "  arguments[1]++;"
+      "  arguments[2]++;"
+      "  return a + b + c;"
+      "}"
+      "f(3,4,5);"
+    );
     jerry_init (JERRY_INIT_EMPTY);
 
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
-                                               (jerry_char_t *) code_to_snapshot_p,
-                                               strlen (code_to_snapshot_p),
+                                               code_to_snapshot,
+                                               sizeof (code_to_snapshot) - 1,
                                                0,
                                                arguments_snapshot_buffer,
                                                SNAPSHOT_BUFFER_SIZE);
@@ -201,14 +203,14 @@ main (void)
   if (jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_SAVE)
       && jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_EXEC))
   {
-    const char *code_to_snapshot_p = "(function () { return 'string from snapshot'; }) ();";
+    const jerry_char_t code_to_snapshot[] = "(function () { return 'string from snapshot'; }) ();";
 
     jerry_init (JERRY_INIT_EMPTY);
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
-                                               (const jerry_char_t *) code_to_snapshot_p,
-                                               strlen (code_to_snapshot_p),
+                                               code_to_snapshot,
+                                               sizeof (code_to_snapshot) - 1,
                                                0,
                                                snapshot_buffer,
                                                SNAPSHOT_BUFFER_SIZE);
@@ -247,11 +249,13 @@ main (void)
   if (jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_SAVE)
       && jerry_is_feature_enabled (JERRY_FEATURE_SNAPSHOT_EXEC))
   {
-    const char *code_to_snapshot_p = ("function func(a, b, c) {"
-                                      "  c = 'snapshot';"
-                                      "  return arguments[0] + ' ' + b + ' ' + arguments[2];"
-                                      "};"
-                                      "func('string', 'from');");
+    const jerry_char_t code_to_snapshot[] = TEST_STRING_LITERAL (
+      "function func(a, b, c) {"
+      "  c = 'snapshot';"
+      "  return arguments[0] + ' ' + b + ' ' + arguments[2];"
+      "};"
+      "func('string', 'from');"
+    );
 
     jerry_init (JERRY_INIT_EMPTY);
     jerry_register_magic_strings (magic_strings,
@@ -261,8 +265,8 @@ main (void)
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
-                                               (jerry_char_t *) code_to_snapshot_p,
-                                               strlen (code_to_snapshot_p),
+                                               code_to_snapshot,
+                                               sizeof (code_to_snapshot) - 1,
                                                JERRY_SNAPSHOT_SAVE_STATIC,
                                                snapshot_buffer,
                                                SNAPSHOT_BUFFER_SIZE);
@@ -291,14 +295,14 @@ main (void)
     size_t snapshot_sizes[2];
     static uint32_t merged_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
 
-    const char *code_to_snapshot_p = "var a = 'hello'; 123";
+    const jerry_char_t code_to_snapshot1[] = "var a = 'hello'; 123";
 
     jerry_init (JERRY_INIT_EMPTY);
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
-                                               (const jerry_char_t *) code_to_snapshot_p,
-                                               strlen (code_to_snapshot_p),
+                                               code_to_snapshot1,
+                                               sizeof (code_to_snapshot1) - 1,
                                                0,
                                                snapshot_buffer_0,
                                                SNAPSHOT_BUFFER_SIZE);
@@ -310,13 +314,13 @@ main (void)
 
     jerry_cleanup ();
 
-    code_to_snapshot_p = "var b = 'hello'; 456";
+    const jerry_char_t code_to_snapshot2[] = "var b = 'hello'; 456";
 
     jerry_init (JERRY_INIT_EMPTY);
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
-                                               (const jerry_char_t *) code_to_snapshot_p,
-                                               strlen (code_to_snapshot_p),
+                                               code_to_snapshot2,
+                                               sizeof (code_to_snapshot2) - 1,
                                                0,
                                                snapshot_buffer_1,
                                                SNAPSHOT_BUFFER_SIZE);
@@ -377,13 +381,13 @@ main (void)
 
     static jerry_char_t literal_buffer_c[LITERAL_BUFFER_SIZE];
     static uint32_t literal_snapshot_buffer[SNAPSHOT_BUFFER_SIZE];
-    static const char *code_for_c_format_p = "var object = { aa:'fo o', Bb:'max', aaa:'xzy0' };";
+    static const jerry_char_t code_for_c_format[] = "var object = { aa:'fo o', Bb:'max', aaa:'xzy0' };";
 
     jerry_value_t generate_result;
     generate_result = jerry_generate_snapshot (NULL,
                                                0,
-                                               (const jerry_char_t *) code_for_c_format_p,
-                                               strlen (code_for_c_format_p),
+                                               code_for_c_format,
+                                               sizeof (code_for_c_format) - 1,
                                                0,
                                                literal_snapshot_buffer,
                                                SNAPSHOT_BUFFER_SIZE);

--- a/tests/unit-core/test-typedarray.c
+++ b/tests/unit-core/test-typedarray.c
@@ -246,13 +246,14 @@ test_typedarray_complex_creation (test_entry_t test_entries[], /**< test cases *
 
     register_js_value ("array", typedarray);
 
-    const char *eval_src_p = (
+    const jerry_char_t eval_src[] = TEST_STRING_LITERAL (
       "assert (array.length == expected_length,"
       "        'expected length: ' + expected_length + ' got: ' + array.length);"
       "assert (array.byteOffset == expected_offset);"
-      "array[0] = 0x11223344;");
-    jerry_value_t result = jerry_eval ((jerry_char_t *) eval_src_p,
-                                       strlen (eval_src_p),
+      "array[0] = 0x11223344;"
+    );
+    jerry_value_t result = jerry_eval (eval_src,
+                                       sizeof (eval_src) - 1,
                                        JERRY_PARSE_STRICT_MODE);
     TEST_ASSERT (!jerry_value_is_error (result));
     jerry_release_value (result);
@@ -470,15 +471,16 @@ main (void)
     }
 
     /* Check read and to write */
-    const char *eval_src_p = (
+    const jerry_char_t eval_src[] = TEST_STRING_LITERAL (
       "assert (array.length == expected_length, 'expected length: ' + expected_length + ' got: ' + array.length);"
       "for (var i = 0; i < array.length; i++)"
       "{"
       "  assert (array[i] == expected_value);"
       "  array[i] = i;"
-      "};");
-    jerry_value_t result = jerry_eval ((jerry_char_t *) eval_src_p,
-                                       strlen (eval_src_p),
+      "};"
+    );
+    jerry_value_t result = jerry_eval (eval_src,
+                                       sizeof (eval_src) - 1,
                                        JERRY_PARSE_STRICT_MODE);
 
     TEST_ASSERT (!jerry_value_is_error (result));

--- a/tests/unit-ext/test-common.h
+++ b/tests/unit-ext/test-common.h
@@ -35,4 +35,6 @@
     } \
   } while (0)
 
+#define TEST_STRING_LITERAL(x) x
+
 #endif /* !TEST_COMMON_H */

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -17,49 +17,47 @@
  * Unit test for jerry-ext/args.
  */
 
+#include <string.h>
 #include "jerryscript.h"
 #include "jerryscript-ext/arg.h"
 #include "test-common.h"
 
-#include <string.h>
-#include <jerryscript-ext/arg.h>
-
-const char *test_source = (
-                           "var arg1 = true;"
-                           "var arg2 = 10.5;"
-                           "var arg3 = 'abc';"
-                           "var arg4 = function foo() {};"
-                           "test_validator1(arg1, arg2, arg3, arg4);"
-                           "arg1 = new Boolean(true);"
-                           "arg3 = new String('abc');"
-                           "test_validator1(arg1, arg2, arg3);"
-                           "test_validator1(arg1, arg2, '');"
-                           "arg2 = new Number(10.5);"
-                           "test_validator1(arg1, arg2, arg3);"
-                           "test_validator1(arg1, 10.5, 'abcdef');"
-                           "var obj_a = new MyObjectA();"
-                           "var obj_b = new MyObjectB();"
-                           "test_validator2.call(obj_a, 5);"
-                           "test_validator2.call(obj_b, 5);"
-                           "test_validator2.call(obj_a, 1);"
-                           "var obj1 = {prop1:true, prop2:'1.5'};"
-                           "test_validator_prop1(obj1);"
-                           "test_validator_prop2(obj1);"
-                           "test_validator_prop2();"
-                           "var obj2 = {prop1:true};"
-                           "Object.defineProperty(obj2, 'prop2', {"
-                           "  get: function() { throw new TypeError('prop2 error') }"
-                           "});"
-                           "test_validator_prop3(obj2);"
-                           "test_validator_int1(-1000, 1000, 128, -1000, 1000, -127,"
-                           "                    -1000, 4294967297, 65536, -2200000000, 4294967297, -2147483647);"
-                           "test_validator_int2(-1.5, -1.5, -1.5, 1.5, 1.5, 1.5, Infinity, -Infinity, 300.5, 300.5);"
-                           "test_validator_int3(NaN);"
-                           "var arr = [1, 2];"
-                           "test_validator_array1(arr);"
-                           "test_validator_array1();"
-                           "test_validator_array2(arr);"
-                           );
+static const jerry_char_t test_source[] = TEST_STRING_LITERAL (
+  "var arg1 = true;"
+  "var arg2 = 10.5;"
+  "var arg3 = 'abc';"
+  "var arg4 = function foo() {};"
+  "test_validator1(arg1, arg2, arg3, arg4);"
+  "arg1 = new Boolean(true);"
+  "arg3 = new String('abc');"
+  "test_validator1(arg1, arg2, arg3);"
+  "test_validator1(arg1, arg2, '');"
+  "arg2 = new Number(10.5);"
+  "test_validator1(arg1, arg2, arg3);"
+  "test_validator1(arg1, 10.5, 'abcdef');"
+  "var obj_a = new MyObjectA();"
+  "var obj_b = new MyObjectB();"
+  "test_validator2.call(obj_a, 5);"
+  "test_validator2.call(obj_b, 5);"
+  "test_validator2.call(obj_a, 1);"
+  "var obj1 = {prop1:true, prop2:'1.5'};"
+  "test_validator_prop1(obj1);"
+  "test_validator_prop2(obj1);"
+  "test_validator_prop2();"
+  "var obj2 = {prop1:true};"
+  "Object.defineProperty(obj2, 'prop2', {"
+  "  get: function() { throw new TypeError('prop2 error') }"
+  "});"
+  "test_validator_prop3(obj2);"
+  "test_validator_int1(-1000, 1000, 128, -1000, 1000, -127,"
+  "                    -1000, 4294967297, 65536, -2200000000, 4294967297, -2147483647);"
+  "test_validator_int2(-1.5, -1.5, -1.5, 1.5, 1.5, 1.5, Infinity, -Infinity, 300.5, 300.5);"
+  "test_validator_int3(NaN);"
+  "var arr = [1, 2];"
+  "test_validator_array1(arr);"
+  "test_validator_array1();"
+  "test_validator_array2(arr);"
+);
 
 static const jerry_object_native_info_t thing_a_info =
 {
@@ -569,7 +567,7 @@ test_utf8_string (void)
   /* test string: 'str: {DESERET CAPITAL LETTER LONG I}' */
   jerry_value_t str = jerry_create_string ((jerry_char_t *) "\x73\x74\x72\x3a \xed\xa0\x81\xed\xb0\x80");
   char expect_utf8_buf[] = "\x73\x74\x72\x3a \xf0\x90\x90\x80";
-  size_t buf_len = strlen (expect_utf8_buf);
+  size_t buf_len = sizeof (expect_utf8_buf) - 1;
   char buf[buf_len+1];
 
   jerryx_arg_t mapping[] =
@@ -662,8 +660,8 @@ main (void)
 
   jerry_value_t parsed_code_val = jerry_parse (NULL,
                                                0,
-                                               (jerry_char_t *) test_source,
-                                               strlen (test_source),
+                                               test_source,
+                                               sizeof (test_source) - 1,
                                                JERRY_PARSE_NO_OPTS);
   TEST_ASSERT (!jerry_value_is_error (parsed_code_val));
 


### PR DESCRIPTION
Their length (size) is known at compile time. Therefore `sizeof`
is more efficient for them.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu