### PR TITLE
Update regular expressions in gen-magic-strings.py

### DIFF
--- a/tools/gen-magic-strings.py
+++ b/tools/gen-magic-strings.py
@@ -119,10 +119,10 @@ def extract_magic_string_refs(debug=False):
         guard_stack = []
 
         for line in fileinput.input(fname):
-            if_match = re.match('^# *if(.*)', line)
-            elif_match = re.match('^# *elif(.*)', line)
-            else_match = re.match('^# *else', line)
-            endif_match = re.match('^# *endif', line)
+            if_match = re.match('^ *# *if(.*)', line)
+            elif_match = re.match('^ *# *elif(.*)', line)
+            else_match = re.match('^ *# *else', line)
+            endif_match = re.match('^ *# *endif', line)
             if if_match is not None:
                 guard_stack.append([process_guard(if_match.group(1))])
             elif elif_match is not None:


### PR DESCRIPTION
In their past form, they could not recognize preprocessor directives,
if they didn't start on column 0. Updated them to fix this problem.

JerryScript-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu