### PR TITLE
Reduce the size of vm_frame_ctx_t

### DIFF
--- a/jerry-core/vm/vm-defines.h
+++ b/jerry-core/vm/vm-defines.h
@@ -52,7 +52,9 @@ typedef struct vm_frame_ctx_t
   ecma_value_t *stack_top_p;                          /**< stack top pointer */
   ecma_value_t *literal_start_p;                      /**< literal list start pointer */
   ecma_object_t *lex_env_p;                           /**< current lexical environment */
+#if defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO)
   struct vm_frame_ctx_t *prev_context_p;              /**< previous context */
+#endif /* defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO) */
   ecma_value_t this_binding;                          /**< this binding */
   ecma_value_t block_result;                          /**< block result */
 #ifdef JERRY_ENABLE_LINE_INFO

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -3464,6 +3464,7 @@ vm_execute (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
 
   JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_DIRECT_EVAL;
 
+  vm_frame_ctx_t *prev_context_p = JERRY_CONTEXT (vm_top_context_p);
   JERRY_CONTEXT (vm_top_context_p) = frame_ctx_p;
 
   vm_init_loop (frame_ctx_p);
@@ -3514,7 +3515,7 @@ vm_execute (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
         JERRY_CONTEXT (vm_recursion_counter)++;
 #endif /* VM_RECURSION_LIMIT */
 
-        JERRY_CONTEXT (vm_top_context_p) = frame_ctx_p->prev_context_p;
+        JERRY_CONTEXT (vm_top_context_p) = prev_context_p;
         return completion_value;
       }
     }
@@ -3574,7 +3575,9 @@ vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data heade
   frame_ctx.byte_code_p = (uint8_t *) literal_p;
   frame_ctx.byte_code_start_p = (uint8_t *) literal_p;
   frame_ctx.lex_env_p = lex_env_p;
+#if defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO)
   frame_ctx.prev_context_p = JERRY_CONTEXT (vm_top_context_p);
+#endif /* defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO) */
   frame_ctx.this_binding = this_binding_value;
   frame_ctx.block_result = ECMA_VALUE_UNDEFINED;
 #ifdef JERRY_ENABLE_LINE_INFO


### PR DESCRIPTION
The reference to the previous context is only used by the debugger, so this element should not be part of the structure by default.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu