### PR TITLE
Fix jerry_get_context_data() API function

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -224,6 +224,7 @@ for the item by default, and if the `init_cb` field is not NULL, it will be call
 an additional custom initializer. The `deinit_cb` (if non-`NULL`) is called during a call to `jerry_cleanup ()` to run
 any custom deinitialization *before* the VM has been fully cleaned up. The `finalize_cb` (if non-`NULL`) is also called
 during a call to `jerry_cleanup ()` to run any custom deinitialization *after* the VM has been fully cleaned up.
+If bytes_needed field is 0, no buffer is allocated for the manager, callback functions are called with NULL pointer.
 
 **Prototype**
 


### PR DESCRIPTION
If manager_p->bytes_needed == 0, jerry_get_context_data() should return
NULL pointer. Additionally init_cb, deinit_cb and finalize_cb should be
called with NULL pointer in this case.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
