### PR TITLE
Fix not checking errno after calling recv()

### DIFF
--- a/jerry-ext/debugger/debugger-tcp.c
+++ b/jerry-ext/debugger/debugger-tcp.c
@@ -78,7 +78,7 @@ jerryx_debugger_tcp_send (jerry_debugger_transport_header_t *header_p, /**< tcp 
   {
     ssize_t is_err = recv (tcp_p->tcp_socket, NULL, 0, MSG_PEEK);
 
-    if (is_err == 0)
+    if (is_err == 0 && errno != EWOULDBLOCK)
     {
       int err_val = errno;
       jerry_debugger_transport_close ();


### PR DESCRIPTION
There was an issue not checking if recv() set the error value to EWOULDBLOCK or EAGAIN (both equals 11).
If recv() returns 0 that means the connection was gracefully closed from the other side. However, if you are using non-blocking sockets, and recv() returns 0, but sets the errno to EWOULDBLOCK or EAGAIN it means the socket operation would block.
This patch fixes #2537

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu