### PR TITLE
Add some progress printing to the test262 tests

### DIFF
--- a/tools/runners/run-test-suite-test262.sh
+++ b/tools/runners/run-test-suite-test262.sh
@@ -62,9 +62,26 @@ rm -f "${PATH_TO_TEST262}/test/suite/ch15/15.9/15.9.3/S15.9.3.1_A5_T6.js"
 
 echo "Starting test262 testing for ${ENGINE}. Running test262 may take a several minutes."
 
+function progress_monitor() {
+  NUM_LINES_GOTTEN=0
+  (>&2 echo)
+  while read line
+  do
+    if [[ $((NUM_LINES_GOTTEN % 100)) == 0 ]]
+    then
+      (>&2 echo -ne "\rExecuted approx ${NUM_LINES_GOTTEN} tests...")
+    fi
+    echo "$line"
+    NUM_LINES_GOTTEN=$((NUM_LINES_GOTTEN + 1))
+  done
+  (>&2 echo)
+  (>&2 echo)
+}
+
 python2 "${PATH_TO_TEST262}"/tools/packaging/test262.py --command "${COMMAND}" \
                                                         --tests="${PATH_TO_TEST262}" --summary \
-                                                        &> "${REPORT_PATH}"
+                                                        | progress_monitor > "${REPORT_PATH}"
+
 TEST262_EXIT_CODE=$?
 if [ $TEST262_EXIT_CODE -ne 0 ]
 then


### PR DESCRIPTION
Previously, these would run for several minutes without printing
any progress. Now, at least print the number of tests executed.