### PR TITLE
Property release the callback result in Array.prototype.[find/findIndex]

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1992,11 +1992,16 @@ ecma_builtin_array_prototype_object_find (ecma_value_t predicate, /**< callback 
         return call_value;
       }
 
-      if (ecma_op_to_boolean (call_value))
+      bool call_value_to_bool = ecma_op_to_boolean (call_value);
+
+      ecma_free_value (call_value);
+
+      if (call_value_to_bool)
       {
         /* 8.f */
         if (is_find)
         {
+          ecma_free_value (current_index);
           return get_value;
         }
 
@@ -2004,7 +2009,6 @@ ecma_builtin_array_prototype_object_find (ecma_value_t predicate, /**< callback 
         return current_index;
       }
 
-      ecma_free_value (call_value);
       ecma_free_value (get_value);
       ecma_free_value (current_index);
     }

--- a/tests/jerry/es2015/regression-test-issue-3049.js
+++ b/tests/jerry/es2015/regression-test-issue-3049.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var func = function (a, b) { return a + b };
+assert(['A'].findIndex(func) == 0);


### PR DESCRIPTION
This patch fixes #3049.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
