### PR TITLE
Use Thumb instructions on TizenRT.

### DIFF
--- a/cmake/toolchain_mcu_artik053.cmake
+++ b/cmake/toolchain_mcu_artik053.cmake
@@ -16,7 +16,9 @@ set(CMAKE_SYSTEM_NAME TizenRT)
 set(CMAKE_SYSTEM_PROCESSOR armv7l)
 set(CMAKE_SYSTEM_VERSION ARTIK053)
 
-set(FLAGS_COMMON_ARCH -mcpu=cortex-r4 -mfpu=vfpv3 -fno-builtin -fno-strict-aliasing -fomit-frame-pointer -fno-strength-reduce -Wall -Werror -Wshadow -Wno-error=conversion)
+set(FLAGS_COMMON_ARCH -mcpu=cortex-r4 -mthumb -mfpu=vfpv3
+                      -fno-builtin -fno-strict-aliasing -fomit-frame-pointer -fno-strength-reduce
+                      -Wall -Werror -Wshadow -Wno-error=conversion)
 
 set(CMAKE_C_COMPILER arm-none-eabi-gcc)
 set(CMAKE_C_COMPILER_WORKS TRUE)


### PR DESCRIPTION
In order to decrease the binary size of JerryScript, enabled the Thumb instruction set that is supported on ARM Cortex-R series processors.

The following table shows the binary size reduction by this patch:

|          | commit: 8410570 (2018-11-28) | this patch|
|--------|-----------|--------|
text     |  199708 B |  130440 B|
bss	   |  74088 B |  74088 B|
data    |  0 B     |  0 B|
rodata |  12341 B |  12342 B|
