### PR TITLE
Fix fast access mode arrays delete property operation

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -420,7 +420,7 @@ ecma_delete_fast_array_properties (ecma_object_t *object_p, /**< fast access mod
     return new_length;
   }
 
-  for (uint32_t i = new_length; i < old_length - 1; i++)
+  for (uint32_t i = new_length; i < old_length; i++)
   {
     if (ecma_is_value_array_hole (values_p[i]))
     {

--- a/tests/jerry/regression-test-issue-3068.js
+++ b/tests/jerry/regression-test-issue-3068.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arr = [0, Infinity];
+Object.defineProperties(arr, {
+    length: {
+    value: 1,
+    }
+});
+
+assert(arr.length === 1);
+assert(arr[0] === 0);


### PR DESCRIPTION
The old last element should be released before reallocating the underlying buffer

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
