### PR TITLE
Ensure that the constructed object in [[Set]] operation with primitive base cannot be extensible

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -144,6 +144,8 @@ vm_op_set_value (ecma_value_t object, /**< base object */
                  ecma_value_t value, /**< ecma value */
                  bool is_strict) /**< strict mode */
 {
+  ecma_object_t * object_p;
+
   if (JERRY_UNLIKELY (!ecma_is_value_object (object)))
   {
     ecma_value_t to_object = ecma_op_to_object (object);
@@ -168,11 +170,15 @@ vm_op_set_value (ecma_value_t object, /**< base object */
 #endif /* ENABLED (JERRY_ERROR_MESSAGES) */
     }
 
-    object = to_object;
+    object_p = ecma_get_object_from_value (to_object);
+    ecma_set_object_extensible (object_p, false);
+  }
+  else
+  {
+    object_p = ecma_get_object_from_value (object);
   }
 
   ecma_string_t *property_p;
-  ecma_object_t *object_p = ecma_get_object_from_value (object);
 
   if (!ecma_is_value_prop_name (property))
   {

--- a/tests/jerry/regression-test-issue-2914.js
+++ b/tests/jerry/regression-test-issue-2914.js
@@ -1,0 +1,48 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var func = function (number) {
+  "use strict";
+  number.foo = "";
+};
+
+var func2 = function (number) {
+  "use strict";
+  number.bar = "";
+};
+
+try {
+  func(-334918463);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  Object.defineProperty(Number.prototype, "foo", { get : function() { throw ReferenceError("foo"); },
+                                                   set : function(a) { throw ReferenceError("bar"); },
+                                                 });
+  func(-334918463);
+  assert(false);
+} catch (e) {
+  assert(e instanceof ReferenceError);
+  assert(e.message === "bar");
+}
+
+var setter_called = false;
+Object.defineProperty(Number.prototype, "bar", { get : function() { assert(false) },
+                                                 set : function(a) { setter_called = true; },
+                                               });
+func2(-334918463);
+assert(setter_called === true);


### PR DESCRIPTION
Related part of the standard: https://www.ecma-international.org/ecma-262/5.1/#sec-8.7 1st note.

This patch fixes #2914.

Co-authored-by: Gabor Loki loki@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu