### PR TITLE
Add missing ecma_deref_ecma_string call to ecma_builtin_json_object

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1659,6 +1659,7 @@ ecma_builtin_json_object (ecma_object_t *obj_p, /**< the object*/
   {
     ecma_free_values_collection (partial_p, 0);
     ecma_deref_ecma_string (stepback_p);
+    ecma_deref_ecma_string (context_p->indent_str_p);
     return ret_value;
   }
 

--- a/tests/jerry/fail/regression-test-issue-2719.js
+++ b/tests/jerry/fail/regression-test-issue-2719.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+JSON.stringify(URIError, valueOf, new String('abc\u2040\u2030cba'));


### PR DESCRIPTION
This patch fixes #2719.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu