### PR TITLE
Reduce ecma_{ref, deref}_object calls while using ecma_builtin_get

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -596,8 +596,9 @@ jerry_value_t
 jerry_get_global_object (void)
 {
   jerry_assert_api_available ();
-
-  return ecma_make_object_value (ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL));
+  ecma_object_t *global_obj_p = ecma_builtin_get_global ();
+  ecma_ref_object (global_obj_p);
+  return ecma_make_object_value (global_obj_p);
 } /* jerry_get_global_object */
 
 /**
@@ -3177,7 +3178,6 @@ jerry_create_typedarray (jerry_typedarray_type_t type_name, /**< type of TypedAr
                                                                         prototype_obj_p,
                                                                         element_size_shift,
                                                                         lit_id);
-  ecma_deref_object (prototype_obj_p);
 
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (array_value));
 
@@ -3232,7 +3232,6 @@ jerry_create_typedarray_for_arraybuffer_sz (jerry_typedarray_type_t type_name, /
   ecma_value_t array_value = ecma_op_create_typedarray (arguments_p, 3, prototype_obj_p, element_size_shift, lit_id);
   ecma_free_value (arguments_p[1]);
   ecma_free_value (arguments_p[2]);
-  ecma_deref_object (prototype_obj_p);
 
   return jerry_return (array_value);
 #else /* CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -492,8 +492,6 @@ ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**<
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_UNDEFINED;
 
-  ecma_deref_object (prototype_obj_p);
-
   if (arguments_list_len == 0)
   {
     ECMA_TRY_CATCH (parse_res_value,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -303,8 +303,6 @@ ecma_builtin_function_prototype_object_bind (ecma_value_t this_arg, /**< this ar
       ext_function_p->u.bound_function.args_len_or_this = args_len_or_this;
     }
 
-    ecma_deref_object (prototype_obj_p);
-
     /*
      * [[Class]] property is not stored explicitly for objects of ECMA_OBJECT_TYPE_FUNCTION type.
      *

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.c
@@ -222,8 +222,6 @@ ecma_typedarray_helper_dispatch_construct (const ecma_value_t *arguments_list_p,
                                                 ecma_typedarray_helper_get_shift_size (builtin_id),
                                                 ecma_typedarray_helper_get_magic_string (builtin_id));
 
-  ecma_deref_object (prototype_obj_p);
-
   return val;
 } /* ecma_typedarray_helper_dispatch_construct */
 

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
@@ -103,7 +103,6 @@ ecma_builtin_typedarray_from (ecma_value_t this_arg, /**< 'this' argument */
   const uint8_t element_size_shift = ecma_typedarray_helper_get_shift_size (builtin_id);
   const lit_magic_string_id_t class_id = ecma_typedarray_helper_get_magic_string (builtin_id);
 
-  ecma_deref_object (proto_p);
 
   return ecma_op_typedarray_from (source,
                                   map_fn,

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array.c
@@ -72,8 +72,6 @@ ecma_builtin_uint32array_dispatch_construct (const ecma_value_t *arguments_list_
                                                 2,
                                                 LIT_MAGIC_STRING_UINT32_ARRAY_UL);
 
-  ecma_deref_object (prototype_obj_p);
-
   return val;
 } /* ecma_builtin_uint32array_dispatch_construct */
 

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray.c
@@ -72,7 +72,6 @@ ecma_builtin_uint8clampedarray_dispatch_construct (const ecma_value_t *arguments
                                                 0,
                                                 LIT_MAGIC_STRING_UINT8_CLAMPED_ARRAY_UL);
 
-  ecma_deref_object (prototype_obj_p);
 
   return val;
 } /* ecma_builtin_uint8clampedarray_dispatch_construct */

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -95,8 +95,6 @@ ecma_op_create_array_object (const ecma_value_t *arguments_list_p, /**< list of 
                                                 sizeof (ecma_extended_object_t),
                                                 ECMA_OBJECT_TYPE_ARRAY);
 
-  ecma_deref_object (array_prototype_object_p);
-
   /*
    * [[Class]] property is not stored explicitly for objects of ECMA_OBJECT_TYPE_ARRAY type.
    *

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -49,7 +49,7 @@ ecma_arraybuffer_new_object (ecma_length_t length) /**< length of the arraybuffe
   ecma_object_t *object_p = ecma_create_object (prototype_obj_p,
                                                 sizeof (ecma_extended_object_t) + length,
                                                 ECMA_OBJECT_TYPE_CLASS);
-  ecma_deref_object (prototype_obj_p);
+
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.class_prop.extra_info = ECMA_ARRAYBUFFER_INTERNAL_MEMORY;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_ARRAY_BUFFER_UL;
@@ -80,7 +80,7 @@ ecma_arraybuffer_new_object_external (ecma_length_t length, /**< length of the b
   ecma_object_t *object_p = ecma_create_object (prototype_obj_p,
                                                 sizeof (ecma_arraybuffer_external_info),
                                                 ECMA_OBJECT_TYPE_CLASS);
-  ecma_deref_object (prototype_obj_p);
+
   ecma_arraybuffer_external_info *array_object_p = (ecma_arraybuffer_external_info *) object_p;
   array_object_p->extended_object.u.class_prop.extra_info = ECMA_ARRAYBUFFER_EXTERNAL_MEMORY;
   array_object_p->extended_object.u.class_prop.class_id = LIT_MAGIC_STRING_ARRAY_BUFFER_UL;

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -53,8 +53,6 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
                                                 sizeof (ecma_extended_object_t),
                                                 ECMA_OBJECT_TYPE_CLASS);
 
-  ecma_deref_object (prototype_obj_p);
-
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_BOOLEAN_UL;
   ext_object_p->u.class_prop.u.value = ecma_make_boolean_value (boolean_value);

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -137,8 +137,6 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
                                                        sizeof (ecma_extended_object_t),
                                                        ECMA_OBJECT_TYPE_CLASS);
 
-  ecma_deref_object (prototype_obj_p);
-
   ((ecma_extended_object_t *) new_error_obj_p)->u.class_prop.class_id = LIT_MAGIC_STRING_ERROR_UL;
 
 #ifdef JERRY_ENABLE_LINE_INFO

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -137,8 +137,6 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
                                               function_object_size,
                                               ECMA_OBJECT_TYPE_FUNCTION);
 
-  ecma_deref_object (prototype_obj_p);
-
   /* 2., 6., 7., 8. */
   /*
    * We don't setup [[Get]], [[Call]], [[Construct]], [[HasInstance]] for each function object.
@@ -215,9 +213,6 @@ ecma_op_create_arrow_function_object (ecma_object_t *scope_p, /**< function's sc
                                               arrow_function_object_size,
                                               ECMA_OBJECT_TYPE_ARROW_FUNCTION);
 
-  ecma_deref_object (prototype_obj_p);
-
-
   ecma_arrow_function_t *arrow_func_p = (ecma_arrow_function_t *) func_p;
 
   ECMA_SET_NON_NULL_POINTER (arrow_func_p->scope_cp, scope_p);
@@ -262,8 +257,6 @@ ecma_op_create_external_function_object (ecma_external_handler_t handler_cb) /**
   function_obj_p = ecma_create_object (prototype_obj_p,
                                        sizeof (ecma_extended_object_t),
                                        ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION);
-
-  ecma_deref_object (prototype_obj_p);
 
   /*
    * [[Class]] property is not stored explicitly for objects of ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION type.
@@ -1019,8 +1012,6 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
       ecma_object_t *prototype_p = ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE);
 
       new_this_obj_p = ecma_create_object (prototype_p, 0, ECMA_OBJECT_TYPE_GENERAL);
-
-      ecma_deref_object (prototype_p);
     }
 
     ecma_free_value (prototype_prop_value);
@@ -1179,8 +1170,6 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
                                            thrower_p,
                                            ECMA_PROPERTY_FIXED,
                                            &caller_prop_p);
-
-      ecma_deref_object (thrower_p);
       return caller_prop_p;
     }
   }
@@ -1290,8 +1279,6 @@ ecma_op_bound_function_try_to_lazy_instantiate_property (ecma_object_t *object_p
                                          thrower_p,
                                          ECMA_PROPERTY_FIXED,
                                          &caller_prop_p);
-
-    ecma_deref_object (thrower_p);
     return caller_prop_p;
   }
 

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -169,14 +169,12 @@ ecma_op_put_value_lex_env_base (ecma_object_t *ref_base_lex_env_p, /**< referenc
     else
     {
       /* 3.b. */
-      ecma_object_t *global_object_p = ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL);
+      ecma_object_t *global_object_p = ecma_builtin_get_global ();
 
       ecma_value_t completion = ecma_op_object_put (global_object_p,
                                                     var_name_string_p,
                                                     value,
                                                     false);
-
-      ecma_deref_object (global_object_p);
 
       JERRY_ASSERT (ecma_is_value_boolean (completion));
 

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -44,8 +44,6 @@ ecma_init_global_lex_env (void)
   JERRY_CONTEXT (ecma_global_lex_env_p) = ecma_create_object_lex_env (NULL,
                                                                       glob_obj_p,
                                                                       ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND);
-
-  ecma_deref_object (glob_obj_p);
 } /* ecma_init_global_lex_env */
 
 /**

--- a/jerry-core/ecma/operations/ecma-map-object.c
+++ b/jerry-core/ecma/operations/ecma-map-object.c
@@ -48,8 +48,6 @@ ecma_op_map_create (const ecma_value_t *arguments_list_p, /**< arguments list */
                                                 sizeof (ecma_map_object_t),
                                                 ECMA_OBJECT_TYPE_CLASS);
 
-  ecma_deref_object (prototype_obj_p);
-
   ecma_map_object_t *map_object_p = (ecma_map_object_t *) object_p;
   map_object_p->header.u.class_prop.class_id = LIT_MAGIC_STRING_MAP_UL;
   map_object_p->header.u.class_prop.extra_info = 0;

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -58,8 +58,6 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
                                                 sizeof (ecma_extended_object_t),
                                                 ECMA_OBJECT_TYPE_CLASS);
 
-  ecma_deref_object (prototype_obj_p);
-
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_NUMBER_UL;
 

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -109,8 +109,6 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
     ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_ARGUMENTS_UL;
   }
 
-  ecma_deref_object (prototype_p);
-
   ecma_property_value_t *prop_value_p;
 
   /* 11.a, 11.b */
@@ -182,8 +180,6 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                      &prop_desc,
                                                      false);
     JERRY_ASSERT (ecma_is_value_true (completion));
-
-    ecma_deref_object (thrower_p);
   }
 
   ecma_string_t *arguments_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_ARGUMENTS);

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -62,11 +62,7 @@ ecma_op_create_object_object_noarg (void)
   ecma_object_t *object_prototype_p = ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE);
 
   /* 3., 4., 6., 7. */
-  ecma_object_t *obj_p = ecma_op_create_object_object_noarg_and_set_prototype (object_prototype_p);
-
-  ecma_deref_object (object_prototype_p);
-
-  return obj_p;
+  return ecma_op_create_object_object_noarg_and_set_prototype (object_prototype_p);
 } /* ecma_op_create_object_object_noarg */
 
 /**

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -492,7 +492,6 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
   ecma_object_t *object_p = ecma_create_object (prototype_obj_p,
                                                 sizeof (ecma_promise_object_t),
                                                 ECMA_OBJECT_TYPE_CLASS);
-  ecma_deref_object (prototype_obj_p);
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_PROMISE_UL;
   ext_object_p->u.class_prop.u.value = ECMA_VALUE_UNDEFINED;

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -218,8 +218,6 @@ ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *bytecode_p) /**<
                                                 sizeof (ecma_extended_object_t),
                                                 ECMA_OBJECT_TYPE_CLASS);
 
-  ecma_deref_object (re_prototype_obj_p);
-
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
 
   /* Set the internal [[Class]] property */
@@ -259,9 +257,6 @@ ecma_op_create_regexp_object (ecma_string_t *pattern_p, /**< input pattern */
   ecma_object_t *object_p = ecma_create_object (re_prototype_obj_p,
                                                 sizeof (ecma_extended_object_t),
                                                 ECMA_OBJECT_TYPE_CLASS);
-
-  ecma_deref_object (re_prototype_obj_p);
-
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_UNDEFINED;
 

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -70,8 +70,6 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
                                                 sizeof (ecma_extended_object_t),
                                                 ECMA_OBJECT_TYPE_CLASS);
 
-  ecma_deref_object (prototype_obj_p);
-
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_STRING_UL;
   ext_object_p->u.class_prop.u.value = prim_value;

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -991,7 +991,6 @@ ecma_op_create_typedarray_with_type_and_length (ecma_object_t *obj_p, /**< Typed
       || !ecma_is_value_object (constructor_value)
       || !ecma_is_constructor (constructor_value))
   {
-    ecma_deref_object (proto_p);
     ecma_free_value (constructor_value);
     return ecma_raise_type_error (ECMA_ERR_MSG ("object.constructor is not a constructor."));
   }
@@ -1004,7 +1003,6 @@ ecma_op_create_typedarray_with_type_and_length (ecma_object_t *obj_p, /**< Typed
 
   if (ECMA_IS_VALUE_ERROR (constructor_prototype))
   {
-    ecma_deref_object (proto_p);
     return constructor_prototype;
   }
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
@@ -1013,8 +1011,6 @@ ecma_op_create_typedarray_with_type_and_length (ecma_object_t *obj_p, /**< Typed
                                                                     proto_p,
                                                                     element_size_shift,
                                                                     class_id);
-
-  ecma_deref_object (proto_p);
 
 #ifndef CONFIG_DISABLE_ES2015_CLASS
   ecma_object_t *constructor_prototype_object_p = ecma_get_object_from_value (constructor_prototype);

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -222,17 +222,14 @@ static const uint16_t vm_decode_table[] JERRY_CONST_DATA =
 ecma_value_t
 vm_run_global (const ecma_compiled_code_t *bytecode_p) /**< pointer to bytecode to run */
 {
-  ecma_object_t *glob_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL);
+  ecma_object_t *glob_obj_p = ecma_builtin_get_global ();
 
-  ecma_value_t ret_value = vm_run (bytecode_p,
-                                   ecma_make_object_value (glob_obj_p),
-                                   ecma_get_global_environment (),
-                                   false,
-                                   NULL,
-                                   0);
-
-  ecma_deref_object (glob_obj_p);
-  return ret_value;
+  return vm_run (bytecode_p,
+                 ecma_make_object_value (glob_obj_p),
+                 ecma_get_global_environment (),
+                 false,
+                 NULL,
+                 0);
 } /* vm_run_global */
 
 /**
@@ -275,7 +272,9 @@ vm_run_eval (ecma_compiled_code_t *bytecode_data_p, /**< byte-code data */
   }
   else
   {
-    this_binding = ecma_make_object_value (ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL));
+    ecma_object_t *global_obj_p = ecma_builtin_get_global ();
+    ecma_ref_object (global_obj_p);
+    this_binding = ecma_make_object_value (global_obj_p);
     lex_env_p = ecma_get_global_environment ();
   }
 
@@ -1107,12 +1106,10 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         }
         case VM_OC_PUSH_OBJECT:
         {
-          ecma_object_t *prototype_p = ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE);
-          ecma_object_t *obj_p = ecma_create_object (prototype_p,
+          ecma_object_t *obj_p = ecma_create_object (ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE),
                                                      0,
                                                      ECMA_OBJECT_TYPE_GENERAL);
 
-          ecma_deref_object (prototype_p);
           *stack_top_p++ = ecma_make_object_value (obj_p);
           continue;
         }
@@ -1398,9 +1395,6 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           ecma_object_t *function_obj_p = ecma_create_object (prototype_obj_p,
                                                               sizeof (ecma_extended_object_t),
                                                               ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION);
-
-
-          ecma_deref_object (prototype_obj_p);
 
           ecma_extended_object_t *ext_func_obj_p = (ecma_extended_object_t *) function_obj_p;
           ext_func_obj_p->u.external_handler_cb = ecma_op_function_implicit_constructor_handler_cb;


### PR DESCRIPTION
The following stucture was highly frequented in the code base:

 - Get a builtin object // This operation increases the reference count of the object
 - Use it for create a new object
 - Deref the builtin object

After a builtin has been instantiated there is always at least one reference to "keep it alive",
so increase/decrease the reference count for getting the value only is unnecessary.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu