### PR TITLE
Improve the vm_loop suspending for exec operations

### DIFF
--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -139,6 +139,8 @@ struct jerry_context_t
   jerry_debugger_transport_header_t *debugger_transport_header_p; /**< head of transport protocol chain */
   uint8_t *debugger_send_buffer_payload_p; /**< start where the outgoing message can be written */
   vm_frame_ctx_t *debugger_stop_context; /**< stop only if the current context is equal to this context */
+  uint8_t *debugger_exception_byte_code_p; /**< Location of the currently executed byte code if an
+                                            *   error occours while the vm_loop is suspended */
   jmem_cpointer_t debugger_byte_code_free_head; /**< head of byte code free linked list */
   jmem_cpointer_t debugger_byte_code_free_tail; /**< tail of byte code free linked list */
   uint32_t debugger_flags; /**< debugger flags */

--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -626,6 +626,8 @@
               VM_OC_SUPER_PROP_REFERENCE) \
   CBC_OPCODE (CBC_EXT_CONSTRUCTOR_RETURN, CBC_NO_FLAG, -1, \
               VM_OC_CONSTRUCTOR_RET | VM_OC_GET_STACK) \
+  CBC_OPCODE (CBC_EXT_ERROR, CBC_NO_FLAG, 0, \
+              VM_OC_ERROR) \
   \
   /* Binary compound assignment opcodes with pushing the result. */ \
   CBC_EXT_BINARY_LVALUE_OPERATION (CBC_EXT_ASSIGN_ADD, \

--- a/jerry-core/vm/vm-defines.h
+++ b/jerry-core/vm/vm-defines.h
@@ -54,7 +54,7 @@ typedef struct vm_frame_ctx_t
   ecma_object_t *lex_env_p;                           /**< current lexical environment */
   struct vm_frame_ctx_t *prev_context_p;              /**< previous context */
   ecma_value_t this_binding;                          /**< this binding */
-  ecma_value_t call_block_result;                     /**< preserve block result during a call */
+  ecma_value_t block_result;                          /**< block result */
 #ifdef JERRY_ENABLE_LINE_INFO
   ecma_value_t resource_name;                         /**< current resource name (usually a file name) */
   uint32_t current_line;                              /**< currently executed line */

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -159,6 +159,7 @@ typedef enum
   VM_OC_CALL,                    /**< call */
   VM_OC_NEW,                     /**< new */
   VM_OC_RESOLVE_BASE_FOR_CALL,   /**< resolve base value before call */
+  VM_OC_ERROR,                   /**< error while the vm_loop is suspended */
 
   VM_OC_JUMP,                    /**< jump */
   VM_OC_BRANCH_IF_STRICT_EQUAL,  /**< branch if stric equal */


### PR DESCRIPTION
Exec operations{call, construct, super_call} related bytecode sequences no longer executed twice.
The execution continues with the next opcode or a specific bytecode sequence if an error occurs during the operation.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu