### PR TITLE
Improve RegExp.prototype.compile

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -64,7 +64,9 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
                                        ecma_value_t flags_arg) /**< flags */
 {
   if (!ecma_is_value_object (this_arg)
-      || !ecma_object_class_is (ecma_get_object_from_value (this_arg), LIT_MAGIC_STRING_REGEXP_UL))
+      || !ecma_object_class_is (ecma_get_object_from_value (this_arg), LIT_MAGIC_STRING_REGEXP_UL)
+      /* The builtin RegExp.prototype object does not have [[RegExpMatcher]] internal slot */
+      || ecma_get_object_from_value (this_arg) == ecma_builtin_get (ECMA_BUILTIN_ID_REGEXP_PROTOTYPE))
   {
     return ecma_raise_type_error (ECMA_ERR_MSG ("Incomplete RegExp type"));
   }
@@ -149,7 +151,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
     re_initialize_props (this_obj_p, pattern_string_p, flags);
     ecma_free_value (obj_this);
 
-    return ECMA_VALUE_UNDEFINED;
+    return ecma_copy_value (this_arg);
   }
 
   ecma_string_t *pattern_string_p = NULL;
@@ -213,7 +215,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
   ecma_free_value (obj_this);
   ecma_deref_ecma_string (pattern_string_p);
 
-  return ECMA_VALUE_UNDEFINED;
+  return ecma_copy_value (this_arg);
 } /* ecma_builtin_regexp_prototype_compile */
 
 #endif /* ENABLED (JERRY_BUILTIN_ANNEXB) */

--- a/tests/jerry/es2015/regression-test-issue-612.js
+++ b/tests/jerry/es2015/regression-test-issue-612.js
@@ -12,5 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var result = RegExp.prototype.compile([]);
-assert(result === undefined);
+try {
+  RegExp.prototype.compile([]);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}

--- a/tests/jerry/regexp-routines.js
+++ b/tests/jerry/regexp-routines.js
@@ -94,7 +94,7 @@ try {
 }
 
 re2.lastIndex = 2;
-re2.compile("asd", "im");
+assert (re2.compile("asd", "im") === re2);
 
 assert (re2 == "/asd/im");
 assert (re2.global === false);
@@ -103,7 +103,7 @@ assert (re2.multiline === true);
 assert (re2.source === "asd");
 assert (re2.lastIndex === 0);
 
-re2.compile(re1);
+assert (re2.compile(re1) === re2);
 assert (re2.toString() === re1.toString());
 assert (re2.global === re1.global);
 assert (re2.ignoreCase === re1.ignoreCase);

--- a/tests/jerry/regression-test-issue-1065.js
+++ b/tests/jerry/regression-test-issue-1065.js
@@ -12,5 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-new (new (new RegExp().constructor)().constructor)().constructor.prototype.toString()
-RegExp().constructor().constructor.prototype.compile(RegExp.prototype)
+new (new (new RegExp().constructor)().constructor)().constructor.prototype.toString();
+
+try {
+  RegExp().constructor().constructor.prototype.compile(RegExp.prototype);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}

--- a/tests/jerry/regression-test-issue-1080.js
+++ b/tests/jerry/regression-test-issue-1080.js
@@ -14,5 +14,12 @@
 
 ((new RegExp("}").constructor)("a", "g").constructor)(undefined).constructor.prototype.toString();
 new Date("2015-07-09T12:13:14.121+01:30").toISOString();
-RegExp(new RegExp("a", "g")).constructor("").constructor.prototype.compile(RegExp.prototype);
+
+try {
+  RegExp(new RegExp("a", "g")).constructor("").constructor.prototype.compile(RegExp.prototype);
+  assert (false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
 new Date("2015-09-17").getUTCFullYear();

--- a/tests/jerry/regression-test-issue-783.js
+++ b/tests/jerry/regression-test-issue-783.js
@@ -12,4 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-RegExp.prototype.compile(RegExp.prototype);
+try {
+  RegExp.prototype.compile(RegExp.prototype);
+  assert(false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes the return value of the routine also fixes several incorrect regression-tests
due to the previously incorrect [[RegExpMatcher]] internal slot check.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
