### PR TITLE
Add new check for a special corner case to typedarray lastIndexOf

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -31,6 +31,7 @@
 #include "ecma-gc.h"
 #include "jmem.h"
 #include "ecma-iterator-object.h"
+#include "math.h"
 
 #if ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY)
 
@@ -1719,7 +1720,8 @@ ecma_builtin_typedarray_prototype_index_helper (ecma_value_t this_arg, /**< this
   uint32_t from_index;
 
   if (args_number == 0
-      || length == 0)
+      || length == 0
+      || !ecma_is_value_number (args[0]))
   {
     return ecma_make_integer_value (-1);
   }
@@ -1736,12 +1738,17 @@ ecma_builtin_typedarray_prototype_index_helper (ecma_value_t this_arg, /**< this
       return ECMA_VALUE_ERROR;
     }
 
-    from_index = ecma_builtin_helper_array_index_normalize (num_var, length, is_last_index_of);
-  }
-
-  if (!ecma_is_value_number (args[0]))
-  {
-    return ecma_make_integer_value (-1);
+    if (!ecma_number_is_nan (num_var)
+        && is_last_index_of
+        && num_var < 0
+        && fabs (num_var) > length)
+    {
+      return ecma_make_integer_value (-1);
+    }
+    else
+    {
+      from_index = ecma_builtin_helper_array_index_normalize (num_var, length, is_last_index_of);
+    }
   }
 
   ecma_number_t search_num = ecma_get_number_from_value (args[0]);

--- a/tests/jerry/es2015/regression-test-issue-3129.js
+++ b/tests/jerry/es2015/regression-test-issue-3129.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arrb = new ArrayBuffer(1);
+var arr = new Uint8Array(arrb);
+arr.lastIndexOf(Number.NaN, -[4294967280]);


### PR DESCRIPTION
Fixes #3129
We need to check if we use the lastIndexOf method  and if the second
argument is a number, negative, and its absolute value is bigger
than the length, then  we should return with -1.

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu