### PR TITLE
Speed-up Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ matrix:
         apt:
           packages: [doxygen, cppcheck, vera++]
 
-    - name: "Linux/x86-64 Build & Correctness Tests"
+    - name: "Linux/x86-64 Build, Correctness & Debugger Tests"
       env:
-        - OPTS="--quiet --jerry-tests --jerry-test-suite"
+        - OPTS="--quiet --jerry-tests --jerry-test-suite --jerry-debugger"
 
     - name: "Linux/x86 (cpointer-32bit) Build & Correctness Tests"
       env:
@@ -55,21 +55,13 @@ matrix:
         apt:
           packages: [gcc-multilib]
 
-    - name: "Unit Tests"
-      env:
-        - OPTS="--unittests"
-
-    - name: "Unit Tests (INIT_FINI)"
-      env:
-        - OPTS="--unittests --buildoptions=--cmake-param=-DFEATURE_INIT_FINI=ON"
-
-    - name: "Debugger Tests"
-      env:
-        - OPTS="--jerry-debugger"
-
     - name: "Conformance Tests"
       env:
         - OPTS="--test262"
+
+    - name: "Unit Tests"
+      env:
+        - OPTS="--unittests"
 
     - name: "ASAN Tests"
       env:
@@ -95,30 +87,6 @@ matrix:
           sources: ubuntu-toolchain-r-test
           packages: [gcc-5, gcc-5-multilib]
 
-    - name: "Coverity Scan"
-      env:
-        # Declaration of the encrypted COVERITY_SCAN_TOKEN, created via the
-        # "travis encrypt" command using the project repo's public key.
-        - secure: "V7BdXv3FCVkFGEfKfWto6I+Sytou1zTCGyn49xurkBfKNsG/3vbkXfsbK1m6lCZxmY7W/1odpfjixpAPZgy2L4FgPZK6/UyVvC8pIFjDOubcEniN48haleSvm/ZFPLDifxDL2+VVFtK1oRYPtDBzzSoUCcfwovgk+Wy+tSBnhnyRLqO/WaI6PqFof7ECYMTRlJVjioZARVP4YmkBruIPmGDdR/3EvwowlxfuiFoPheix61ug4x3tpTBW2qWgvFjDyCZXFz4pJrBQPTAIbyKMxHcBykJjl9eR+dWAOsvE1Uw48tFOJxjKDfUttVQUPsyKFllmcCVS0fDYB5pzZOmRUPxJmox1jt8J1FY85Ri1PGY0THBPM2H7to4Yf2418Y3539epbN8p+79dwaM7e2OiJ2owukbWI7PoNqIz5DV5zxpIKsOQfeWuNLJOgsBePEIU7lz133Si/2d5W/7If46B1d+hZRBJfSYksgDqDU6G/voZkPf0K5bKe2O2BxiIW1DYk4yQ1ecZAkqGjZ8jG3zYGMG3mSF4VyuU4UGFG1Pg8fw7Ap5zuHxSVY1H9dtu4T6JQG3aj/x1omlzfw48DjgkwxVhf7Xvl3yfR7pzydYheLX3MZYtcVo7rWnglZFZoUjWDK1StbmzsvPftvwWtoDTWlzo4xeSXhahSJvJyc4U8Wc="
-      addons:
-        coverity_scan:
-          project:
-            name: "jerryscript-project/jerryscript"
-            description: "Ultra-lightweight JavaScript engine for the Internet of Things."
-          notification_email: rsipka.uszeged@partner.samsung.com
-          build_command: "tools/build.py --clean"
-          branch_pattern: master
-      script: skip # Changed to nop, Coverity Scan has already built the project by the time 'script' stage is reached.
-
-    - name: "SonarQube"
-      addons:
-        sonarcloud:
-          organization: "jerryscript-project"
-      script: tools/check-sonarqube.sh
-      cache:
-        directories:
-          - '${HOME}/.sonar/cache'
-
     - name: "ESP8266 Build Test"
       install: make -f ./targets/esp8266/Makefile.travis install-noapt
       script: make -f ./targets/esp8266/Makefile.travis script
@@ -136,6 +104,13 @@ matrix:
       python: 3.6
       install: make -f ./targets/mbedos5/Makefile.travis install
       script: make -f ./targets/mbedos5/Makefile.travis script
+
+    - name: "Zephyr/Arduino 101 Build Test"
+      install: make -f ./targets/zephyr/Makefile.travis install-noapt
+      script: make -f ./targets/zephyr/Makefile.travis script
+      addons:
+        apt:
+          packages: [gperf, dfu-util, device-tree-compiler, python3-ply, python3-pip]
 
     - name: "NuttX/STM32F4 Build Test"
       install: make -f targets/nuttx-stm32f4/Makefile.travis install-noapt
@@ -163,12 +138,26 @@ matrix:
       install: make -f ./targets/tizenrt-artik053/Makefile.travis install
       script: make -f ./targets/tizenrt-artik053/Makefile.travis script
 
-    - name: "Zephyr/Arduino 101 Build Test"
-      install: make -f ./targets/zephyr/Makefile.travis install-noapt
-      script: make -f ./targets/zephyr/Makefile.travis script
+    - name: "Coverity Scan & SonarQube"
+      env:
+        # Declaration of the encrypted COVERITY_SCAN_TOKEN, created via the
+        # "travis encrypt" command using the project repo's public key.
+        - secure: "V7BdXv3FCVkFGEfKfWto6I+Sytou1zTCGyn49xurkBfKNsG/3vbkXfsbK1m6lCZxmY7W/1odpfjixpAPZgy2L4FgPZK6/UyVvC8pIFjDOubcEniN48haleSvm/ZFPLDifxDL2+VVFtK1oRYPtDBzzSoUCcfwovgk+Wy+tSBnhnyRLqO/WaI6PqFof7ECYMTRlJVjioZARVP4YmkBruIPmGDdR/3EvwowlxfuiFoPheix61ug4x3tpTBW2qWgvFjDyCZXFz4pJrBQPTAIbyKMxHcBykJjl9eR+dWAOsvE1Uw48tFOJxjKDfUttVQUPsyKFllmcCVS0fDYB5pzZOmRUPxJmox1jt8J1FY85Ri1PGY0THBPM2H7to4Yf2418Y3539epbN8p+79dwaM7e2OiJ2owukbWI7PoNqIz5DV5zxpIKsOQfeWuNLJOgsBePEIU7lz133Si/2d5W/7If46B1d+hZRBJfSYksgDqDU6G/voZkPf0K5bKe2O2BxiIW1DYk4yQ1ecZAkqGjZ8jG3zYGMG3mSF4VyuU4UGFG1Pg8fw7Ap5zuHxSVY1H9dtu4T6JQG3aj/x1omlzfw48DjgkwxVhf7Xvl3yfR7pzydYheLX3MZYtcVo7rWnglZFZoUjWDK1StbmzsvPftvwWtoDTWlzo4xeSXhahSJvJyc4U8Wc="
       addons:
-        apt:
-          packages: [gperf, dfu-util, device-tree-compiler, python3-ply, python3-pip]
+        coverity_scan:
+          project:
+            name: "jerryscript-project/jerryscript"
+            description: "Ultra-lightweight JavaScript engine for the Internet of Things."
+          notification_email: rsipka.uszeged@partner.samsung.com
+          build_command: "tools/build.py --clean"
+          branch_pattern: master
+        sonarcloud:
+          organization: "jerryscript-project"
+      # Coverity Scan has already built the project by the time 'script' stage is reached.
+      script: tools/check-sonarqube.sh
+      cache:
+        directories:
+          - '${HOME}/.sonar/cache'
 
   fast_finish: true
 

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -33,6 +33,7 @@ Options.__new__.__defaults__ = ([], [], False)
 def skip_if(condition, desc):
     return desc if condition else False
 
+OPTIONS_COMMON = ['--lto=off']
 OPTIONS_PROFILE_MIN = ['--profile=minimal']
 OPTIONS_PROFILE_ES51 = [] # NOTE: same as ['--profile=es5.1']
 OPTIONS_PROFILE_ES2015 = ['--profile=es2015-subset']
@@ -48,64 +49,67 @@ OPTIONS_DOCTESTS = ['--doctests=on', '--jerry-cmdline=off', '--error-messages=on
 # Test options for unittests
 JERRY_UNITTESTS_OPTIONS = [
     Options('unittests-es2015_subset',
-            OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES2015),
+            OPTIONS_COMMON + OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES2015),
     Options('unittests-es2015_subset-debug',
-            OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG),
+            OPTIONS_COMMON + OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG),
     Options('doctests-es2015_subset',
-            OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES2015),
+            OPTIONS_COMMON + OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES2015),
     Options('doctests-es2015_subset-debug',
-            OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG),
+            OPTIONS_COMMON + OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG),
     Options('unittests-es5.1',
-            OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES51),
+            OPTIONS_COMMON + OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES51),
     Options('unittests-es5.1-debug',
-            OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG),
+            OPTIONS_COMMON + OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG),
     Options('doctests-es5.1',
-            OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES51),
+            OPTIONS_COMMON + OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES51),
     Options('doctests-es5.1-debug',
-            OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG)
+            OPTIONS_COMMON + OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG),
+    Options('unittests-es5.1-debug-init-fini',
+            OPTIONS_COMMON + OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG
+            + ['--cmake-param=-DFEATURE_INIT_FINI=ON']),
 ]
 
 # Test options for jerry-tests
 JERRY_TESTS_OPTIONS = [
+    Options('jerry_tests-es2015_subset-debug',
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT),
     Options('jerry_tests-es5.1',
-            OPTIONS_PROFILE_ES51 + OPTIONS_STACK_LIMIT),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_STACK_LIMIT),
     Options('jerry_tests-es5.1-snapshot',
-            OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_STACK_LIMIT,
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_STACK_LIMIT,
             ['--snapshot']),
     Options('jerry_tests-es5.1-debug',
-            OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT),
     Options('jerry_tests-es5.1-debug-snapshot',
-            OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT,
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT,
             ['--snapshot']),
     Options('jerry_tests-es5.1-debug-cpointer_32bit',
-            OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT
             + ['--cpointer-32bit=on', '--mem-heap=1024']),
     Options('jerry_tests-es5.1-debug-external_context',
-            OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + ['--external-context=on']),
-    Options('jerry_tests-es2015_subset-debug',
-            OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + ['--external-context=on']),
 ]
 
 # Test options for jerry-test-suite
 JERRY_TEST_SUITE_OPTIONS = JERRY_TESTS_OPTIONS[:]
 JERRY_TEST_SUITE_OPTIONS.extend([
     Options('jerry_test_suite-minimal',
-            OPTIONS_PROFILE_MIN),
+            OPTIONS_COMMON + OPTIONS_PROFILE_MIN),
     Options('jerry_test_suite-minimal-snapshot',
-            OPTIONS_PROFILE_MIN + OPTIONS_SNAPSHOT,
+            OPTIONS_COMMON + OPTIONS_PROFILE_MIN + OPTIONS_SNAPSHOT,
             ['--snapshot']),
     Options('jerry_test_suite-minimal-debug',
-            OPTIONS_PROFILE_MIN + OPTIONS_DEBUG),
+            OPTIONS_COMMON + OPTIONS_PROFILE_MIN + OPTIONS_DEBUG),
     Options('jerry_test_suite-minimal-debug-snapshot',
-            OPTIONS_PROFILE_MIN + OPTIONS_SNAPSHOT + OPTIONS_DEBUG,
+            OPTIONS_COMMON + OPTIONS_PROFILE_MIN + OPTIONS_SNAPSHOT + OPTIONS_DEBUG,
             ['--snapshot']),
     Options('jerry_test_suite-es2015_subset',
-            OPTIONS_PROFILE_ES2015),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES2015),
     Options('jerry_test_suite-es2015_subset-snapshot',
-            OPTIONS_PROFILE_ES2015 + OPTIONS_SNAPSHOT,
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES2015 + OPTIONS_SNAPSHOT,
             ['--snapshot']),
     Options('jerry_test_suite-es2015_subset-debug-snapshot',
-            OPTIONS_PROFILE_ES2015 + OPTIONS_SNAPSHOT + OPTIONS_DEBUG,
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES2015 + OPTIONS_SNAPSHOT + OPTIONS_DEBUG,
             ['--snapshot']),
 ])
 


### PR DESCRIPTION
This PR reduces the time it takes for Travis to complete the checks.
The following changes are made:
  - Disabled LTO for test builds
  - Merged Debugger tests into x86-64 Conformance tests
  - Moved the INIT_FINI unittests into the regular unittests
  - Merged SonarQube and Coverity Scan tasks
  - Re-arranged some of the tasks

Overall this reduces Travis build times from around 35-40 minutes to 20-25 minutes.