### PR TITLE
Ensure that Map/Set object keys can always have MAP_KEY_STRING internal property

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-3062.js
+++ b/tests/jerry/es2015/regression-test-issue-3062.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var map = new Map();
+var obj = Object.freeze({});
+map.set(obj, 1);
+assert(map.has(obj));


### PR DESCRIPTION
This patch fixes #3062.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
