### PR TITLE
Make API unavailable while processing native free callbacks

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -5179,7 +5179,8 @@ You can get them by calling jerry_get_object_native_pointer later.
 
 *Note*: If a non-NULL free callback is specified in the native type information,
         it will be called by the garbage collector when the object is freed.
-        The type info is always overwrites the previous value, so passing
+        This callback **must not** invoke API functions.
+        The type info always overwrites the previous value, so passing
         a NULL value deletes the current type info.
 
 **Prototype**

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2655,7 +2655,8 @@ jerry_get_object_native_pointer (const jerry_value_t obj_val, /**< object to get
  * Note:
  *      If a non-NULL free callback is specified in the native type info,
  *      it will be called by the garbage collector when the object is freed.
- *      The type info is always overwrites the previous value, so passing
+ *      This callback **must not** invoke API functions.
+ *      The type info always overwrites the previous value, so passing
  *      a NULL value deletes the current type info.
  */
 void

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -527,6 +527,10 @@ ecma_gc_free_native_pointer (ecma_property_t *property_p) /**< property */
   native_pointer_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_native_pointer_t,
                                                       value_p->value);
 
+#ifndef JERRY_NDEBUG
+  JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_API_AVAILABLE;
+#endif /* !JERRY_NDEBUG */
+
   while (native_pointer_p != NULL)
   {
     if (native_pointer_p->info_p != NULL)
@@ -545,6 +549,10 @@ ecma_gc_free_native_pointer (ecma_property_t *property_p) /**< property */
 
     native_pointer_p = next_p;
   }
+
+#ifndef JERRY_NDEBUG
+  JERRY_CONTEXT (status_flags) |= ECMA_STATUS_API_AVAILABLE;
+#endif /* !JERRY_NDEBUG */
 } /* ecma_gc_free_native_pointer */
 
 /**


### PR DESCRIPTION
This patch fixes #2889 and extends the API documentation of the native free callbacks.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu