### PR TITLE
Fix String.prototype.repeat for empty strings

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1907,12 +1907,12 @@ ecma_builtin_string_prototype_object_repeat (ecma_string_t *original_string_p, /
     return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid count value"));
   }
 
-  if (length == 0 || isNan)
+  lit_utf8_size_t size = ecma_string_get_utf8_size (original_string_p);
+
+  if (length == 0 || size == 0 || isNan)
   {
     return ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
-
-  lit_utf8_size_t size = ecma_string_get_utf8_size (original_string_p);
 
   if ((uint32_t) length >= (ECMA_STRING_SIZE_LIMIT / size))
   {

--- a/tests/jerry/es2015/regression-test-issue-3084.js
+++ b/tests/jerry/es2015/regression-test-issue-3084.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert(String.prototype.repeat(1.1) === "");


### PR DESCRIPTION
This patch fixes #3084.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
