### PR TITLE
Fix skipping empty statements during class literal scanning

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -1414,12 +1414,8 @@ scanner_scan_all (parser_context_t *context_p) /**< context */
         {
           JERRY_ASSERT (stack_top == SCAN_STACK_CLASS_STATEMENT || stack_top == SCAN_STACK_CLASS_EXPRESSION);
 
+          lexer_skip_empty_statements (context_p);
           lexer_scan_identifier (context_p, LEXER_SCAN_CLASS_PROPERTY);
-
-          if (context_p->token.type == LEXER_SEMICOLON)
-          {
-            break;
-          }
 
           if (context_p->token.type == LEXER_RIGHT_BRACE)
           {

--- a/tests/jerry/es2015/regression-test-issue-3123.js
+++ b/tests/jerry/es2015/regression-test-issue-3123.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+switch ($) {
+  case $: class $ {;}
+  case $$: class $$ {; ; ; ; ;;;; ;}
+  case 6:
+}
+


### PR DESCRIPTION
This patch fixes #3123

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
