### PR TITLE
Fix an issue while debugging with static snapshots

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -3255,7 +3255,8 @@ error:
                                   | JERRY_DEBUGGER_VM_EXCEPTION_THROWN);
 
       if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
-          && !(frame_ctx_p->bytecode_header_p->status_flags & CBC_CODE_FLAGS_DEBUGGER_IGNORE)
+          && !(frame_ctx_p->bytecode_header_p->status_flags
+               & (CBC_CODE_FLAGS_DEBUGGER_IGNORE | CBC_CODE_FLAGS_STATIC_FUNCTION))
           && !(JERRY_CONTEXT (debugger_flags) & dont_stop))
       {
         /* Save the error to a local value, because the engine enters breakpoint mode after,


### PR DESCRIPTION
The issue was present when the executed code would have thrown an error.

Co-authored-by: Robert Fancsik frobert@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu