### PR TITLE
Properly handle CBC_PUSH_THIS_LITERAL for unary lvalue operations

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -83,7 +83,8 @@ static void
 parser_emit_unary_lvalue_opcode (parser_context_t *context_p, /**< context */
                                  cbc_opcode_t opcode) /**< opcode */
 {
-  if (PARSER_IS_PUSH_LITERAL (context_p->last_cbc_opcode)
+  if ((PARSER_IS_PUSH_LITERAL (context_p->last_cbc_opcode)
+       || context_p->last_cbc_opcode == CBC_PUSH_THIS_LITERAL)
       && context_p->last_cbc.literal_type == LEXER_IDENT_LITERAL)
   {
     if (context_p->status_flags & PARSER_IS_STRICT)
@@ -124,6 +125,13 @@ parser_emit_unary_lvalue_opcode (parser_context_t *context_p, /**< context */
                                  CBC_DELETE_IDENT_PUSH_RESULT,
                                  context_p->last_cbc.value);
       }
+      else if (context_p->last_cbc_opcode == CBC_PUSH_THIS_LITERAL)
+      {
+        context_p->last_cbc_opcode = CBC_PUSH_THIS;
+        parser_emit_cbc_literal (context_p,
+                                 CBC_DELETE_IDENT_PUSH_RESULT,
+                                 context_p->lit_object.index);
+      }
       else
       {
         JERRY_ASSERT (context_p->last_cbc_opcode == CBC_PUSH_THREE_LITERALS);
@@ -149,6 +157,13 @@ parser_emit_unary_lvalue_opcode (parser_context_t *context_p, /**< context */
                                (uint16_t) (opcode + CBC_UNARY_LVALUE_WITH_IDENT),
                                context_p->last_cbc.value);
     }
+    else if (context_p->last_cbc_opcode == CBC_PUSH_THIS_LITERAL)
+    {
+      context_p->last_cbc_opcode = CBC_PUSH_THIS;
+      parser_emit_cbc_literal (context_p,
+                               (uint16_t) (opcode + CBC_UNARY_LVALUE_WITH_IDENT),
+                               context_p->lit_object.index);
+    }
     else
     {
       JERRY_ASSERT (context_p->last_cbc_opcode == CBC_PUSH_THREE_LITERALS);
@@ -163,14 +178,6 @@ parser_emit_unary_lvalue_opcode (parser_context_t *context_p, /**< context */
   {
     JERRY_ASSERT (CBC_SAME_ARGS (CBC_PUSH_PROP, opcode));
     context_p->last_cbc_opcode = (uint16_t) opcode;
-  }
-  else if (context_p->last_cbc_opcode == CBC_PUSH_THIS_LITERAL
-           && context_p->last_cbc.literal_type == LEXER_IDENT_LITERAL)
-  {
-    context_p->last_cbc_opcode = CBC_PUSH_THIS;
-    parser_emit_cbc_literal (context_p,
-                             (uint16_t) (opcode + CBC_UNARY_LVALUE_WITH_IDENT),
-                             context_p->lit_object.index);
   }
   else
   {

--- a/tests/jerry/regression-test-issue-3048.js
+++ b/tests/jerry/regression-test-issue-3048.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+this[delete $];


### PR DESCRIPTION
This patch fixes #3048.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
