### PR TITLE
Fix length check for typedarray copyWithin

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1891,7 +1891,7 @@ ecma_builtin_typedarray_prototype_copy_within (ecma_value_t this_arg, /**< this 
   int32_t offset = (int32_t) (length - target);
   int32_t count = JERRY_MIN (distance, offset);
 
-  if (target >= length || start >= length || end == 0)
+  if (target >= length || end == 0 || start >= end)
   {
     return ecma_copy_value (this_arg);
   }

--- a/tests/jerry/es2015/regression-test-issue-3107.js
+++ b/tests/jerry/es2015/regression-test-issue-3107.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arr = new Int8Array(200);
+var result = arr.copyWithin(100, 14, 5);
+
+assert (arr === result);
+
+for (i = 0; i < 200; i++)
+{
+    assert (arr[i] === 0);
+}


### PR DESCRIPTION
We should check if the start index is equal or greater than the end index,
if thats the case, we should return with the original typedArray.

Fixes #3107

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
