### PR TITLE
Ensure that tests are always executed in a proper time zone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ matrix:
     - env:
         - JOBNAME="Conformance Tests"
         - OPTS="--test262"
-        - TZ=America/Los_Angeles
 
     - env:
         - JOBNAME="ASAN Tests"


### PR DESCRIPTION
The America/Los_Angeles time zone is already enforced for Travis CI
jobs but that doesn't guarantee the correctness of locally executed
tests. So, this patch moves the setting of the `TZ` environment
variable from `.travis.yml` to `run-tests.py`.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu