### PR TITLE
Fix pre-scanner function name parsing.

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2447,6 +2447,22 @@ lexer_scan_identifier (parser_context_t *context_p, /**< context */
       return;
     }
   }
+#if ENABLED (JERRY_ES2015_CLASS)
+  if (ident_opts & LEXER_SCAN_CLASS_PROPERTY)
+  {
+    lexer_next_token (context_p);
+
+    if (context_p->token.type == LEXER_LITERAL
+#if ENABLED (JERRY_ES2015_OBJECT_INITIALIZER)
+        || context_p->token.type == LEXER_LEFT_SQUARE
+#endif /* ENABLED (JERRY_ES2015_OBJECT_INITIALIZER) */
+        || context_p->token.type == LEXER_RIGHT_BRACE
+        || context_p->token.type == LEXER_SEMICOLON)
+    {
+      return;
+    }
+  }
+#endif /* ENABLED (JERRY_ES2015_CLASS) */
 
   parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
 } /* lexer_scan_identifier */

--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -262,7 +262,10 @@ typedef enum
 {
   LEXER_SCAN_IDENT_NO_OPTS = (1u << 0),          /**< no options */
   LEXER_SCAN_IDENT_PROPERTY = (1u << 1),         /**< scan valid property names */
-  LEXER_SCAN_IDENT_NO_KEYW = (1u << 2),          /**< don\t scan keywords (e.g. get/set) */
+  LEXER_SCAN_IDENT_NO_KEYW = (1u << 2),          /**< don't scan keywords (e.g. get/set) */
+#if ENABLED (JERRY_ES2015_CLASS)
+  LEXER_SCAN_CLASS_PROPERTY = (1u << 3),         /**< scan valid class property names */
+#endif /* ENABLED (JERRY_ES2015_CLASS) */
 } lexer_scan_ident_opts_t;
 
 /**

--- a/tests/jerry/es2015/class.js
+++ b/tests/jerry/es2015/class.js
@@ -83,12 +83,21 @@ class C {
   3() {
     return 3;
   }
+
+  super() {
+    return 42;
+  }
+  return() {
+    return 43;
+  }
 }
 
 var c = new C;
 assert (c.c1() === 5);
 assert (c.c2() === undefined);
 assert (c["3"]() === 3);
+assert (c.super() === 42);
+assert (c.return() === 43);
 assert (c.constructor === C);
 
 class D {
@@ -151,6 +160,10 @@ var F = class ClassF {
   static 2 (a) {
     return 2 * a;
   }
+
+  static function(a) {
+    return 3 * a;
+  }
 }
 
 var f = new F(5);
@@ -163,6 +176,7 @@ assert (F.f3(1, 1) === 2);
 assert (F.constructor(5) === 5);
 assert (F.static(5) === 5);
 assert (F["2"](5) === 10);
+assert (F.function(5) === 15);
 assert (f.constructor === F);
 
 var G = class {
@@ -202,3 +216,6 @@ G["1"] = 20;
 assert (G["1"] === 20);
 G.constructor = 30;
 assert (G.constructor === 30);
+
+// Pre-scanner regression test
+for (var tmp in {}) ;


### PR DESCRIPTION
The function names of classes were incorrectly parsed.
Also made the parsing more strict (more issues were captured by the pre-scanner).

Fixes #3088
Fixes #3089