### PR TITLE
Limit the constructed string size in String.prototype.repeat

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1348,6 +1348,11 @@ typedef enum
 #define ECMA_GET_DIRECT_STRING_VALUE(string_p) \
   (((uintptr_t) (string_p)) >> ECMA_DIRECT_STRING_SHIFT)
 
+/**
+ * Maximum number of bytes that a long-utf8-string is able to store
+ */
+#define ECMA_STRING_SIZE_LIMIT UINT32_MAX
+
 typedef enum
 {
   ECMA_STRING_CONTAINER_HEAP_UTF8_STRING, /**< actual data is on the heap as an utf-8 (cesu8) string

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1913,6 +1913,12 @@ ecma_builtin_string_prototype_object_repeat (ecma_string_t *original_string_p, /
   }
 
   lit_utf8_size_t size = ecma_string_get_utf8_size (original_string_p);
+
+  if ((uint32_t) length >= (ECMA_STRING_SIZE_LIMIT / size))
+  {
+    return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid string length"));
+  }
+
   lit_utf8_size_t total_size = size * (lit_utf8_size_t) length;
 
   JMEM_DEFINE_LOCAL_ARRAY (str_buffer, total_size, lit_utf8_byte_t);

--- a/tests/jerry/es2015/regression-test-issue-3063.js
+++ b/tests/jerry/es2015/regression-test-issue-3063.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var str = "123" + "test123";
+
+try {
+  str.repeat([1073741823]);
+  assert(false);
+} catch (e) {
+  assert (e instanceof RangeError);
+}


### PR DESCRIPTION
This patch fixes #3063.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
