### PR TITLE
jerryscript-ext/module.h: extern and symbol macro for modules

### DIFF
--- a/jerry-ext/include/jerryscript-ext/module.h
+++ b/jerry-ext/include/jerryscript-ext/module.h
@@ -83,6 +83,12 @@ typedef struct jerryx_native_module_t
   {                                                                    \
     jerryx_native_module_unregister(&_##module_name##_definition);     \
   }
+  
+#define JERRYX_NATIVE_MODULE_EXTERN(module_name) \
+  extern jerryx_native_module_t _ ## module_name ## _definition
+
+#define JERRYX_NATIVE_MODULE_SYMBOL(module_name) \
+  _ ## module_name ## _definition
 
 /**
  * Register a native module. This makes it available for loading via jerryx_module_resolve, when


### PR DESCRIPTION
The two macros `JERRYX_MODULE_EXTERN(module_name)` and `JERRYX_MODULE_SYMBOL(module_name)` have been added.

- `_EXTERN(module_name)`: Returns an `extern jerryx_native_module_t` declaration.
- `_SYMBOL(module_name)`: Returns the identifier that references the `jerryx_native_module_t` symbol.