### PR TITLE
Fix the internal object reference count in Map/Set.prototype.forEach

### DIFF
--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -463,6 +463,8 @@ ecma_op_container_foreach (ecma_value_t this_arg, /**< this argument */
 
   ecma_value_t ret_value = ECMA_VALUE_UNDEFINED;
 
+  ecma_ref_object (internal_obj_p);
+
   while (ecma_value_p != NULL)
   {
     ecma_string_t *prop_name_p = ecma_get_prop_name_from_value (*ecma_value_p);
@@ -516,6 +518,7 @@ ecma_op_container_foreach (ecma_value_t this_arg, /**< this argument */
     ecma_value_p = ecma_collection_iterator_next (ecma_value_p);
   }
 
+  ecma_deref_object (internal_obj_p);
   ecma_free_values_collection (props_p, 0);
 
   return ret_value;

--- a/tests/jerry/es2015/regression-test-issue-3079.js
+++ b/tests/jerry/es2015/regression-test-issue-3079.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+for (b = 0; b < 100; b++) {
+    var setv = new Set();
+    setv.add(1);
+    setv.add(Math.SQRT2);
+    setv.forEach(function(value, key, set) {
+        setv.clear();
+        (eval)("" + 123);
+    });
+}


### PR DESCRIPTION
This patch fixes #3079.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
