### PR TITLE
CBC_PUSH_THIS_LITERAL must be converted back to CBC_PUSH_THIS during emitting unary lvalue opcode

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -164,6 +164,14 @@ parser_emit_unary_lvalue_opcode (parser_context_t *context_p, /**< context */
     JERRY_ASSERT (CBC_SAME_ARGS (CBC_PUSH_PROP, opcode));
     context_p->last_cbc_opcode = (uint16_t) opcode;
   }
+  else if (context_p->last_cbc_opcode == CBC_PUSH_THIS_LITERAL
+           && context_p->last_cbc.literal_type == LEXER_IDENT_LITERAL)
+  {
+    context_p->last_cbc_opcode = CBC_PUSH_THIS;
+    parser_emit_cbc_literal (context_p,
+                             (uint16_t) (opcode + CBC_UNARY_LVALUE_WITH_IDENT),
+                             context_p->lit_object.index);
+  }
   else
   {
     switch (context_p->last_cbc_opcode)

--- a/tests/jerry/regression-test-issue-2937.js
+++ b/tests/jerry/regression-test-issue-2937.js
@@ -1,0 +1,30 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var c = 0;
+var p1 = this[c++];
+assert (p1 === undefined);
+assert (c === 1);
+
+var p2 = this[c--];
+assert (p2 === undefined);
+assert (c === 0);
+
+var p3 = this[++c];
+assert (p3 === undefined);
+assert (c === 1);
+
+var p4 = this[--c];
+assert (p4 === undefined);
+assert (c === 0);


### PR DESCRIPTION
This patch fixes #2937.

Co-authored-by: Gabor Loki loki@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu