### PR TITLE
Fix check-magic-strings.sh to return with non-zero if error happens

### DIFF
--- a/tools/check-magic-strings.sh
+++ b/tools/check-magic-strings.sh
@@ -20,13 +20,17 @@ MAGIC_STRINGS_TEMP=`mktemp lit-magic-strings.inc.h.XXXXXXXXXX`
 
 cp $MAGIC_STRINGS_INC_H $MAGIC_STRINGS_TEMP
 $MAGIC_STRINGS_GEN
-diff -q $MAGIC_STRINGS_INC_H $MAGIC_STRINGS_TEMP
 DIFF_RESULT=$?
-mv $MAGIC_STRINGS_TEMP $MAGIC_STRINGS_INC_H
 
-if [ $DIFF_RESULT -ne 0 ]
+if [ $DIFF_RESULT -eq 0 ]
 then
-  echo -e "\e[1;33m$MAGIC_STRINGS_INC_H must be re-generated. Run $MAGIC_STRINGS_GEN\e[0m"
+  diff -q $MAGIC_STRINGS_INC_H $MAGIC_STRINGS_TEMP
+  DIFF_RESULT=$?
+  if [ $DIFF_RESULT -ne 0 ]
+  then
+    echo -e "\e[1;33m$MAGIC_STRINGS_INC_H must be re-generated. Run $MAGIC_STRINGS_GEN\e[0m"
+  fi
 fi
+mv $MAGIC_STRINGS_TEMP $MAGIC_STRINGS_INC_H
 
 exit $DIFF_RESULT


### PR DESCRIPTION
Running `tools/run_tests.py --check-magic-string` causes an IndexError,
but the script exits with 0, indicating error-less run.
Added some error checking to the files, and solution for the IndexError.

JerryScript-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu