### PR TITLE
There is no need to update the scanner info chain after a for/while statement.

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -842,8 +842,9 @@ parser_parse_while_statement_end (parser_context_t *context_p) /**< context */
   parser_emit_cbc_backward_branch (context_p, (uint16_t) opcode, while_statement.start_offset);
   parser_set_breaks_to_current_position (context_p, loop.branch_list_p);
 
+  /* Calling scanner_seek is unnecessary because all
+   * info blocks inside the while statement should be processed. */
   scanner_set_location (context_p, &location);
-  scanner_seek (context_p);
   context_p->token = current_token;
 } /* parser_parse_while_statement_end */
 
@@ -1186,8 +1187,9 @@ parser_parse_for_statement_end (parser_context_t *context_p) /**< context */
   parser_emit_cbc_backward_branch (context_p, (uint16_t) opcode, for_statement.start_offset);
   parser_set_breaks_to_current_position (context_p, loop.branch_list_p);
 
+  /* Calling scanner_seek is unnecessary because all
+   * info blocks inside the for statement should be processed. */
   scanner_set_location (context_p, &location);
-  scanner_seek (context_p);
   context_p->token = current_token;
 } /* parser_parse_for_statement_end */
 

--- a/tests/jerry/fail/regression-test-issue-3131.js
+++ b/tests/jerry/fail/regression-test-issue-3131.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+switch ( $) { case $: for ( ; ; ) ; case $ :}

--- a/tests/jerry/switch-case.js
+++ b/tests/jerry/switch-case.js
@@ -103,3 +103,6 @@ switch ("var") {
 }
 
 assert (flow === '123a4');
+
+switch (0) { case 0: for (;false;); case 1: }
+switch (0) { case 0: while (false); case 1: }


### PR DESCRIPTION
Fixes #3131.