### PR TITLE
Update URLs in GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,16 +1,4 @@
 # Site settings
 title: JerryScript Engine
-#email: your-email@domain.com
-description: > # this means to ignore newlines until "baseurl:"
-  JerryScript is a very lightweight JavaScript engine with capability to run on microcontrollers with less than 8KB of RAM.
+description: JerryScript is a very lightweight JavaScript engine with capability to run on microcontrollers with less than 8KB of RAM.
 # baseurl: "/jerryscript" # the subpath of your site, e.g. /blog/
-# url: "http://samsung.github.io" # the base hostname & protocol for your site
-#twitter_username: jekyllrb
-#github_username:  samsung
-
-# Build settings
-highlighter: rouge
-
-markdown: kramdown
-kramdown:
-  input: GFM

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,12 +9,12 @@
   <title>JavaScript engine for Internet of Things{% if page.title %}: {{ page.title }} {% endif %}</title>
 
   <!-- Bootstrap core CSS -->
-  <link rel="stylesheet" href="{{ site.github.url }}/css/bootstrap.min.css" >
-  <link rel="stylesheet" href="{{ site.github.url }}/css/table.css">
-  <link rel="stylesheet" href="{{ site.github.url }}/css/bytecode.css">
-  <link rel="stylesheet" href="{{ site.github.url }}/css/block.css">
-  <link rel="stylesheet" href="{{ site.github.url }}/css/main.css">
-  <link rel="stylesheet" href="{{ site.github.url }}/css/img.css">
+  <link rel="stylesheet" href="{{ '/css/bootstrap.min.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/css/table.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/css/bytecode.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/css/block.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/css/main.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/css/img.css' | relative_url }}">
 
   <script>
     window.addEventListener("hashchange", function() { scrollBy(0, -50) });

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,25 +7,25 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="{{ site.github.url }}/"><b>JerryScript</b></a>
+      <a class="navbar-brand" href="{{ '/' | relative_url }}"><b>JerryScript</b></a>
     </div>
     <div id="navbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
         {% if page.url == "/" %}
-          <li class="active"><a href="{{ site.github.url }}/">Home</a></li>
+          <li class="active"><a href="{{ '/' | relative_url }}">Home</a></li>
         {% else %}
-          <li><a href="{{ site.github.url }}/">Home</a></li>
+          <li><a href="{{ '/' | relative_url }}">Home</a></li>
         {% endif %}
-        <li><a href="http://www.iotjs.net">Powering <b>IoT.js</b></a></li>
+        <li><a href="https://www.iotjs.net">Powering <b>IoT.js</b></a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
         {% for p in site.pages %}
           {% if p.title %}
             {% if p.category == "navbar" %}
               {% if page.url == p.url %}
-                <li class="active"><a href="{{ p.url | prepend: site.github.url }}" >{{ p.title }}</a></li>
+                <li class="active"><a href="{{ p.url | relative_url }}" >{{ p.title }}</a></li>
               {% else %}
-                <li><a href="{{ p.url | prepend: site.github.url }}" >{{ p.title }}</a></li>
+                <li><a href="{{ p.url | relative_url }}" >{{ p.title }}</a></li>
               {% endif %}
             {% endif %}
           {% endif %}
@@ -35,7 +35,7 @@
             {% assign doclist = site.pages | sort: 'title' %}
             {% for p in doclist %}
               {% if p.title and p.category == "documents" %}
-                <li><a href="{{ p.url | prepend: site.github.url }}" >{{ p.title }}</a></li>
+                <li><a href="{{ p.url | relative_url }}" >{{ p.title }}</a></li>
               {% endif %}
             {% endfor %}
           </ul>
@@ -44,4 +44,4 @@
     </div><!--/.nav-collapse -->
   </div>
 </nav>
-<a href="https://github.com/pando-project/jerryscript"><img style="position: absolute; top: 50; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>
+<a href="https://github.com/jerryscript-project/jerryscript"><img style="position: absolute; top: 50; right: 0; border: 0;" src="https://camo.githubusercontent.com/652c5b9acfaddf3a9c326fa6bde407b87f7be0f4/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6f72616e67655f6666373630302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_orange_ff7600.png"></a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
 
     <!-- Bootstrap core JavaScript -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script src="{{ site.github.url }}/js/bootstrap.min.js"></script>
+    <script src="{{ '/js/bootstrap.min.js' | relative_url }}"></script>
 
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ permalink: /
 </p>
 </div>
 <div class="learn_more">
-<p>To learn more, please visit the <a href="http://github.com/pando-project/jerryscript">project on GitHub.</a></p>
-<p>If you want to try JerryScript take a look at our documentation. It includes <a href="{{ site.github.url }}/getting-started/">Getting Started</a> guides and <a href="{{ site.github.url }}/api-reference/">JerryScript APIs reference</a>. </p>
-<p>Please, report all bugs and feature requests on JerryScript <a href="https://github.com/pando-project/jerryscript/issues">issue tracker</a>. Feel free to ask questions on <a href="https://github.com/pando-project/jerryscript/labels/question">issue tracker</a>.</p>
+<p>To learn more, please visit the <a href="https://github.com/jerryscript-project/jerryscript">project on GitHub.</a></p>
+<p>If you want to try JerryScript take a look at our documentation. It includes <a href="{{ '/getting-started/' | relative_url }}">Getting Started</a> guides and <a href="{{ '/api-reference/' | relative_url }}">JerryScript APIs reference</a>. </p>
+<p>Please, report all bugs and feature requests on JerryScript <a href="https://github.com/jerryscript-project/jerryscript/issues">issue tracker</a>. Feel free to ask questions on <a href="https://github.com/jerryscript-project/jerryscript/labels/question">issue tracker</a>.</p>
 </div>


### PR DESCRIPTION
Project is now under https://github.com/jerryscript-project and
https://jerryscript.net . Update hardcoded URLs to use HTTPS, both
for JerryScript and IoT.js. Make non-hardcoded URLs use Jekyll's
`relative_url` filter to avoid mixed content errors on GH Pages.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
