### PR TITLE
Fix building with build.py on Windows

### DIFF
--- a/tests/unit-doc/CMakeLists.txt
+++ b/tests/unit-doc/CMakeLists.txt
@@ -14,17 +14,21 @@
 
 cmake_minimum_required (VERSION 2.8.12)
 project (unit-doc C)
+find_package(PythonInterp REQUIRED)
 
 set(GEN_DOCTEST "${CMAKE_SOURCE_DIR}/tools/gen-doctest.py")
 file(GLOB DOC_FILES "${CMAKE_SOURCE_DIR}/docs/*.md")
 
-set(COMPILE_FLAGS_DOCTEST "-Wno-unused-parameter -Wno-unused-function -Wno-unused-variable")
+if(NOT (${CMAKE_C_COMPILER_ID} STREQUAL MSVC))
+  set(COMPILE_FLAGS_DOCTEST "-Wno-unused-parameter -Wno-unused-function -Wno-unused-variable")
+endif()
+
 
 # Dry run of the doctest generator: analyze MarkDown files and get the list of
 # file names that will be generated. This allows the definition of proper
 # dependencies between the MarkDown files and the generated sources.
 execute_process(
-  COMMAND ${GEN_DOCTEST} --dry -d ${CMAKE_CURRENT_BINARY_DIR} ${DOC_FILES}
+  COMMAND ${Python_EXECUTABLE} ${GEN_DOCTEST} --dry -d ${CMAKE_CURRENT_BINARY_DIR} ${DOC_FILES}
   OUTPUT_VARIABLE DOCTEST_OUTPUT
   RESULT_VARIABLE GEN_DOCTEST_RESULT
 )

--- a/tools/gen-doctest.py
+++ b/tools/gen-doctest.py
@@ -96,7 +96,7 @@ class DoctestExtractor(object):
         :param decl: the dictionary of the declaration parameters.
         :param code: the list of lines of the doctest.
         """
-        outname = os.path.join(self._outdir, decl['name'])
+        outname = os.path.join(self._outdir, decl['name']).replace('\\', '/')
         action = decl['test']
         if self._dry:
             print('%s %s' % (action, outname))


### PR DESCRIPTION
Changes:
  - gen-doctest.py: Use slashes in paths to make cmake happy.
  - unit-doc/CMakeLists.txt: Don't add invalid arguments to MSVC and call gen-doctest.py properly.
  - build.py: Build and install with cmake calls on Windows.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
