### PR TITLE
Fix array initialization with array holes

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -186,13 +186,6 @@ ecma_fast_array_convert_to_normal (ecma_object_t *object_p) /**< fast access mod
   ecma_deref_object (object_p);
 } /* ecma_fast_array_convert_to_normal */
 
-/**
- * Maximum number of array holes in a fast mode access array.
- * If the number of holes exceeds this limit, the array is converted back
- * to normal property list based array.
- */
-#define ECMA_FAST_ARRAY_MAX_HOLE_COUNT 32
-
 #if ENABLED (JERRY_SYSTEM_ALLOCATOR)
 /**
  * Maximum length of the array length to allocate fast mode access for it

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -26,6 +26,13 @@
  */
 
 /**
+ * Maximum number of array holes in a fast mode access array.
+ * If the number of holes exceeds this limit, the array is converted back
+ * to normal property list based array.
+ */
+#define ECMA_FAST_ARRAY_MAX_HOLE_COUNT 32
+
+/**
  * Flags for ecma_op_array_object_set_length
  */
 typedef enum

--- a/tests/jerry/regression-test-issue-3072.js
+++ b/tests/jerry/regression-test-issue-3072.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arr = [ , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , ];
+arr [4294967294] = 0
+assert (arr.length === 4294967295);
+assert (arr[4294967294] === 0);


### PR DESCRIPTION
Fast mode access arrays must be converted back to normal if the array hole count reaches the limit during the initializtaion.
This patch fixes #3075.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
