### PR TITLE
Ensure fresh Python 2.7 on Trusty and compatible Intervaltree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,8 @@ matrix:
           sources:
             - sourceline: ppa:team-gcc-arm-embedded/ppa
           packages: [gcc-arm-embedded]
+      language: python # NOTE: only way to ensure python>=2.7.10 on Trusty image
+      python: 2.7
       install: make -f ./targets/mbedos5/Makefile.travis install
       script: make -f ./targets/mbedos5/Makefile.travis script
 

--- a/targets/mbedos5/Makefile.travis
+++ b/targets/mbedos5/Makefile.travis
@@ -23,17 +23,17 @@ all:
 
 # Deploy Mbed and install Mbed Python dependencies.
 install:
-	pip install --user mbed-cli
+	pip install mbed-cli
 	cd targets/mbedos5 && mbed deploy
-	pip install --user mbed-host-tests==1.4.2 # FIXME: mbed-host-tests 1.4.4 requires pyocd>=0.14.0, which cannot be satisfied for whatever reason
-	pip install --user -r targets/mbedos5/mbed-os/requirements.txt
+	pip install intervaltree==2.1.0 # FIXME: workaround until chaimleib/intervaltree#77 is fixed
+	pip install -r targets/mbedos5/mbed-os/requirements.txt
 
 
 ## Targets for building Mbed OS 5 with JerryScript.
 
 # Build the firmware (Mbed OS 5 with JerryScript).
 script:
-	pip install --user -r targets/mbedos5/tools/requirements.txt
+	pip install -r targets/mbedos5/tools/requirements.txt
 	# HACK: `EXTRA_SRC[_MOD]` are abused to pass `--library` to `mbed compile` in the `all` make target that builds an app
 	# HACK: this is needed because the Mbed OS 5 target code does not contain any `main` function, so the `all` make target does not link
 	# HACK: but the `library` make target does not build either because the launcher sources require `jerry-targetjs.h` that are explicitly not generated for libraries


### PR DESCRIPTION
Recent failures of the Mbed OS target came from two independent
issues:
- some python packages started requiring Python>=2.7.10, and
- the latest Intervaltree 3.0.0 release was released broken.

This patch ensures a fresh python by 'lying' to the CI that this
is a Python project (Python images on the CI come with a recent
interpreter, not with the one shipped as default with the OS), and
locks Intervaltree to a stable version.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu