### PR TITLE
General optimizations around compressed pointer management

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -494,8 +494,8 @@ typedef struct
  */
 typedef struct
 {
-  jmem_cpointer_t getter_p; /**< pointer to getter object */
-  jmem_cpointer_t setter_p; /**< pointer to setter object */
+  jmem_cpointer_t getter_cp; /**< compressed pointer to getter object */
+  jmem_cpointer_t setter_cp; /**< compressed pointer to setter object */
 } ecma_getter_setter_pointers_t;
 
 /**
@@ -563,11 +563,6 @@ typedef struct
  */
 #define ECMA_PROPERTY_VALUE_PTR(property_p) \
   ((ecma_property_value_t *) ECMA_PROPERTY_VALUE_DATA_PTR (property_p))
-
-/**
- * Depth limit for property search (maximum prototype chain depth).
- */
-#define ECMA_PROPERTY_SEARCH_DEPTH_LIMIT 128
 
 /**
  * Property reference. It contains the value pointer
@@ -744,10 +739,19 @@ typedef struct
   jmem_cpointer_t gc_next_cp;
 
   /** compressed pointer to property list or bound object */
-  jmem_cpointer_t property_list_or_bound_object_cp;
+  union
+  {
+    jmem_cpointer_t property_list_cp; /**< compressed pointer to object's
+                                       *  or declerative lexical environments's property list */
+    jmem_cpointer_t bound_object_cp;  /**< compressed pointer to lexical environments's the bound object */
+  } u1;
 
   /** object prototype or outer reference */
-  jmem_cpointer_t prototype_or_outer_reference_cp;
+  union
+  {
+    jmem_cpointer_t prototype_cp; /**< compressed pointer to the object's prototype  */
+    jmem_cpointer_t outer_reference_cp; /**< compressed pointer to the lexical environments's outer reference  */
+  } u2;
 } ecma_object_t;
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers-values-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-values-collection.c
@@ -56,15 +56,16 @@ void
 ecma_free_values_collection (ecma_collection_header_t *header_p, /**< collection's header */
                              uint32_t flags) /**< combination of ecma_collection_flag_t flags */
 {
-  ecma_collection_chunk_t *chunk_p = ECMA_GET_POINTER (ecma_collection_chunk_t,
-                                                       header_p->first_chunk_cp);
+  jmem_cpointer_t chunk_cp = header_p->first_chunk_cp;
 
   jmem_pools_free (header_p, sizeof (ecma_collection_header_t));
 
-  if (chunk_p == NULL)
+  if (chunk_cp == JMEM_CP_NULL)
   {
     return;
   }
+
+  ecma_collection_chunk_t *chunk_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_chunk_t, chunk_cp);
 
   do
   {
@@ -110,7 +111,7 @@ ecma_append_to_values_collection (ecma_collection_header_t *header_p, /**< colle
     item_index = 0;
     chunk_p = (ecma_collection_chunk_t *) jmem_heap_alloc_block (sizeof (ecma_collection_chunk_t));
 
-    ECMA_SET_POINTER (header_p->first_chunk_cp, chunk_p);
+    ECMA_SET_NON_NULL_POINTER (header_p->first_chunk_cp, chunk_p);
     header_p->last_chunk_cp = header_p->first_chunk_cp;
   }
   else
@@ -129,7 +130,7 @@ ecma_append_to_values_collection (ecma_collection_header_t *header_p, /**< colle
       next_chunk_p = (ecma_collection_chunk_t *) jmem_heap_alloc_block (sizeof (ecma_collection_chunk_t));
 
       chunk_p->items[ECMA_COLLECTION_CHUNK_ITEMS] = ecma_make_pointer_value ((void *) next_chunk_p);
-      ECMA_SET_POINTER (header_p->last_chunk_cp, next_chunk_p);
+      ECMA_SET_NON_NULL_POINTER (header_p->last_chunk_cp, next_chunk_p);
 
       chunk_p = next_chunk_p;
     }

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -335,13 +335,11 @@ bool JERRY_ATTR_PURE ecma_is_lexical_environment (const ecma_object_t *object_p)
 bool JERRY_ATTR_PURE ecma_get_object_extensible (const ecma_object_t *object_p);
 void ecma_set_object_extensible (ecma_object_t *object_p, bool is_extensible);
 ecma_object_type_t JERRY_ATTR_PURE ecma_get_object_type (const ecma_object_t *object_p);
-ecma_object_t JERRY_ATTR_PURE *ecma_get_object_prototype (const ecma_object_t *object_p);
 bool JERRY_ATTR_PURE ecma_get_object_is_builtin (const ecma_object_t *object_p);
 void ecma_set_object_is_builtin (ecma_object_t *object_p);
 uint8_t ecma_get_object_builtin_id (ecma_object_t *object_p);
 ecma_lexical_environment_type_t JERRY_ATTR_PURE ecma_get_lex_env_type (const ecma_object_t *object_p);
 ecma_object_t JERRY_ATTR_PURE *ecma_get_lex_env_outer_reference (const ecma_object_t *object_p);
-ecma_property_header_t JERRY_ATTR_PURE *ecma_get_property_list (const ecma_object_t *object_p);
 ecma_object_t JERRY_ATTR_PURE *ecma_get_lex_env_binding_object (const ecma_object_t *object_p);
 
 ecma_property_value_t *
@@ -363,8 +361,8 @@ uint32_t ecma_delete_array_properties (ecma_object_t *object_p, uint32_t new_len
 void ecma_named_data_property_assign_value (ecma_object_t *obj_p, ecma_property_value_t *prop_value_p,
                                             ecma_value_t value);
 
-ecma_object_t *ecma_get_named_accessor_property_getter (const ecma_property_value_t *prop_value_p);
-ecma_object_t *ecma_get_named_accessor_property_setter (const ecma_property_value_t *prop_value_p);
+ecma_getter_setter_pointers_t *
+ecma_get_named_accessor_property (const ecma_property_value_t *prop_value_p);
 void ecma_set_named_accessor_property_getter (ecma_object_t *object_p, ecma_property_value_t *prop_value_p,
                                               ecma_object_t *getter_p);
 void ecma_set_named_accessor_property_setter (ecma_object_t *object_p, ecma_property_value_t *prop_value_p,

--- a/jerry-core/ecma/base/ecma-property-hashmap.h
+++ b/jerry-core/ecma/base/ecma-property-hashmap.h
@@ -53,6 +53,8 @@ typedef struct
    */
 } ecma_property_hashmap_t;
 
+#if ENABLED (JERRY_PROPRETY_HASHMAP)
+
 /**
  * Simple ecma values
  */
@@ -70,7 +72,7 @@ void ecma_property_hashmap_insert (ecma_object_t *object_p, ecma_string_t *name_
 ecma_property_hashmap_delete_status ecma_property_hashmap_delete (ecma_object_t *object_p, jmem_cpointer_t name_cp,
                                                                   ecma_property_t *property_p);
 
-#if ENABLED (JERRY_PROPRETY_HASHMAP)
+
 ecma_property_t *ecma_property_hashmap_find (ecma_property_hashmap_t *hashmap_p, ecma_string_t *name_p,
                                              jmem_cpointer_t *property_real_name_cp);
 #endif /* ENABLED (JERRY_PROPRETY_HASHMAP) */

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -276,7 +276,9 @@ ecma_builtin_is (ecma_object_t *obj_p, /**< pointer to an object */
 
   /* If a built-in object is not instantiated, its value is NULL,
      hence it cannot be equal to a valid object. */
-  return (obj_p == ECMA_GET_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[builtin_id]));
+  jmem_cpointer_t builtin_cp = JERRY_CONTEXT (ecma_builtin_objects)[builtin_id];
+
+  return (builtin_cp != JMEM_CP_NULL && (obj_p == ECMA_GET_NON_NULL_POINTER (ecma_object_t, builtin_cp)));
 } /* ecma_builtin_is */
 
 /**

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -170,17 +170,20 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 ecma_standard_error_t
 ecma_get_error_type (ecma_object_t *error_object) /**< possible error object */
 {
-  ecma_object_t *prototype_p = ecma_get_object_prototype (error_object);
-  if (prototype_p != NULL)
+  if (error_object->u2.prototype_cp == JMEM_CP_NULL)
   {
-    uint8_t builtin_id = ecma_get_object_builtin_id (prototype_p);
+    return ECMA_ERROR_NONE;
+  }
 
-    for (uint8_t idx = 0; idx < sizeof (ecma_error_mappings) / sizeof (ecma_error_mappings[0]); idx++)
+  ecma_object_t *prototype_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, error_object->u2.prototype_cp);
+
+  uint8_t builtin_id = ecma_get_object_builtin_id (prototype_p);
+
+  for (uint8_t idx = 0; idx < sizeof (ecma_error_mappings) / sizeof (ecma_error_mappings[0]); idx++)
+  {
+    if (ecma_error_mappings[idx].error_prototype_id == builtin_id)
     {
-      if (ecma_error_mappings[idx].error_prototype_id == builtin_id)
-      {
-        return ecma_error_mappings[idx].error_type;
-      }
+      return ecma_error_mappings[idx].error_type;
     }
   }
 

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -50,7 +50,7 @@ ecma_op_get_value_lex_env_base (ecma_object_t *lex_env_p, /**< lexical environme
   JERRY_ASSERT (lex_env_p != NULL
                 && ecma_is_lexical_environment (lex_env_p));
 
-  while (lex_env_p != NULL)
+  while (true)
   {
     switch (ecma_get_lex_env_type (lex_env_p))
     {
@@ -89,7 +89,12 @@ ecma_op_get_value_lex_env_base (ecma_object_t *lex_env_p, /**< lexical environme
       }
     }
 
-    lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
+    if (lex_env_p->u2.outer_reference_cp == JMEM_CP_NULL)
+    {
+      break;
+    }
+
+    lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, lex_env_p->u2.outer_reference_cp);
   }
 
   *ref_base_lex_env_p = NULL;
@@ -147,10 +152,7 @@ ecma_op_get_value_object_base (ecma_value_t base_value, /**< base value */
 
   ecma_value_t ret_value = ECMA_VALUE_UNDEFINED;
 
-  /* Circular reference is possible in JavaScript and testing it is complicated. */
-  int max_depth = ECMA_PROPERTY_SEARCH_DEPTH_LIMIT;
-
-  do
+  while (true)
   {
     ecma_value_t value = ecma_op_object_find_own (base_value, object_p, property_name_p);
 
@@ -160,14 +162,13 @@ ecma_op_get_value_object_base (ecma_value_t base_value, /**< base value */
       break;
     }
 
-    if (--max_depth == 0)
+    if (object_p->u2.prototype_cp == JMEM_CP_NULL)
     {
       break;
     }
 
-    object_p = ecma_get_object_prototype (object_p);
+    object_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, object_p->u2.prototype_cp);
   }
-  while (object_p != NULL);
 
   ecma_free_value (object_base);
 
@@ -191,7 +192,7 @@ ecma_op_put_value_lex_env_base (ecma_object_t *lex_env_p, /**< lexical environme
   JERRY_ASSERT (lex_env_p != NULL
                 && ecma_is_lexical_environment (lex_env_p));
 
-  while (lex_env_p != NULL)
+  while (true)
   {
     switch (ecma_get_lex_env_type (lex_env_p))
     {
@@ -245,7 +246,12 @@ ecma_op_put_value_lex_env_base (ecma_object_t *lex_env_p, /**< lexical environme
       }
     }
 
-    lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
+    if (lex_env_p->u2.outer_reference_cp == JMEM_CP_NULL)
+    {
+      break;
+    }
+
+    lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, lex_env_p->u2.outer_reference_cp);
   }
 
   if (is_strict)

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -448,10 +448,15 @@ ecma_op_general_object_define_own_property (ecma_object_t *object_p, /**< the ob
         /* a. */
         ecma_property_value_t *value_p = ext_property_ref.property_ref.value_p;
 
+        ecma_getter_setter_pointers_t *get_set_pair_p = ecma_get_named_accessor_property (value_p);
+        jmem_cpointer_t prop_desc_getter_cp, prop_desc_setter_cp;
+        ECMA_SET_POINTER (prop_desc_getter_cp, property_desc_p->get_p);
+        ECMA_SET_POINTER (prop_desc_setter_cp, property_desc_p->set_p);
+
         if ((property_desc_p->is_get_defined
-             && property_desc_p->get_p != ecma_get_named_accessor_property_getter (value_p))
+             && prop_desc_getter_cp != get_set_pair_p->getter_cp)
             || (property_desc_p->is_set_defined
-                && property_desc_p->set_p != ecma_get_named_accessor_property_setter (value_p)))
+                && prop_desc_setter_cp != get_set_pair_p->setter_cp))
         {
           /* i., ii. */
           return ecma_reject (is_throw);
@@ -478,12 +483,12 @@ ecma_op_general_object_define_own_property (ecma_object_t *object_p, /**< the ob
 #if ENABLED (JERRY_CPOINTER_32_BIT)
       ecma_getter_setter_pointers_t *getter_setter_pair_p;
       getter_setter_pair_p = jmem_pools_alloc (sizeof (ecma_getter_setter_pointers_t));
-      getter_setter_pair_p->getter_p = JMEM_CP_NULL;
-      getter_setter_pair_p->setter_p = JMEM_CP_NULL;
-      ECMA_SET_POINTER (value_p->getter_setter_pair_cp, getter_setter_pair_p);
+      getter_setter_pair_p->getter_cp = JMEM_CP_NULL;
+      getter_setter_pair_p->setter_cp = JMEM_CP_NULL;
+      ECMA_SET_NON_NULL_POINTER (value_p->getter_setter_pair_cp, getter_setter_pair_p);
 #else /* !ENABLED (JERRY_CPOINTER_32_BIT) */
-      value_p->getter_setter_pair.getter_p = JMEM_CP_NULL;
-      value_p->getter_setter_pair.setter_p = JMEM_CP_NULL;
+      value_p->getter_setter_pair.getter_cp = JMEM_CP_NULL;
+      value_p->getter_setter_pair.setter_cp = JMEM_CP_NULL;
 #endif /* ENABLED (JERRY_CPOINTER_32_BIT) */
     }
     else
@@ -491,8 +496,8 @@ ecma_op_general_object_define_own_property (ecma_object_t *object_p, /**< the ob
       JERRY_ASSERT (current_property_type == ECMA_PROPERTY_TYPE_NAMEDACCESSOR);
 #if ENABLED (JERRY_CPOINTER_32_BIT)
       ecma_getter_setter_pointers_t *getter_setter_pair_p;
-      getter_setter_pair_p = ECMA_GET_POINTER (ecma_getter_setter_pointers_t,
-                                               value_p->getter_setter_pair_cp);
+      getter_setter_pair_p = ECMA_GET_NON_NULL_POINTER (ecma_getter_setter_pointers_t,
+                                                        value_p->getter_setter_pair_cp);
       jmem_pools_free (getter_setter_pair_p, sizeof (ecma_getter_setter_pointers_t));
 #endif /* ENABLED (JERRY_CPOINTER_32_BIT) */
       value_p->value = ECMA_VALUE_UNDEFINED;

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -1015,7 +1015,7 @@ ecma_op_create_typedarray_with_type_and_length (ecma_object_t *obj_p, /**< Typed
 #if ENABLED (JERRY_ES2015_CLASS)
   ecma_object_t *constructor_prototype_object_p = ecma_get_object_from_value (constructor_prototype);
   ecma_object_t *new_obj_p = ecma_get_object_from_value (new_obj);
-  ECMA_SET_POINTER (new_obj_p->prototype_or_outer_reference_cp, constructor_prototype_object_p);
+  ECMA_SET_NON_NULL_POINTER (new_obj_p->u2.prototype_cp, constructor_prototype_object_p);
 
   ecma_deref_object (constructor_prototype_object_p);
 #endif /* ENABLED (JERRY_ES2015_CLASS) */

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -245,8 +245,8 @@ opfunc_for_in (ecma_value_t left_value, /**< left value */
 
   if (prop_names_coll_p->item_count != 0)
   {
-    prop_names_p = ECMA_GET_POINTER (ecma_collection_chunk_t,
-                                     prop_names_coll_p->first_chunk_cp);
+    prop_names_p = ECMA_GET_NON_NULL_POINTER (ecma_collection_chunk_t,
+                                              prop_names_coll_p->first_chunk_cp);
 
     ecma_ref_object (obj_p);
     *result_obj_p = ecma_make_object_value (obj_p);

--- a/jerry-core/vm/vm-stack.c
+++ b/jerry-core/vm/vm-stack.c
@@ -72,7 +72,8 @@ vm_stack_context_abort (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
 #endif /* ENABLED (JERRY_ES2015_CLASS) */
     {
       ecma_object_t *lex_env_p = frame_ctx_p->lex_env_p;
-      frame_ctx_p->lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
+      JERRY_ASSERT (lex_env_p->u2.outer_reference_cp != JMEM_CP_NULL);
+      frame_ctx_p->lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, lex_env_p->u2.outer_reference_cp);
       ecma_deref_object (lex_env_p);
 
       VM_MINUS_EQUAL_U16 (frame_ctx_p->context_depth, PARSER_WITH_CONTEXT_STACK_ALLOCATION);
@@ -244,7 +245,8 @@ vm_stack_find_finally (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
       else
       {
         ecma_object_t *lex_env_p = frame_ctx_p->lex_env_p;
-        frame_ctx_p->lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
+        JERRY_ASSERT (lex_env_p->u2.outer_reference_cp != JMEM_CP_NULL);
+        frame_ctx_p->lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, lex_env_p->u2.outer_reference_cp);
         ecma_deref_object (lex_env_p);
 
         if (byte_code_p[0] == CBC_CONTEXT_END)

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -294,12 +294,12 @@ vm_run_eval (ecma_compiled_code_t *bytecode_data_p, /**< byte-code data */
 
     while (chain_index != 0)
     {
-      lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
-
-      if (JERRY_UNLIKELY (lex_env_p == NULL))
+      if (JERRY_UNLIKELY (lex_env_p->u2.outer_reference_cp == JMEM_CP_NULL))
       {
         return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid scope chain index for eval"));
       }
+
+      lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, lex_env_p->u2.outer_reference_cp);
 
       if ((ecma_get_lex_env_type (lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND)
           || (ecma_get_lex_env_type (lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_DECLARATIVE))
@@ -1387,7 +1387,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           ecma_object_t *super_class_p = ecma_get_lex_env_binding_object (frame_ctx_p->lex_env_p);
 
-          if (ecma_get_object_prototype (super_class_p))
+          if (super_class_p->u2.prototype_cp != JMEM_CP_NULL)
           {
             ecma_value_t super_prototype_value = ecma_op_object_get_by_magic_id (super_class_p,
                                                                                  LIT_MAGIC_STRING_PROTOTYPE);
@@ -1403,8 +1403,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             {
               ecma_object_t *super_prototype_class_p = ecma_get_object_from_value (super_prototype_value);
 
-              ECMA_SET_POINTER (child_prototype_class_p->prototype_or_outer_reference_cp, super_prototype_class_p);
-              ECMA_SET_POINTER (child_class_p->prototype_or_outer_reference_cp, super_class_p);
+              ECMA_SET_NON_NULL_POINTER (child_prototype_class_p->u2.prototype_cp, super_prototype_class_p);
+              ECMA_SET_NON_NULL_POINTER (child_class_p->u2.prototype_cp, super_class_p);
 
             }
             ecma_free_value (super_prototype_value);
@@ -3050,7 +3050,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (VM_GET_CONTEXT_TYPE (stack_top_p[-1]) == VM_CONTEXT_CATCH)
           {
             ecma_object_t *lex_env_p = frame_ctx_p->lex_env_p;
-            frame_ctx_p->lex_env_p = ecma_get_lex_env_outer_reference (lex_env_p);
+            JERRY_ASSERT (lex_env_p->u2.outer_reference_cp != JMEM_CP_NULL);
+            frame_ctx_p->lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, lex_env_p->u2.outer_reference_cp);
             ecma_deref_object (lex_env_p);
           }
 


### PR DESCRIPTION
ECMA_GET_POINTER is removed from:
 - property list iteration
 - lexical environment chain iteration
 - prototype chain iteration

For all these iteration the compressed pointer can be used to get the elements and only decompressed them if it is necessary.

- Properly guard ecma property hashmap routines
- Remove the redundant NULL pointer check from ecma_create_property
- Remove ecma_gc_get_object_next since it became unnecessary
- Substitute ECMA_{GET,SET}_POINTER with ECMA_{GET,SET}_NON_NULL pointer when we can assume the pointer is not NULL
- Remove ecma_get_object_prototype and ecma_get_lex_env_outer_reference helper function the reduce the number of NULL pointer checks during decompressing the pointers
- Remove ecma_get_named_accessor_property_{getter,setter} helper functions for also reduce the number of NULL pointer checks/decompressions
- Remove ECMA_PROPERTY_SEARCH_DEPTH_LIMIT since in ES5.1 there is no way to create circular prototype chain, and the ES2015 setPrototypeOf method can resolve this error so this check during the property lookup can be eliminated.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
