### PR TITLE
Class expression scanning must be continued with post primary expression scanning.

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -1423,7 +1423,7 @@ scanner_scan_all (parser_context_t *context_p) /**< context */
 
           if (context_p->token.type == LEXER_RIGHT_BRACE)
           {
-            scanner_context.mode = (stack_top == SCAN_STACK_CLASS_EXPRESSION ? SCAN_MODE_PRIMARY_EXPRESSION_END
+            scanner_context.mode = (stack_top == SCAN_STACK_CLASS_EXPRESSION ? SCAN_MODE_POST_PRIMARY_EXPRESSION
                                                                              : SCAN_MODE_STATEMENT);
             parser_stack_pop_uint8 (context_p);
             break;

--- a/tests/jerry/fail/regression-test-issue-3117.js
+++ b/tests/jerry/fail/regression-test-issue-3117.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var $ = class { } .prototype  = [ ]
+switch ( '1' ) {

--- a/tests/jerry/fail/regression-test-issue-3119.js
+++ b/tests/jerry/fail/regression-test-issue-3119.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+a ( ) = { m ( ) { } } .m ( ) = class { m ( ) { } }.sameValue


### PR DESCRIPTION
This patch fixes #3117 and fixes #3119.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

