### PR TITLE
Fix a typo in Object.getOwnPropertyNames test

### DIFF
--- a/tests/jerry/object-get-own-property-names.js
+++ b/tests/jerry/object-get-own-property-names.js
@@ -65,7 +65,7 @@ assert (props.length === 2);
 
 // Test non-object argument
 try {
-  Object.getOwnPrototypeNames("hello");
+  Object.getOwnPropertyNames("hello");
   assert (false);
 } catch (e) {
   assert (e instanceof TypeError);


### PR DESCRIPTION
With the change the test file truly checks the corresponding part of the standard (ECMAScript v5, 15.2.3.4.1).

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu