### PR TITLE
Rework op_construct.

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2213,6 +2213,7 @@ jerry_invoke_function (bool is_invoke_as_constructor, /**< true - invoke functio
     JERRY_ASSERT (jerry_value_is_constructor (func_obj_val));
 
     return jerry_return (ecma_op_function_construct (ecma_get_object_from_value (func_obj_val),
+                                                     ECMA_VALUE_UNDEFINED,
                                                      args_p,
                                                      args_count));
   }

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -59,8 +59,8 @@ ecma_op_function_call (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
                        const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 
 ecma_value_t
-ecma_op_function_construct (ecma_object_t *func_obj_p, const ecma_value_t *arguments_list_p,
-                            ecma_length_t arguments_list_len);
+ecma_op_function_construct (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
+                            const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 
 ecma_property_t *
 ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -494,6 +494,7 @@ opfunc_construct (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
     ecma_object_t *constructor_obj_p = ecma_get_object_from_value (constructor_value);
 
     completion_value = ecma_op_function_construct (constructor_obj_p,
+                                                   ECMA_VALUE_UNDEFINED,
                                                    stack_top_p,
                                                    arguments_list_len);
   }


### PR DESCRIPTION
The new form should be more suitable for ES5 class implementation. No binary / perf / mem change.