### PR TITLE
Fix Math.pow

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -412,6 +412,11 @@ ecma_builtin_math_dispatch_routine (uint16_t builtin_routine_id, /**< built-in w
           /* Handle differences between ES5.1 and ISO C standards for pow. */
           x = ecma_number_make_nan ();
         }
+        else if (ecma_number_is_zero (y))
+        {
+          /* Handle differences between ES5.1 and ISO C standards for pow. */
+          x = (ecma_number_t) 1.0;
+        }
         else
         {
           x = DOUBLE_TO_ECMA_NUMBER_T (pow (x, y));


### PR DESCRIPTION
The Math.pow implementation calls libm's pow. The ISO C and ES5.1
standards differ on some special cases of pow. jerry-libm is already
ES5.1 conform, but system libm libraries on Linux and Windows aren't.

Math.pow(NaN, +/-0.0) is NaN on Windows and Linux with system libm,
but should be 1.0 according to ES5.1 / 15.8.2.13.

This patch handles this special case in Math.pow instead of calling pow of libm.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu