### PR TITLE
Add fast array support for property name enumeration

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-3050.js
+++ b/tests/jerry/es2015/regression-test-issue-3050.js
@@ -1,0 +1,27 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var counter = 0;
+var expected = [0];
+
+var b = [$];
+function dConstr () { }
+dConstr.prototype = b;
+var d = new dConstr()
+for (var $ in d) {
+  counter++;
+  assert($ in expected);
+}
+
+assert(counter === 1);


### PR DESCRIPTION
Since fast access mode arrays can be part of the prototype chain these objects must be handed separately.
This patch fixes #3050.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
