### PR TITLE
Fix buffer overflow in example for jerry_string_to_char_buffer() API function

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -2790,7 +2790,7 @@ main (void)
 
   // Read the string into a byte buffer.
   jerry_size_t string_size = jerry_get_string_size (value);
-  jerry_char_t *string_buffer_p = (jerry_char_t *) malloc (sizeof (jerry_char_t) * string_size);
+  jerry_char_t *string_buffer_p = (jerry_char_t *) malloc (sizeof (jerry_char_t) * (string_size + 1));
 
   jerry_size_t copied_bytes = jerry_string_to_char_buffer (value, string_buffer_p, string_size);
   string_buffer_p[copied_bytes] = '\0';


### PR DESCRIPTION
We need one more byte allocated for the trailing '\0'.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu