### PR TITLE
Disable unsupported doctest tests on Windows

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -6425,7 +6425,7 @@ jerry_create_context (uint32_t heap_size,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # (test="compile", name="02.API-REFERENCE-create-context.c")
 
 ```c
 #include <stdlib.h>

--- a/docs/11.EXT-REFERENCE-AUTORELEASE.md
+++ b/docs/11.EXT-REFERENCE-AUTORELEASE.md
@@ -12,7 +12,7 @@ using the `__cleanup__` variable attribute. For other compilers, no support has 
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # (test="compile", name="11.EXT-REFERENCE-AUTORELEASE.c")
 
 ```c
 #include "jerryscript.h"

--- a/tests/unit-doc/CMakeLists.txt
+++ b/tests/unit-doc/CMakeLists.txt
@@ -54,6 +54,16 @@ foreach(DOCTEST_ELEMENT IN LISTS DOCTEST_LIST)
   endif()
 endforeach()
 
+# Disable 02.API-REFERENCE-create-context.c on Windows, because there is no pthread on it.
+if("${PLATFORM}" STREQUAL "WINDOWS")
+  list(REMOVE_ITEM DOCTEST_COMPILE ${CMAKE_CURRENT_BINARY_DIR}/02.API-REFERENCE-create-context.c)
+endif()
+
+# Disable 11.EXT-REFERENCE-AUTORELEASE.c if compiler is MSVC, because MSVC doesn't support cleanup attribute.
+if(USING_MSVC)
+  list(REMOVE_ITEM DOCTEST_COMPILE ${CMAKE_CURRENT_BINARY_DIR}/11.EXT-REFERENCE-AUTORELEASE.c)
+endif()
+
 # Add custom command to run doctest generator if any of the MarkDown sources
 # changes.
 add_custom_command(

--- a/tests/unit-ext/CMakeLists.txt
+++ b/tests/unit-ext/CMakeLists.txt
@@ -20,6 +20,11 @@ set(INCLUDE_UNIT_EXT ${CMAKE_CURRENT_SOURCE_DIR})
 # Unit tests main modules
 file(GLOB SOURCE_UNIT_TEST_EXT_MODULES *.c)
 
+# Disable test-ext-autorelease.c if compiler is MSVC, because MSVC doesn't support cleanup attribute.
+if(USING_MSVC)
+  list(REMOVE_ITEM SOURCE_UNIT_TEST_EXT_MODULES ${CMAKE_CURRENT_SOURCE_DIR}/test-ext-autorelease.c)
+endif()
+
 # Unit tests declaration
 add_custom_target(unittests-ext)
 


### PR DESCRIPTION
This test is based on pthread, and there is no pthread on Windows.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
