### PR TITLE
Use logical operators for bool converions.

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -666,7 +666,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       const ecma_compiled_code_t *bytecode_data_p = ecma_op_function_get_compiled_code (ext_func_p);
 
 #ifndef CONFIG_DISABLE_ES2015_CLASS
-      bool is_class_constructor = (bool) (bytecode_data_p->status_flags & CBC_CODE_FLAGS_CONSTRUCTOR);
+      bool is_class_constructor = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_CONSTRUCTOR) != 0;
 
       if (is_class_constructor && !ecma_op_function_has_construct_flag (arguments_list_p))
       {
@@ -674,8 +674,8 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       }
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
 
-      bool is_strict = (bool) (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE);
-      bool is_no_lex_env = (bool) (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED);
+      bool is_strict = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE) != 0;
+      bool is_no_lex_env = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED) != 0;
 
       /* 1. */
       if (!is_strict)
@@ -775,7 +775,7 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
 
       const ecma_compiled_code_t *bytecode_data_p = ecma_op_arrow_function_get_compiled_code (arrow_func_p);
 
-      is_no_lex_env = (bool) (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED);
+      is_no_lex_env = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_LEXICAL_ENV_NOT_NEEDED) != 0;
 
       ecma_object_t *local_env_p = scope_p;
 

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2194,7 +2194,7 @@ lexer_construct_regexp_object (parser_context_t *context_p, /**< context */
                                           current_flags);
   ecma_deref_ecma_string (pattern_str_p);
 
-  bool is_throw = (bool) ECMA_IS_VALUE_ERROR (completion_value);
+  bool is_throw = ECMA_IS_VALUE_ERROR (completion_value) != 0;
 
   ecma_free_value (completion_value);
 

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -418,7 +418,7 @@ parser_parse_class_literal (parser_context_t *context_p) /**< context */
       JERRY_ASSERT (context_p->last_cbc_opcode == CBC_PUSH_LITERAL);
 
       cbc_ext_opcode_t opcode;
-      bool is_static = (bool) (status_flags & PARSER_CLASS_STATIC_FUNCTION);
+      bool is_static = (status_flags & PARSER_CLASS_STATIC_FUNCTION) != 0;
 
       if (is_computed)
       {
@@ -1366,7 +1366,7 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
           break;
         }
 
-        bool is_static = (bool) (context_p->status_flags & PARSER_CLASS_STATIC_FUNCTION);
+        bool is_static = (context_p->status_flags & PARSER_CLASS_STATIC_FUNCTION) != 0;
         parser_emit_cbc_ext (context_p, is_static ? CBC_EXT_PUSH_STATIC_SUPER : CBC_EXT_PUSH_SUPER);
         break;
       }


### PR DESCRIPTION
The explicit boolean type conversion (introduced by #2575) desn't work
with TizenRT if custom boolean representation is used. Of course,
TizenRT gives an opportunity to use the C99 standard boolean (that works
well if that is set).

I've replaced all the explicit boolean type conversions with double
negations that helps to work JerryScript well with custom boolean types.

(Note: this patch fixes 14 tests on TizenRT.)