### PR TITLE
Remove the JERRY_SNAPSHOT_FOUR_BYTE_CPOINTER snapshot flag.

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -42,9 +42,6 @@ snapshot_get_global_flags (bool has_regex, /**< regex literal is present */
 
   uint32_t flags = 0;
 
-#ifdef JERRY_CPOINTER_32_BIT
-  flags |= JERRY_SNAPSHOT_FOUR_BYTE_CPOINTER;
-#endif /* JERRY_CPOINTER_32_BIT */
 #ifndef CONFIG_DISABLE_REGEXP_BUILTIN
   flags |= (has_regex ? JERRY_SNAPSHOT_HAS_REGEX_LITERAL : 0);
 #endif /* !CONFIG_DISABLE_REGEXP_BUILTIN */

--- a/jerry-core/api/jerry-snapshot.h
+++ b/jerry-core/api/jerry-snapshot.h
@@ -52,7 +52,7 @@ typedef enum
   JERRY_SNAPSHOT_HAS_REGEX_LITERAL = (1u << 0), /**< byte code has regex literal */
   JERRY_SNAPSHOT_HAS_CLASS_LITERAL = (1u << 1), /**< byte code has class literal */
   /* 24 bits are reserved for compile time features */
-  JERRY_SNAPSHOT_FOUR_BYTE_CPOINTER = (1u << 8) /**< compressed pointers are four byte long */
+  JERRY_SNAPSHOT_FOUR_BYTE_CPOINTER = (1u << 8) /**< deprecated, an unused placeholder now */
 } jerry_snapshot_global_flags_t;
 
 #endif /* !JERRY_SNAPSHOT_H */


### PR DESCRIPTION
Removed the `JERRY_SNAPSHOT_FOUR_BYTE_CPOINTER` flag because that is not necessary. Also updated the snapshot version. 