### PR TITLE
Refactor ecma_op_to_object

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -1243,7 +1243,9 @@ jerry_value_to_object (const jerry_value_t value) /**< input value */
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (error_value_msg_p)));
   }
 
-  return jerry_return (ecma_op_to_object (value));
+  ecma_object_t *obj_p = ecma_op_to_object (value);
+
+  return jerry_return (obj_p == NULL ? ECMA_VALUE_ERROR : ecma_make_object_value ((obj_p)));
 } /* jerry_value_to_object */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -2046,14 +2046,12 @@ ecma_builtin_array_prototype_dispatch_routine (uint16_t builtin_routine_id, /**<
                                                                                     *   passed to routine */
                                               ecma_length_t arguments_number) /**< length of arguments' list */
 {
-  ecma_value_t obj_this = ecma_op_to_object (this_arg);
+  ecma_object_t *obj_p = ecma_op_to_object (this_arg);
 
-  if (ECMA_IS_VALUE_ERROR (obj_this))
+  if (JERRY_UNLIKELY (obj_p == NULL))
   {
-    return obj_this;
+    return ECMA_VALUE_ERROR;
   }
-
-  ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
 
   if (JERRY_UNLIKELY (builtin_routine_id <= ECMA_ARRAY_PROTOTYPE_CONCAT))
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
@@ -82,11 +82,11 @@ ecma_builtin_boolean_dispatch_construct (const ecma_value_t *arguments_list_p, /
 
   if (arguments_list_len == 0)
   {
-    return ecma_op_create_boolean_object (ECMA_VALUE_FALSE);
+    return ecma_make_object_value (ecma_op_create_boolean_object (ECMA_VALUE_FALSE));
   }
   else
   {
-    return ecma_op_create_boolean_object (arguments_list_p[0]);
+    return ecma_make_object_value (ecma_op_create_boolean_object (arguments_list_p[0]));
   }
 } /* ecma_builtin_boolean_dispatch_construct */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -127,16 +127,12 @@ ecma_builtin_helper_object_to_string (const ecma_value_t this_arg) /**< this arg
   }
   else
   {
-    ecma_value_t obj_this = ecma_op_to_object (this_arg);
+    ecma_object_t *obj_p = ecma_op_to_object (this_arg);
 
-    if (ECMA_IS_VALUE_ERROR (obj_this))
+    if (JERRY_UNLIKELY (obj_p == NULL))
     {
-      return obj_this;
+      return ECMA_VALUE_ERROR;
     }
-
-    JERRY_ASSERT (ecma_is_value_object (obj_this));
-
-    ecma_object_t *obj_p = ecma_get_object_from_value (obj_this);
 
     type_string = ecma_object_get_class_name (obj_p);
 
@@ -205,54 +201,59 @@ ecma_value_t
 ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< this object */
                                                    uint32_t index) /**< array index */
 {
-  ecma_value_t ret_value = ECMA_VALUE_EMPTY;
   ecma_string_t *index_string_p = ecma_new_ecma_string_from_uint32 (index);
+  ecma_value_t index_value = ecma_op_object_get (obj_p, index_string_p);
+  ecma_deref_ecma_string (index_string_p);
 
-  ECMA_TRY_CATCH (index_value,
-                  ecma_op_object_get (obj_p, index_string_p),
-                  ret_value);
+  if (ECMA_IS_VALUE_ERROR (index_value))
+  {
+    return index_value;
+  }
 
   if (ecma_is_value_undefined (index_value) || ecma_is_value_null (index_value))
   {
-    ret_value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
+    return ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
   }
-  else
+
+  ecma_object_t *index_obj_p = ecma_op_to_object (index_value);
+  JERRY_ASSERT (index_obj_p != NULL);
+
+  ecma_value_t to_locale_value = ecma_op_object_get_by_magic_id (index_obj_p, LIT_MAGIC_STRING_TO_LOCALE_STRING_UL);
+
+  ecma_value_t ret_value = ECMA_VALUE_ERROR;
+
+  if (ECMA_IS_VALUE_ERROR (to_locale_value))
   {
-    ECMA_TRY_CATCH (index_obj_value,
-                    ecma_op_to_object (index_value),
-                    ret_value);
-
-    ecma_object_t *index_obj_p = ecma_get_object_from_value (index_obj_value);
-
-    ECMA_TRY_CATCH (to_locale_value,
-                    ecma_op_object_get_by_magic_id (index_obj_p, LIT_MAGIC_STRING_TO_LOCALE_STRING_UL),
-                    ret_value);
-
-    if (ecma_op_is_callable (to_locale_value))
-    {
-      ecma_object_t *locale_func_obj_p = ecma_get_object_from_value (to_locale_value);
-      ECMA_TRY_CATCH (call_value,
-                      ecma_op_function_call (locale_func_obj_p,
-                                             ecma_make_object_value (index_obj_p),
-                                             NULL,
-                                             0),
-                      ret_value);
-      ret_value = ecma_op_to_string (call_value);
-      ECMA_FINALIZE (call_value);
-
-    }
-    else
-    {
-      ret_value = ecma_raise_type_error (ECMA_ERR_MSG ("'toLocaleString' is missing or not a function."));
-    }
-
-    ECMA_FINALIZE (to_locale_value);
-    ECMA_FINALIZE (index_obj_value);
+    goto cleanup;
   }
 
-  ECMA_FINALIZE (index_value);
+  if (!ecma_op_is_callable (to_locale_value))
+  {
+    ecma_free_value (to_locale_value);
+    ecma_raise_type_error (ECMA_ERR_MSG ("'toLocaleString' is missing or not a function."));
+    goto cleanup;
+  }
 
-  ecma_deref_ecma_string (index_string_p);
+  ecma_object_t *locale_func_obj_p = ecma_get_object_from_value (to_locale_value);
+
+  ecma_value_t call_value = ecma_op_function_call (locale_func_obj_p,
+                                                   ecma_make_object_value (index_obj_p),
+                                                   NULL,
+                                                   0);
+
+  ecma_deref_object (locale_func_obj_p);
+
+  if (ECMA_IS_VALUE_ERROR (call_value))
+  {
+    goto cleanup;
+  }
+
+  ret_value = ecma_op_to_string (call_value);
+  ecma_free_value (call_value);
+
+cleanup:
+  ecma_deref_object (index_obj_p);
+  ecma_free_value (index_value);
 
   return ret_value;
 } /* ecma_builtin_helper_get_to_locale_string_at_index */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
@@ -84,12 +84,21 @@ ecma_builtin_number_dispatch_construct (const ecma_value_t *arguments_list_p, /*
 
   if (arguments_list_len == 0)
   {
-    ecma_value_t completion = ecma_op_create_number_object (ecma_make_integer_value (0));
-    return completion;
+    ecma_object_t *obj_p = ecma_op_create_number_object (ecma_make_integer_value (0));
+
+    JERRY_ASSERT (obj_p != NULL);
+
+    return ecma_make_object_value (obj_p);
   }
   else
   {
-    return ecma_op_create_number_object (arguments_list_p[0]);
+    ecma_object_t *obj_p = ecma_op_create_number_object (arguments_list_p[0]);
+    if (JERRY_UNLIKELY (obj_p == NULL))
+    {
+      return ECMA_VALUE_ERROR;
+    }
+
+    return ecma_make_object_value (obj_p);
   }
 } /* ecma_builtin_number_dispatch_construct */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -92,7 +92,8 @@ ecma_builtin_object_prototype_object_to_string (ecma_value_t this_arg) /**< this
 static ecma_value_t
 ecma_builtin_object_prototype_object_value_of (ecma_value_t this_arg) /**< this argument */
 {
-  return ecma_op_to_object (this_arg);
+  ecma_object_t *obj_p = ecma_op_to_object (this_arg);
+  return obj_p == NULL ? ECMA_VALUE_ERROR : ecma_make_object_value (obj_p);
 } /* ecma_builtin_object_prototype_object_value_of */
 
 /**
@@ -161,14 +162,12 @@ ecma_builtin_object_prototype_object_is_prototype_of (ecma_object_t *obj_p, /**<
                                                       ecma_value_t arg) /**< routine's first argument */
 {
   /* 3. Compare prototype to object */
-  ecma_value_t v_obj_value = ecma_op_to_object (arg);
+  ecma_object_t *v_obj_p = ecma_op_to_object (arg);
 
-  if (ECMA_IS_VALUE_ERROR (v_obj_value))
+  if (JERRY_UNLIKELY (v_obj_p == NULL))
   {
-    return v_obj_value;
+    return ECMA_VALUE_ERROR;
   }
-
-  ecma_object_t *v_obj_p = ecma_get_object_from_value (v_obj_value);
 
   ecma_value_t ret_value = ecma_make_boolean_value (ecma_op_object_is_prototype_of (obj_p, v_obj_p));
 
@@ -245,14 +244,12 @@ ecma_builtin_object_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
       }
     }
 
-    ecma_value_t to_object = ecma_op_to_object (this_arg);
+    ecma_object_t *obj_p = ecma_op_to_object (this_arg);
 
-    if (ECMA_IS_VALUE_ERROR (to_object))
+    if (JERRY_UNLIKELY (obj_p == NULL))
     {
-      return to_object;
+      return ECMA_VALUE_ERROR;
     }
-
-    ecma_object_t *obj_p = ecma_get_object_from_value (to_object);
 
     ecma_value_t ret_value;
 
@@ -279,15 +276,13 @@ ecma_builtin_object_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
     return ECMA_VALUE_ERROR;
   }
 
-  ecma_value_t to_object = ecma_op_to_object (this_arg);
+  ecma_object_t *obj_p = ecma_op_to_object (this_arg);
 
-  if (ECMA_IS_VALUE_ERROR (to_object))
+  if (JERRY_UNLIKELY (obj_p == NULL))
   {
     ecma_deref_ecma_string (prop_name_p);
-    return to_object;
+    return ECMA_VALUE_ERROR;
   }
-
-  ecma_object_t *obj_p = ecma_get_object_from_value (to_object);
 
   ecma_value_t ret_value;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -436,7 +436,7 @@ ecma_builtin_promise_do_all (ecma_value_t array, /**< the array for all */
   ecma_value_t value_array = ecma_op_create_array_object (&result_array_length_val, 1, true);
   ecma_free_value (result_array_length_val);
   /* 4. */
-  ecma_value_t remaining = ecma_op_create_number_object (ecma_make_integer_value (1));
+  ecma_value_t remaining = ecma_make_object_value (ecma_op_create_number_object (ecma_make_integer_value (1)));
   /* 5. */
   ecma_length_t index = 0;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
@@ -157,7 +157,8 @@ ecma_builtin_string_dispatch_construct (const ecma_value_t *arguments_list_p, /*
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
-  return ecma_op_create_string_object (arguments_list_p, arguments_list_len);
+  ecma_object_t *obj_p = ecma_op_create_string_object (arguments_list_p, arguments_list_len);
+  return obj_p == NULL ? ECMA_VALUE_ERROR : ecma_make_object_value (obj_p);
 } /* ecma_builtin_string_dispatch_construct */
 
 /**

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -32,13 +32,13 @@
 
 /**
  * Boolean object creation operation.
+ * This operation cannot fail.
  *
  * See also: ECMA-262 v5, 15.6.2.1
  *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
+ * @return ecma_object_t
  */
-ecma_value_t
+ecma_object_t *
 ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boolean constructor */
 {
   bool boolean_value = ecma_op_to_boolean (arg);
@@ -57,7 +57,7 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_BOOLEAN_UL;
   ext_object_p->u.class_prop.u.value = ecma_make_boolean_value (boolean_value);
 
-  return ecma_make_object_value (object_p);
+  return object_p;
 } /* ecma_op_create_boolean_object */
 
 /**

--- a/jerry-core/ecma/operations/ecma-boolean-object.h
+++ b/jerry-core/ecma/operations/ecma-boolean-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-ecma_value_t ecma_op_create_boolean_object (ecma_value_t arg);
+ecma_object_t *ecma_op_create_boolean_object (ecma_value_t arg);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -48,7 +48,7 @@ ecma_value_t ecma_op_to_number (ecma_value_t value);
 ecma_value_t ecma_get_number (ecma_value_t value, ecma_number_t *number_p);
 ecma_value_t ecma_op_to_string (ecma_value_t value);
 ecma_string_t *ecma_op_to_prop_name (ecma_value_t value);
-ecma_value_t ecma_op_to_object (ecma_value_t value);
+ecma_object_t *ecma_op_to_object (ecma_value_t value);
 ecma_value_t ecma_op_to_integer (ecma_value_t value, ecma_number_t *number_p);
 ecma_value_t ecma_op_to_length (ecma_value_t value, uint32_t *length);
 

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -97,6 +97,18 @@ ecma_is_constructor (ecma_value_t value) /**< ecma value */
 
   ecma_object_t *obj_p = ecma_get_object_from_value (value);
 
+  return ecma_object_is_constructor (obj_p);
+} /* ecma_is_constructor */
+
+/**
+ * Checks whether the Object that implements [[Construct]].
+ *
+ * @return true - if it is constructor object;
+ *         false - otherwise
+ */
+bool
+ecma_object_is_constructor (ecma_object_t *obj_p) /**< ecma object */
+{
   JERRY_ASSERT (obj_p != NULL);
   JERRY_ASSERT (!ecma_is_lexical_environment (obj_p));
 
@@ -108,7 +120,7 @@ ecma_is_constructor (ecma_value_t value) /**< ecma value */
 
   return (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION
           || ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION);
-} /* ecma_is_constructor */
+} /* ecma_object_is_constructor */
 
 /**
  * Function object creation operation.
@@ -770,7 +782,8 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
         else if (!ecma_is_value_object (this_binding))
         {
           /* 3., 4. */
-          this_binding = ecma_op_to_object (this_binding);
+          /* ecma_op_to_object will only raise error on null/undefined values but those are handled above. */
+          this_binding = ecma_make_object_value (ecma_op_to_object (this_binding));
           free_this_binding = true;
 
           JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (this_binding));

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -30,6 +30,7 @@ bool ecma_is_normal_or_arrow_function (ecma_object_type_t type);
 
 bool ecma_op_is_callable (ecma_value_t value);
 bool ecma_is_constructor (ecma_value_t value);
+bool ecma_object_is_constructor (ecma_object_t *obj_p);
 
 ecma_object_t *
 ecma_op_create_function_object (ecma_object_t *scope_p, const ecma_compiled_code_t *bytecode_data_p);

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -143,10 +143,10 @@ ecma_op_get_value_object_base (ecma_value_t base_value, /**< base value */
     return ecma_make_uint32_value (ecma_string_get_length (string_p));
   }
 
-  ecma_value_t object_base = ecma_op_to_object (base_value);
-  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (object_base));
+  ecma_object_t *object_base_p = ecma_op_to_object (base_value);
+  JERRY_ASSERT (object_base_p != NULL);
 
-  ecma_object_t *object_p = ecma_get_object_from_value (object_base);
+  ecma_object_t *object_p = object_base_p;
   JERRY_ASSERT (object_p != NULL
                 && !ecma_is_lexical_environment (object_p));
 
@@ -170,7 +170,7 @@ ecma_op_get_value_object_base (ecma_value_t base_value, /**< base value */
     object_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, object_p->u2.prototype_cp);
   }
 
-  ecma_free_value (object_base);
+  ecma_deref_object (object_base_p);
 
   return ret_value;
 } /* ecma_op_get_value_object_base */

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -35,17 +35,16 @@
  *
  * See also: ECMA-262 v5, 15.7.2.1
  *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
+ * @return ecma_object_t
  */
-ecma_value_t
+ecma_object_t *
 ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Number constructor */
 {
   ecma_value_t conv_to_num_completion = ecma_op_to_number (arg);
 
   if (ECMA_IS_VALUE_ERROR (conv_to_num_completion))
   {
-    return conv_to_num_completion;
+    return NULL;
   }
 
 #if ENABLED (JERRY_BUILTIN_NUMBER)
@@ -64,7 +63,7 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
   /* Pass reference (no need to free conv_to_num_completion). */
   ext_object_p->u.class_prop.u.value = conv_to_num_completion;
 
-  return ecma_make_object_value (object_p);
+  return object_p;
 } /* ecma_op_create_number_object */
 
 /**

--- a/jerry-core/ecma/operations/ecma-number-object.h
+++ b/jerry-core/ecma/operations/ecma-number-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-ecma_value_t ecma_op_create_number_object (ecma_value_t arg);
+ecma_object_t *ecma_op_create_number_object (ecma_value_t arg);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -84,7 +84,8 @@ ecma_op_create_object_object_arg (ecma_value_t value) /**< argument of construct
       || ecma_is_value_boolean (value))
   {
     /* 1.b, 1.c, 1.d */
-    return ecma_op_to_object (value);
+    ecma_object_t *obj_p = ecma_op_to_object (value);
+    return obj_p == NULL ? ECMA_VALUE_ERROR : ecma_make_object_value (obj_p);
   }
   else
   {

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -890,14 +890,13 @@ ecma_op_get_method_by_symbol_id (ecma_value_t value, /**< ecma value */
                                  lit_magic_string_id_t property_id) /**< property symbol id */
 {
   /* 2. */
-  ecma_value_t obj_value = ecma_op_to_object (value);
+  ecma_object_t *obj_p = ecma_op_to_object (value);
 
-  if (ECMA_IS_VALUE_ERROR (obj_value))
+  if (JERRY_UNLIKELY (obj_p == NULL))
   {
-    return obj_value;
+    return ECMA_VALUE_ERROR;
   }
 
-  ecma_object_t *obj_p = ecma_get_object_from_value (obj_value);
   ecma_value_t func = ecma_op_object_get_by_symbol_id (obj_p, property_id);
   ecma_deref_object (obj_p);
 

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -420,7 +420,7 @@ ecma_promise_resolving_functions_t *
 ecma_promise_create_resolving_functions (ecma_object_t *object_p) /**< the promise object */
 {
   /* 1. */
-  ecma_value_t already_resolved = ecma_op_create_boolean_object (ECMA_VALUE_FALSE);
+  ecma_value_t already_resolved = ecma_make_object_value (ecma_op_create_boolean_object (ECMA_VALUE_FALSE));
 
   ecma_string_t *str_promise_p = ecma_get_magic_string (LIT_INTERNAL_MAGIC_STRING_PROMISE);
   ecma_string_t *str_already_resolved_p = ecma_get_magic_string (LIT_INTERNAL_MAGIC_STRING_ALREADY_RESOLVED);

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -35,10 +35,9 @@
  *
  * See also: ECMA-262 v5, 15.5.2.1
  *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
+ * @return ecma_object_t
  */
-ecma_value_t
+ecma_object_t *
 ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of arguments that
                                                                          are passed to String constructor */
                               ecma_length_t arguments_list_len) /**< length of the arguments' list */
@@ -54,7 +53,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
     if (ECMA_IS_VALUE_ERROR (prim_value))
     {
-      return prim_value;
+      return NULL;
     }
 
     JERRY_ASSERT (ecma_is_value_string (prim_value));
@@ -74,7 +73,7 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_STRING_UL;
   ext_object_p->u.class_prop.u.value = prim_value;
 
-  return ecma_make_object_value (object_p);
+  return object_p;
 } /* ecma_op_create_string_object */
 
 /**

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -25,7 +25,7 @@
  * @{
  */
 
-ecma_value_t
+ecma_object_t *
 ecma_op_create_string_object (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 
 void

--- a/jerry-core/ecma/operations/ecma-symbol-object.c
+++ b/jerry-core/ecma/operations/ecma-symbol-object.c
@@ -72,13 +72,13 @@ ecma_op_create_symbol (const ecma_value_t *arguments_list_p, /**< list of argume
 
 /**
  * Symbol object creation operation.
+ * This operation cannot fail.
  *
  * See also: ECMA-262 v6, 19.4.1
  *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
+ * @return ecma_object_t
  */
-ecma_value_t
+ecma_object_t *
 ecma_op_create_symbol_object (const ecma_value_t value) /**< symbol value */
 {
   JERRY_ASSERT (ecma_is_value_symbol (value));
@@ -97,7 +97,7 @@ ecma_op_create_symbol_object (const ecma_value_t value) /**< symbol value */
   ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_SYMBOL_UL;
   ext_object_p->u.class_prop.u.value = ecma_copy_value (value);
 
-  return ecma_make_object_value (object_p);
+  return object_p;
 } /* ecma_op_create_symbol_object */
 
 /**

--- a/jerry-core/ecma/operations/ecma-symbol-object.h
+++ b/jerry-core/ecma/operations/ecma-symbol-object.h
@@ -29,7 +29,7 @@
 ecma_value_t
 ecma_op_create_symbol (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 
-ecma_value_t
+ecma_object_t *
 ecma_op_create_symbol_object (const ecma_value_t value);
 
 bool

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -173,12 +173,8 @@ vm_op_delete_prop (ecma_value_t object, /**< base object */
     return ECMA_VALUE_ERROR;
   }
 
-  ecma_value_t obj_value = ecma_op_to_object (object);
-  /* The ecma_op_check_object_coercible call already checked the op_to_object error cases. */
-  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (obj_value));
-  JERRY_ASSERT (ecma_is_value_object (obj_value));
-  ecma_object_t *obj_p = ecma_get_object_from_value (obj_value);
-  JERRY_ASSERT (!ecma_is_lexical_environment (obj_p));
+  ecma_object_t *obj_p = ecma_op_to_object (object);
+  JERRY_ASSERT (!ecma_is_lexical_environment (obj_p) && obj_p != NULL);
 
   ecma_value_t delete_op_ret = ecma_op_object_delete (obj_p, name_string_p, is_strict);
   JERRY_ASSERT (ecma_is_value_boolean (delete_op_ret) || (is_strict == true && ECMA_IS_VALUE_ERROR (delete_op_ret)));
@@ -238,10 +234,9 @@ opfunc_for_in (ecma_value_t left_value, /**< left value */
   }
 
   /* 4. */
-  ecma_value_t obj_expr_value = ecma_op_to_object (left_value);
+  ecma_object_t *obj_p = ecma_op_to_object (left_value);
   /* ecma_op_to_object will only raise error on null/undefined values but those are handled above. */
-  JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (obj_expr_value));
-  ecma_object_t *obj_p = ecma_get_object_from_value (obj_expr_value);
+  JERRY_ASSERT (obj_p != NULL);
   ecma_collection_t *prop_names_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_ENUMERABLE_PROTOTYPE);
 
   if (prop_names_p->item_count != 0)


### PR DESCRIPTION
Previously the ecma_op_to_object method returned an ecma_object_t wrapped in
an ecma_value_t. In this new method, we only return the pointer to the
object, since the methods that are using ecma_op_to_object will probably
use this pointer.

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu