### PR TITLE
Don't use VLAs in unit tests and API examples

### DIFF
--- a/docs/03.API-EXAMPLE.md
+++ b/docs/03.API-EXAMPLE.md
@@ -634,14 +634,21 @@ print_value (const jerry_value_t jsvalue)
   /* String value */
   else if (jerry_value_is_string (value))
   {
+    jerry_char_t str_buf_p[256];
+
     /* Determining required buffer size */
     jerry_size_t req_sz = jerry_get_string_size (value);
-    jerry_char_t str_buf_p[req_sz + 1];
 
-    jerry_string_to_char_buffer (value, str_buf_p, req_sz);
-    str_buf_p[req_sz] = '\0';
-
-    printf ("%s", (const char *) str_buf_p);
+    if (req_sz <= 255)
+    {
+      jerry_string_to_char_buffer (value, str_buf_p, req_sz);
+      str_buf_p[req_sz] = '\0';
+      printf ("%s", (const char *) str_buf_p);
+    }
+    else
+    {
+      printf ("error: buffer isn't big enough");
+    }
   }
   /* Object reference */
   else if (jerry_value_is_object (value))
@@ -721,14 +728,21 @@ print_value (const jerry_value_t jsvalue)
   /* String value */
   else if (jerry_value_is_string (value))
   {
+    jerry_char_t str_buf_p[256];
+
     /* Determining required buffer size */
     jerry_size_t req_sz = jerry_get_string_size (value);
-    jerry_char_t str_buf_p[req_sz + 1];
 
-    jerry_string_to_char_buffer (value, str_buf_p, req_sz);
-    str_buf_p[req_sz] = '\0';
-
-    printf ("%s", (const char *) str_buf_p);
+    if (req_sz <= 255)
+    {
+      jerry_string_to_char_buffer (value, str_buf_p, req_sz);
+      str_buf_p[req_sz] = '\0';
+      printf ("%s", (const char *) str_buf_p);
+    }
+    else
+    {
+      printf ("error: buffer isn't big enough");
+    }
   }
   /* Object reference */
   else if (jerry_value_is_object (value))
@@ -737,7 +751,6 @@ print_value (const jerry_value_t jsvalue)
   }
 
   printf ("\n");
-
   jerry_release_value (value);
 }
 

--- a/tests/unit-core/test-api-strings.c
+++ b/tests/unit-core/test-api-strings.c
@@ -60,8 +60,8 @@ main (void)
   utf8_sz = jerry_get_string_size (args[0]);
   cesu8_sz = jerry_get_string_size (args[1]);
 
-  char string_from_utf8[utf8_sz];
-  char string_from_cesu8[cesu8_sz];
+  JERRY_VLA (char, string_from_utf8, utf8_sz);
+  JERRY_VLA (char, string_from_cesu8, cesu8_sz);
 
   jerry_string_to_char_buffer (args[0], (jerry_char_t *) string_from_utf8, utf8_sz);
   jerry_string_to_char_buffer (args[1], (jerry_char_t *) string_from_cesu8, cesu8_sz);
@@ -85,8 +85,8 @@ main (void)
 
   TEST_ASSERT (utf8_sz == cesu8_sz);
 
-  char string_from_utf8_string[utf8_sz];
-  char string_from_cesu8_string[cesu8_sz];
+  JERRY_VLA (char, string_from_utf8_string, utf8_sz);
+  JERRY_VLA (char, string_from_cesu8_string, cesu8_sz);
 
   jerry_string_to_utf8_char_buffer (args[0], (jerry_char_t *) string_from_utf8_string, utf8_sz);
   jerry_string_to_utf8_char_buffer (args[1], (jerry_char_t *) string_from_cesu8_string, cesu8_sz);
@@ -108,7 +108,7 @@ main (void)
   TEST_ASSERT (cesu8_sz != utf8_sz);
   TEST_ASSERT (utf8_sz == 14 && cesu8_sz == 18);
 
-  char test_string[utf8_sz];
+  JERRY_VLA (char, test_string, utf8_sz);
 
   TEST_ASSERT (jerry_string_to_utf8_char_buffer (args[0], (jerry_char_t *) test_string, utf8_sz) == 14);
   TEST_ASSERT (!strncmp (test_string, "\x73\x74\x72\x3a \xf0\x9d\x94\xa3 \xf0\x9d\x94\xa4", utf8_sz));
@@ -210,7 +210,7 @@ main (void)
   /* Buffer size */
   cesu8_sz = 5;
 
-  char substring[cesu8_sz];
+  JERRY_VLA (char, substring, cesu8_sz);
   sz = jerry_substring_to_char_buffer (args[0], 3, 8, (jerry_char_t *) substring, cesu8_sz);
   TEST_ASSERT (sz == 5);
   TEST_ASSERT (!strncmp (substring, "ascii", sz));
@@ -238,7 +238,7 @@ main (void)
   TEST_ASSERT (cesu8_length == 15);
   TEST_ASSERT (cesu8_length == cesu8_sz);
 
-  char fullstring[cesu8_sz];
+  JERRY_VLA (char, fullstring, cesu8_sz);
   sz = jerry_substring_to_char_buffer (args[0], 0, cesu8_length, (jerry_char_t *) fullstring, cesu8_sz);
   TEST_ASSERT (sz == 15);
   TEST_ASSERT (!strncmp (fullstring, "an ascii string", sz));
@@ -249,7 +249,7 @@ main (void)
   args[0] = jerry_create_string ((jerry_char_t *) "0101");
   cesu8_sz = jerry_get_string_size (args[0]);
 
-  char number_substring[cesu8_sz];
+  JERRY_VLA (char, number_substring, cesu8_sz);
 
   sz = jerry_substring_to_char_buffer (args[0], 1, 3, (jerry_char_t *) number_substring, cesu8_sz);
   TEST_ASSERT (sz == 2);
@@ -264,7 +264,7 @@ main (void)
   TEST_ASSERT (cesu8_sz == 11);
   TEST_ASSERT (cesu8_length = 7);
 
-  char supl_substring[cesu8_sz];
+  JERRY_VLA (char, supl_substring, cesu8_sz);
 
   sz = jerry_substring_to_char_buffer (args[0], 0, cesu8_length, (jerry_char_t *) supl_substring, cesu8_sz);
   TEST_ASSERT (sz == 11);

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -902,7 +902,7 @@ main (void)
   cesu8_length = jerry_get_string_length (args[0]);
   cesu8_sz = jerry_get_string_size (args[0]);
 
-  char string_console[cesu8_sz];
+  JERRY_VLA (char, string_console, cesu8_sz);
   jerry_string_to_char_buffer (args[0], (jerry_char_t *) string_console, cesu8_sz);
 
   TEST_ASSERT (!strncmp (string_console, "console", cesu8_sz));
@@ -923,7 +923,7 @@ main (void)
   cesu8_length = jerry_get_string_length (args[1]);
   cesu8_sz = jerry_get_string_size (args[1]);
 
-  char string_greek_zero_sign[cesu8_sz];
+  JERRY_VLA (char, string_greek_zero_sign, cesu8_sz);
   jerry_string_to_char_buffer (args[1], (jerry_char_t *) string_greek_zero_sign, cesu8_sz);
 
   TEST_ASSERT (!strncmp (string_greek_zero_sign, "\xed\xa0\x80\xed\xb6\x8a", cesu8_sz));
@@ -944,7 +944,7 @@ main (void)
     jerry_value_t parsed_data = jerry_get_property (parsed_json, key);
     TEST_ASSERT (jerry_value_is_string (parsed_data)== true);
     jerry_size_t buff_size = (jerry_size_t) jerry_get_string_length (parsed_data);
-    char buff[buff_size + 1];
+    JERRY_VLA (char, buff, buff_size + 1);
     jerry_string_to_char_buffer (parsed_data, (jerry_char_t *) buff, buff_size);
     buff[buff_size] = '\0';
     TEST_ASSERT (strcmp (data_check, buff) == false);
@@ -965,7 +965,7 @@ main (void)
     jerry_release_value (res);
     jerry_value_t stringified = jerry_json_stringify (obj);
     TEST_ASSERT (jerry_value_is_string (stringified));
-    char buff[jerry_get_string_length (stringified)];
+    JERRY_VLA (char, buff, stringified);
     jerry_string_to_char_buffer (stringified, (jerry_char_t *) buff,
                                 (jerry_size_t) jerry_get_string_length (stringified));
     buff[jerry_get_string_length (stringified)] = '\0';

--- a/tests/unit-core/test-arraybuffer.c
+++ b/tests/unit-core/test-arraybuffer.c
@@ -57,7 +57,7 @@ assert_handler (const jerry_value_t func_obj_val, /**< function object */
       && jerry_value_is_string (args_p[1]))
   {
     jerry_length_t utf8_sz = jerry_get_string_size (args_p[1]);
-    char string_from_utf8[utf8_sz];
+    JERRY_VLA (char, string_from_utf8, utf8_sz);
     string_from_utf8[utf8_sz] = 0;
 
     jerry_string_to_char_buffer (args_p[1], (jerry_char_t *) string_from_utf8, utf8_sz);
@@ -255,7 +255,7 @@ main (void)
     const uint32_t buffer_size = 15;
     const uint8_t base_value = 51;
 
-    uint8_t buffer_p[buffer_size];
+    JERRY_VLA (uint8_t, buffer_p, buffer_size);
     memset (buffer_p, base_value, buffer_size);
 
     jerry_value_t arrayb = jerry_create_arraybuffer_external (buffer_size, buffer_p, test_free_cb);
@@ -270,7 +270,7 @@ main (void)
       TEST_ASSERT (buffer_p[i] == base_value);
     }
 
-    uint8_t test_buffer[buffer_size];
+    JERRY_VLA (uint8_t, test_buffer, buffer_size);
     jerry_length_t read = jerry_arraybuffer_read (arrayb, 0, test_buffer, buffer_size);
     TEST_ASSERT (read == buffer_size);
     TEST_ASSERT (test_buffer[0] == new_value);
@@ -287,7 +287,7 @@ main (void)
   /* Test ArrayBuffer external memory map/unmap */
   {
     const uint32_t buffer_size = 20;
-    uint8_t buffer_p[buffer_size];
+    JERRY_VLA (uint8_t, buffer_p, buffer_size);
     {
       jerry_value_t input_buffer = jerry_create_arraybuffer_external (buffer_size, buffer_p, NULL);
       register_js_value ("input_buffer", input_buffer);

--- a/tests/unit-core/test-regexp.c
+++ b/tests/unit-core/test-regexp.c
@@ -48,7 +48,7 @@ main (void)
   jerry_value_t is_global = jerry_get_property_by_index (res, 2);
 
   jerry_size_t str_size = jerry_get_string_size (regex_res_str);
-  jerry_char_t res_buff[str_size];
+  JERRY_VLA (jerry_char_t, res_buff, str_size);
   jerry_size_t res_size = jerry_string_to_char_buffer (regex_res_str, res_buff, str_size);
 
   const char expected_result[] = "something";

--- a/tests/unit-core/test-symbol.c
+++ b/tests/unit-core/test-symbol.c
@@ -171,7 +171,7 @@ main (void)
 
   jerry_size_t bar_symbol_string_size = jerry_get_string_size (bar_symbol_string);
   TEST_ASSERT (bar_symbol_string_size == (sizeof (SYMBOL_DESCIPTIVE_STRING_BAR) - 1));
-  jerry_char_t str_buff[bar_symbol_string_size];
+  JERRY_VLA (jerry_char_t, str_buff, bar_symbol_string_size);
 
   jerry_string_to_char_buffer (bar_symbol_string, str_buff, bar_symbol_string_size);
   TEST_ASSERT (memcmp (str_buff, SYMBOL_DESCIPTIVE_STRING_BAR, sizeof (SYMBOL_DESCIPTIVE_STRING_BAR) - 1) == 0);

--- a/tests/unit-core/test-typedarray.c
+++ b/tests/unit-core/test-typedarray.c
@@ -69,7 +69,7 @@ assert_handler (const jerry_value_t func_obj_val, /**< function object */
         && jerry_value_is_string (args_p[1]))
     {
       jerry_length_t utf8_sz = jerry_get_string_size (args_p[1]);
-      char string_from_utf8[utf8_sz];
+      JERRY_VLA (char, string_from_utf8, utf8_sz);
       string_from_utf8[utf8_sz] = 0;
 
       jerry_string_to_char_buffer (args_p[1], (jerry_char_t *) string_from_utf8, utf8_sz);
@@ -204,7 +204,7 @@ test_typedarray_complex_creation (test_entry_t test_entries[], /**< test cases *
 {
   const uint32_t arraybuffer_size = 256;
 
-  uint8_t buffer_ext[arraybuffer_size];
+  JERRY_VLA (uint8_t, buffer_ext, arraybuffer_size);
   memset (buffer_ext, 0, arraybuffer_size);
 
   for (uint32_t i = 0; test_entries[i].constructor_name != NULL; i++)
@@ -265,7 +265,7 @@ test_typedarray_complex_creation (test_entry_t test_entries[], /**< test cases *
       TEST_ASSERT (byte_length == element_count * bytes_per_element);
       TEST_ASSERT (byte_offset == offset);
 
-      uint8_t test_buffer[arraybuffer_size];
+      JERRY_VLA (uint8_t, test_buffer, arraybuffer_size);
 
       jerry_typedarray_type_t type = jerry_get_typedarray_type (typedarray);
       jerry_value_t read_count = jerry_arraybuffer_read (buffer, 0, test_buffer, offset + byte_length);
@@ -448,7 +448,7 @@ main (void)
     jerry_value_t array = jerry_create_typedarray (JERRY_TYPEDARRAY_UINT8, element_count);
 
     {
-      uint8_t expected_data[element_count];
+      JERRY_VLA (uint8_t, expected_data, element_count);
       memset (expected_data, expected_value, element_count);
 
       jerry_length_t byte_length;
@@ -493,7 +493,7 @@ main (void)
       jerry_value_t buffer = jerry_get_typedarray_buffer (array, &offset, &byte_length);
       TEST_ASSERT (byte_length == element_count);
 
-      uint8_t result_data[element_count];
+      JERRY_VLA (uint8_t, result_data, element_count);
 
       jerry_length_t read_count = jerry_arraybuffer_read (buffer, offset, result_data, byte_length);
       TEST_ASSERT (read_count == byte_length);

--- a/tests/unit-ext/module/jerry-module-test.c
+++ b/tests/unit-ext/module/jerry-module-test.c
@@ -86,7 +86,7 @@ resolve_differently_handled_module (const jerry_value_t name,
                                     jerry_value_t *result)
 {
   jerry_size_t name_size = jerry_get_utf8_string_size (name);
-  jerry_char_t name_string[name_size];
+  JERRY_VLA (jerry_char_t, name_string, name_size);
   jerry_string_to_utf8_char_buffer (name, name_string, name_size);
 
   if (!strncmp ((char *) name_string, "differently-handled-module", name_size))
@@ -113,7 +113,7 @@ cache_check (const jerry_value_t name,
              jerry_value_t *result)
 {
   jerry_size_t name_size = jerry_get_utf8_string_size (name);
-  jerry_char_t name_string[name_size];
+  JERRY_VLA (jerry_char_t, name_string, name_size);
   jerry_string_to_utf8_char_buffer (name, name_string, name_size);
 
   if (!strncmp ((char *) name_string, "cache-check", name_size))

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -801,7 +801,7 @@ test_utf8_string (void)
   jerry_value_t str = jerry_create_string ((jerry_char_t *) "\x73\x74\x72\x3a \xed\xa0\x81\xed\xb0\x80");
   char expect_utf8_buf[] = "\x73\x74\x72\x3a \xf0\x90\x90\x80";
   size_t buf_len = sizeof (expect_utf8_buf) - 1;
-  char buf[buf_len+1];
+  JERRY_VLA (char, buf, buf_len + 1);
 
   jerryx_arg_t mapping[] =
   {

--- a/tests/unit-ext/test-ext-module-canonical.c
+++ b/tests/unit-ext/test-ext-module-canonical.c
@@ -26,7 +26,7 @@ static jerry_value_t
 get_canonical_name (const jerry_value_t name)
 {
   jerry_size_t name_size = jerry_get_string_size (name);
-  jerry_char_t name_string[name_size + 1];
+  JERRY_VLA (jerry_char_t, name_string, name_size + 1);
   jerry_string_to_char_buffer (name, name_string, name_size);
   name_string[name_size] = 0;
 
@@ -48,7 +48,7 @@ static bool
 resolve (const jerry_value_t canonical_name, jerry_value_t *result)
 {
   jerry_size_t name_size = jerry_get_string_size (canonical_name);
-  jerry_char_t name_string[name_size + 1];
+  JERRY_VLA (jerry_char_t, name_string, name_size + 1);
   jerry_string_to_char_buffer (canonical_name, name_string, name_size);
   name_string[name_size] = 0;
 


### PR DESCRIPTION
MSVC doesn't support C99 VLA (variable-length array).
Use fixed size arrays in API examples and use JERRY_VLA macro
in unit tests to make these tests buildable on Windows too.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
