### PR TITLE
Improve the evaluate requests

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -80,10 +80,18 @@ typedef enum
   ECMA_TYPE___MAX = ECMA_TYPE_ERROR /** highest value for ecma types */
 } ecma_type_t;
 
+#ifdef JERRY_DEBUGGER
+/**
+ * Shift for scope chain index part in ecma_parse_opts
+ */
+#define ECMA_PARSE_CHAIN_INDEX_SHIFT 16
+#endif
+
 /**
  * Option flags for script parsing.
  * Note:
  *      The enum members must be kept in sync with parser_general_flags_t
+ *      The last 16 bits are reserved for scope chain index
  */
 typedef enum
 {

--- a/jerry-core/include/jerryscript-debugger.h
+++ b/jerry-core/include/jerryscript-debugger.h
@@ -31,7 +31,7 @@ extern "C"
 /**
  * JerryScript debugger protocol version.
  */
-#define JERRY_DEBUGGER_VERSION (7)
+#define JERRY_DEBUGGER_VERSION (8)
 
 /**
  * Types for the client source wait and run method.

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -252,6 +252,26 @@ vm_run_eval (ecma_compiled_code_t *bytecode_data_p, /**< byte-code data */
   {
     this_binding = ecma_copy_value (JERRY_CONTEXT (vm_top_context_p)->this_binding);
     lex_env_p = JERRY_CONTEXT (vm_top_context_p)->lex_env_p;
+
+#ifdef JERRY_DEBUGGER
+    uint32_t chain_index = parse_opts >> ECMA_PARSE_CHAIN_INDEX_SHIFT;
+
+    while (chain_index != 0)
+    {
+      lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
+
+      if (JERRY_UNLIKELY (lex_env_p == NULL))
+      {
+        return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid scope chain index for eval"));
+      }
+
+      if ((ecma_get_lex_env_type (lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND)
+          || (ecma_get_lex_env_type (lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_DECLARATIVE))
+      {
+        chain_index--;
+      }
+    }
+#endif
   }
   else
   {

--- a/jerry-debugger/jerry_client.py
+++ b/jerry-debugger/jerry_client.py
@@ -171,6 +171,29 @@ class DebuggerPrompt(Cmd):
         self.stop = True
     do_e = do_eval
 
+    def do_eval_at(self, args):
+        """ Evaluate JavaScript source code at a scope chain level """
+
+        code = ''
+        index = 0
+        try:
+            args = args.split(" ", 1)
+
+            index = int(args[0])
+
+            if len(args) == 2:
+                code = args[1]
+
+            if index < 0 or index > 65535:
+                raise ValueError("Invalid scope chain index: %d (must be between 0 and 65535)" % index)
+
+        except ValueError as val_errno:
+            print("Error: %s" % (val_errno))
+            return
+
+        self.debugger.eval_at(code, index)
+        self.stop = True
+
     def do_memstats(self, _):
         """ Memory statistics """
         self.debugger.memstats()

--- a/tests/debugger/do_eval_at.cmd
+++ b/tests/debugger/do_eval_at.cmd
@@ -1,0 +1,20 @@
+eval_at 0
+eval_at 0 b
+n
+eval_at 0 b
+b do_eval_at.js:20
+n
+scopes
+eval_at 0 b
+eval_at 1 b
+eval_at 0 b=20
+eval_at 1 b=100
+n
+eval_at 0 a
+scopes
+eval_at 0 b
+eval_at -1 b
+eval_at 65536 b
+eval_at b
+eval_at 200
+c

--- a/tests/debugger/do_eval_at.expected
+++ b/tests/debugger/do_eval_at.expected
@@ -1,0 +1,44 @@
+Connecting to: localhost:5001
+Stopped at tests/debugger/do_eval_at.js:15
+(jerry-debugger) eval_at 0
+undefined
+(jerry-debugger) eval_at 0 b
+undefined
+(jerry-debugger) n
+Stopped at tests/debugger/do_eval_at.js:23
+(jerry-debugger) eval_at 0 b
+2
+(jerry-debugger) b do_eval_at.js:20
+Breakpoint 1 at tests/debugger/do_eval_at.js:20 (in f() at line:17, col:1)
+(jerry-debugger) n
+Stopped at breakpoint:1 tests/debugger/do_eval_at.js:20 (in f() at line:17, col:1)
+(jerry-debugger) scopes
+level | type   
+0     | local  
+1     | global 
+(jerry-debugger) eval_at 0 b
+6
+(jerry-debugger) eval_at 1 b
+2
+(jerry-debugger) eval_at 0 b=20
+20
+(jerry-debugger) eval_at 1 b=100
+100
+(jerry-debugger) n
+Stopped at tests/debugger/do_eval_at.js:25
+(jerry-debugger) eval_at 0 a
+23
+(jerry-debugger) scopes
+level | type   
+0     | global 
+(jerry-debugger) eval_at 0 b
+100
+(jerry-debugger) eval_at -1 b
+Error: Invalid scope chain index: -1 (must be between 0 and 65535)
+(jerry-debugger) eval_at 65536 b
+Error: Invalid scope chain index: 65536 (must be between 0 and 65535)
+(jerry-debugger) eval_at b
+Error: invalid literal for int() with base 10: 'b'
+(jerry-debugger) eval_at 200
+Uncaught exception: Error
+(jerry-debugger) c

--- a/tests/debugger/do_eval_at.js
+++ b/tests/debugger/do_eval_at.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var b = 2;
+
+function f(a)
+{
+  var b = 6;
+  return a + b;
+}
+
+var a = f(3);
+
+null;

--- a/tests/debugger/do_help.expected
+++ b/tests/debugger/do_help.expected
@@ -4,9 +4,10 @@ Stopped at tests/debugger/do_help.js:15
 
 Documented commands (type help <topic>):
 ========================================
-abort      bt        display  exception  list      next     s       src      
-b          c         dump     f          memstats  quit     scopes  step     
-backtrace  continue  e        finish     ms        res      scroll  throw    
-break      delete    eval     help       n         restart  source  variables
+abort      c         e          finish    n        s       step     
+b          continue  eval       help      next     scopes  throw    
+backtrace  delete    eval_at    list      quit     scroll  variables
+break      display   exception  memstats  res      source
+bt         dump      f          ms        restart  src   
 
 (jerry-debugger) quit


### PR DESCRIPTION
Currently it evaluates the given expression in the context of the top most stack frame.
The expression should access to any variables and arguments that are in the scope chain.
Implement the eval_at request with the level of the scope chain as a further argument.
