### PR TITLE
Temporarily disable class Array/%TypedArray%.prototype.{slice, map, concat, filter, splice} related tests

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -154,41 +154,12 @@ ecma_op_create_array_object_by_constructor (const ecma_value_t *arguments_list_p
                                             ecma_object_t *object_p) /**< The object from whom the new array object
                                                                       *   is being created */
 {
-  ecma_value_t constructor_value = ecma_op_object_get_by_magic_id (object_p, LIT_MAGIC_STRING_CONSTRUCTOR);
+  /* TODO: Use @@species after Symbol has been implemented */
+  JERRY_UNUSED (object_p);
 
-  if (ECMA_IS_VALUE_ERROR (constructor_value)
-      || !ecma_is_value_object (constructor_value)
-      || !ecma_is_constructor (constructor_value))
-  {
-    ecma_free_value (constructor_value);
-    return ecma_raise_type_error (ECMA_ERR_MSG ("object.constructor is not a constructor."));
-  }
-
-  ecma_object_t *constructor_object_p = ecma_get_object_from_value (constructor_value);
-  ecma_value_t constructor_prototype = ecma_op_object_get_by_magic_id (constructor_object_p,
-                                                                       LIT_MAGIC_STRING_PROTOTYPE);
-
-  ecma_deref_object (constructor_object_p);
-
-  if (ECMA_IS_VALUE_ERROR (constructor_prototype))
-  {
-    return constructor_prototype;
-  }
-
-  ecma_value_t result = ecma_op_create_array_object (arguments_list_p,
-                                                     arguments_list_len,
-                                                     is_treat_single_arg_as_length);
-
-  if (ecma_is_value_object (constructor_prototype))
-  {
-    ecma_object_t *result_object_p = ecma_get_object_from_value (result);
-    ecma_object_t *constructor_prototpye_object_p = ecma_get_object_from_value (constructor_prototype);
-    ECMA_SET_POINTER (result_object_p->prototype_or_outer_reference_cp, constructor_prototpye_object_p);
-  }
-
-  ecma_free_value (constructor_prototype);
-
-  return result;
+  return ecma_op_create_array_object (arguments_list_p,
+                                      arguments_list_len,
+                                      is_treat_single_arg_as_length);
 } /* ecma_op_create_array_object_by_constructor */
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
 

--- a/tests/jerry/es2015/class-inheritance-builtin-array.js
+++ b/tests/jerry/es2015/class-inheritance-builtin-array.js
@@ -47,6 +47,7 @@
  assert (c.g () === 5);
  assert (c.h () === 5);
 
+/* TODO: Enable these tests after Symbol has been implemented
  // Test built-in Array prototype methods
  var mapped = c.map ((x) => x * 2);
  isInstanceofArray (mapped);
@@ -114,3 +115,4 @@
  } catch (e) {
    assert (e instanceof TypeError);
  }
+*/

--- a/tests/jerry/es2015/class-inheritance-builtin-typedarray.js
+++ b/tests/jerry/es2015/class-inheritance-builtin-typedarray.js
@@ -46,6 +46,7 @@
  assert (c.g () === 5)
  assert (c.h () === 5)
 
+/* TODO: Enable these tests after Symbol has been implemented
  var mapped = c.map ((x) => x * 2);
  isInstanceofTypedArray (mapped);
 
@@ -72,3 +73,4 @@
  } catch (e) {
    assert (e instanceof TypeError)
  }
+*/

--- a/tests/jerry/es2015/regression-test-issue-2587.js
+++ b/tests/jerry/es2015/regression-test-issue-2587.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f(a,b,c) {
+  var args = Array.prototype.slice.call(arguments, 3);
+  assert (typeof args.splice === "function");
+}
+f();


### PR DESCRIPTION
This patch temporarily fixes #2587.

The reason of disabling these tests is that the current implementation slightly differs from the related part of the standard (ECMA-262 v6, 9.4.2.3.6.d.1).
This part requires the hidden Symbol.@@species property, hence this functionality has not been implemented yet in the project.
Also add the related test case to prevent further errors.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu