### PR TITLE
Disable test-mem-stats.c unittest if system allocator is used

### DIFF
--- a/tests/unit-core/CMakeLists.txt
+++ b/tests/unit-core/CMakeLists.txt
@@ -26,6 +26,11 @@ endif()
 # Unit tests main modules
 file(GLOB SOURCE_UNIT_TEST_MAIN_MODULES *.c)
 
+# jerry_heap_stats_t.size == 0 if system allocator is used.
+if(JERRY_SYSTEM_ALLOCATOR)
+  list(REMOVE_ITEM SOURCE_UNIT_TEST_MAIN_MODULES ${CMAKE_CURRENT_SOURCE_DIR}/test-mem-stats.c)
+endif()
+
 # Unit tests declaration
 add_custom_target(unittests-core)
 


### PR DESCRIPTION
If system allocator is used jerry_heap_stats_t.size
is always 0 and we can't get detailed heap statistics.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
