### PR TITLE
Don't use ecma_create_named_data_property in fast mode arrays

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -335,6 +335,9 @@ ecma_create_property (ecma_object_t *object_p, /**< the object */
   JERRY_ASSERT (ECMA_PROPERTY_PAIR_ITEM_COUNT == 2);
   JERRY_ASSERT (name_p != NULL);
   JERRY_ASSERT (object_p != NULL);
+  JERRY_ASSERT (ecma_is_lexical_environment (object_p)
+                || ecma_get_object_type (object_p) != ECMA_OBJECT_TYPE_ARRAY
+                || !((ecma_extended_object_t *) object_p)->u.array.is_fast_mode);
 
   jmem_cpointer_t *property_list_head_p = &object_p->u1.property_list_cp;
 
@@ -686,6 +689,9 @@ ecma_get_named_data_property (ecma_object_t *obj_p, /**< object to find property
 {
   JERRY_ASSERT (obj_p != NULL);
   JERRY_ASSERT (name_p != NULL);
+  JERRY_ASSERT (ecma_is_lexical_environment (obj_p)
+                || ecma_get_object_type (obj_p) != ECMA_OBJECT_TYPE_ARRAY
+                || !((ecma_extended_object_t *) obj_p)->u.array.is_fast_mode);
 
   ecma_property_t *property_p = ecma_find_named_property (obj_p, name_p);
 

--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -15,6 +15,7 @@
 
 #include "ecma-alloc.h"
 #include "ecma-builtins.h"
+#include "ecma-builtin-helpers.h"
 #include "ecma-exceptions.h"
 #include "ecma-function-object.h"
 #include "ecma-gc.h"
@@ -250,16 +251,17 @@ ecma_op_container_to_key (ecma_value_t key_arg) /**< key argument */
     if (property_p == NULL)
     {
       object_key_string = ecma_new_map_key_string (key_arg);
-      ecma_property_value_t *value_p = ecma_create_named_data_property (obj_p,
-                                                                        key_string_p,
-                                                                        ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
-                                                                        NULL);
-      value_p->value = ecma_make_string_value (object_key_string);
+      ecma_value_t put_comp = ecma_builtin_helper_def_prop (obj_p,
+                                                            key_string_p,
+                                                            ecma_make_string_value (object_key_string),
+                                                            ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
+
+      JERRY_ASSERT (ecma_is_value_true (put_comp));
+      ecma_deref_ecma_string (object_key_string);
     }
     else
     {
       object_key_string = ecma_get_string_from_value (ECMA_PROPERTY_VALUE_PTR (property_p)->value);
-
     }
 
     ecma_ref_ecma_string (object_key_string);

--- a/tests/jerry/es2015/regression-test-issue-3040.js
+++ b/tests/jerry/es2015/regression-test-issue-3040.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var map = new Map();
+var array = Array();
+map.set(array);
+assert(map.has(array));


### PR DESCRIPTION
Remove invalid use of named data properties in fast mode arrays.
Fixes #3040

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu