### PR TITLE
Fix LCache invalidation issue for native properties during GC.

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -545,7 +545,8 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
         {
           ecma_gc_free_native_pointer (property_p);
         }
-        else if (prop_iter_p->types[i] != ECMA_PROPERTY_TYPE_DELETED)
+
+        if (prop_iter_p->types[i] != ECMA_PROPERTY_TYPE_DELETED)
         {
           ecma_free_property (object_p, name_cp, property_p);
         }

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -764,8 +764,10 @@ ecma_free_property (ecma_object_t *object_p, /**< object the property belongs to
     {
       JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (*property_p) == ECMA_PROPERTY_TYPE_INTERNAL);
 
-      /* Currently no internal property can reach this point. */
-      JERRY_UNREACHABLE ();
+      /* Must be a native pointer. */
+      JERRY_ASSERT (ECMA_PROPERTY_GET_NAME_TYPE (*property_p) == ECMA_DIRECT_STRING_MAGIC
+                    && (name_cp == LIT_INTERNAL_MAGIC_STRING_NATIVE_POINTER));
+      break;
     }
   }
 

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -196,7 +196,8 @@ ecma_lcache_invalidate (ecma_object_t *object_p, /**< object */
   JERRY_ASSERT (object_p != NULL);
   JERRY_ASSERT (prop_p != NULL && ecma_is_property_lcached (prop_p));
   JERRY_ASSERT (ECMA_PROPERTY_GET_TYPE (*prop_p) == ECMA_PROPERTY_TYPE_NAMEDDATA
-                || ECMA_PROPERTY_GET_TYPE (*prop_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
+                || ECMA_PROPERTY_GET_TYPE (*prop_p) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR
+                || ECMA_PROPERTY_GET_TYPE (*prop_p) == ECMA_PROPERTY_TYPE_INTERNAL);
 
   jmem_cpointer_t object_cp;
   ECMA_SET_NON_NULL_POINTER (object_cp, object_p);


### PR DESCRIPTION
Unit test: I think it is too difficult (or too fragile) to create a unit test for this. Basically the requirement is creating an object, free it by gc, and create an object into the exactly same place again. I don't think the allocator can be exploited in this way.