### PR TITLE
Remove leading space from before `#if`s

### DIFF
--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -33,7 +33,7 @@
  * @{
  */
 
- #ifndef JERRY_SYSTEM_ALLOCATOR
+#ifndef JERRY_SYSTEM_ALLOCATOR
 /**
  * Heap structure
  *

--- a/jerry-port/default/default-debugger.c
+++ b/jerry-port/default/default-debugger.c
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
- #if !defined (_XOPEN_SOURCE) || _XOPEN_SOURCE < 500
- #undef _XOPEN_SOURCE
- /* Required macro for sleep functions (nanosleep or usleep) */
- #define _XOPEN_SOURCE 500
- #endif
+#if !defined (_XOPEN_SOURCE) || _XOPEN_SOURCE < 500
+#undef _XOPEN_SOURCE
+/* Required macro for sleep functions (nanosleep or usleep) */
+#define _XOPEN_SOURCE 500
+#endif
 
 #ifdef HAVE_TIME_H
 #include <time.h>


### PR DESCRIPTION
It is both against coding style and confuses the
`gen-magic-strings.py` build tool.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu