### PR TITLE
Rewrite debugger test runner to use portable redirect-and-append notation

### DIFF
--- a/tools/runners/run-debugger-test.sh
+++ b/tools/runners/run-debugger-test.sh
@@ -40,11 +40,11 @@ sleep 1s
 
 RESULT_TEMP=`mktemp ${TEST_CASE}.out.XXXXXXXXXX`
 
-(cat "${TEST_CASE}.cmd" | ${DEBUGGER_CLIENT} --non-interactive ${CLIENT_ARGS}) &> ${RESULT_TEMP}
+(cat "${TEST_CASE}.cmd" | ${DEBUGGER_CLIENT} --non-interactive ${CLIENT_ARGS}) >${RESULT_TEMP} 2>&1
 
 if [[ $TEST_CASE == *"restart"* ]]; then
   CONTINUE_CASE=$(sed "s/restart/continue/g" <<< "$TEST_CASE")
-  (cat "${CONTINUE_CASE}.cmd" | ${DEBUGGER_CLIENT} --non-interactive ${CLIENT_ARGS}) &>> ${RESULT_TEMP}
+  (cat "${CONTINUE_CASE}.cmd" | ${DEBUGGER_CLIENT} --non-interactive ${CLIENT_ARGS}) >>${RESULT_TEMP} 2>&1
 fi
 
 diff -U0 ${TEST_CASE}.expected ${RESULT_TEMP}


### PR DESCRIPTION
The test runner used `&>>` to channel stderr to stdout and append
all that to a file. However, that's Bash 4 syntax, which is not
available everywhere, e.g., on MacOS. Bash pre-4 syntax requires
the classic `>>file 2>&1` notation.

This commit rewrites the test runner to use the portable syntax.
Moreover, it also rewrites `&>` to `>file 2>&1` for the sake of
consistency.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu