### PR TITLE
Fix array hole calculation for fast access mode arrays

### DIFF
--- a/tests/jerry/regression-test-issue-3060.js
+++ b/tests/jerry/regression-test-issue-3060.js
@@ -1,0 +1,24 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arr = [];
+arr.length = 10;
+arr.splice(0, 17);
+arr.length = 4294967294;
+arr.splice(1, 1, 1);
+
+assert(arr.length === 4294967294);
+assert(arr[0] === undefined);
+assert(arr[1] === 1);
+assert(arr[2] === undefined);


### PR DESCRIPTION
This patch fixes #3060.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
