### PR TITLE
Added missing include for debugger build.

### DIFF
--- a/jerry-ext/debugger/debugger-tcp.c
+++ b/jerry-ext/debugger/debugger-tcp.c
@@ -23,6 +23,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/socket.h>
 
 /**
  * Implementation of transport over tcp/ip.


### PR DESCRIPTION
In certain platforms the explicit include of 'sys/socket.h' is needed,
e.g.: TizenRT.

JerryScript-DCO-1.0-Signed-off-by: László Langó llango.u-szeged@partner.samsung.com