### PR TITLE
Make libfuzzer driver properly handle ES2015 test inputs with Promises

### DIFF
--- a/jerry-main/libfuzzer.c
+++ b/jerry-main/libfuzzer.c
@@ -31,6 +31,9 @@ int LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
     {
       jerry_value_t run_value = jerry_run (parse_value);
       jerry_release_value (run_value);
+
+      jerry_value_t run_queue_value = jerry_run_all_enqueued_jobs ();
+      jerry_release_value (run_queue_value);
     }
 
     jerry_release_value (parse_value);


### PR DESCRIPTION
Not running enqueued jobs (resulting from promises) caused false
alarms (internal assertion failures) at cleanup.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu