### PR TITLE
Resolve build error after #2888

### DIFF
--- a/jerry-core/vm/vm-defines.h
+++ b/jerry-core/vm/vm-defines.h
@@ -47,9 +47,9 @@ typedef struct vm_frame_ctx_t
   ecma_value_t *stack_top_p;                          /**< stack top pointer */
   ecma_value_t *literal_start_p;                      /**< literal list start pointer */
   ecma_object_t *lex_env_p;                           /**< current lexical environment */
-#if defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO)
+#if defined (JERRY_DEBUGGER) || ENABLED (JERRY_LINE_INFO)
   struct vm_frame_ctx_t *prev_context_p;              /**< previous context */
-#endif /* defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO) */
+#endif /* defined (JERRY_DEBUGGER) || ENABLED (JERRY_LINE_INFO) */
   ecma_value_t this_binding;                          /**< this binding */
   ecma_value_t block_result;                          /**< block result */
 #if ENABLED (JERRY_LINE_INFO)

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -3663,9 +3663,9 @@ vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data heade
   frame_ctx.byte_code_p = (uint8_t *) literal_p;
   frame_ctx.byte_code_start_p = (uint8_t *) literal_p;
   frame_ctx.lex_env_p = lex_env_p;
-#if defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO)
+#if defined (JERRY_DEBUGGER) || ENABLED (JERRY_LINE_INFO)
   frame_ctx.prev_context_p = JERRY_CONTEXT (vm_top_context_p);
-#endif /* defined (JERRY_DEBUGGER) || defined (JERRY_ENABLE_LINE_INFO) */
+#endif /* defined (JERRY_DEBUGGER) || ENABLED (JERRY_LINE_INFO) */
   frame_ctx.this_binding = this_binding_value;
   frame_ctx.block_result = ECMA_VALUE_UNDEFINED;
 #if ENABLED (JERRY_LINE_INFO)


### PR DESCRIPTION
This patch fixes the build error due to #2888 since this patch has been merged without rebasing to #2903.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu