### PR TITLE
Calculate string hashes only when needed

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -583,6 +583,7 @@ ecma_find_named_property (ecma_object_t *obj_p, /**< object to find property in 
   ecma_property_t *property_p = NULL;
 
 #ifndef CONFIG_ECMA_LCACHE_DISABLE
+  ecma_string_calc_hash_maybe (name_p);
   property_p = ecma_lcache_lookup (obj_p, name_p);
   if (property_p != NULL)
   {

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -201,6 +201,7 @@ ecma_string_t *ecma_new_ecma_string_from_uint32 (uint32_t uint32_number);
 ecma_string_t *ecma_get_ecma_string_from_uint32 (uint32_t uint32_number);
 ecma_string_t *ecma_new_ecma_string_from_number (ecma_number_t num);
 ecma_string_t *ecma_get_magic_string (lit_magic_string_id_t id);
+void ecma_string_calc_hash_maybe (ecma_string_t *string_p);
 ecma_string_t *ecma_append_chars_to_string (ecma_string_t *string1_p,
                                             const lit_utf8_byte_t *cesu8_string2_p,
                                             lit_utf8_size_t cesu8_string2_size,
@@ -244,11 +245,11 @@ ecma_string_t *ecma_string_from_property_name (ecma_property_t property, jmem_cp
 lit_string_hash_t ecma_string_get_property_name_hash (ecma_property_t property, jmem_cpointer_t prop_name_cp);
 uint32_t ecma_string_get_property_index (ecma_property_t property, jmem_cpointer_t prop_name_cp);
 bool ecma_string_compare_to_property_name (ecma_property_t property, jmem_cpointer_t prop_name_cp,
-                                           const ecma_string_t *string_p);
+                                           ecma_string_t *string_p);
 
-bool ecma_compare_ecma_strings (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
-bool ecma_compare_ecma_non_direct_strings (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
-bool ecma_compare_ecma_strings_relational (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
+bool ecma_compare_ecma_strings (ecma_string_t *string1_p, ecma_string_t *string2_p);
+bool ecma_compare_ecma_non_direct_strings (ecma_string_t *string1_p, ecma_string_t *string2_p);
+bool ecma_compare_ecma_strings_relational (ecma_string_t *string1_p, ecma_string_t *string2_p);
 ecma_length_t ecma_string_get_length (const ecma_string_t *string_p);
 ecma_length_t ecma_string_get_utf8_length (const ecma_string_t *string_p);
 lit_utf8_size_t ecma_string_get_size (const ecma_string_t *string_p);

--- a/jerry-core/ecma/operations/ecma-map-object.c
+++ b/jerry-core/ecma/operations/ecma-map-object.c
@@ -124,7 +124,7 @@ ecma_builtin_map_search (jmem_cpointer_t first_chunk_cp, /**< first chunk */
                                                                 first_chunk_cp);
 
   bool is_direct = true;
-  const ecma_string_t *key_str_p = NULL;
+  ecma_string_t *key_str_p = NULL;
   ecma_number_t key_float = 0;
 
   if (ecma_is_value_non_direct_string (key))
@@ -471,7 +471,7 @@ ecma_op_map_delete (ecma_value_t this_arg, /**< this argument */
                                                                 map_object_p->first_chunk_cp);
 
   bool is_direct = true;
-  const ecma_string_t *key_str_p = NULL;
+  ecma_string_t *key_str_p = NULL;
   ecma_number_t key_float = 0;
 
   if (ecma_is_value_non_direct_string (key_arg))


### PR DESCRIPTION
It is not necessary to calculate the hash values for non-direct
strings on every operation. This patch aims to improve performance
by delaying the hash computations until the value is actually
required. This patch was done in cooperation with Tamás Kéri.

JerryScript-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu