### PR TITLE
targets: Speculative workaround for Zephry Travis CI

### DIFF
--- a/targets/zephyr/Makefile.travis
+++ b/targets/zephyr/Makefile.travis
@@ -36,6 +36,8 @@ install-zephyr:
 	git clone https://github.com/zephyrproject-rtos/zephyr.git ../zephyr -b v1.13.0
 	pip3 install --user -U pip
 	pip3 install --user -U setuptools
+	# FIXME: It's temporary workaround to make Travis CI happy for Zephry v1.13.0.
+	pip3 install --user pyocd==0.12.0
 	pip3 install --user -r ../zephyr/scripts/requirements.txt
 
 # Perform all the necessary (JerryScript-independent) installation steps.


### PR DESCRIPTION
The latest version of Pyocd does not install on Linux,
in Zephry master branch the version was locked to 0.12.0 in requirements.txt.
It's temporary workaround to fix Travis CI for Zephry v1.13.0.

JerryScript-DCO-1.0-Signed-off-by: Adam Kallai kadam@inf.u-szeged.hu