### PR TITLE
Move version numbers to public headers

### DIFF
--- a/jerry-core/api/jerry-snapshot.h
+++ b/jerry-core/api/jerry-snapshot.h
@@ -39,11 +39,6 @@ typedef struct
 #define JERRY_SNAPSHOT_MAGIC (0x5952524Au)
 
 /**
- * Jerry snapshot format version.
- */
-#define JERRY_SNAPSHOT_VERSION (18u)
-
-/**
  * Snapshot configuration flags.
  */
 typedef enum

--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -24,11 +24,6 @@
 /* JerryScript debugger protocol is a simplified version of RFC-6455 (WebSockets). */
 
 /**
- * JerryScript debugger protocol version.
- */
-#define JERRY_DEBUGGER_VERSION (6)
-
-/**
  * Frequency of calling jerry_debugger_receive() by the VM.
  */
 #define JERRY_DEBUGGER_MESSAGE_FREQUENCY 5

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -29,6 +29,11 @@ extern "C"
  */
 
 /**
+ * JerryScript debugger protocol version.
+ */
+#define JERRY_DEBUGGER_VERSION (6)
+
+/**
  * Types for the client source wait and run method.
  */
 typedef enum

--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -28,6 +28,11 @@ extern "C"
  */
 
 /**
+ * Jerry snapshot format version.
+ */
+#define JERRY_SNAPSHOT_VERSION (18u)
+
+/**
  * Flags for jerry_generate_snapshot and jerry_generate_function_snapshot.
  */
 typedef enum


### PR DESCRIPTION
JERRY_SNAPSHOT_VERSION and JERRY_DEBUGGER_VERSION were moved into public headers, to grant access to them.

JerryScript-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu