### PR TITLE
docs: Fix jerry_get_property API example

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3792,7 +3792,7 @@ jerry_get_property (const jerry_value_t obj_val,
   jerry_value_t global_object = jerry_get_global_object ();
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "my_prop");
 
-  jerry_value_t prop_value = jerry_get_property (obj_val, prop_name);
+  jerry_value_t prop_value = jerry_get_property (global_object, prop_name);
 
   jerry_release_value (prop_name);
   jerry_release_value (global_object);


### PR DESCRIPTION
The first paramter of the function should be 'global_object' instead of obj_val
in this case.