### PR TITLE
Reduce ecma_builtin_helper_def_prop arguments

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -876,10 +876,8 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t this_arg, /**< 'this' ar
       ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                             to_idx_str_p,
                                                             get_value,
-                                                            true, /* Writable */
-                                                            true, /* Enumerable */
-                                                            true, /* Configurable */
-                                                            false);
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                            false); /* Failure handling */
       JERRY_ASSERT (ecma_is_value_true (put_comp));
 
       ecma_deref_ecma_string (to_idx_str_p);
@@ -1297,10 +1295,8 @@ ecma_builtin_array_prototype_object_splice (ecma_value_t this_arg, /**< this arg
       ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                             idx_str_new_p,
                                                             get_value,
-                                                            true, /* Writable */
-                                                            true, /* Enumerable */
-                                                            true, /* Configurable */
-                                                            false);
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                            false); /* Failure handling */
       JERRY_ASSERT (ecma_is_value_true (put_comp));
 
       ecma_deref_ecma_string (idx_str_new_p);
@@ -2052,10 +2048,8 @@ ecma_builtin_array_prototype_object_map (ecma_value_t this_arg, /**< this argume
         ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                               index_str_p,
                                                               mapped_value,
-                                                              true, /* Writable */
-                                                              true, /* Enumerable */
-                                                              true, /* Configurable */
-                                                              false);
+                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                              false); /* Failure handling */
         JERRY_ASSERT (ecma_is_value_true (put_comp));
 
         ECMA_FINALIZE (mapped_value);
@@ -2181,10 +2175,8 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t this_arg, /**< this arg
           ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                                 to_index_string_p,
                                                                 get_value,
-                                                                true, /* Writable */
-                                                                true, /* Enumerable */
-                                                                true, /* Configurable */
-                                                                false);
+                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                                false); /* Failure handling */
           JERRY_ASSERT (ecma_is_value_true (put_comp));
 
           ecma_deref_ecma_string (to_index_string_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -211,9 +211,7 @@ ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /**< object */
     ecma_value_t completion = ecma_builtin_helper_def_prop (new_array_p,
                                                             index_string_p,
                                                             *ecma_value_p,
-                                                            true, /* Writable */
-                                                            true, /* Enumerable */
-                                                            true, /* Configurable */
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                                             false); /* Failure handling */
 
     JERRY_ASSERT (ecma_is_value_true (completion));
@@ -360,10 +358,8 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
         ecma_value_t put_comp = ecma_builtin_helper_def_prop (obj_p,
                                                               new_array_index_string_p,
                                                               get_value,
-                                                              true, /* Writable */
-                                                              true, /* Enumerable */
-                                                              true, /* Configurable */
-                                                              false); /* Failure handling */
+                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                              false);  /* Failure handling */
 
         JERRY_ASSERT (ecma_is_value_true (put_comp));
         ecma_deref_ecma_string (new_array_index_string_p);
@@ -388,10 +384,8 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
     ecma_value_t put_comp = ecma_builtin_helper_def_prop (obj_p,
                                                           new_array_index_string_p,
                                                           value,
-                                                          true, /* Writable */
-                                                          true, /* Enumerable */
-                                                          true, /* Configurable */
-                                                          false); /* Failure handling */
+                                                          ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                          false);  /* Failure handling */
 
     JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -660,9 +654,7 @@ ecma_value_t
 ecma_builtin_helper_def_prop (ecma_object_t *obj_p, /**< object */
                               ecma_string_t *index_p, /**< index string */
                               ecma_value_t value, /**< value */
-                              bool writable, /**< writable */
-                              bool enumerable, /**< enumerable */
-                              bool configurable, /**< configurable */
+                              uint32_t opts, /**< any combination of ecma_property_flag_t bits */
                               bool is_throw) /**< is_throw */
 {
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
@@ -671,13 +663,13 @@ ecma_builtin_helper_def_prop (ecma_object_t *obj_p, /**< object */
   prop_desc.value = value;
 
   prop_desc.is_writable_defined = true;
-  prop_desc.is_writable = ECMA_BOOL_TO_BITFIELD (writable);
+  prop_desc.is_writable = (opts & ECMA_PROPERTY_FLAG_WRITABLE) != 0;
 
   prop_desc.is_enumerable_defined = true;
-  prop_desc.is_enumerable = ECMA_BOOL_TO_BITFIELD (enumerable);
+  prop_desc.is_enumerable = (opts & ECMA_PROPERTY_FLAG_ENUMERABLE) != 0;
 
   prop_desc.is_configurable_defined = true;
-  prop_desc.is_configurable = ECMA_BOOL_TO_BITFIELD (configurable);
+  prop_desc.is_configurable = (opts & ECMA_PROPERTY_FLAG_CONFIGURABLE) != 0;
 
   return ecma_op_object_define_own_property (obj_p,
                                              index_p,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -46,7 +46,7 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, ecma_strin
                                        ecma_length_t start_pos, ecma_length_t *ret_index_p);
 ecma_value_t
 ecma_builtin_helper_def_prop (ecma_object_t *obj_p, ecma_string_t *index_p, ecma_value_t value,
-                              bool writable, bool enumerable, bool configurable, bool is_throw);
+                              uint32_t opts, bool is_throw);
 
 #ifndef CONFIG_DISABLE_DATE_BUILTIN
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -543,9 +543,7 @@ ecma_builtin_json_define_value_property (ecma_object_t *obj_p, /**< this object 
   ecma_value_t completion_value = ecma_builtin_helper_def_prop (obj_p,
                                                                 property_name_p,
                                                                 value,
-                                                                true, /* Writable */
-                                                                true, /* Enumerable */
-                                                                true, /* Configurable */
+                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                                                 false); /* Failure handling */
 
   JERRY_ASSERT (ecma_is_value_boolean (completion_value));
@@ -685,9 +683,7 @@ ecma_builtin_json_parse_value (ecma_json_token_t *token_p) /**< token argument *
         ecma_value_t completion = ecma_builtin_helper_def_prop (array_p,
                                                                 index_str_p,
                                                                 value,
-                                                                true, /* Writable */
-                                                                true, /* Enumerable */
-                                                                true, /* Configurable */
+                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                                                 false); /* Failure handling */
 
         JERRY_ASSERT (ecma_is_value_true (completion));

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -540,9 +540,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_arg, /**< this arg
             ecma_value_t completion = ecma_builtin_helper_def_prop (new_array_obj_p,
                                                                     current_index_str_p,
                                                                     match_string_value,
-                                                                    true, /* Writable */
-                                                                    true, /* Enumerable */
-                                                                    true, /* Configurable */
+                                                                    ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                                                     false); /* Failure handling */
 
             JERRY_ASSERT (ecma_is_value_true (completion));
@@ -1472,10 +1470,8 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
       ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                             zero_str_p,
                                                             this_to_string_val,
-                                                            true,
-                                                            true,
-                                                            true,
-                                                            false);
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                            false); /* Failure handling */
 
       JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -1550,10 +1546,8 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
           ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                                 zero_str_p,
                                                                 this_to_string_val,
-                                                                true,
-                                                                true,
-                                                                true,
-                                                                false);
+                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                                false); /* Failure handling */
 
           JERRY_ASSERT (ecma_is_value_true (put_comp));
           ecma_deref_ecma_string (zero_str_p);
@@ -1642,10 +1636,9 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
               ecma_value_t put_comp = ecma_builtin_helper_def_prop (match_obj_p,
                                                                     zero_str_p,
                                                                     ecma_make_string_value (separator_str_p),
-                                                                    true,
-                                                                    true,
-                                                                    true,
-                                                                    true);
+                                                                    ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                                    true); /* Failure handling */
+
               JERRY_ASSERT (ecma_is_value_true (put_comp));
 
               index_prop_value_p = ecma_create_named_data_property (match_obj_p,
@@ -1689,10 +1682,8 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
             ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                                   array_length_str_p,
                                                                   ecma_make_string_value (substr_str_p),
-                                                                  true,
-                                                                  true,
-                                                                  true,
-                                                                  false);
+                                                                  ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                                  false); /* Failure handling */
 
             JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -1736,10 +1727,8 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
               put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                        new_array_idx_str_p,
                                                        match_comp_value,
-                                                       true,
-                                                       true,
-                                                       true,
-                                                       false);
+                                                       ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                       false); /* Failure handling */
 
               JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -1784,10 +1773,8 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_arg, /**< this arg
           ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                                 array_length_string_p,
                                                                 ecma_make_string_value (substr_str_p),
-                                                                true,
-                                                                true,
-                                                                true,
-                                                                false);
+                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                                                false); /* Failure handling */
 
           JERRY_ASSERT (ecma_is_value_true (put_comp));
 

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -121,9 +121,7 @@ ecma_op_create_array_object (const ecma_value_t *arguments_list_p, /**< list of 
     ecma_builtin_helper_def_prop (object_p,
                                   item_name_string_p,
                                   array_items_p[index],
-                                  true, /* Writable */
-                                  true, /* Enumerable */
-                                  true, /* Configurable */
+                                  ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                   false); /* Failure handling */
 
     ecma_deref_ecma_string (item_name_string_p);

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -157,9 +157,8 @@ ecma_op_create_mutable_binding (ecma_object_t *lex_env_p, /**< lexical environme
     completion = ecma_builtin_helper_def_prop (binding_obj_p,
                                                name_p,
                                                ECMA_VALUE_UNDEFINED,
-                                               true, /* Writable */
-                                               true, /* Enumerable */
-                                               is_deletable, /* Configurable */
+                                               is_deletable ? ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE
+                                                            : ECMA_PROPERTY_ENUMERABLE_WRITABLE,
                                                true); /* Failure handling */
 
     if (ECMA_IS_VALUE_ERROR (completion))

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -947,10 +947,8 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
           return ecma_builtin_helper_def_prop (object_p,
                                                property_name_p,
                                                value,
-                                               true, /* Writable */
-                                               true, /* Enumerable */
-                                               true, /* Configurable */
-                                               is_throw); /* Failure handling */
+                                               ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
+                                               true); /* Failure handling */
         }
       }
 

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1159,18 +1159,14 @@ re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
   ecma_builtin_helper_def_prop (array_obj_p,
                                 ecma_get_magic_string (LIT_MAGIC_STRING_INDEX),
                                 ecma_make_int32_value (index),
-                                true, /* Writable */
-                                true, /* Enumerable */
-                                true, /* Configurable */
+                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                 true); /* Failure handling */
 
   /* Set input property of the result array */
   ecma_builtin_helper_def_prop (array_obj_p,
                                 ecma_get_magic_string (LIT_MAGIC_STRING_INPUT),
                                 ecma_make_string_value (input_str_p),
-                                true, /* Writable */
-                                true, /* Enumerable */
-                                true, /* Configurable */
+                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                 true); /* Failure handling */
 
   /* Set length property of the result array */


### PR DESCRIPTION
This patch uses the ECMA_PROPERTY_CONFIGURABLE[_ENUMERABLE_[WRITABLE]] marco to pass the options instead of using 3 boolean arguments for it.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu