### PR TITLE
Fix [[Delete]] operation for fast arrays.

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -368,6 +368,16 @@ ecma_array_object_delete_property (ecma_object_t *object_p, /**< object */
 
   ecma_free_value_if_not_object (values_p[index]);
 
+  if (JERRY_UNLIKELY (ext_obj_p->u.array.length == 1))
+  {
+    const uint32_t old_length_aligned = ECMA_FAST_ARRAY_ALIGN_LENGTH (ext_obj_p->u.array.length);
+    jmem_heap_free_block (values_p, old_length_aligned * sizeof (ecma_value_t));
+    ext_obj_p->u.array.hole_count = 0;
+    ext_obj_p->u.array.length = 0;
+    object_p->u1.property_list_cp = JMEM_CP_NULL;
+    return;
+  }
+
   values_p[index] = ECMA_VALUE_ARRAY_HOLE;
 
   if (++ext_obj_p->u.array.hole_count > ECMA_FAST_ARRAY_MAX_HOLE_COUNT)

--- a/tests/jerry/es2015/regression-test-issue-3106.js
+++ b/tests/jerry/es2015/regression-test-issue-3106.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var symbol = Symbol();
+var arr = [{}];
+with (arr.pop()){
+    arr.push(symbol.valueOf());
+}
+
+try {
+  arr.length = String.fromCharCode(Object.freeze(arr));
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
When popping the last element from a fast array the underlying buffer must be released.
This patch fixes #3106.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
