### PR TITLE
Improve libfuzz integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,16 +64,6 @@ if(NOT USING_CLANG)
   set(JERRY_LIBFUZZER_MESSAGE " (FORCED BY COMPILER)")
 endif()
 
-if(JERRY_LIBFUZZER)
-  set(JERRY_CMDLINE          OFF)
-  set(JERRY_CMDLINE_TEST     OFF)
-  set(JERRY_CMDLINE_SNAPSHOT OFF)
-
-  set(JERRY_CMDLINE_MESSAGE          " (FORCED BY LIBFUZZER)")
-  set(JERRY_CMDLINE_TEST_MESSAGE     " (FORCED BY LIBFUZZER)")
-  set(JERRY_CMDLINE_SNAPSHOT_MESSAGE " (FORCED BY LIBFUZZER)")
-endif()
-
 if(JERRY_CMDLINE OR JERRY_CMDLINE_TEST OR JERRY_CMDLINE_SNAPSHOT OR JERRY_LIBFUZZER OR UNITTESTS OR DOCTESTS)
   set(JERRY_PORT_DEFAULT ON)
 
@@ -224,7 +214,7 @@ if(USING_MSVC)
 endif()
 
 if(JERRY_LIBFUZZER)
-  jerry_add_compile_flags(-fsanitize=address,fuzzer)
+  jerry_add_compile_flags(-fsanitize=fuzzer-no-link)
 endif()
 
 # Strip binary

--- a/docs/01.GETTING-STARTED.md
+++ b/docs/01.GETTING-STARTED.md
@@ -123,7 +123,7 @@ allocator is used.
 **To build with libfuzzer support**
 
 ```bash
-CC=clang python tools/build.py --libfuzzer=on --lto=off
+CC=clang python tools/build.py --libfuzzer=on --compile-flag=-fsanitize=address --lto=off
 ```
 
 Check the documentation of libfuzzer to get the runtime settings of the created fuzzer

--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -57,7 +57,7 @@ endmacro()
 # Jerry with libfuzzer support
 if(JERRY_LIBFUZZER)
   jerry_create_executable("jerry-libfuzzer" "libfuzzer.c")
-  target_link_libraries("jerry-libfuzzer" jerry-port-default)
+  target_link_libraries("jerry-libfuzzer" jerry-port-default -fsanitize=fuzzer)
 endif()
 
 # Jerry standalones

--- a/jerry-main/libfuzzer.c
+++ b/jerry-main/libfuzzer.c
@@ -13,11 +13,14 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
+
 #include "jerryscript.h"
 
 
 int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 {
+  srand (0);
   jerry_init (JERRY_INIT_EMPTY);
 
   if (jerry_is_valid_utf8_string ((jerry_char_t *) data, (jerry_size_t) size))


### PR DESCRIPTION
- Allow command line tools to build together with libfuzzer driver.
  Compile everything with `-fsanitize=fuzzer-no-link` to prevent
  linking in libfuzzers's `main` symbol in all executables (causing
  duplicate symbol errors in command line tools), and add
  `-fsanitize=fuzzer` to the libfuzzer driver only.

- Make ASan optional when building with libfuzzer to allow the user
  to choose freely from available sanitizers (e.g., UBSan, MSan,
  HWASan).

- Stabilize libfuzzer by resetting PRNG seed at every invocation.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu