### PR TITLE
Fix possible failure in backtrace info

### DIFF
--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -130,7 +130,10 @@ jerry_debugger_send_backtrace (const uint8_t *recv_buffer_p) /**< pointer to the
     uint32_t frame_count = 0;
     while (iter_frame_ctx_p != NULL)
     {
-      frame_count++;
+      if (!(iter_frame_ctx_p->bytecode_header_p->status_flags & (CBC_CODE_FLAGS_STATIC_FUNCTION)))
+      {
+        frame_count++;
+      }
       iter_frame_ctx_p = iter_frame_ctx_p->prev_context_p;
     }
     memcpy (backtrace_total_p->frame_count, &frame_count, sizeof (frame_count));
@@ -160,7 +163,8 @@ jerry_debugger_send_backtrace (const uint8_t *recv_buffer_p) /**< pointer to the
 
     while (frame_ctx_p != NULL && min_depth_offset++ < max_depth)
     {
-      if (frame_ctx_p->bytecode_header_p->status_flags & CBC_CODE_FLAGS_DEBUGGER_IGNORE)
+      if (frame_ctx_p->bytecode_header_p->status_flags
+          & (CBC_CODE_FLAGS_DEBUGGER_IGNORE | CBC_CODE_FLAGS_STATIC_FUNCTION))
       {
         frame_ctx_p = frame_ctx_p->prev_context_p;
         continue;


### PR DESCRIPTION
Make sure to ignore static snapshots when sending backtrace information to the debugger.
The `JMEM_SET_NON_NULL_POINTER` macro requires the frame context's `bytecode_header_p` pointer to be a heap pointer, but due to the static snapshot it might not be, causing an assertion failure.

This PR is identical to #2608 which I sadly couldn't reopen.
Test environment is not added yet, however this one might be a blocker as well since our VSCode extension uses backtrace and total frame count requests.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu