### PR TITLE
Fix comma after an arrow function.

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -202,7 +202,7 @@ scanner_process_simple_arrow (parser_context_t *context_p, /**< context */
 /**
  * Scan primary expression.
  *
- * @return true for continue, false for break
+ * @return SCAN_NEXT_TOKEN to read the next token, or SCAN_KEEP_TOKEN to do nothing
  */
 static scan_return_types_t
 scanner_scan_primary_expression (parser_context_t *context_p, /**< context */
@@ -403,7 +403,7 @@ scanner_scan_post_primary_expression (parser_context_t *context_p, /**< context 
 /**
  * Scan the tokens after the primary expression.
  *
- * @return true for continue, false for break
+ * @return SCAN_NEXT_TOKEN to read the next token, or SCAN_KEEP_TOKEN to do nothing
  */
 static scan_return_types_t
 scanner_scan_primary_expression_end (parser_context_t *context_p, /**< context */
@@ -434,6 +434,12 @@ scanner_scan_primary_expression_end (parser_context_t *context_p, /**< context *
           scanner_context_p->mode = SCAN_MODE_VAR_STATEMENT;
           return SCAN_NEXT_TOKEN;
         }
+#if ENABLED (JERRY_ES2015_ARROW_FUNCTION)
+        case SCAN_STACK_ARROW_EXPRESSION:
+        {
+          break;
+        }
+#endif /* ENABLED (JERRY_ES2015_ARROW_FUNCTION) */
 #if ENABLED (JERRY_ES2015_FUNCTION_PARAMETER_INITIALIZER)
         case SCAN_STACK_FUNCTION_PARAMETERS:
         {
@@ -444,11 +450,11 @@ scanner_scan_primary_expression_end (parser_context_t *context_p, /**< context *
 #endif /* ENABLED (JERRY_ES2015_FUNCTION_PARAMETER_INITIALIZER) */
         default:
         {
-          break;
+          scanner_context_p->mode = SCAN_MODE_PRIMARY_EXPRESSION;
+          return SCAN_NEXT_TOKEN;
         }
       }
-      scanner_context_p->mode = SCAN_MODE_PRIMARY_EXPRESSION;
-      return SCAN_NEXT_TOKEN;
+      break;
     }
     case LEXER_COLON:
     {
@@ -839,7 +845,7 @@ scanner_scan_primary_expression_end (parser_context_t *context_p, /**< context *
 /**
  * Scan statements.
  *
- * @return true for continue, false for break
+ * @return SCAN_NEXT_TOKEN to read the next token, or SCAN_KEEP_TOKEN to do nothing
  */
 static scan_return_types_t
 scanner_scan_statement (parser_context_t *context_p, /**< context */
@@ -1336,7 +1342,7 @@ scanner_scan_statement (parser_context_t *context_p, /**< context */
 /**
  * Scan statement terminator.
  *
- * @return true for continue, false for break
+ * @return SCAN_NEXT_TOKEN to read the next token, or SCAN_KEEP_TOKEN to do nothing
  */
 static scan_return_types_t
 scanner_scan_statement_end (parser_context_t *context_p, /**< context */

--- a/tests/jerry/fail/regresssion-test-issue-3152.js
+++ b/tests/jerry/fail/regresssion-test-issue-3152.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+$ = { $: () => 0, $: $ }


### PR DESCRIPTION
Fixes #3152.