### PR TITLE
Fix unused parameter related build issues on Windows

### DIFF
--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -310,8 +310,10 @@ wait_for_source_callback (const jerry_char_t *resource_name_p, /**< resource nam
                           size_t resource_name_size, /**< size of resource name */
                           const jerry_char_t *source_p, /**< source code */
                           size_t source_size, /**< source code size */
-                          void *user_p __attribute__((unused))) /**< user pointer */
+                          void *user_p /**< user pointer */)
 {
+  (void) user_p;
+
   jerry_value_t ret_val = jerry_parse (resource_name_p,
                                        resource_name_size,
                                        source_p,

--- a/tests/unit-core/test-api-set-and-clear-error-flag.c
+++ b/tests/unit-core/test-api-set-and-clear-error-flag.c
@@ -20,10 +20,10 @@ static void
 compare_str (jerry_value_t value, const jerry_char_t *str_p, size_t str_len)
 {
   jerry_size_t size = jerry_get_string_size (value);
-  JERRY_ASSERT (str_len == size);
+  TEST_ASSERT (str_len == size);
   JERRY_VLA (jerry_char_t, str_buff, size);
   jerry_string_to_utf8_char_buffer (value, str_buff, size);
-  JERRY_ASSERT (!memcmp (str_p, str_buff, str_len));
+  TEST_ASSERT (!memcmp (str_p, str_buff, str_len));
 } /* compare_str */
 
 int
@@ -39,7 +39,7 @@ main (void)
 
   obj_val = jerry_get_value_from_error (err_val, true);
 
-  JERRY_ASSERT (obj_val != err_val);
+  TEST_ASSERT (obj_val != err_val);
   jerry_release_value (err_val);
   jerry_release_value (obj_val);
 
@@ -79,7 +79,7 @@ main (void)
   str = jerry_create_string (pterodactylus);
   error = jerry_create_error_from_value (str, true);
   error = jerry_create_abort_from_value (error, true);
-  JERRY_ASSERT (jerry_value_is_abort (error));
+  TEST_ASSERT (jerry_value_is_abort (error));
   str = jerry_get_value_from_error (error, true);
 
   compare_str (str, pterodactylus, pterodactylus_size);
@@ -88,7 +88,7 @@ main (void)
   str = jerry_create_string (pterodactylus);
   error = jerry_create_error_from_value (str, true);
   jerry_value_t error2 = jerry_create_abort_from_value (error, false);
-  JERRY_ASSERT (jerry_value_is_abort (error2));
+  TEST_ASSERT (jerry_value_is_abort (error2));
   jerry_release_value (error);
   str = jerry_get_value_from_error (error2, true);
 
@@ -98,77 +98,77 @@ main (void)
   double test_num = 3.1415926;
   jerry_value_t num = jerry_create_number (test_num);
   jerry_value_t num2 = jerry_create_error_from_value (num, false);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   jerry_release_value (num);
   num2 = jerry_get_value_from_error (num2, true);
-  JERRY_ASSERT (jerry_get_number_value (num2) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num2) == test_num);
   jerry_release_value (num2);
 
   num = jerry_create_number (test_num);
   num2 = jerry_create_error_from_value (num, true);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   num2 = jerry_get_value_from_error (num2, true);
-  JERRY_ASSERT (jerry_get_number_value (num2) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num2) == test_num);
   jerry_release_value (num2);
 
   num = jerry_create_number (test_num);
   num2 = jerry_create_error_from_value (num, false);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   jerry_release_value (num);
   jerry_value_t num3 = jerry_create_error_from_value (num2, false);
-  JERRY_ASSERT (jerry_value_is_error (num3));
+  TEST_ASSERT (jerry_value_is_error (num3));
   jerry_release_value (num2);
   num2 = jerry_get_value_from_error (num3, true);
-  JERRY_ASSERT (jerry_get_number_value (num2) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num2) == test_num);
   jerry_release_value (num2);
 
   num = jerry_create_number (test_num);
   num2 = jerry_create_error_from_value (num, true);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   num3 = jerry_create_error_from_value (num2, true);
-  JERRY_ASSERT (jerry_value_is_error (num3));
+  TEST_ASSERT (jerry_value_is_error (num3));
   num2 = jerry_get_value_from_error (num3, true);
-  JERRY_ASSERT (jerry_get_number_value (num2) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num2) == test_num);
   jerry_release_value (num2);
 
   num = jerry_create_number (test_num);
   error = jerry_create_abort_from_value (num, true);
-  JERRY_ASSERT (jerry_value_is_abort (error));
+  TEST_ASSERT (jerry_value_is_abort (error));
   num2 = jerry_create_error_from_value (error, true);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   num = jerry_get_value_from_error (num2, true);
-  JERRY_ASSERT (jerry_get_number_value (num) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num) == test_num);
   jerry_release_value (num);
 
   num = jerry_create_number (test_num);
   error = jerry_create_abort_from_value (num, false);
   jerry_release_value (num);
-  JERRY_ASSERT (jerry_value_is_abort (error));
+  TEST_ASSERT (jerry_value_is_abort (error));
   num2 = jerry_create_error_from_value (error, true);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   num = jerry_get_value_from_error (num2, true);
-  JERRY_ASSERT (jerry_get_number_value (num) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num) == test_num);
   jerry_release_value (num);
 
   num = jerry_create_number (test_num);
   error = jerry_create_abort_from_value (num, true);
-  JERRY_ASSERT (jerry_value_is_abort (error));
+  TEST_ASSERT (jerry_value_is_abort (error));
   num2 = jerry_create_error_from_value (error, false);
   jerry_release_value (error);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   num = jerry_get_value_from_error (num2, true);
-  JERRY_ASSERT (jerry_get_number_value (num) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num) == test_num);
   jerry_release_value (num);
 
   num = jerry_create_number (test_num);
   error = jerry_create_abort_from_value (num, false);
   jerry_release_value (num);
-  JERRY_ASSERT (jerry_value_is_abort (error));
+  TEST_ASSERT (jerry_value_is_abort (error));
   num2 = jerry_create_error_from_value (error, false);
   jerry_release_value (error);
-  JERRY_ASSERT (jerry_value_is_error (num2));
+  TEST_ASSERT (jerry_value_is_error (num2));
   num = jerry_get_value_from_error (num2, true);
-  JERRY_ASSERT (jerry_get_number_value (num) == test_num);
+  TEST_ASSERT (jerry_get_number_value (num) == test_num);
   jerry_release_value (num);
 
   jerry_value_t value = jerry_create_number (42);

--- a/tests/unit-core/test-common.h
+++ b/tests/unit-core/test-common.h
@@ -16,7 +16,7 @@
 #ifndef TEST_COMMON_H
 #define TEST_COMMON_H
 
-#include "jrt.h"
+#include "jerryscript-port.h"
 
 #include <math.h>
 #include <setjmp.h>
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+
+#define JERRY_UNUSED(x) ((void) (x))
 
 #define TEST_ASSERT(x) \
   do \
@@ -36,7 +38,7 @@
                       __FILE__, \
                       __func__, \
                       (unsigned long) __LINE__); \
-      jerry_fatal (ERR_FAILED_INTERNAL_ASSERTION); \
+      jerry_port_fatal (ERR_FAILED_INTERNAL_ASSERTION); \
     } \
   } while (0)
 

--- a/tests/unit-ext/test-common.h
+++ b/tests/unit-ext/test-common.h
@@ -20,6 +20,8 @@
 
 #define ARRAY_SIZE(array) ((unsigned long) (sizeof (array) / sizeof ((array)[0])))
 
+#define JERRY_UNUSED(x) ((void) (x))
+
 #define TEST_ASSERT(x) \
   do \
   { \

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -106,11 +106,12 @@ static int validator_restore_count = 0;
  *
  */
 static jerry_value_t
-test_validator1_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
+test_validator1_handler (const jerry_value_t func_obj_val, /**< function object */
                          const jerry_value_t this_val, /**< this value */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
 
   bool arg1;
   double arg2 = 0.0;
@@ -209,11 +210,13 @@ my_custom_transform (jerryx_arg_js_iterator_t *js_arg_iter_p, /**< available JS 
  *   arg1: should pass the custom tranform function.
  */
 static jerry_value_t
-test_validator2_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
+test_validator2_handler (const jerry_value_t func_obj_val, /**< function object */
                          const jerry_value_t this_val, /**< this value */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+
   my_type_a_t *thing_p;
 
   jerryx_arg_t mapping[] =
@@ -253,11 +256,13 @@ test_validator2_handler (const jerry_value_t func_obj_val __attribute__((unused)
  *
  */
 static jerry_value_t
-test_validator3_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
+test_validator3_handler (const jerry_value_t func_obj_val, /**< function object */
                          const jerry_value_t this_val, /**< this value */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
+
+  JERRY_UNUSED (func_obj_val);
 
   bool arg1 = false;
   bool arg2 = false;
@@ -318,11 +323,15 @@ test_validator3_handler (const jerry_value_t func_obj_val __attribute__((unused)
  * Calling jerryx_arg_transform_object_properties directly.
  */
 static jerry_value_t
-test_validator_prop1_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                              const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_prop1_handler (const jerry_value_t func_obj_val, /**< function object */
+                              const jerry_value_t this_val, /**< this value */
                               const jerry_value_t args_p[], /**< arguments list */
-                              const jerry_length_t args_cnt __attribute__((unused))) /**< arguments length */
+                              const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (args_cnt);
+
   bool native1 = false;
   double native2 = 0;
   double native3 = 3;
@@ -357,11 +366,14 @@ test_validator_prop1_handler (const jerry_value_t func_obj_val __attribute__((un
  * using jerryx_arg_object_properties.
  */
 static jerry_value_t
-test_validator_prop2_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                              const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_prop2_handler (const jerry_value_t func_obj_val, /**< function object */
+                              const jerry_value_t this_val, /**< this value */
                               const jerry_value_t args_p[], /**< arguments list */
                               const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+
   bool native1 = false;
   double native2 = 0;
   double native3 = 3;
@@ -405,11 +417,15 @@ test_validator_prop2_handler (const jerry_value_t func_obj_val __attribute__((un
 } /* test_validator_prop2_handler */
 
 static jerry_value_t
-test_validator_prop3_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                              const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_prop3_handler (const jerry_value_t func_obj_val, /**< function object */
+                              const jerry_value_t this_val, /**< this value */
                               const jerry_value_t args_p[], /**< arguments list */
-                              const jerry_length_t args_cnt __attribute__((unused))) /**< arguments length */
+                              const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (args_cnt);
+
   bool native1 = false;
   bool native2 = true;
 
@@ -441,11 +457,14 @@ test_validator_prop3_handler (const jerry_value_t func_obj_val __attribute__((un
  * args_p[0-2] are uint8, args_p[3-5] are int8, args_p[6-8] are uint32, args_p[9-11] are int32.
  */
 static jerry_value_t
-test_validator_int1_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                             const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_int1_handler (const jerry_value_t func_obj_val, /**< function object */
+                             const jerry_value_t this_val, /**< this value */
                              const jerry_value_t args_p[], /**< arguments list */
                              const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+
   uint8_t num0, num1, num2;
   int8_t num3, num4, num5;
   uint32_t num6, num7, num8;
@@ -493,11 +512,14 @@ test_validator_int1_handler (const jerry_value_t func_obj_val __attribute__((unu
 } /* test_validator_int1_handler */
 
 static jerry_value_t
-test_validator_int2_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                             const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_int2_handler (const jerry_value_t func_obj_val, /**< function object */
+                             const jerry_value_t this_val, /**< this value */
                              const jerry_value_t args_p[], /**< arguments list */
                              const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+
   int8_t num0, num1, num2, num3, num4, num5, num6, num7, num8, num9;
   num8 = 123;
   num9 = 123;
@@ -540,11 +562,14 @@ test_validator_int2_handler (const jerry_value_t func_obj_val __attribute__((unu
 } /* test_validator_int2_handler */
 
 static jerry_value_t
-test_validator_int3_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                             const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_int3_handler (const jerry_value_t func_obj_val, /**< function object */
+                             const jerry_value_t this_val, /**< this value */
                              const jerry_value_t args_p[], /**< arguments list */
                              const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+
   int8_t num0;
 
   jerryx_arg_t mapping[] =
@@ -566,11 +591,14 @@ test_validator_int3_handler (const jerry_value_t func_obj_val __attribute__((unu
 } /* test_validator_int3_handler */
 
 static jerry_value_t
-test_validator_array1_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                               const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_array1_handler (const jerry_value_t func_obj_val, /**< function object */
+                               const jerry_value_t this_val, /**< this value */
                                const jerry_value_t args_p[], /**< arguments list */
                                const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+
   double native1 = 0;
   double native2 = 0;
   double native3 = 0;
@@ -610,11 +638,15 @@ test_validator_array1_handler (const jerry_value_t func_obj_val __attribute__((u
 } /* test_validator_array1_handler */
 
 static jerry_value_t
-test_validator_array2_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                               const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_array2_handler (const jerry_value_t func_obj_val, /**< function object */
+                               const jerry_value_t this_val, /**< this value */
                                const jerry_value_t args_p[], /**< arguments list */
-                               const jerry_length_t args_cnt __attribute__((unused))) /**< arguments length */
+                               const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (args_cnt);
+
   double native1 = 0;
   bool native2 = false;
 
@@ -764,11 +796,14 @@ jerry_arg_to_double_or_bool_t (jerryx_arg_js_iterator_t *js_arg_iter_p,
  * order doesn't matter (so we'll call it twice with the orders reversed).
 */
 static jerry_value_t
-test_validator_restore_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
-                                const jerry_value_t this_val __attribute__((unused)), /**< this value */
+test_validator_restore_handler (const jerry_value_t func_obj_val, /**< function object */
+                                const jerry_value_t this_val, /**< this value */
                                 const jerry_value_t args_p[], /**< arguments list */
-                                const jerry_length_t args_cnt __attribute__((unused))) /**< arguments length */
+                                const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (this_val);
+
   double_or_bool_t arg1;
   double_or_bool_t arg2;
 
@@ -820,11 +855,15 @@ test_utf8_string (void)
 } /* test_utf8_string */
 
 static jerry_value_t
-create_object_a_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
+create_object_a_handler (const jerry_value_t func_obj_val, /**< function object */
                          const jerry_value_t this_val, /**< this value */
-                         const jerry_value_t args_p[] __attribute__((unused)), /**< arguments list */
-                         const jerry_length_t args_cnt __attribute__((unused))) /**< arguments length */
+                         const jerry_value_t args_p[], /**< arguments list */
+                         const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (args_p);
+  JERRY_UNUSED (args_cnt);
+
   TEST_ASSERT (jerry_value_is_object (this_val));
 
   my_thing_a.x = 1;
@@ -836,11 +875,15 @@ create_object_a_handler (const jerry_value_t func_obj_val __attribute__((unused)
 } /* create_object_a_handler */
 
 static jerry_value_t
-create_object_b_handler (const jerry_value_t func_obj_val __attribute__((unused)), /**< function object */
+create_object_b_handler (const jerry_value_t func_obj_val, /**< function object */
                          const jerry_value_t this_val, /**< this value */
-                         const jerry_value_t args_p[] __attribute__((unused)), /**< arguments list */
-                         const jerry_length_t args_cnt __attribute__((unused))) /**< arguments length */
+                         const jerry_value_t args_p[], /**< arguments list */
+                         const jerry_length_t args_cnt) /**< arguments length */
 {
+  JERRY_UNUSED (func_obj_val);
+  JERRY_UNUSED (args_p);
+  JERRY_UNUSED (args_cnt);
+
   TEST_ASSERT (jerry_value_is_object (this_val));
 
   my_thing_b.x = false;


### PR DESCRIPTION
MSVC doen't support __attribute__((unused)),
we should use JERRY_UNUSED macro instead.

Additionally removed the internal jrt.h include from
tests/unit-core/test-common.h which was layering violation.
It made JERRY_ASSERT unavailable, we should use TEST_ASSERT.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
