### PR TITLE
Add test generator

### DIFF
--- a/tests/jerry/generators/generate-octal.py
+++ b/tests/jerry/generators/generate-octal.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+
+file = open("tests/jerry/octal.js", "w")
+
+random.seed(532566)
+
+for i in range(1000):
+	N = random.randint(-99999999999, 99999999999)
+	file.write("assert (" + str(N) + " === " + str(oct(N)) + ");\n")
+	file.write("assert (" + str(N) + " !== " + str(oct(N + 1)) + ");\n")
+	file.write("assert (" + str(N) + " !== " + str(oct(N - 1)) + ");\n")
+	file.write("assert (typeof " + str(N) + " === 'number');\n")
+	file.write("assert (typeof " + str(oct(N - 1)) + " === 'number');\n\n")
+
+
+file.write("assert (Number.MAX_VALUE != Number.MIN_VALUE);\n")
+
+file.close()

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -156,6 +156,8 @@ def get_arguments():
                         help='Add a comma separated list of patterns of the excluded JS-tests')
     parser.add_argument('--outdir', metavar='DIR', default=OUTPUT_DIR,
                         help='Specify output directory (default: %(default)s)')
+    parser.add_argument('--generate-tests', action='store_true',
+                        help='Generate tests')
     parser.add_argument('--check-signed-off', metavar='TYPE', nargs='?',
                         choices=['strict', 'tolerant', 'travis'], const='strict',
                         help='Run signed-off check (%(choices)s; default type if not given: %(const)s)')
@@ -281,6 +283,11 @@ def iterate_test_runner_jobs(jobs, options):
         test_cmd = [settings.TEST_RUNNER_SCRIPT, bin_path]
 
         yield job, ret_build, test_cmd
+
+def generate_tests(options):
+    for filename in os.listdir("./tests/jerry/generators/"):
+        if filename.endswith(".py"):
+            execfile("./tests/jerry/generators/" + str(filename))
 
 def run_check(runnable, env=None):
     report_command('Test command:', runnable, env=env)
@@ -423,6 +430,7 @@ Check = collections.namedtuple('Check', ['enabled', 'runner', 'arg'])
 
 def main(options):
     checks = [
+        Check(options.generate_tests, generate_tests, options),
         Check(options.check_signed_off, run_check, [settings.SIGNED_OFF_SCRIPT]
               + {'tolerant': ['--tolerant'], 'travis': ['--travis']}.get(options.check_signed_off, [])),
         Check(options.check_cppcheck, run_check, [settings.CPPCHECK_SCRIPT]),


### PR DESCRIPTION
Added test generator which test octal numbers
Added --generate-tests option to run-tests.py, what runs generators
from /tests/jerry/generators folder.

JerryScript-DCO-1.0-Signed-off-by: Csaba Repasi repasics@inf.u-szeged.hu