### PR TITLE
Fine-tune pylint and debugger test scripts

### DIFF
--- a/jerry-debugger/jerry_client.py
+++ b/jerry-debugger/jerry_client.py
@@ -27,7 +27,6 @@ import jerry_client_main
 from jerry_client_websocket import WebSocket
 from jerry_client_rawpacket import RawPacket
 from jerry_client_tcp import Socket
-from jerry_client_serial import Serial
 
 def write(string):
     print(string, end='')
@@ -268,6 +267,7 @@ def main():
 
         protocol = Socket(address)
     elif args.protocol == "serial":
+        from jerry_client_serial import Serial
         protocol = Serial(args.serial_config)
     else:
         print("Unsupported transmission protocol")

--- a/tools/apt-get-install-deps.sh
+++ b/tools/apt-get-install-deps.sh
@@ -19,4 +19,4 @@ sudo apt-get install -q -y \
     make cmake \
     gcc gcc-multilib \
     doxygen \
-    cppcheck vera++ python
+    cppcheck vera++ python pylint python-serial

--- a/tools/check-pylint.sh
+++ b/tools/check-pylint.sh
@@ -14,5 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+TERM_NORMAL='\033[0m'
+TERM_RED='\033[1;31m'
+
+pylint --version &>/dev/null
+if [ $? -ne 0 ]
+then
+    echo -e "${TERM_RED}Can't run check-pylint because pylint isn't installed.${TERM_NORMAL}\n"
+    exit 1
+fi
+
 find ./tools ./jerry-debugger -name "*.py" \
     | xargs pylint --rcfile=tools/pylint/pylintrc


### PR DESCRIPTION
- Added pylint and python-serial to apt-get-install-deps.sh.
- Make Jerry debugger import python serial module only if needed.
- Check-pylint.sh warns if pylint isn't installed.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
