### PR TITLE
Container object's properties must be marked during GC.

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-2895.js
+++ b/tests/jerry/es2015/regression-test-issue-2895.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function createMap (count) {
+  var map = new Map ( )
+  for (var i = { member : 0, valueOf: function () { return this.member } }; i < count ; i ++) {
+    map.set(i);
+  }
+  return map
+}
+createMap(2000).forEach(function($, $) {})

--- a/tests/jerry/es2015/regression-test-issue-2911.js
+++ b/tests/jerry/es2015/regression-test-issue-2911.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var m = new Map;
+var obj = { $: 0 };
+assert(m.set("strItem", obj) === m);
+gc();
+assert(m.get("st" + "rItem") === obj);


### PR DESCRIPTION
This patch fixes #2895 and fixes #2911.

Co-authored-by: Gabor Loki loki@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu