### PR TITLE
Fix possible failure in backtrace info

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -160,7 +160,8 @@ jerry_debugger_send_backtrace (const uint8_t *recv_buffer_p) /**< pointer to the
 
     while (frame_ctx_p != NULL && min_depth_offset++ < max_depth)
     {
-      if (frame_ctx_p->bytecode_header_p->status_flags & CBC_CODE_FLAGS_DEBUGGER_IGNORE)
+      if (frame_ctx_p->bytecode_header_p->status_flags
+          & (CBC_CODE_FLAGS_DEBUGGER_IGNORE | CBC_CODE_FLAGS_STATIC_FUNCTION))
       {
         frame_ctx_p = frame_ctx_p->prev_context_p;
         continue;


### PR DESCRIPTION
Make sure to ignore static snapshots when sending backtrace information to the debugger.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu