### PR TITLE
Properly decode literal index before CBC_MOV_IDENT

### DIFF
--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -605,6 +605,26 @@
 #define CBC_LOWER_SEVEN_BIT_MASK 0x7f
 
 /**
+ * Literal encoding limit when full literal encoding mode is enabled
+ */
+#define CBC_FULL_LITERAL_ENCODING_LIMIT 128
+
+/**
+ * Literal encoding delta when full literal encoding mode is enabled
+ */
+#define CBC_FULL_LITERAL_ENCODING_DELTA 0x8000
+
+/**
+ * Literal encoding limit when full literal encoding mode is disabled
+ */
+#define CBC_SMALL_LITERAL_ENCODING_LIMIT 255
+
+/**
+ * Literal encoding delta when full literal encoding mode is disabled
+ */
+#define CBC_SMALL_LITERAL_ENCODING_DELTA 0xfe01
+
+/**
  * Literal indicies belong to one of the following groups:
  *
  * 0 <= index < argument_end                    : arguments

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -773,13 +773,13 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
   /* Prepare. */
   if (!(bytecode_header_p->status_flags & CBC_CODE_FLAGS_FULL_LITERAL_ENCODING))
   {
-    encoding_limit = 255;
-    encoding_delta = 0xfe01;
+    encoding_limit = CBC_SMALL_LITERAL_ENCODING_LIMIT;
+    encoding_delta = CBC_SMALL_LITERAL_ENCODING_DELTA;
   }
   else
   {
-    encoding_limit = 128;
-    encoding_delta = 0x8000;
+    encoding_limit = CBC_FULL_LITERAL_ENCODING_LIMIT;
+    encoding_delta = CBC_FULL_LITERAL_ENCODING_DELTA;
   }
 
   if (frame_ctx_p->bytecode_header_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)
@@ -931,13 +931,13 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
   /* Prepare for byte code execution. */
   if (!(bytecode_header_p->status_flags & CBC_CODE_FLAGS_FULL_LITERAL_ENCODING))
   {
-    encoding_limit = 255;
-    encoding_delta = 0xfe01;
+    encoding_limit = CBC_SMALL_LITERAL_ENCODING_LIMIT;
+    encoding_delta = CBC_SMALL_LITERAL_ENCODING_DELTA;
   }
   else
   {
-    encoding_limit = 128;
-    encoding_delta = 0x8000;
+    encoding_limit = CBC_FULL_LITERAL_ENCODING_LIMIT;
+    encoding_delta = CBC_FULL_LITERAL_ENCODING_DELTA;
   }
 
   if (bytecode_header_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)

--- a/tests/jerry/regression-test-issue-3055.js
+++ b/tests/jerry/regression-test-issue-3055.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+var src = '(function () {'
+for (var i = 0; i < 550; i++) { src += 'var a' + i + ' = 5; ' }
+src += '})()'
+eval(src)


### PR DESCRIPTION
This patch fixes #3055.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
