### PR TITLE
Disable INIT_FINI unittest on Windows

### DIFF
--- a/docs/12.EXT-REFERENCE-MODULE.md
+++ b/docs/12.EXT-REFERENCE-MODULE.md
@@ -37,7 +37,8 @@ resolved using the native JerryScript module resolver `jerryx_module_native_reso
 `jerryx_module_resolve()`. Native modules are registered during application startup and by calling `dlopen()` by means
 of library constructors, support for which can be turned on using the `FEATURE_INIT_FINI` build flag. In the absence of
 such a flag, the module registration and unregistration functions are exposed as global symbols which can be called
-explicitly.
+explicitly. Note: `FEATURE_INIT_FINI` build flag isn't supported on Windows, because Microsoft Visual C/C++ Compiler
+doesn't support library constructors and destructors.
 
 ## jerryx_module_resolve
 

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -17,7 +17,7 @@ set(JERRY_EXT_NAME jerry-ext)
 project (${JERRY_EXT_NAME} C)
 
 # Optional features
-set(FEATURE_INIT_FINI OFF CACHE BOOL "Enable init/fini arrays?")
+set(FEATURE_INIT_FINI OFF CACHE BOOL "Enable library constructor/destructor support?")
 
 # Status messages
 message(STATUS "FEATURE_INIT_FINI           " ${FEATURE_INIT_FINI})

--- a/jerry-ext/include/jerryscript-ext/module.h
+++ b/jerry-ext/include/jerryscript-ext/module.h
@@ -44,6 +44,10 @@ typedef struct jerryx_native_module_t
  * library constructor/destructor support.
  */
 #ifdef ENABLE_INIT_FINI
+#ifdef _MSC_VER
+#error "`FEATURE_INIT_FINI` build flag isn't supported on Windows, because Microsoft Visual C/C++ Compiler \
+doesn't support library constructors and destructors."
+#endif
 #define JERRYX_MODULE_CONSTRUCTOR_ATTRIBUTE __attribute__((constructor))
 #define JERRYX_MODULE_DESTRUCTOR_ATTRIBUTE __attribute__((destructor))
 #define JERRYX_MODULE_REGISTRATION_QUALIFIER static

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -66,7 +66,10 @@ JERRY_UNITTESTS_OPTIONS = [
             OPTIONS_COMMON + OPTIONS_DOCTESTS + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG),
     Options('unittests-es5.1-debug-init-fini',
             OPTIONS_COMMON + OPTIONS_UNITTESTS + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG
-            + ['--cmake-param=-DFEATURE_INIT_FINI=ON']),
+            + ['--cmake-param=-DFEATURE_INIT_FINI=ON'],
+            skip=skip_if((sys.platform == 'win32'), 'FEATURE_INIT_FINI build flag isn\'t supported on Windows,' +
+                         ' because Microsoft Visual C/C++ Compiler doesn\'t support' +
+                         ' library constructors and destructors.')),
 ]
 
 # Test options for jerry-tests
@@ -445,6 +448,9 @@ def run_test262_test_suite(options):
 def run_unittests(options):
     ret_build = ret_test = 0
     for job in JERRY_UNITTESTS_OPTIONS:
+        if job.skip:
+            report_skip(job)
+            continue
         ret_build, build_dir_path = create_binary(job, options)
         if ret_build:
             print("\n%sBuild failed%s\n" % (TERM_RED, TERM_NORMAL))


### PR DESCRIPTION
MSVC doesn't support library constructor/destructor, let's disable
the related unittest and clarify the documentation and error messages.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
