### PR TITLE
Make CONFIG_ECMA_LCACHE_DISABLE and CONFIG_ECMA_PROPERTY_HASHMAP_DISABLE build-tested

### DIFF
--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -142,6 +142,8 @@ JERRY_BUILDOPTIONS = [
                 platform.system() != 'Linux' or (platform.machine() != 'i386' and platform.machine() != 'x86_64'),
                 '-m32 is only supported on x86[-64]-linux')
            ),
+    Options('buildoption_test-no_lcache_prophashmap',
+            ['--compile-flag=-DCONFIG_ECMA_LCACHE_DISABLE', '--compile-flag=-DCONFIG_ECMA_PROPERTY_HASHMAP_DISABLE']),
     Options('buildoption_test-external_context',
             ['--external-context=on']),
     Options('buildoption_test-shared_libs',


### PR DESCRIPTION
Because these feature guards don't have their counterpart options in cmake, they
seem to be less tested. This commit makes them build-tested at least.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu