### PR TITLE
[Debugger] Modify the object representation in case of variables request.

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -492,14 +492,7 @@ jerry_debugger_send_scope_variables (const uint8_t *recv_buffer_p) /**< pointer 
 
         jerry_debugger_scope_variable_type_t variable_type = jerry_debugger_get_variable_type (prop_value_p.value);
 
-        if (variable_type == JERRY_DEBUGGER_VALUE_OBJECT)
-        {
-          property_value = ecma_builtin_json_string_from_object (prop_value_p.value);
-        }
-        else
-        {
-          property_value = ecma_op_to_string (prop_value_p.value);
-        }
+        property_value = ecma_op_to_string (prop_value_p.value);
 
         if (!jerry_debugger_copy_variables_to_string_message (variable_type,
                                                               ecma_get_string_from_value (property_value),

--- a/tests/debugger/do_variables.expected
+++ b/tests/debugger/do_variables.expected
@@ -119,10 +119,10 @@ name | type      | value
 h    | undefined | undefined 
 a    | Array     | [1,2,3]   
 (jerry-debugger) variables 2
-name | type    | value                    
-b    | Number  | 10                       
-x    | Boolean | true                     
-user | Object  | {"name":"John","age":30} 
-m    | Null    | null                     
-c    | Number  | 10                       
+name | type    | value           
+b    | Number  | 10              
+x    | Boolean | true            
+user | Object  | [object Object] 
+m    | Null    | null            
+c    | Number  | 10              
 (jerry-debugger) c


### PR DESCRIPTION
Return with the object`s toString() method instead of create a json formated string from it. 
If this method is not overridden in a custom object, toString() returns "[object Object]" string.

It is just a quick fix. It could have led to an error in previous cases (an object contains itself etc.).
I'm planning to create a feature to retrieve the property list of an object.