### PR TITLE
Add dependency info for accessing memstats from API

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -8,8 +8,8 @@ Enum that contains the following elements:
  - JERRY_INIT_SHOW_OPCODES - dump byte-code to log after parse
  - JERRY_INIT_SHOW_REGEXP_OPCODES - dump regexp byte-code to log after compilation
  - JERRY_INIT_MEM_STATS - dump memory statistics
- - JERRY_INIT_MEM_STATS_SEPARATE - dump memory statistics and reset peak values after parse
- - JERRY_INIT_DEBUGGER - deprecated, an unused placeholder now
+ - JERRY_INIT_MEM_STATS_SEPARATE - **deprecated**, dump memory statistics and reset peak values after parse
+ - JERRY_INIT_DEBUGGER - **deprecated**, an unused placeholder now
 
 ## jerry_type_t
 
@@ -790,6 +790,14 @@ main (void)
 
 Get heap memory stats.
 
+**Notes**:
+- The engine must be initialized with the `JERRY_INIT_MEM_STATS` option to allow
+  heap statistic collections. See [jerry_init](#jerry_init)
+- This API depends on a build option (`JERRY_MEM_STATS`) and can be checked
+  in runtime with the `JERRY_FEATURE_MEM_STATS` feature enum value,
+  see: [jerry_is_feature_enabled](#jerry_is_feature_enabled).
+
+
 **Prototype**
 
 ```c
@@ -799,12 +807,15 @@ jerry_get_memory_stats (jerry_heap_stats_t *out_stats_p);
 
 - `out_stats_p` - out parameter, that provides the heap statistics.
 - return value
-  - true, if run was successful
-  - false, otherwise. Usually it is because the MEM_STATS feature is not enabled.
+  - true, if stats were written into the `out_stats_p` pointer.
+  - false, otherwise. Usually it is because the `JERRY_FEATURE_MEM_STATS` feature is not enabled.
 
 **Example**
 
 ```c
+jerry_init (JERRY_INIT_MEM_STATS);
+// ...
+
 jerry_heap_stats_t stats = {0};
 bool get_stats_ret = jerry_get_memory_stats (&stats);
 ```


### PR DESCRIPTION
The documentation of `jerry_get_memory_stats` method was missing
the requirements on what build option or feature is required.