### PR TITLE
Fix MbedOS build

### DIFF
--- a/targets/mbedos5/Makefile.travis
+++ b/targets/mbedos5/Makefile.travis
@@ -25,6 +25,7 @@ all:
 install:
 	pip install --user mbed-cli
 	cd targets/mbedos5 && mbed deploy
+	pip install --user mbed-host-tests==1.4.2 # FIXME: mbed-host-tests 1.4.4 requires pyocd>=0.14.0, which cannot be satisfied for whatever reason
 	pip install --user -r targets/mbedos5/mbed-os/requirements.txt
 
 


### PR DESCRIPTION
Since recently, the newly released mbed-host-tests 1.4.4 gets
installed during the python requirement installation step. That
package requires pyocd>=0.14.0, which cannot be satisfied for
whatever reason. This quick fix pins mbed-host-tests to version
1.4.2, which does not have unsatisfiable requirements.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu