### PR TITLE
Correctly propagate super prop ref when parsing expressions

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -2245,6 +2245,16 @@ parser_parse_expression (parser_context_t *context_p, /**< context */
 
   parser_stack_push_uint8 (context_p, LEXER_EXPRESSION_START);
 
+#if ENABLED (JERRY_ES2015_CLASS)
+  /* Parsing a new expression:
+   *  So save, remove, and at the end restore the super prop reference indicator.
+   *
+   * If this is not done, it is possible to carry the flag over to the next expression.
+   */
+  bool has_super_ref = (context_p->status_flags & PARSER_CLASS_SUPER_PROP_REFERENCE);
+  context_p->status_flags &= (uint32_t) ~PARSER_CLASS_SUPER_PROP_REFERENCE;
+#endif
+
   while (true)
   {
     if (options & PARSE_EXPR_HAS_LITERAL)
@@ -2409,6 +2419,14 @@ parser_parse_expression (parser_context_t *context_p, /**< context */
   {
     parser_push_result (context_p);
   }
+
+#if ENABLED (JERRY_ES2015_CLASS)
+  /* Restore the super prop ref flag. */
+  if (has_super_ref)
+  {
+    context_p->status_flags |= (uint32_t) PARSER_CLASS_SUPER_PROP_REFERENCE;
+  }
+#endif /* ENABLED (JERRY_ES2015_CLASS) */
 } /* parser_parse_expression */
 
 /**

--- a/tests/jerry/es2015/regression-test-issue-3067.js
+++ b/tests/jerry/es2015/regression-test-issue-3067.js
@@ -1,0 +1,32 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test case minimalized from issue #3067
+
+function f () { }
+
+class B extends f {
+  constructor () {
+    super (0)
+    super.$
+    this.$ = $
+  }
+}
+
+try {
+  var b = new B;
+  assert (false);
+} catch (ex) {
+  assert (ex instanceof ReferenceError);
+}


### PR DESCRIPTION
The "super prop ref" flag is incorrectly used at multiple expressions
as it was only cleared if there was an assignment operation.
