### PR TITLE
List scope chain levels and their variables to the selected stack frame.

### DIFF
--- a/jerry-core/debugger/debugger.h
+++ b/jerry-core/debugger/debugger.h
@@ -152,7 +152,10 @@ typedef enum
   JERRY_DEBUGGER_WAIT_FOR_SOURCE = 25, /**< engine waiting for source code */
   JERRY_DEBUGGER_OUTPUT_RESULT = 26, /**< output sent by the program to the debugger */
   JERRY_DEBUGGER_OUTPUT_RESULT_END = 27, /**< last output result data */
-
+  JERRY_DEBUGGER_SCOPE_CHAIN = 28, /**< scope chain */
+  JERRY_DEBUGGER_SCOPE_CHAIN_END = 29, /**< last output of scope chain */
+  JERRY_DEBUGGER_SCOPE_VARIABLES = 30, /**< scope variables */
+  JERRY_DEBUGGER_SCOPE_VARIABLES_END = 31, /**< last output of scope variables */
   JERRY_DEBUGGER_MESSAGES_OUT_MAX_COUNT, /**< number of different type of output messages by the debugger */
 
   /* Messages sent by the client to server. */
@@ -182,7 +185,8 @@ typedef enum
   JERRY_DEBUGGER_GET_BACKTRACE = 16, /**< get backtrace */
   JERRY_DEBUGGER_EVAL = 17, /**< first message of evaluating a string */
   JERRY_DEBUGGER_EVAL_PART = 18, /**< next message of evaluating a string */
-
+  JERRY_DEBUGGER_GET_SCOPE_CHAIN = 19, /**< get type names of the scope chain */
+  JERRY_DEBUGGER_GET_SCOPE_VARIABLES = 20, /**< get variables of a scope */
   JERRY_DEBUGGER_MESSAGES_IN_MAX_COUNT, /**< number of different type of input messages */
 } jerry_debugger_header_type_t;
 
@@ -228,6 +232,34 @@ typedef enum
   JERRY_DEBUGGER_OUTPUT_DEBUG = 4, /**< output result, debug */
   JERRY_DEBUGGER_OUTPUT_TRACE = 5, /**< output result, trace */
 } jerry_debugger_output_subtype_t;
+
+/**
+ * Types of scopes.
+ */
+typedef enum
+{
+  JERRY_DEBUGGER_SCOPE_WITH = 1, /**< with */
+  JERRY_DEBUGGER_SCOPE_LOCAL = 2, /**< local */
+  JERRY_DEBUGGER_SCOPE_CLOSURE = 3, /**< closure */
+  JERRY_DEBUGGER_SCOPE_GLOBAL = 4, /**< global */
+  JERRY_DEBUGGER_SCOPE_NON_CLOSURE = 5 /**< non closure */
+} jerry_debugger_scope_chain_type_t;
+
+/**
+ * Type of scope variables.
+ */
+typedef enum
+{
+  JERRY_DEBUGGER_VALUE_NONE = 1,
+  JERRY_DEBUGGER_VALUE_UNDEFINED = 2,
+  JERRY_DEBUGGER_VALUE_NULL = 3,
+  JERRY_DEBUGGER_VALUE_BOOLEAN = 4,
+  JERRY_DEBUGGER_VALUE_NUMBER = 5,
+  JERRY_DEBUGGER_VALUE_STRING = 6,
+  JERRY_DEBUGGER_VALUE_FUNCTION = 7,
+  JERRY_DEBUGGER_VALUE_ARRAY = 8,
+  JERRY_DEBUGGER_VALUE_OBJECT = 9
+} jerry_debugger_scope_variable_type_t;
 
 /**
  * Byte data for evaluating expressions and receiving client source.
@@ -365,6 +397,15 @@ typedef struct
 } jerry_debugger_send_backtrace_t;
 
 /**
+ * Outgoing message: scope chain.
+ */
+typedef struct
+{
+  uint8_t type; /**< type of the message */
+  uint8_t scope_types[]; /**< scope types */
+} jerry_debugger_send_scope_chain_t;
+
+/**
  * Outgoing message: number of total frames in backtrace.
  */
 typedef struct
@@ -410,6 +451,15 @@ typedef struct
   uint8_t type; /**< type of the message */
   uint8_t eval_size[sizeof (uint32_t)]; /**< total size of the message */
 } jerry_debugger_receive_eval_first_t;
+
+/**
+ * Incoming message: get scope variables
+*/
+typedef struct
+{
+  uint8_t type; /**< type of the message */
+  uint8_t chain_index[sizeof (uint32_t)]; /**< index element of the scope */
+} jerry_debugger_receive_get_scope_variables_t;
 
 /**
  * Incoming message: first message of client source.

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -701,6 +701,13 @@ typedef enum
 #define ECMA_OBJECT_FLAG_EXTENSIBLE 0x20
 
 /**
+ * Non closure flag for debugger.
+ */
+#ifdef JERRY_DEBUGGER
+#define ECMA_OBJECT_FLAG_NON_CLOSURE 0x20
+#endif /* JERRY_DEBUGGER */
+
+/**
  * Value for increasing or decreasing the object reference counter.
  */
 #define ECMA_OBJECT_REF_ONE (1u << 6)
@@ -719,7 +726,7 @@ typedef struct
   /** type : 4 bit : ecma_object_type_t or ecma_lexical_environment_type_t
                      depending on ECMA_OBJECT_FLAG_BUILT_IN_OR_LEXICAL_ENV
       flags : 2 bit : ECMA_OBJECT_FLAG_BUILT_IN_OR_LEXICAL_ENV,
-                      ECMA_OBJECT_FLAG_EXTENSIBLE
+                      ECMA_OBJECT_FLAG_EXTENSIBLE or ECMA_OBJECT_FLAG_NON_CLOSURE
       refs : 10 bit (max 1023) */
   uint16_t type_flags_refs;
 

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -31,7 +31,7 @@ extern "C"
 /**
  * JerryScript debugger protocol version.
  */
-#define JERRY_DEBUGGER_VERSION (6)
+#define JERRY_DEBUGGER_VERSION (7)
 
 /**
  * Types for the client source wait and run method.

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -3315,6 +3315,9 @@ error:
           }
 
           ecma_object_t *catch_env_p = ecma_create_decl_lex_env (frame_ctx_p->lex_env_p);
+#ifdef JERRY_DEBUGGER
+          catch_env_p->type_flags_refs |= (uint16_t) ECMA_OBJECT_FLAG_NON_CLOSURE;
+#endif /* JERRY_DEBUGGER */
 
           ecma_string_t *catch_name_p = ecma_get_string_from_value (literal_start_p[literal_index]);
           ecma_op_create_mutable_binding (catch_env_p, catch_name_p, false);

--- a/jerry-debugger/jerry_client.py
+++ b/jerry-debugger/jerry_client.py
@@ -118,6 +118,11 @@ class DebuggerPrompt(Cmd):
         self.stop = True
     do_bt = do_backtrace
 
+    def do_variables(self, args):
+        """ Get scope variables from debugger """
+        write(self.debugger.scope_variables(args))
+        self.stop = True
+
     def do_src(self, args):
         """ Get current source code """
         if args:
@@ -171,6 +176,11 @@ class DebuggerPrompt(Cmd):
         self.debugger.memstats()
         self.stop = True
     do_ms = do_memstats
+
+    def do_scopes(self, _):
+        """ Memory statistics """
+        self.debugger.scope_chain()
+        self.stop = True
 
     def do_abort(self, args):
         """ Throw an exception """

--- a/tests/debugger/do_help.expected
+++ b/tests/debugger/do_help.expected
@@ -4,9 +4,9 @@ Stopped at tests/debugger/do_help.js:15
 
 Documented commands (type help <topic>):
 ========================================
-abort      bt        display  exception  list      next     s       step 
-b          c         dump     f          memstats  quit     scroll  throw
-backtrace  continue  e        finish     ms        res      source
-break      delete    eval     help       n         restart  src   
+abort      bt        display  exception  list      next     s       src      
+b          c         dump     f          memstats  quit     scopes  step     
+backtrace  continue  e        finish     ms        res      scroll  throw    
+break      delete    eval     help       n         restart  source  variables
 
 (jerry-debugger) quit

--- a/tests/debugger/do_scopes.cmd
+++ b/tests/debugger/do_scopes.cmd
@@ -1,0 +1,19 @@
+scopes
+b do_scopes.js:22
+c
+scopes
+c
+scopes
+b do_scopes.js:28
+c
+scopes
+b do_scopes.js:31
+c
+scopes
+b do_scopes.js:33
+c
+scopes
+b do_scopes.js:35
+c
+scopes
+c

--- a/tests/debugger/do_scopes.expected
+++ b/tests/debugger/do_scopes.expected
@@ -1,0 +1,63 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_scopes.js:15
+(jerry-debugger) scopes
+level | type   
+0     | global 
+(jerry-debugger) b do_scopes.js:22
+Breakpoint 1 at tests/debugger/do_scopes.js:22 (in f() at line:17, col:1)
+(jerry-debugger) c
+Exception throw detected (to disable automatic stop type exception 0)
+Exception hint: error
+Stopped at tests/debugger/do_scopes.js:19 (in f() at line:17, col:1)
+(jerry-debugger) scopes
+level | type   
+0     | local  
+1     | global 
+(jerry-debugger) c
+Stopped at breakpoint:1 tests/debugger/do_scopes.js:22 (in f() at line:17, col:1)
+(jerry-debugger) scopes
+level | type   
+0     | catch  
+1     | local  
+2     | global 
+(jerry-debugger) b do_scopes.js:28
+Breakpoint 2 at tests/debugger/do_scopes.js:28 (in function() at line:27, col:4)
+(jerry-debugger) c
+Stopped at breakpoint:2 tests/debugger/do_scopes.js:28 (in function() at line:27, col:4)
+(jerry-debugger) scopes
+level | type    
+0     | local   
+1     | closure 
+2     | global  
+(jerry-debugger) b do_scopes.js:31
+Breakpoint 3 at tests/debugger/do_scopes.js:31 (in function() at line:27, col:4)
+(jerry-debugger) c
+Stopped at breakpoint:3 tests/debugger/do_scopes.js:31 (in function() at line:27, col:4)
+(jerry-debugger) scopes
+level | type    
+0     | with    
+1     | local   
+2     | closure 
+3     | global  
+(jerry-debugger) b do_scopes.js:33
+Breakpoint 4 at tests/debugger/do_scopes.js:33 (in function() at line:27, col:4)
+(jerry-debugger) c
+Stopped at breakpoint:4 tests/debugger/do_scopes.js:33 (in function() at line:27, col:4)
+(jerry-debugger) scopes
+level | type    
+0     | with    
+1     | with    
+2     | local   
+3     | closure 
+4     | global  
+(jerry-debugger) b do_scopes.js:35
+Breakpoint 5 at tests/debugger/do_scopes.js:35 (in function() at line:27, col:4)
+(jerry-debugger) c
+Stopped at breakpoint:5 tests/debugger/do_scopes.js:35 (in function() at line:27, col:4)
+(jerry-debugger) scopes
+level | type    
+0     | with    
+1     | local   
+2     | closure 
+3     | global  
+(jerry-debugger) c

--- a/tests/debugger/do_scopes.js
+++ b/tests/debugger/do_scopes.js
@@ -1,0 +1,41 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var c = 4;
+
+function f() {
+  try {
+    throw "error";
+  }
+  catch (err) {
+    var c = 10;
+  }
+
+  var z = true;
+  var g = 0;
+  (function() {
+    var a = [1,2,3]
+    a.y = "abc";
+    with (a) {
+      var h = [4,5,6]
+      with (h) {
+        h.d = "dfg"
+      }
+      a.d = g + c;
+    }
+  })();
+}
+
+f();
+

--- a/tests/debugger/do_variables.cmd
+++ b/tests/debugger/do_variables.cmd
@@ -1,0 +1,28 @@
+scopes
+variables
+variables 1
+variables 0
+b tests/debugger/do_variables.js:20
+c
+scopes
+variables 0
+variables 1
+variables 2
+b tests/debugger/do_variables.js:30
+c
+scopes
+variables 1
+variables 0
+b tests/debugger/do_variables.js:33
+c
+c
+scopes
+variables 0
+variables 1
+b tests/debugger/do_variables.js:50
+c
+scopes
+variables 0
+variables 1
+variables 2
+c

--- a/tests/debugger/do_variables.expected
+++ b/tests/debugger/do_variables.expected
@@ -1,0 +1,128 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_variables.js:15
+(jerry-debugger) scopes
+level | type   
+0     | global 
+(jerry-debugger) variables
+name   | type      | value     
+f      | Function  |           
+addX   | Function  |           
+z      | undefined | undefined 
+c      | undefined | undefined 
+print  | Function  |           
+gc     | Function  |           
+assert | Function  |           
+(jerry-debugger) variables 1
+name | type | value 
+(jerry-debugger) variables 0
+name   | type      | value     
+f      | Function  |           
+addX   | Function  |           
+z      | undefined | undefined 
+c      | undefined | undefined 
+print  | Function  |           
+gc     | Function  |           
+assert | Function  |           
+(jerry-debugger) b tests/debugger/do_variables.js:20
+Breakpoint 1 at tests/debugger/do_variables.js:20 (in function() at line:19, col:10)
+(jerry-debugger) c
+Stopped at breakpoint:1 tests/debugger/do_variables.js:20 (in function() at line:19, col:10)
+(jerry-debugger) scopes
+level | type    
+0     | local   
+1     | closure 
+2     | global  
+(jerry-debugger) variables 0
+name | type      | value     
+n    | Number    | 9         
+b    | undefined | undefined 
+(jerry-debugger) variables 1
+name | type   | value 
+x    | Number | 3     
+(jerry-debugger) variables 2
+name     | type     | value 
+addThree | Function |       
+f        | Function |       
+addX     | Function |       
+z        | Number   | 5     
+c        | Number   | 4     
+print    | Function |       
+gc       | Function |       
+assert   | Function |       
+(jerry-debugger) b tests/debugger/do_variables.js:30
+Breakpoint 2 at tests/debugger/do_variables.js:30 (in f() at line:28, col:1)
+(jerry-debugger) c
+Stopped at breakpoint:2 tests/debugger/do_variables.js:30 (in f() at line:28, col:1)
+(jerry-debugger) scopes
+level | type   
+0     | local  
+1     | global 
+(jerry-debugger) variables 1
+name     | type     | value 
+d        | Number   | 12    
+addThree | Function |       
+f        | Function |       
+addX     | Function |       
+z        | Number   | 5     
+c        | Number   | 4     
+print    | Function |       
+gc       | Function |       
+assert   | Function |       
+(jerry-debugger) variables 0
+name | type      | value     
+b    | undefined | undefined 
+x    | undefined | undefined 
+user | undefined | undefined 
+m    | undefined | undefined 
+c    | undefined | undefined 
+(jerry-debugger) b tests/debugger/do_variables.js:33
+Breakpoint 3 at tests/debugger/do_variables.js:33 (in f() at line:28, col:1)
+(jerry-debugger) c
+Exception throw detected (to disable automatic stop type exception 0)
+Exception hint: error
+Stopped at breakpoint:2 tests/debugger/do_variables.js:30 (in f() at line:28, col:1)
+(jerry-debugger) c
+Stopped at breakpoint:3 tests/debugger/do_variables.js:33 (in f() at line:28, col:1)
+(jerry-debugger) scopes
+level | type   
+0     | catch  
+1     | local  
+2     | global 
+(jerry-debugger) variables 0
+name | type   | value 
+err  | String | error 
+(jerry-debugger) variables 1
+name | type      | value     
+b    | undefined | undefined 
+x    | undefined | undefined 
+user | undefined | undefined 
+m    | undefined | undefined 
+c    | undefined | undefined 
+(jerry-debugger) b tests/debugger/do_variables.js:50
+Breakpoint 4 at tests/debugger/do_variables.js:50 (in function() at line:46, col:4)
+(jerry-debugger) c
+Stopped at breakpoint:4 tests/debugger/do_variables.js:50 (in function() at line:46, col:4)
+(jerry-debugger) scopes
+level | type    
+0     | with    
+1     | local   
+2     | closure 
+3     | global  
+(jerry-debugger) variables 0
+name | type   | value 
+y    | String | abc   
+2    | Number | 3     
+1    | Number | 2     
+0    | Number | 1     
+(jerry-debugger) variables 1
+name | type      | value     
+h    | undefined | undefined 
+a    | Array     | [1,2,3]   
+(jerry-debugger) variables 2
+name | type    | value                    
+b    | Number  | 10                       
+x    | Boolean | true                     
+user | Object  | {"name":"John","age":30} 
+m    | Null    | null                     
+c    | Number  | 10                       
+(jerry-debugger) c

--- a/tests/debugger/do_variables.js
+++ b/tests/debugger/do_variables.js
@@ -1,0 +1,60 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var c = 4;
+var z = 5;
+
+function addX(x) {
+  return function(n) {
+    var b = 2;
+    return n + x;
+  }
+}
+
+addThree = addX(3);
+d = addThree(c+z);
+
+function f() {
+  try {
+    throw "error";
+  }
+  catch (err) {
+    var c = 10;
+  }
+
+  var m = null;
+
+  var user = {
+    name: "John",
+    age: 30
+  };
+
+  var x = true;
+  var b = 10;
+
+  (function() {
+    var a = [1,2,3]
+    a.y = "abc";
+    with (a) {
+      var h = [4,5,6]
+      with (h) {
+        h.d = "dfg"
+      }
+      a.d = x;
+    }
+  })();
+}
+
+f();
+


### PR DESCRIPTION
It supports to list the scope chain of the current execution context and see which variables are available.

Please note that this is not a complete list, virtual properties are not included. I plan to expand them in a follow-up patch.

An example run should look like this:

test.js
```javascript

1 var c = 4;
2 var z = 5;
3 
4 function addX(x) {
5  return function(n) {
6     var b = 2;
7     return n + x;
8   }
9 }
10 addThree = addX(3);
11 d = addThree(c+z);
12 
13 function f() {
14   var x = true;
15   var g = 0;
16   (function() {
17     var a = [1,2,3]
18     a.y = "abc";
20     with (a) {
21       var h = [4,5,6]
22       with (h) {
23         h.d = "dfg"
24       }
25       a.d = x + g;
26     }
27   })();
28 }
29 
30 f();
```

```bash
$ ./build/bin/jerry --start-debug-server test.js
```
```bash
$ ./jerry-debugger/jerry_client.py
```

```bash
Connecting to: localhost:5001
Stopped at test.js:1
(jerry-debugger) b test.js:21
Breakpoint 1 at test.js:21 (in function() at line:16, col:4)
(jerry-debugger) c
Press enter to stop JavaScript execution.
Stopped at breakpoint:1 test.js:21 (in function() at line:16, col:4)
(jerry-debugger) scopes
level | type    
0     | with    
1     | local   
2     | closure 
3     | global  
(jerry-debugger) variables 0
name | type   | value 
y    | String | abc   
2    | Number | 3     
1    | Number | 2     
0    | Number | 1     
(jerry-debugger) variables 1
name | type  | value   
h    | Array | [4,5,6] 
a    | Array | [1,2,3] 
(jerry-debugger) variables 2
name | type    | value 
g    | Number  | 0     
x    | Boolean | true  
(jerry-debugger) variables 3
name     | type     | value                        
d        | Number   | 12                           
addThree | Function | function(){/* ecmascript */} 
f        | Function | function(){/* ecmascript */} 
addX     | Function | function(){/* ecmascript */} 
z        | Number   | 5                            
c        | Number   | 4                            
print    | Function | function(){/* ecmascript */} 
gc       | Function | function(){/* ecmascript */} 
assert   | Function | function(){/* ecmascript */} 
(jerry-debugger)
```

