### PR TITLE
Reduce the size of the jerry_context_t structure

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2575,7 +2575,7 @@ jerry_objects_foreach (jerry_objects_foreach_t foreach_p, /**< function pointer 
 
   JERRY_ASSERT (foreach_p != NULL);
 
-  for (ecma_object_t *iter_p = JERRY_CONTEXT (ecma_gc_objects_p);
+  for (ecma_object_t *iter_p = ECMA_GET_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_gc_objects_cp));
        iter_p != NULL;
        iter_p = ECMA_GET_POINTER (ecma_object_t, iter_p->gc_next_cp))
   {
@@ -2609,7 +2609,7 @@ jerry_objects_foreach_by_native_info (const jerry_object_native_info_t *native_i
 
   ecma_native_pointer_t *native_pointer_p;
 
-  for (ecma_object_t *iter_p = JERRY_CONTEXT (ecma_gc_objects_p);
+  for (ecma_object_t *iter_p = ECMA_GET_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_gc_objects_cp));
        iter_p != NULL;
        iter_p = ECMA_GET_POINTER (ecma_object_t, iter_p->gc_next_cp))
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -276,7 +276,7 @@ ecma_builtin_is (ecma_object_t *obj_p, /**< pointer to an object */
 
   /* If a built-in object is not instantiated, its value is NULL,
      hence it cannot be equal to a valid object. */
-  return (obj_p == JERRY_CONTEXT (ecma_builtin_objects)[builtin_id]);
+  return (obj_p == ECMA_GET_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[builtin_id]));
 } /* ecma_builtin_is */
 
 /**
@@ -292,12 +292,12 @@ ecma_builtin_get (ecma_builtin_id_t builtin_id) /**< id of built-in to check on 
 {
   JERRY_ASSERT (builtin_id < ECMA_BUILTIN_ID__COUNT);
 
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (ecma_builtin_objects)[builtin_id] == NULL))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (ecma_builtin_objects)[builtin_id] == JMEM_CP_NULL))
   {
     ecma_instantiate_builtin (builtin_id);
   }
 
-  return JERRY_CONTEXT (ecma_builtin_objects)[builtin_id];
+  return ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[builtin_id]);
 } /* ecma_builtin_get */
 
 /**
@@ -311,9 +311,9 @@ ecma_builtin_get (ecma_builtin_id_t builtin_id) /**< id of built-in to check on 
 inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_get_global (void)
 {
-  JERRY_ASSERT (JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL] != NULL);
+  JERRY_ASSERT (JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL] != JMEM_CP_NULL);
 
-  return JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL];
+  return ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[ECMA_BUILTIN_ID_GLOBAL]);
 } /* ecma_builtin_get_global */
 
 /**
@@ -339,7 +339,7 @@ static void
 ecma_instantiate_builtin (ecma_builtin_id_t obj_builtin_id) /**< built-in id */
 {
   JERRY_ASSERT (obj_builtin_id < ECMA_BUILTIN_ID__COUNT);
-  JERRY_ASSERT (JERRY_CONTEXT (ecma_builtin_objects)[obj_builtin_id] == NULL);
+  JERRY_ASSERT (JERRY_CONTEXT (ecma_builtin_objects)[obj_builtin_id] == JMEM_CP_NULL);
 
   ecma_builtin_descriptor_t builtin_desc = ecma_builtin_descriptors[obj_builtin_id];
   ecma_builtin_id_t object_prototype_builtin_id = (ecma_builtin_id_t) (builtin_desc >> ECMA_BUILTIN_PROTOTYPE_ID_SHIFT);
@@ -352,11 +352,12 @@ ecma_instantiate_builtin (ecma_builtin_id_t obj_builtin_id) /**< built-in id */
   }
   else
   {
-    if (JERRY_CONTEXT (ecma_builtin_objects)[object_prototype_builtin_id] == NULL)
+    if (JERRY_CONTEXT (ecma_builtin_objects)[object_prototype_builtin_id] == JMEM_CP_NULL)
     {
       ecma_instantiate_builtin (object_prototype_builtin_id);
     }
-    prototype_obj_p = JERRY_CONTEXT (ecma_builtin_objects)[object_prototype_builtin_id];
+    prototype_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t,
+                                                 JERRY_CONTEXT (ecma_builtin_objects)[object_prototype_builtin_id]);
     JERRY_ASSERT (prototype_obj_p != NULL);
   }
 
@@ -502,7 +503,7 @@ ecma_instantiate_builtin (ecma_builtin_id_t obj_builtin_id) /**< built-in id */
     }
   }
 
-  JERRY_CONTEXT (ecma_builtin_objects)[obj_builtin_id] = obj_p;
+  ECMA_SET_NON_NULL_POINTER (JERRY_CONTEXT (ecma_builtin_objects)[obj_builtin_id], obj_p);
 } /* ecma_instantiate_builtin */
 
 /**
@@ -515,10 +516,10 @@ ecma_finalize_builtins (void)
        id < ECMA_BUILTIN_ID__COUNT;
        id = (ecma_builtin_id_t) (id + 1))
   {
-    if (JERRY_CONTEXT (ecma_builtin_objects)[id] != NULL)
+    if (JERRY_CONTEXT (ecma_builtin_objects)[id] != JMEM_CP_NULL)
     {
-      ecma_deref_object (JERRY_CONTEXT (ecma_builtin_objects)[id]);
-      JERRY_CONTEXT (ecma_builtin_objects)[id] = NULL;
+      ecma_deref_object (ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[id]));
+      JERRY_CONTEXT (ecma_builtin_objects)[id] = JMEM_CP_NULL;
     }
   }
 } /* ecma_finalize_builtins */

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -41,9 +41,10 @@ ecma_init_global_lex_env (void)
 {
   ecma_object_t *glob_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_GLOBAL);
 
-  JERRY_CONTEXT (ecma_global_lex_env_p) = ecma_create_object_lex_env (NULL,
-                                                                      glob_obj_p,
-                                                                      ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND);
+  ecma_object_t *global_lex_env_p = ecma_create_object_lex_env (NULL,
+                                                                glob_obj_p,
+                                                                ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND);
+  ECMA_SET_NON_NULL_POINTER (JERRY_CONTEXT (ecma_global_lex_env_cp), global_lex_env_p);
 } /* ecma_init_global_lex_env */
 
 /**
@@ -52,8 +53,8 @@ ecma_init_global_lex_env (void)
 void
 ecma_finalize_global_lex_env (void)
 {
-  ecma_deref_object (JERRY_CONTEXT (ecma_global_lex_env_p));
-  JERRY_CONTEXT (ecma_global_lex_env_p) = NULL;
+  ecma_deref_object (ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_global_lex_env_cp)));
+  JERRY_CONTEXT (ecma_global_lex_env_cp) = JMEM_CP_NULL;
 } /* ecma_finalize_global_lex_env */
 
 /**
@@ -65,7 +66,8 @@ ecma_finalize_global_lex_env (void)
 ecma_object_t *
 ecma_get_global_environment (void)
 {
-  return JERRY_CONTEXT (ecma_global_lex_env_p);
+  JERRY_ASSERT (JERRY_CONTEXT (ecma_global_lex_env_cp) != JMEM_CP_NULL);
+  return ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_global_lex_env_cp));
 } /* ecma_get_global_environment */
 
 /**

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -111,11 +111,11 @@ struct jerry_context_t
 #endif /* ENABLED (JERRY_EXTERNAL_CONTEXT) */
 
   /* Update JERRY_CONTEXT_FIRST_MEMBER if the first non-external member changes */
-  ecma_object_t *ecma_builtin_objects[ECMA_BUILTIN_ID__COUNT]; /**< pointer to instances of built-in objects */
+  jmem_cpointer_t ecma_builtin_objects[ECMA_BUILTIN_ID__COUNT]; /**< pointer to instances of built-in objects */
 #if ENABLED (JERRY_BUILTIN_REGEXP)
   const re_compiled_code_t *re_cache[RE_CACHE_SIZE]; /**< regex cache */
 #endif /* ENABLED (JERRY_BUILTIN_REGEXP) */
-  ecma_object_t *ecma_gc_objects_p; /**< List of currently alive objects. */
+  jmem_cpointer_t ecma_gc_objects_cp; /**< List of currently alive objects. */
   jmem_heap_free_t *jmem_heap_list_skip_p; /**< This is used to speed up deallocation. */
   jmem_pools_chunk_t *jmem_free_8_byte_chunk_p; /**< list of free eight byte pool chunks */
 #if ENABLED (JERRY_CPOINTER_32_BIT)
@@ -128,7 +128,7 @@ struct jerry_context_t
   ecma_lit_storage_item_t *symbol_list_first_p; /**< first item of the global symbol list */
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_SYMBOL) */
   ecma_lit_storage_item_t *number_list_first_p; /**< first item of the literal number list */
-  ecma_object_t *ecma_global_lex_env_p; /**< global lexical environment */
+  jmem_cpointer_t ecma_global_lex_env_cp; /**< global lexical environment */
 
 #if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
   ecma_module_t *ecma_modules_p; /**< list of referenced modules */


### PR DESCRIPTION
This patch substitutes several global pointer with compressed pointers to reduce the size of the structure.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
