### PR TITLE
Optimize ecma_builtin_helper_def_prop

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -935,6 +935,23 @@ typedef struct
 } ecma_map_object_t;
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_MAP) || ENABLED (JERRY_ES2015_BUILTIN_SET) */
 
+typedef enum
+{
+  ECMA_PROP_NO_OPTS = (0), /** empty property descriptor */
+  ECMA_PROP_IS_GET_DEFINED = (1 << 0), /** Is [[Get]] defined? */
+  ECMA_PROP_IS_SET_DEFINED = (1 << 1), /** Is [[Set]] defined? */
+
+  ECMA_PROP_IS_CONFIGURABLE = (1 << 2), /** [[Configurable]] */
+  ECMA_PROP_IS_ENUMERABLE = (1 << 3), /** [[Enumerable]] */
+  ECMA_PROP_IS_WRITABLE = (1 << 4), /** [[Writable]] */
+  ECMA_PROP_IS_THROW = (1 << 5), /** Flag that controls failure handling */
+
+  ECMA_PROP_IS_VALUE_DEFINED = (1 << 6), /** Is [[Value]] defined? */
+  ECMA_PROP_IS_CONFIGURABLE_DEFINED = (1 << 7), /** Is [[Configurable]] defined? */
+  ECMA_PROP_IS_ENUMERABLE_DEFINED = (1 << 8), /** Is [[Enumerable]] defined? */
+  ECMA_PROP_IS_WRITABLE_DEFINED = (1 << 9), /** Is [[Writable]] defined? */
+} ecma_property_descriptor_status_flags_t;
+
 /**
  * Description of ECMA property descriptor
  *
@@ -943,35 +960,13 @@ typedef struct
  * Note:
  *      If a component of descriptor is undefined then corresponding
  *      field should contain it's default value.
+ *      The struct members must be in this order or keep in sync with ecma_property_flags_t and ECMA_IS_THROW flag.
  */
 typedef struct
 {
-  /** Is [[Value]] defined? */
-  unsigned int is_value_defined : 1;
 
-  /** Is [[Get]] defined? */
-  unsigned int is_get_defined : 1;
-
-  /** Is [[Set]] defined? */
-  unsigned int is_set_defined : 1;
-
-  /** Is [[Writable]] defined? */
-  unsigned int is_writable_defined : 1;
-
-  /** [[Writable]] */
-  unsigned int is_writable : 1;
-
-  /** Is [[Enumerable]] defined? */
-  unsigned int is_enumerable_defined : 1;
-
-  /** [[Enumerable]] */
-  unsigned int is_enumerable : 1;
-
-  /** Is [[Configurable]] defined? */
-  unsigned int is_configurable_defined : 1;
-
-  /** [[Configurable]] */
-  unsigned int is_configurable : 1;
+  /** any combination of ecma_property_descriptor_status_flags_t bits */
+  uint16_t flags;
 
   /** [[Value]] */
   ecma_value_t value;
@@ -982,6 +977,29 @@ typedef struct
   /** [[Set]] */
   ecma_object_t *set_p;
 } ecma_property_descriptor_t;
+
+/**
+ * Bitfield which represents a namedata property options in an ecma_property_descriptor_t
+ * Attributes:
+ *  - is_get_defined, is_set_defined : false
+ *  - is_configurable, is_writable, is_enumberable : undefined (false)
+ *  - is_throw : undefined (false)
+ *  - is_value_defined : true
+ *  - is_configurable_defined, is_writable_defined, is_enumberable_defined : true
+ */
+#define ECMA_NAME_DATA_PROPERTY_DESCRIPTOR_BITS 0x3c0
+
+/**
+ * Bitmask to get a the physical property flags from an ecma_property_descriptor
+ */
+#define ECMA_PROPERTY_FLAGS_MASK 0x1c
+
+/**
+ * Flag that controls failure handling during defining property
+ *
+ * Note: This flags represents the [[DefineOwnProperty]] (P, Desc, Throw) 3rd argument
+ */
+#define ECMA_IS_THROW (1 << 5)
 
 #if !ENABLED (JERRY_NUMBER_TYPE_FLOAT64)
 /**

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1275,17 +1275,9 @@ ecma_make_empty_property_descriptor (void)
 {
   ecma_property_descriptor_t prop_desc;
 
-  prop_desc.is_value_defined = false;
+  prop_desc.flags = 0;
   prop_desc.value = ECMA_VALUE_UNDEFINED;
-  prop_desc.is_writable_defined = false;
-  prop_desc.is_writable = false;
-  prop_desc.is_enumerable_defined = false;
-  prop_desc.is_enumerable = false;
-  prop_desc.is_configurable_defined = false;
-  prop_desc.is_configurable = false;
-  prop_desc.is_get_defined = false;
   prop_desc.get_p = NULL;
-  prop_desc.is_set_defined = false;
   prop_desc.set_p = NULL;
 
   return prop_desc;
@@ -1298,18 +1290,18 @@ ecma_make_empty_property_descriptor (void)
 void
 ecma_free_property_descriptor (ecma_property_descriptor_t *prop_desc_p) /**< property descriptor */
 {
-  if (prop_desc_p->is_value_defined)
+  if (prop_desc_p->flags & ECMA_PROP_IS_VALUE_DEFINED)
   {
     ecma_free_value (prop_desc_p->value);
   }
 
-  if (prop_desc_p->is_get_defined
+  if ((prop_desc_p->flags & ECMA_PROP_IS_GET_DEFINED)
       && prop_desc_p->get_p != NULL)
   {
     ecma_deref_object (prop_desc_p->get_p);
   }
 
-  if (prop_desc_p->is_set_defined
+  if ((prop_desc_p->flags & ECMA_PROP_IS_SET_DEFINED)
       && prop_desc_p->set_p != NULL)
   {
     ecma_deref_object (prop_desc_p->set_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -804,12 +804,10 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t arg1, /**< start */
     if (ecma_is_value_found (get_value))
     {
       /* 10.c.ii */
-      /* This will always be a simple value since 'is_throw' is false, so no need to free. */
       ecma_value_t put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                                      n,
                                                                      get_value,
-                                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                     false); /* Failure handling */
+                                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
       JERRY_ASSERT (ecma_is_value_true (put_comp));
       ecma_free_value (get_value);
     }
@@ -1187,12 +1185,10 @@ ecma_builtin_array_prototype_object_splice (const ecma_value_t args[], /**< argu
     if (ecma_is_value_found (get_value))
     {
       /* 9.c.ii */
-      /* This will always be a simple value since 'is_throw' is false, so no need to free. */
       ecma_value_t put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                                      k,
                                                                      get_value,
-                                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                     false); /* Failure handling */
+                                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
       JERRY_ASSERT (ecma_is_value_true (put_comp));
 
       ecma_free_value (get_value);
@@ -1748,12 +1744,11 @@ ecma_builtin_array_prototype_object_map (ecma_value_t arg1, /**< callbackfn */
       }
 
       /* 8.c.iii */
-      /* This will always be a simple value since 'is_throw' is false, so no need to free. */
       ecma_value_t put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                                      index,
                                                                      mapped_value,
-                                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                     false); /* Failure handling */
+                                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
+
       JERRY_ASSERT (ecma_is_value_true (put_comp));
 
       ecma_free_value (mapped_value);
@@ -1848,12 +1843,10 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t arg1, /**< callbackfn *
       /* 9.c.iii */
       if (ecma_op_to_boolean (call_value))
       {
-        /* This will always be a simple value since 'is_throw' is false, so no need to free. */
         ecma_value_t put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                                        new_array_index,
                                                                        get_value,
-                                                                       ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                       false); /* Failure handling */
+                                                                       ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
         JERRY_ASSERT (ecma_is_value_true (put_comp));
         new_array_index++;
       }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -291,8 +291,7 @@ ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /**< object */
     ecma_value_t completion = ecma_builtin_helper_def_prop (new_array_p,
                                                             index_string_p,
                                                             *ecma_value_p,
-                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                            false); /* Failure handling */
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
     JERRY_ASSERT (ecma_is_value_true (completion));
 
@@ -438,8 +437,7 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
         ecma_value_t put_comp = ecma_builtin_helper_def_prop (obj_p,
                                                               new_array_index_string_p,
                                                               get_value,
-                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                              false);  /* Failure handling */
+                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
         JERRY_ASSERT (ecma_is_value_true (put_comp));
         ecma_deref_ecma_string (new_array_index_string_p);
@@ -464,9 +462,7 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, /**< array */
     ecma_value_t put_comp = ecma_builtin_helper_def_prop (obj_p,
                                                           new_array_index_string_p,
                                                           value,
-                                                          ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                          false);  /* Failure handling */
-
+                                                          ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
     JERRY_ASSERT (ecma_is_value_true (put_comp));
 
     ecma_deref_ecma_string (new_array_index_string_p);
@@ -802,24 +798,21 @@ ecma_value_t
 ecma_builtin_helper_def_prop_by_index (ecma_object_t *obj_p, /**< object */
                                        uint32_t index, /**< property index */
                                        ecma_value_t value, /**< value */
-                                       uint32_t opts, /**< any combination of ecma_property_flag_t bits */
-                                       bool is_throw) /**< is_throw */
+                                       uint32_t opts) /**< any combination of ecma_property_flag_t bits */
 {
   if (JERRY_LIKELY (index <= ECMA_DIRECT_STRING_MAX_IMM))
   {
     return ecma_builtin_helper_def_prop (obj_p,
                                          ECMA_CREATE_DIRECT_UINT32_STRING (index),
                                          value,
-                                         opts,
-                                         is_throw);
+                                         opts);
   }
 
   ecma_string_t *index_str_p = ecma_new_non_direct_string_from_uint32 (index);
   ecma_value_t ret_value = ecma_builtin_helper_def_prop (obj_p,
                                                          index_str_p,
                                                          value,
-                                                         opts,
-                                                         is_throw);
+                                                         opts);
   ecma_deref_ecma_string (index_str_p);
 
   return ret_value;
@@ -839,27 +832,18 @@ ecma_value_t
 ecma_builtin_helper_def_prop (ecma_object_t *obj_p, /**< object */
                               ecma_string_t *index_p, /**< index string */
                               ecma_value_t value, /**< value */
-                              uint32_t opts, /**< any combination of ecma_property_flag_t bits */
-                              bool is_throw) /**< is_throw */
+                              uint32_t opts) /**< any combination of ecma_property_flag_t bits
+                                              *   with the optional ECMA_IS_THROW flag */
 {
-  ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
+  ecma_property_descriptor_t prop_desc;
 
-  prop_desc.is_value_defined = true;
+  prop_desc.flags = (uint16_t) (ECMA_NAME_DATA_PROPERTY_DESCRIPTOR_BITS | opts);
+
   prop_desc.value = value;
-
-  prop_desc.is_writable_defined = true;
-  prop_desc.is_writable = (opts & ECMA_PROPERTY_FLAG_WRITABLE) != 0;
-
-  prop_desc.is_enumerable_defined = true;
-  prop_desc.is_enumerable = (opts & ECMA_PROPERTY_FLAG_ENUMERABLE) != 0;
-
-  prop_desc.is_configurable_defined = true;
-  prop_desc.is_configurable = (opts & ECMA_PROPERTY_FLAG_CONFIGURABLE) != 0;
 
   return ecma_op_object_define_own_property (obj_p,
                                              index_p,
-                                             &prop_desc,
-                                             is_throw);
+                                             &prop_desc);
 } /* ecma_builtin_helper_def_prop */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -58,11 +58,10 @@ bool
 ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, ecma_string_t *search_str_p, bool first_index,
                                        ecma_length_t start_pos, ecma_length_t *ret_index_p);
 ecma_value_t
-ecma_builtin_helper_def_prop (ecma_object_t *obj_p, ecma_string_t *index_p, ecma_value_t value,
-                              uint32_t opts, bool is_throw);
+ecma_builtin_helper_def_prop (ecma_object_t *obj_p, ecma_string_t *index_p, ecma_value_t value, uint32_t opts);
+
 ecma_value_t
-ecma_builtin_helper_def_prop_by_index (ecma_object_t *obj_p, uint32_t index, ecma_value_t value,
-                                       uint32_t opts, bool is_throw);
+ecma_builtin_helper_def_prop_by_index (ecma_object_t *obj_p, uint32_t index, ecma_value_t value, uint32_t opts);
 
 #if ENABLED (JERRY_BUILTIN_DATE)
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -543,8 +543,7 @@ ecma_builtin_json_define_value_property (ecma_object_t *obj_p, /**< this object 
   ecma_value_t completion_value = ecma_builtin_helper_def_prop (obj_p,
                                                                 property_name_p,
                                                                 value,
-                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                false); /* Failure handling */
+                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
   JERRY_ASSERT (ecma_is_value_boolean (completion_value));
 } /* ecma_builtin_json_define_value_property */
@@ -683,8 +682,7 @@ ecma_builtin_json_parse_value (ecma_json_token_t *token_p) /**< token argument *
         ecma_value_t completion = ecma_builtin_helper_def_prop (array_p,
                                                                 index_str_p,
                                                                 value,
-                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                false); /* Failure handling */
+                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
         JERRY_ASSERT (ecma_is_value_true (completion));
 
@@ -918,8 +916,7 @@ static ecma_value_t ecma_builtin_json_str_helper (const ecma_value_t arg1, /**< 
   ecma_value_t put_comp_val = ecma_builtin_helper_def_prop (obj_wrapper_p,
                                                             empty_str_p,
                                                             arg1,
-                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                            false);
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
   JERRY_ASSERT (ecma_is_value_true (put_comp_val));
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -482,8 +482,7 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
     ecma_value_t put_ret = ecma_builtin_helper_def_prop (ecma_get_object_from_value (value_array),
                                                          index_to_str_p,
                                                          undefined_val,
-                                                         ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                         false);
+                                                         ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
     ecma_deref_ecma_string (index_to_str_p);
 
     if (ECMA_IS_VALUE_ERROR (put_ret))

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -462,8 +462,7 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_to_string_value, /
       ecma_value_t completion = ecma_builtin_helper_def_prop (new_array_obj_p,
                                                               current_index_str_p,
                                                               match_string_value,
-                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                              false); /* Failure handling */
+                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
       JERRY_ASSERT (ecma_is_value_true (completion));
 
@@ -1358,8 +1357,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
     ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                           zero_str_p,
                                                           this_to_string_val,
-                                                          ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                          false); /* Failure handling */
+                                                          ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
     JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -1435,8 +1433,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
       ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                             zero_str_p,
                                                             this_to_string_val,
-                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                            false); /* Failure handling */
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
       JERRY_ASSERT (ecma_is_value_true (put_comp));
       ecma_deref_ecma_string (zero_str_p);
@@ -1520,13 +1517,13 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
         }
         else
         {
+          const uint32_t opts = ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE | ECMA_IS_THROW;
           ecma_string_t *separator_str_p = ecma_get_string_from_value (separator);
 
           ecma_value_t put_comp = ecma_builtin_helper_def_prop (match_obj_p,
                                                                 zero_str_p,
                                                                 ecma_make_string_value (separator_str_p),
-                                                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                true); /* Failure handling */
+                                                                opts);
 
           JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -1571,8 +1568,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
         ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                               array_length_str_p,
                                                               ecma_make_string_value (substr_str_p),
-                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                              false); /* Failure handling */
+                                                              ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
         JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -1616,8 +1612,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
           put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                    new_array_idx_str_p,
                                                    match_comp_value,
-                                                   ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                   false); /* Failure handling */
+                                                   ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
           JERRY_ASSERT (ecma_is_value_true (put_comp));
 
@@ -1662,8 +1657,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
       ecma_value_t put_comp = ecma_builtin_helper_def_prop (new_array_p,
                                                             array_length_string_p,
                                                             ecma_make_string_value (substr_str_p),
-                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                            false); /* Failure handling */
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
       JERRY_ASSERT (ecma_is_value_true (put_comp));
 

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -119,8 +119,7 @@ ecma_op_create_array_object (const ecma_value_t *arguments_list_p, /**< list of 
     ecma_builtin_helper_def_prop (object_p,
                                   item_name_string_p,
                                   array_items_p[index],
-                                  ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                  false); /* Failure handling */
+                                  ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
     ecma_deref_ecma_string (item_name_string_p);
   }
@@ -275,42 +274,44 @@ ecma_op_array_object_set_length (ecma_object_t *object_p, /**< the array object 
 ecma_value_t
 ecma_op_array_object_define_own_property (ecma_object_t *object_p, /**< the array object */
                                           ecma_string_t *property_name_p, /**< property name */
-                                          const ecma_property_descriptor_t *property_desc_p, /**< property descriptor */
-                                          bool is_throw) /**< flag that controls failure handling */
+                                          const ecma_property_descriptor_t *property_desc_p) /**< property descriptor */
 {
   if (ecma_string_is_length (property_name_p))
   {
-    JERRY_ASSERT (property_desc_p->is_configurable_defined || !property_desc_p->is_configurable);
-    JERRY_ASSERT (property_desc_p->is_enumerable_defined || !property_desc_p->is_enumerable);
-    JERRY_ASSERT (property_desc_p->is_writable_defined || !property_desc_p->is_writable);
+    JERRY_ASSERT ((property_desc_p->flags & ECMA_PROP_IS_CONFIGURABLE_DEFINED)
+                  || !(property_desc_p->flags & ECMA_PROP_IS_CONFIGURABLE));
+    JERRY_ASSERT ((property_desc_p->flags & ECMA_PROP_IS_ENUMERABLE_DEFINED)
+                  || !(property_desc_p->flags & ECMA_PROP_IS_ENUMERABLE));
+    JERRY_ASSERT ((property_desc_p->flags & ECMA_PROP_IS_WRITABLE_DEFINED)
+                  || !(property_desc_p->flags & ECMA_PROP_IS_WRITABLE));
 
     uint32_t flags = 0;
 
-    if (is_throw)
+    if (property_desc_p->flags & ECMA_PROP_IS_THROW)
     {
       flags |= ECMA_ARRAY_OBJECT_SET_LENGTH_FLAG_IS_THROW;
     }
 
     /* Only the writable and data properties can be modified. */
-    if (property_desc_p->is_configurable
-        || property_desc_p->is_enumerable
-        || property_desc_p->is_get_defined
-        || property_desc_p->is_set_defined)
+    if (property_desc_p->flags & (ECMA_PROP_IS_CONFIGURABLE
+                                  | ECMA_PROP_IS_ENUMERABLE
+                                  | ECMA_PROP_IS_GET_DEFINED
+                                  | ECMA_PROP_IS_SET_DEFINED))
     {
       flags |= ECMA_ARRAY_OBJECT_SET_LENGTH_FLAG_REJECT;
     }
 
-    if (property_desc_p->is_writable_defined)
+    if (property_desc_p->flags & ECMA_PROP_IS_WRITABLE_DEFINED)
     {
       flags |= ECMA_ARRAY_OBJECT_SET_LENGTH_FLAG_WRITABLE_DEFINED;
     }
 
-    if (property_desc_p->is_writable)
+    if (property_desc_p->flags & ECMA_PROP_IS_WRITABLE)
     {
       flags |= ECMA_ARRAY_OBJECT_SET_LENGTH_FLAG_WRITABLE;
     }
 
-    if (property_desc_p->is_value_defined)
+    if (property_desc_p->flags & ECMA_PROP_IS_VALUE_DEFINED)
     {
       return ecma_op_array_object_set_length (object_p, property_desc_p->value, flags);
     }
@@ -328,7 +329,7 @@ ecma_op_array_object_define_own_property (ecma_object_t *object_p, /**< the arra
 
   if (index == ECMA_STRING_NOT_ARRAY_INDEX)
   {
-    return ecma_op_general_object_define_own_property (object_p, property_name_p, property_desc_p, is_throw);
+    return ecma_op_general_object_define_own_property (object_p, property_name_p, property_desc_p);
   }
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
@@ -337,18 +338,22 @@ ecma_op_array_object_define_own_property (ecma_object_t *object_p, /**< the arra
 
   if (update_length && !ecma_is_property_writable (ext_object_p->u.array.length_prop))
   {
-    return ecma_reject (is_throw);
+    return ecma_reject (property_desc_p->flags & ECMA_PROP_IS_THROW);
   }
+
+  ecma_property_descriptor_t prop_desc;
+
+  prop_desc = *property_desc_p;
+  prop_desc.flags &= (uint16_t) ~ECMA_PROP_IS_THROW;
 
   ecma_value_t completition = ecma_op_general_object_define_own_property (object_p,
                                                                           property_name_p,
-                                                                          property_desc_p,
-                                                                          false);
+                                                                          &prop_desc);
   JERRY_ASSERT (ecma_is_value_boolean (completition));
 
   if (ecma_is_value_false (completition))
   {
-    return ecma_reject (is_throw);
+    return ecma_reject (property_desc_p->flags & ECMA_PROP_IS_THROW);
   }
 
   if (update_length)

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -54,7 +54,7 @@ ecma_op_array_object_set_length (ecma_object_t *object_p, ecma_value_t new_value
 
 ecma_value_t
 ecma_op_array_object_define_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
-                                          const ecma_property_descriptor_t *property_desc_p, bool is_throw);
+                                          const ecma_property_descriptor_t *property_desc_p);
 
 void
 ecma_op_array_list_lazy_property_names (ecma_object_t *obj_p, bool separate_enumerable,

--- a/jerry-core/ecma/operations/ecma-iterator-object.c
+++ b/jerry-core/ecma/operations/ecma-iterator-object.c
@@ -64,8 +64,7 @@ ecma_create_array_from_iter_element (ecma_value_t value, /**< value */
     ecma_value_t completion = ecma_builtin_helper_def_prop (new_array_p,
                                                             index_string_p,
                                                             (index == 0) ? index_value : value,
-                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                            false); /* Failure handling */
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
 
     /* 4.b */
     JERRY_ASSERT (ecma_is_value_true (completion));

--- a/jerry-core/ecma/operations/ecma-lex-env.c
+++ b/jerry-core/ecma/operations/ecma-lex-env.c
@@ -143,18 +143,18 @@ ecma_op_create_mutable_binding (ecma_object_t *lex_env_p, /**< lexical environme
 
     ecma_object_t *binding_obj_p = ecma_get_lex_env_binding_object (lex_env_p);
 
-    ecma_value_t completion;
     if (!ecma_get_object_extensible (binding_obj_p))
     {
       return ECMA_VALUE_EMPTY;
     }
 
-    completion = ecma_builtin_helper_def_prop (binding_obj_p,
-                                               name_p,
-                                               ECMA_VALUE_UNDEFINED,
-                                               is_deletable ? ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE
-                                                            : ECMA_PROPERTY_ENUMERABLE_WRITABLE,
-                                               true); /* Failure handling */
+    const uint32_t flags = ECMA_PROPERTY_ENUMERABLE_WRITABLE | ECMA_IS_THROW;
+
+    ecma_value_t completion = ecma_builtin_helper_def_prop (binding_obj_p,
+                                                            name_p,
+                                                            ECMA_VALUE_UNDEFINED,
+                                                            is_deletable ? flags | ECMA_PROPERTY_FLAG_CONFIGURABLE
+                                                                         : flags);
 
     if (ECMA_IS_VALUE_ERROR (completion))
     {

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -28,6 +28,6 @@ ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *object_p, ecma_string_t *property_name_p, bool is_throw);
 ecma_value_t
 ecma_op_arguments_object_define_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
-                                              const ecma_property_descriptor_t *property_desc_p, bool is_throw);
+                                              const ecma_property_descriptor_t *property_desc_p);
 
 #endif /* !ECMA_OBJECTS_ARGUMENTS_H */

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -34,8 +34,7 @@ ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object
 ecma_value_t ecma_op_general_object_delete (ecma_object_t *obj_p, ecma_string_t *property_name_p, bool is_throw);
 ecma_value_t ecma_op_general_object_default_value (ecma_object_t *obj_p, ecma_preferred_type_hint_t hint);
 ecma_value_t ecma_op_general_object_define_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
-                                                         const ecma_property_descriptor_t *property_desc_p,
-                                                         bool is_throw);
+                                                         const ecma_property_descriptor_t *property_desc_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -52,7 +52,7 @@ ecma_value_t ecma_op_object_delete_by_uint32_index (ecma_object_t *obj_p, uint32
 ecma_value_t ecma_op_object_delete_by_number_index (ecma_object_t *obj_p, ecma_number_t index, bool is_throw);
 ecma_value_t ecma_op_object_default_value (ecma_object_t *obj_p, ecma_preferred_type_hint_t hint);
 ecma_value_t ecma_op_object_define_own_property (ecma_object_t *obj_p, ecma_string_t *property_name_p,
-                                                 const ecma_property_descriptor_t *property_desc_p, bool is_throw);
+                                                 const ecma_property_descriptor_t *property_desc_p);
 bool ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, ecma_string_t *property_name_p,
                                                  ecma_property_descriptor_t *prop_desc_p);
 ecma_value_t ecma_op_object_has_instance (ecma_object_t *obj_p, ecma_value_t value);

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1141,27 +1141,24 @@ re_set_result_array_properties (ecma_object_t *array_obj_p, /**< result array */
   ecma_builtin_helper_def_prop (array_obj_p,
                                 ecma_get_magic_string (LIT_MAGIC_STRING_INDEX),
                                 ecma_make_int32_value (index),
-                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                true); /* Failure handling */
+                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE | ECMA_IS_THROW);
 
   /* Set input property of the result array */
   ecma_builtin_helper_def_prop (array_obj_p,
                                 ecma_get_magic_string (LIT_MAGIC_STRING_INPUT),
                                 ecma_make_string_value (input_str_p),
-                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                true); /* Failure handling */
+                                ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE | ECMA_IS_THROW);
 
   /* Set length property of the result array */
   {
     ecma_property_descriptor_t array_item_prop_desc = ecma_make_empty_property_descriptor ();
-    array_item_prop_desc.is_value_defined = true;
+    array_item_prop_desc.flags |= (ECMA_PROP_IS_VALUE_DEFINED | ECMA_PROP_IS_THROW);
 
     array_item_prop_desc.value = ecma_make_uint32_value (num_of_elements);
 
     ecma_op_object_define_own_property (array_obj_p,
                                         ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH),
-                                        &array_item_prop_desc,
-                                        true);
+                                        &array_item_prop_desc);
   }
 } /* re_set_result_array_properties */
 

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -831,25 +831,19 @@ ecma_op_typedarray_define_index_prop (ecma_object_t *obj_p, /**< a TypedArray ob
 
   ecma_length_t array_length = ecma_typedarray_get_length (obj_p);
 
-  if (index >= array_length)
+  if ((index >= array_length)
+      || (property_desc_p->flags & (ECMA_PROP_IS_GET_DEFINED | ECMA_PROP_IS_SET_DEFINED))
+      || ((property_desc_p->flags & (ECMA_PROP_IS_CONFIGURABLE_DEFINED | ECMA_PROP_IS_CONFIGURABLE))
+           == (ECMA_PROP_IS_CONFIGURABLE_DEFINED | ECMA_PROP_IS_CONFIGURABLE))
+      || ((property_desc_p->flags & ECMA_PROP_IS_ENUMERABLE_DEFINED)
+          && !(property_desc_p->flags & ECMA_PROP_IS_ENUMERABLE))
+      || ((property_desc_p->flags & ECMA_PROP_IS_WRITABLE_DEFINED)
+          && !(property_desc_p->flags & ECMA_PROP_IS_WRITABLE)))
   {
     return false;
   }
 
-  if (property_desc_p->is_get_defined
-      || property_desc_p->is_set_defined)
-  {
-    return false;
-  }
-
-  if ((property_desc_p->is_configurable_defined && property_desc_p->is_configurable)
-      || (property_desc_p->is_enumerable_defined && !property_desc_p->is_enumerable)
-      || (property_desc_p->is_writable_defined && !property_desc_p->is_writable))
-  {
-    return false;
-  }
-
-  if (property_desc_p->is_value_defined)
+  if (property_desc_p->flags & ECMA_PROP_IS_VALUE_DEFINED)
   {
     return ecma_op_typedarray_set_index_prop (obj_p, index, property_desc_p->value);
   }


### PR DESCRIPTION
This patch removes the ecma_property_descriptor_t structure bitfields and substitutes it with an uint16_t flag field
to reduce the cost of the transformation from/into the ecma_property_flags_t.
Also the is_throw last arguments is embedded to the property descriptor structure during the property defining process to reduce the number of arguments of the function.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu