### PR TITLE
Fix byteLength validation in DataView constructor

### DIFF
--- a/jerry-core/ecma/operations/ecma-dataview-object.c
+++ b/jerry-core/ecma/operations/ecma-dataview-object.c
@@ -118,6 +118,11 @@ ecma_op_dataview_create (const ecma_value_t *arguments_list_p, /**< arguments li
     }
     else if (ecma_number_is_infinity (byte_length))
     {
+      if (ecma_number_is_negative (byte_length))
+      {
+        return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid DataView length"));
+      }
+
       viewByteLength = UINT32_MAX;
     }
     else if (byte_length_int32 <= 0)

--- a/tests/jerry/es2015/regression-test-issue-3072.js
+++ b/tests/jerry/es2015/regression-test-issue-3072.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arrb = new ArrayBuffer(13);
+
+try {
+  var d = new DataView(arrb, 12, -Infinity);
+  d.setFloat32(1, 1);
+  assert (false);
+} catch (e) {
+  assert (e instanceof RangeError);
+}


### PR DESCRIPTION
This patch fixes #3072.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
