### PR TITLE
Change jerry_port interface to allow for a correct implementation of timezones.

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -76,27 +76,37 @@ void jerry_port_log (jerry_log_level_t level, const char *fmt, ...);
 
 ```c
 /**
- * Jerry time zone structure
- */
-typedef struct
-{
-  int offset;                /**< minutes from west */
-  int daylight_saving_time;  /**< daylight saving time (1 - DST applies, 0 - not on DST) */
-} jerry_time_zone_t;
-
-/**
- * Get timezone and daylight saving data
+ * Get local time zone adjustment, in milliseconds, for the given timestamp.
+ * The timestamp can be specified in either UTC or local time, depending on
+ * the value of is_utc. Adding the value returned from this function to
+ * a timestamp in UTC time should result in local time for the current time
+ * zone, and subtracting it from a timestamp in local time should result in
+ * UTC time.
+ *
+ * Ideally, this function should satisfy the stipulations applied to LocalTZA
+ * in section 20.3.1.7 of the ECMAScript version 9.0 spec.
+ *
+ * See Also:
+ *          ECMA-262 v9, 20.3.1.7
  *
  * Note:
  *      This port function is called by jerry-core when
  *      CONFIG_DISABLE_DATE_BUILTIN is _not_ defined. Otherwise this function is
  *      not used.
  *
- * @param[out] tz_p time zone structure to fill.
- * @return true  - if success
- *         false - otherwise
+ * @param unix_ms The unix timestamp we want an offset for, given in
+ *                millisecond precision (could be now, in the future,
+ *                or in the past). As with all unix timestamps, 0 refers to
+ *                1970-01-01, a day is exactly 86 400 000 milliseconds, and
+ *                leap seconds cause the same second to occur twice.
+ * @param is_utc Is the given timestamp in UTC time? If false, it is in local
+ *               time.
+ *
+ * @return milliseconds between local time and UTC for the given timestamp,
+ *         if available
+ *.        0 if not available / we are in UTC.
  */
-bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p);
+double jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc);
 
 /**
  * Get system time
@@ -194,31 +204,26 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
 ## Date
 
 ```c
+#include <time.h>
 #include <sys/time.h>
 #include "jerryscript-port.h"
 
 /**
- * Default implementation of jerry_port_get_time_zone.
+ * Default implementation of jerry_port_get_local_time_zone_adjustment.
  */
-bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
+double jerry_port_get_local_time_zone_adjustment (double unix_ms, /**< ms since unix epoch */
+                                                  bool is_utc)    /**< is the time above in UTC? */
 {
-  struct timeval tv;
-  struct timezone tz;
-
-  /* gettimeofday may not fill tz, so zero-initializing */
-  tz.tz_minuteswest = 0;
-  tz.tz_dsttime = 0;
-
-  if (gettimeofday (&tv, &tz) != 0)
+  struct tm tm;
+  time_t now = (time_t) (unix_ms / 1000);
+  localtime_r (&now, &tm);
+  if (!is_utc)
   {
-    return false;
+    now -= tm.tm_gmtoff;
+    localtime_r (&now, &tm);
   }
-
-  tz_p->offset = tz.tz_minuteswest;
-  tz_p->daylight_saving_time = tz.tz_dsttime > 0 ? 1 : 0;
-
-  return true;
-} /* jerry_port_get_time_zone */
+  return ((double) tm.tm_gmtoff) * 1000;
+} /* jerry_port_get_local_time_zone_adjustment */
 
 /**
  * Default implementation of jerry_port_get_current_time.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -600,7 +600,7 @@ ecma_builtin_date_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< 
 
     if (!BUILTIN_DATE_FUNCTION_IS_UTC (builtin_routine_id))
     {
-      this_num += ecma_date_local_time_zone (this_num);
+      this_num += ecma_date_local_time_zone_adjustment (this_num);
     }
 
     if (builtin_routine_id <= ECMA_DATE_PROTOTYPE_GET_UTC_TIMEZONE_OFFSET)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -100,7 +100,7 @@ ecma_number_t ecma_date_year_from_time (ecma_number_t time);
 ecma_number_t ecma_date_month_from_time (ecma_number_t time);
 ecma_number_t ecma_date_date_from_time (ecma_number_t time);
 ecma_number_t ecma_date_week_day (ecma_number_t time);
-ecma_number_t ecma_date_local_time_zone (ecma_number_t time);
+ecma_number_t ecma_date_local_time_zone_adjustment (ecma_number_t time);
 ecma_number_t ecma_date_utc (ecma_number_t time);
 ecma_number_t ecma_date_hour_from_time (ecma_number_t time);
 ecma_number_t ecma_date_min_from_time (ecma_number_t time);

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -111,27 +111,37 @@ void JERRY_ATTR_FORMAT (printf, 2, 3) jerry_port_log (jerry_log_level_t level, c
  */
 
 /**
- * Jerry time zone structure
- */
-typedef struct
-{
-  int offset;                /**< minutes from west */
-  int daylight_saving_time;  /**< daylight saving time (1 - DST applies, 0 - not on DST) */
-} jerry_time_zone_t;
-
-/**
- * Get timezone and daylight saving data
+ * Get local time zone adjustment, in milliseconds, for the given timestamp.
+ * The timestamp can be specified in either UTC or local time, depending on
+ * the value of is_utc. Adding the value returned from this function to
+ * a timestamp in UTC time should result in local time for the current time
+ * zone, and subtracting it from a timestamp in local time should result in
+ * UTC time.
+ *
+ * Ideally, this function should satisfy the stipulations applied to LocalTZA
+ * in section 20.3.1.7 of the ECMAScript version 9.0 spec.
+ *
+ * See Also:
+ *          ECMA-262 v9, 20.3.1.7
  *
  * Note:
  *      This port function is called by jerry-core when
  *      CONFIG_DISABLE_DATE_BUILTIN is _not_ defined. Otherwise this function is
  *      not used.
  *
- * @param[out] tz_p time zone structure to fill.
- * @return true  - if success
- *         false - otherwise
+ * @param unix_ms The unix timestamp we want an offset for, given in
+ *                millisecond precision (could be now, in the future,
+ *                or in the past). As with all unix timestamps, 0 refers to
+ *                1970-01-01, a day is exactly 86 400 000 milliseconds, and
+ *                leap seconds cause the same second to occur twice.
+ * @param is_utc Is the given timestamp in UTC time? If false, it is in local
+ *               time.
+ *
+ * @return milliseconds between local time and UTC for the given timestamp,
+ *         if available
+ *.        0 if not available / we are in UTC.
  */
-bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p);
+double jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc);
 
 /**
  * Get system time

--- a/jerry-port/default/CMakeLists.txt
+++ b/jerry-port/default/CMakeLists.txt
@@ -26,6 +26,19 @@ file(GLOB SOURCE_PORT_DEFAULT *.c)
 # (should only be necessary if we used compiler default libc but not checking that)
 set(DEFINES_PORT_DEFAULT _BSD_SOURCE _DEFAULT_SOURCE)
 
+INCLUDE (CheckStructHasMember)
+# CHECK_STRUCT_HAS_MEMBER works by trying to compile some C code that accesses the
+# given field of the given struct. However, our default compiler options break this
+# C code, so turn a couple of them off for this.
+set(CMAKE_REQUIRED_FLAGS "-Wno-error=strict-prototypes -Wno-error=old-style-definition")
+# tm.tm_gmtoff is non-standard, so glibc doesn't expose it in c99 mode
+# (our default). Define some macros to expose it anyway.
+set(CMAKE_REQUIRED_DEFINITIONS "-D_BSD_SOURCE -D_DEFAULT_SOURCE")
+CHECK_STRUCT_HAS_MEMBER ("struct tm" tm_gmtoff time.h HAVE_TM_GMTOFF)
+if(HAVE_TM_GMTOFF)
+  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_TM_GMTOFF)
+endif()
+
 # Sleep function availability check
 INCLUDE (CheckIncludeFiles)
 CHECK_INCLUDE_FILES (time.h HAVE_TIME_H)

--- a/targets/curie_bsp/source/curie-bsp-port.c
+++ b/targets/curie_bsp/source/curie-bsp-port.c
@@ -52,16 +52,13 @@ void jerry_port_fatal (jerry_fatal_code_t code)
 } /* jerry_port_fatal */
 
 /**
- * Curie BSP implementation of jerry_port_get_time_zone.
+ * Curie BSP implementation of jerry_port_get_local_time_zone_adjustment.
  */
-bool jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
+double jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc)
 {
   //EMPTY implementation
-  tz_p->offset = 0;
-  tz_p->daylight_saving_time = 0;
-
-  return true;
-} /* jerry_port_get_time_zone */
+  return 0;
+} /* jerry_port_get_local_time_zone_adjustment */
 
 /**
  * Curie BSP implementation of jerry_port_get_current_time.

--- a/targets/esp8266/user/jerry_port.c
+++ b/targets/esp8266/user/jerry_port.c
@@ -61,16 +61,13 @@ jerry_port_get_current_time (void)
 } /* jerry_port_get_current_time */
 
 /**
- * Dummy function to get the time zone.
+ * Dummy function to get the time zone adjustment.
  *
- * @return true
+ * @return 0
  */
-bool
-jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
+double
+jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc)
 {
   /* We live in UTC. */
-  tz_p->offset = 0;
-  tz_p->daylight_saving_time = 0;
-
-  return true;
-} /* jerry_port_get_time_zone */
+  return 0;
+} /* jerry_port_get_local_time_zone_adjustment */

--- a/targets/mbedos5/source/jerry_port_mbed.c
+++ b/targets/mbedos5/source/jerry_port_mbed.c
@@ -46,17 +46,15 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
 #endif /* JSMBED_OVERRIDE_JERRY_PORT_LOG */
 
 /**
- * Implementation of jerry_port_get_time_zone.
+ * Implementation of jerry_port_get_local_time_zone_adjustment.
  *
- * @return true - if success
+ * @return 0, as we live in UTC.
  */
-bool
-jerry_port_get_time_zone (jerry_time_zone_t *tz_p) /**< timezone pointer */
+double
+jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc)
 {
-  tz_p->offset = 0;
-  tz_p->daylight_saving_time = 0;
-  return true;
-} /* jerry_port_get_time_zone */
+  return 0;
+} /* jerry_port_get_local_time_zone_adjustment */
 
 /**
  * Implementation of jerry_port_get_current_time.

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -492,19 +492,16 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
 } /* jerry_port_log */
 
 /**
- * Dummy function to get the time zone.
+ * Dummy function to get the time zone adjustment.
  *
- * @return true
+ * @return 0
  */
-bool
-jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
+double
+jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc)
 {
   /* We live in UTC. */
-  tz_p->offset = 0;
-  tz_p->daylight_saving_time = 0;
-
-  return true;
-} /* jerry_port_get_time_zone */
+  return 0;
+} /* jerry_port_get_local_time_zone_adjustment */
 
 /**
  * Dummy function to get the current time.

--- a/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
+++ b/targets/tizenrt-artik053/apps/jerryscript/jerry_main.c
@@ -474,19 +474,16 @@ jerry_port_log (jerry_log_level_t level, /**< log level */
 } /* jerry_port_log */
 
 /**
- * Dummy function to get the time zone.
+ * Dummy function to get the time zone adjustment.
  *
- * @return true
+ * @return 0
  */
-bool
-jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
+double
+jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc)
 {
   /* We live in UTC. */
-  tz_p->offset = 0;
-  tz_p->daylight_saving_time = 0;
-
-  return true;
-} /* jerry_port_get_time_zone */
+  return 0;
+} /* jerry_port_get_local_time_zone_adjustment */
 
 /**
  * Dummy function to get the current time.

--- a/targets/zephyr/src/jerry-port.c
+++ b/targets/zephyr/src/jerry-port.c
@@ -59,19 +59,16 @@ jerry_port_get_current_time (void)
 } /* jerry_port_get_current_time */
 
 /**
- * Dummy function to get the time zone.
+ * Dummy function to get the time zone adjustment.
  *
- * @return true
+ * @return 0
  */
-bool
-jerry_port_get_time_zone (jerry_time_zone_t *tz_p)
+double
+jerry_port_get_local_time_zone_adjustment (double unix_ms, bool is_utc)
 {
   /* We live in UTC. */
-  tz_p->offset = 0;
-  tz_p->daylight_saving_time = 0;
-
-  return true;
-} /* jerry_port_get_time_zone */
+  return 0;
+} /* jerry_port_get_local_time_zone_adjustment */
 
 /**
  * Provide the implementation of jerryx_port_handler_print_char.

--- a/tests/jerry/date-getters.js
+++ b/tests/jerry/date-getters.js
@@ -24,8 +24,7 @@ assert (d.getUTCDate() == 9);
 assert (d.getDay() == 4);
 assert (d.getUTCDay() == 4);
 assert (d.getHours() == 12);
-// FIXME: Missing timezone adjustment.
-//assert (d.getUTCHours() == (12 + d.getTimezoneOffset() / 60));
+assert (d.getUTCHours() == (12 + d.getTimezoneOffset() / 60));
 assert (d.getMinutes() == 13);
 assert (d.getUTCMinutes() == 13);
 assert (d.getSeconds() == 14);
@@ -44,9 +43,8 @@ assert (d.getDate() == 9);
 assert (d.getUTCDate() == 9);
 assert (d.getDay() == 4);
 assert (d.getUTCDay() == 4);
-// FIXME: Missing timezone adjustment.
-//assert (d.getHours() == 12);
-//assert (d.getUTCHours() == (12 + d.getTimezoneOffset() / 60));
+assert (d.getHours() == Math.floor(12 - 1.5 + d.getTimezoneOffset() / 60));
+assert (d.getUTCHours() == Math.floor(12 - 1.5));
 assert (d.getMinutes() == 43);
 assert (d.getUTCMinutes() == 43);
 assert (d.getSeconds() == 14);
@@ -65,8 +63,7 @@ assert (d.getDate() == 1);
 assert (d.getUTCDate() == 1);
 assert (d.getDay() == 4);
 assert (d.getUTCDay() == 4);
-// FIXME: Missing timezone adjustment.
-// assert (d.getHours() == 0 - (d.getTimezoneOffset() / 60));
+assert (d.getHours() == 0 - (d.getTimezoneOffset() / 60));
 assert (d.getUTCHours() == 0);
 assert (d.getMinutes() == 0);
 assert (d.getUTCMinutes() == 0);

--- a/tests/jerry/date-setters.js
+++ b/tests/jerry/date-setters.js
@@ -82,25 +82,24 @@ assert (d.getUTCSeconds() == 1);
 assert (d.getUTCMilliseconds() == 1);
 
 /* 15.9.5.34 Date.prototype.setHours (hour [, min [, sec [, ms ] ] ] ) */
-// FIXME: Missing timezone adjustment.
-//d.setTime(0);
-//assert (d.setHours(1) == hour + d.getTimezoneOffset() * 60000);
-//assert (d.getHours() == 1);
-//d.setTime(0);
-//assert (d.setHours(1, 1) == hour + min + d.getTimezoneOffset() * 60000);
-//assert (d.getHours() == 1);
-//assert (d.getMinutes() == 1);
-//d.setTime(0);
-//assert (d.setHours(1, 1, 1) == hour + min + sec + d.getTimezoneOffset() * 60000);
-//assert (d.getHours() == 1);
-//assert (d.getMinutes() == 1);
-//assert (d.getSeconds() == 1);
-//d.setTime(0);
-//assert (d.setHours(1, 1, 1, 1) == hour + min + sec + ms + d.getTimezoneOffset() * 60000);
-//assert (d.getHours() == 1);
-//assert (d.getMinutes() == 1);
-//assert (d.getSeconds() == 1);
-//assert (d.getMilliseconds() == 1);
+d.setTime(0);
+assert (d.setHours(1) == hour + d.getTimezoneOffset() * 60000);
+assert (d.getHours() == 1);
+d.setTime(0);
+assert (d.setHours(1, 1) == hour + min + d.getTimezoneOffset() * 60000);
+assert (d.getHours() == 1);
+assert (d.getMinutes() == 1);
+d.setTime(0);
+assert (d.setHours(1, 1, 1) == hour + min + sec + d.getTimezoneOffset() * 60000);
+assert (d.getHours() == 1);
+assert (d.getMinutes() == 1);
+assert (d.getSeconds() == 1);
+d.setTime(0);
+assert (d.setHours(1, 1, 1, 1) == hour + min + sec + ms + d.getTimezoneOffset() * 60000);
+assert (d.getHours() == 1);
+assert (d.getMinutes() == 1);
+assert (d.getSeconds() == 1);
+assert (d.getMilliseconds() == 1);
 
 /* 15.9.5.35 Date.prototype.setUTCHours (hour [, min [, sec [, ms ] ] ] ) */
 d.setTime(0);

--- a/tools/runners/run-test-suite-test262.sh
+++ b/tools/runners/run-test-suite-test262.sh
@@ -52,15 +52,8 @@ fi
 rm -rf "${PATH_TO_TEST262}/test/suite/bestPractice"
 rm -rf "${PATH_TO_TEST262}/test/suite/intl402"
 
-# TODO: Enable these tests after daylight saving calculation is fixed.
-rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T1.js"
-rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T2.js"
-rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T3.js"
-rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T4.js"
-rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T5.js"
-rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T6.js"
+echo "Starting test262 testing for ${ENGINE}. Running test262 may take several minutes."
 
-echo "Starting test262 testing for ${ENGINE}. Running test262 may take a several minutes."
 
 function progress_monitor() {
   NUM_LINES_GOTTEN=0
@@ -85,7 +78,7 @@ python2 "${PATH_TO_TEST262}"/tools/packaging/test262.py --command "${COMMAND}" \
 TEST262_EXIT_CODE=$?
 if [ $TEST262_EXIT_CODE -ne 0 ]
 then
-  echo -e "\nFailed to run test2626\n"
+  echo -e "\nFailed to run test262\n"
   echo "$0: see ${REPORT_PATH} for details about failures"
   exit $TEST262_EXIT_CODE
 fi


### PR DESCRIPTION
The previous jerry_port interface did not allow timezones to be handled correctly,
even if the host system was up to the task. This PR changes the jerry_port interface
to allow a completely correct implementation to exist, and provides one (for Linux/BSD
systems) in default-date.c.

There is some additional background in my comment on the original issue https://github.com/jerryscript-project/jerryscript/issues/1661#issuecomment-420782958, but essentially, this solution resolves the original ticket by allowing the jerry_port interface to from the time-invariant 
```c
jerry_port_get_time_zone(utc_offset_out*, is_dst_out*)
```
to the time-dependent
```c
jerry_port_get_local_tza(time, is_utc)
```
As dst state and timezone rules in general change over time, it's necessary to give the time as an argument to correctly determine the local time offset at that time.

This interface also allows the platform to figure out the local time adjustment for a given date in whichever way it pleases. On most Linux / BSD systems, the `tm_gmtoff` field of `struct tm` can be used. On windows, `GetTimeZoneInformationForYear` can be used. On most embedded platforms, UTC can always be assumed, or some other local timezone.

The alternative is to have jerryscript link in some external timezone library, with all of the logic for handling timezones. However, I can't see any big advantage to this approach, and the libraries are often quite large. Most systems that run JerryScript simply don't need the complexity (they can just run UTC), and the ones that do need the complexity probably already have some other system which will be fairly easy to just link into the provided jerry_port interface (Linux and Windows are both quite easy, about 10 lines, to hook into this interface).

Fixes #1661

JerryScript-DCO-1.0-Signed-off-by: crazy2be crazy1be@gmail.com