### PR TITLE
Fix floating number parsing.

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -958,13 +958,12 @@ lexer_parse_number (parser_context_t *context_p) /**< context */
   }
   else
   {
-    do
+    while (source_p < source_end_p
+           && source_p[0] >= LIT_CHAR_0
+           && source_p[0] <= LIT_CHAR_9)
     {
       source_p++;
     }
-    while (source_p < source_end_p
-           && source_p[0] >= LIT_CHAR_0
-           && source_p[0] <= LIT_CHAR_9);
 
     can_be_float = true;
   }

--- a/tests/jerry/regression-test-issue-2614.js
+++ b/tests/jerry/regression-test-issue-2614.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(".5.");
+  assert(false);
+} catch(e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patches fixes floating point number parsing when the number starts with dot.

Fixes #2614.