### PR TITLE
Fix type conversion errors in case of TizenRT.

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -666,7 +666,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       const ecma_compiled_code_t *bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
 
 #ifndef CONFIG_DISABLE_ES2015_CLASS
-      bool is_class_constructor = bytecode_data_p->status_flags & CBC_CODE_FLAGS_CONSTRUCTOR;
+      bool is_class_constructor = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_CONSTRUCTOR) ? true : false;
 
       if (is_class_constructor && !ecma_op_function_has_construct_flag (arguments_list_p))
       {

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -418,7 +418,7 @@ parser_parse_class_literal (parser_context_t *context_p) /**< context */
       JERRY_ASSERT (context_p->last_cbc_opcode == CBC_PUSH_LITERAL);
 
       cbc_ext_opcode_t opcode;
-      bool is_static = (status_flags & PARSER_CLASS_STATIC_FUNCTION);
+      bool is_static = (status_flags & PARSER_CLASS_STATIC_FUNCTION) ? true : false;
 
       if (is_computed)
       {
@@ -1281,7 +1281,7 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
           break;
         }
 
-        bool is_static = context_p->status_flags & PARSER_CLASS_STATIC_FUNCTION;
+        bool is_static = (context_p->status_flags & PARSER_CLASS_STATIC_FUNCTION) ? true : false;
         parser_emit_cbc_ext (context_p, is_static ? CBC_EXT_PUSH_STATIC_SUPER : CBC_EXT_PUSH_SUPER);
         break;
       }

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -2055,7 +2055,7 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 
         bool return_with_literal = (context_p->last_cbc_opcode == CBC_PUSH_LITERAL);
 #ifndef CONFIG_DISABLE_ES2015_CLASS
-        return_with_literal &= !PARSER_IS_CLASS_CONSTRUCTOR_SUPER (context_p->status_flags);
+        return_with_literal = return_with_literal && !PARSER_IS_CLASS_CONSTRUCTOR_SUPER (context_p->status_flags);
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
 
         if (return_with_literal)


### PR DESCRIPTION
There are some conversion errors when building JerryScript for TizenRT. This patch fixes that.