### PR TITLE
Parse rest function arguments in the pre-scanner.

### DIFF
--- a/tests/jerry/es2015/function-rest-parameter.js
+++ b/tests/jerry/es2015/function-rest-parameter.js
@@ -78,3 +78,6 @@ assert (g2 () === 11);
 assert (g2 (1) === 3);
 assert (g2 (1, 2) === 3);
 assert (g2 (1, 2, 3) === 4);
+
+// Pre-scanner regression test
+for (var tmp in {}) ;

--- a/tests/jerry/es2015/regression-test-issue-3097.js
+++ b/tests/jerry/es2015/regression-test-issue-3097.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+switch ($) {
+  case $: function $( $ = $, ... c ) { }
+  case $ :
+}


### PR DESCRIPTION
Fixes #3097.

Note: this code is adapted from another work in progress patch.
