### PR TITLE
Fix implicit integer conversion reported by Clang 8

### DIFF
--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -69,7 +69,7 @@ ecma_op_container_create (const ecma_value_t *arguments_list_p, /**< arguments l
                                                 ECMA_OBJECT_TYPE_CLASS);
 
   ecma_map_object_t *map_obj_p = (ecma_map_object_t *) object_p;
-  map_obj_p->header.u.class_prop.class_id = lit_id;
+  map_obj_p->header.u.class_prop.class_id = (uint16_t) lit_id;
   map_obj_p->header.u.class_prop.u.value = ecma_op_container_create_internal_object ();
   map_obj_p->size = 0;
 
@@ -669,7 +669,7 @@ ecma_op_container_create_iterator (ecma_value_t this_arg, /**< this argument */
 
   return ecma_op_create_iterator_object (this_arg,
                                          ecma_builtin_get (proto_id),
-                                         iterator_type,
+                                         (uint8_t) iterator_type,
                                          type);
 } /* ecma_op_container_create_iterator */
 


### PR DESCRIPTION
When building on Ubuntu 18.04.2 LTS (Linux 4.15.0 x86_64) with Clang 8, the compilation fails:

```sh
$ CC=clang-8 ./tools/build.py --clean --debug --profile=es2015-subset --lto=off
jerry-core/ecma/operations/ecma-container-object.c:72:45: error: implicit conversion loses integer precision: 'lit_magic_string_id_t' to 'uint16_t'
      (aka 'unsigned short') [-Werror,-Wimplicit-int-conversion]
  map_obj_p->header.u.class_prop.class_id = lit_id;
                                          ~ ^~~~~~
jerry-core/ecma/operations/ecma-container-object.c:672:42: error: implicit conversion loses integer precision: 'ecma_pseudo_array_type_t' to 'uint8_t'
      (aka 'unsigned char') [-Werror,-Wimplicit-int-conversion]
                                         iterator_type,
                                         ^~~~~~~~~~~~~
```

This commit fixes the issue by adding explicit conversions. After the change, the build succeeds.
