### PR TITLE
Container object's internal object must be allocated firstly

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -254,6 +254,8 @@ ecma_gc_mark_container_object (ecma_object_t *object_p) /**< object */
   ecma_map_object_t *map_object_p = (ecma_map_object_t *) object_p;
   ecma_object_t *internal_obj_p = ecma_get_object_from_value (map_object_p->header.u.class_prop.u.value);
 
+  ecma_gc_set_object_visited (internal_obj_p);
+
   ecma_property_header_t *prop_iter_p = ecma_get_property_list (internal_obj_p);
 
   if (prop_iter_p != NULL && prop_iter_p->types[0] == ECMA_PROPERTY_TYPE_HASHMAP)
@@ -719,7 +721,6 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 #if ENABLED (JERRY_ES2015_BUILTIN_SET)
         case LIT_MAGIC_STRING_SET_UL:
         {
-          ecma_op_container_clear_map ((ecma_map_object_t *) object_p);
           ecma_dealloc_extended_object (object_p, sizeof (ecma_map_object_t));
           return;
         }
@@ -727,7 +728,6 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 #if ENABLED (JERRY_ES2015_BUILTIN_MAP)
         case LIT_MAGIC_STRING_MAP_UL:
         {
-          ecma_op_container_clear_map ((ecma_map_object_t *) object_p);
           ecma_dealloc_extended_object (object_p, sizeof (ecma_map_object_t));
           return;
         }

--- a/jerry-core/ecma/operations/ecma-container-object.h
+++ b/jerry-core/ecma/operations/ecma-container-object.h
@@ -37,7 +37,7 @@ ecma_value_t ecma_op_container_foreach (ecma_value_t this_arg, ecma_value_t pred
 ecma_value_t ecma_op_container_has (ecma_value_t this_arg, ecma_value_t key_arg, lit_magic_string_id_t lit_id);
 ecma_value_t ecma_op_container_set (ecma_value_t this_arg, ecma_value_t key_arg, ecma_value_t value_arg,
                                     lit_magic_string_id_t lit_id);
-void ecma_op_container_clear_map (ecma_map_object_t *map_object_p);
+
 ecma_value_t ecma_op_container_clear (ecma_value_t this_arg, lit_magic_string_id_t lit_id);
 ecma_value_t ecma_op_container_delete (ecma_value_t this_arg, ecma_value_t key_arg, lit_magic_string_id_t lit_id);
 ecma_value_t ecma_op_container_create_iterator (ecma_value_t this_arg, uint8_t type, lit_magic_string_id_t lit_id,

--- a/tests/jerry/es2015/regression-test-issue-2951.js
+++ b/tests/jerry/es2015/regression-test-issue-2951.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// To trigger the assertion the engine must be compiled with --system allocator=ON and --mem-stress-test=ON
+m = new Map([]);


### PR DESCRIPTION
This patch slightly reworks the container objects internal objects allocation.
This rework allows the same lifetime of the objects without the manual allocation/deallocation of the internal object.

This patch also fixes #2951.

Co-authored-by: Dániel Bátyai <dbatyai@inf.u-szeged.hu>
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
