### PR TITLE
Fix class extends value

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1048,6 +1048,16 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
                                               arguments_list_len);
       break;
     }
+    case ECMA_OBJECT_TYPE_GENERAL:
+    {
+      /* Catch the special case when a the class extends value in null
+         and the class has no explicit constructor to raise TypeError.*/
+      JERRY_ASSERT (!ecma_op_function_has_construct_flag (arguments_list_p));
+      JERRY_ASSERT (ecma_get_object_prototype (func_obj_p) == NULL);
+
+      ret_value = ecma_raise_type_error (ECMA_ERR_MSG ("Super constructor null is not a constructor."));
+      break;
+    }
 #endif /* !CONFIG_DISABLE_ES2015_CLASS */
     default:
     {

--- a/tests/jerry/es2015/regression-test-issue-2658.js
+++ b/tests/jerry/es2015/regression-test-issue-2658.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  var A = class extends null { }
+  new A;
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #2658 and ensures that when a class extends value is null and the class has no explicit constructor
the proper error is raised during constructing a class instance.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu