### PR TITLE
Fix ecma_op_function_list_lazy_property_names in case of arrow function

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1119,7 +1119,19 @@ ecma_op_function_list_lazy_property_names (ecma_object_t *object_p, /**< functio
                                     0);
 
   const ecma_compiled_code_t *bytecode_data_p;
+
+#ifndef CONFIG_DISABLE_ES2015_ARROW_FUNCTION
+  if (ecma_get_object_type (object_p) == ECMA_OBJECT_TYPE_ARROW_FUNCTION)
+  {
+    bytecode_data_p = ecma_op_arrow_function_get_compiled_code ((ecma_arrow_function_t *) object_p);
+  }
+  else
+  {
+    bytecode_data_p = ecma_op_function_get_compiled_code ((ecma_extended_object_t *) object_p);
+  }
+#else /* CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
   bytecode_data_p = ecma_op_function_get_compiled_code ((ecma_extended_object_t *) object_p);
+#endif /* !CONFIG_DISABLE_ES2015_ARROW_FUNCTION */
 
   if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE)
   {

--- a/tests/jerry/es2015/regression-test-issue-2528.js
+++ b/tests/jerry/es2015/regression-test-issue-2528.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+for (/a/ in a => { }, a => { }, a => { }) throw 1


### PR DESCRIPTION
Fixes #2528.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu