### PR TITLE
Add more `const`s to external magic strings to get data moved from .data to .rodata

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -634,7 +634,7 @@ Registers an external magic string array.
 
 ```c
 void
-jerry_register_magic_strings  (const jerry_char_t **ex_str_items_p,
+jerry_register_magic_strings  (const jerry_char_t * const *ex_str_items_p,
                                uint32_t count,
                                const jerry_length_t *str_lengths_p);
 ```
@@ -657,11 +657,11 @@ main (void)
 
   // must be static, because 'jerry_register_magic_strings' does not copy
   // the items must be sorted by size at first, then lexicographically
-  static const jerry_char_t *magic_string_items[] = {
-                                                      (const jerry_char_t *) "magicstring1",
-                                                      (const jerry_char_t *) "magicstring2",
-                                                      (const jerry_char_t *) "magicstring3"
-                                                    };
+  static const jerry_char_t * const magic_string_items[] = {
+                                                             (const jerry_char_t *) "magicstring1",
+                                                             (const jerry_char_t *) "magicstring2",
+                                                             (const jerry_char_t *) "magicstring3"
+                                                           };
   uint32_t num_magic_string_items = (uint32_t) (sizeof (magic_string_items) / sizeof (jerry_char_t *));
 
   // must be static, because 'jerry_register_magic_strings' does not copy

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -258,14 +258,16 @@ jerry_get_context_data (const jerry_context_data_manager_t *manager_p)
  * Register external magic string array
  */
 void
-jerry_register_magic_strings (const jerry_char_t **ex_str_items_p, /**< character arrays, representing
-                                                                    *   external magic strings' contents */
+jerry_register_magic_strings (const jerry_char_t * const *ex_str_items_p, /**< character arrays, representing
+                                                                           *   external magic strings' contents */
                               uint32_t count, /**< number of the strings */
                               const jerry_length_t *str_lengths_p) /**< lengths of all strings */
 {
   jerry_assert_api_available ();
 
-  lit_magic_strings_ex_set ((const lit_utf8_byte_t **) ex_str_items_p, count, (const lit_utf8_size_t *) str_lengths_p);
+  lit_magic_strings_ex_set ((const lit_utf8_byte_t * const *) ex_str_items_p,
+                            count,
+                            (const lit_utf8_size_t *) str_lengths_p);
 } /* jerry_register_magic_strings */
 
 /**

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -303,7 +303,8 @@ typedef struct jerry_context_t jerry_context_t;
  */
 void jerry_init (jerry_init_flag_t flags);
 void jerry_cleanup (void);
-void jerry_register_magic_strings (const jerry_char_t **ex_str_items_p, uint32_t count,
+void jerry_register_magic_strings (const jerry_char_t * const *ex_str_items_p,
+                                   uint32_t count,
                                    const jerry_length_t *str_lengths_p);
 void jerry_gc (jerry_gc_mode_t mode);
 void *jerry_get_context_data (const jerry_context_data_manager_t *manager_p);

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -94,7 +94,7 @@ struct jerry_context_t
   jmem_pools_chunk_t *jmem_free_16_byte_chunk_p; /**< list of free sixteen byte pool chunks */
 #endif /* JERRY_CPOINTER_32_BIT */
   jmem_free_unused_memory_callback_t jmem_free_unused_memory_callback; /**< Callback for freeing up memory. */
-  const lit_utf8_byte_t **lit_magic_string_ex_array; /**< array of external magic strings */
+  const lit_utf8_byte_t * const *lit_magic_string_ex_array; /**< array of external magic strings */
   const lit_utf8_size_t *lit_magic_string_ex_sizes; /**< external magic string lengths */
   ecma_lit_storage_item_t *string_list_first_p; /**< first item of the literal string list */
   ecma_lit_storage_item_t *number_list_first_p; /**< first item of the literal number list */

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -134,8 +134,8 @@ lit_get_magic_string_ex_size (lit_magic_string_ex_id_t id) /**< external magic s
  * Register external magic strings
  */
 void
-lit_magic_strings_ex_set (const lit_utf8_byte_t **ex_str_items, /**< character arrays, representing
-                                                                 *   external magic strings' contents */
+lit_magic_strings_ex_set (const lit_utf8_byte_t * const *ex_str_items, /**< character arrays, representing
+                                                                        *   external magic strings' contents */
                           uint32_t count,                       /**< number of the strings */
                           const lit_utf8_size_t *ex_str_sizes)  /**< sizes of the strings */
 {

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -58,7 +58,8 @@ lit_utf8_size_t lit_get_magic_string_size (lit_magic_string_id_t id);
 const lit_utf8_byte_t *lit_get_magic_string_ex_utf8 (lit_magic_string_ex_id_t id);
 lit_utf8_size_t lit_get_magic_string_ex_size (lit_magic_string_ex_id_t id);
 
-void lit_magic_strings_ex_set (const lit_utf8_byte_t **ex_str_items, uint32_t count,
+void lit_magic_strings_ex_set (const lit_utf8_byte_t * const *ex_str_items,
+                               uint32_t count,
                                const lit_utf8_size_t *ex_str_sizes);
 
 lit_magic_string_id_t lit_is_utf8_string_magic (const lit_utf8_byte_t *string_p, lit_utf8_size_t string_size);


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com