### PR TITLE
Fix run-test-suite-test262.py with python3

### DIFF
--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -47,6 +47,7 @@ def run_test262_tests(runtime, engine, path_to_test262):
                              '--command', (runtime + ' ' + engine).strip(),
                              '--tests', path_to_test262,
                              '--summary'],
+                            universal_newlines=True,
                             stdout=subprocess.PIPE)
 
     return_code = 0


### PR DESCRIPTION
subprocess.Popen needs universal_newlines=True parameter
to open the file in text mode instead of binary mode.
With this fix readline() returns str instead of bytes.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
