### PR TITLE
Fix an issue when shrinking arrays

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -436,6 +436,11 @@ ecma_delete_fast_array_properties (ecma_object_t *object_p, /**< fast access mod
                                                            old_aligned_length * sizeof (ecma_value_t),
                                                            new_aligned_length * sizeof (ecma_value_t));
 
+  for (uint32_t i = new_length; i < new_aligned_length; i++)
+  {
+    new_values_p[i] = ECMA_VALUE_ARRAY_HOLE;
+  }
+
   ext_obj_p->u.array.length = new_length;
 
   ECMA_SET_POINTER (object_p->u1.property_list_cp, new_values_p);

--- a/tests/jerry/regression-test-issue-3039.js
+++ b/tests/jerry/regression-test-issue-3039.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = [];
+for (var i = 0; i < 200; ++i) {
+  a[ i ] = 0;
+}
+
+a.length = 1;
+for (var i = 0; i < 5; ++i) {
+  a[ i ] = 0;
+}


### PR DESCRIPTION
There was an issue with fast arrays not correctly inserting "holes" when shrinking them.

Fixes #3039

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu