### PR TITLE
Add missing release value call to %TypedArray%.prototype.findIndex routine

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1550,7 +1550,13 @@ ecma_builtin_typedarray_prototype_find_helper (ecma_value_t this_arg, /**< this 
 
     if (call_result)
     {
-      return is_find ? element_value : ecma_make_uint32_value (buffer_index);
+      if (is_find)
+      {
+        return element_value;
+      }
+
+      ecma_free_value (element_value);
+      return ecma_make_uint32_value (buffer_index);
     }
     buffer_index++;
     ecma_free_value (element_value);

--- a/tests/jerry/es2015/regression-test-issue-2947.js
+++ b/tests/jerry/es2015/regression-test-issue-2947.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert(new Uint32Array(Array(undefined, 9040650076)).findIndex(function (p_0) { return p_0 }) === 1);


### PR DESCRIPTION
This patch fixes #2947

Co-authored-by: Gabor Loki loki@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
