### PR TITLE
Make ecma_number_make_nan more optimal and C99 conform

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1024,6 +1024,15 @@ typedef struct
  */
 typedef float ecma_number_t;
 
+/**
+ * It makes possible to read/write an ecma_number_t as uint32_t without strict aliasing rule violation.
+ */
+typedef union
+{
+  ecma_number_t as_ecma_number_t;
+  uint32_t as_uint32_t;
+} ecma_number_accessor_t;
+
 #define DOUBLE_TO_ECMA_NUMBER_T(value) (ecma_number_t) (value)
 
 /**
@@ -1059,6 +1068,15 @@ typedef float ecma_number_t;
  * Description of an ecma-number
  */
 typedef double ecma_number_t;
+
+/**
+ * It makes possible to read/write an ecma_number_t as uint64_t without strict aliasing rule violation.
+ */
+typedef union
+{
+  ecma_number_t as_ecma_number_t;
+  uint64_t as_uint64_t;
+} ecma_number_accessor_t;
 
 #define DOUBLE_TO_ECMA_NUMBER_T(value) value
 

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -477,26 +477,12 @@ ecma_make_nan_value (void)
 static inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_number_equal_to_positive_zero (ecma_number_t ecma_number) /**< number */
 {
+  ecma_number_accessor_t u;
+  u.as_ecma_number_t = ecma_number;
 #if !ENABLED (JERRY_NUMBER_TYPE_FLOAT64)
-  union
-  {
-    uint32_t u32_value;
-    ecma_number_t float_value;
-  } u;
-
-  u.float_value = ecma_number;
-
-  return u.u32_value == 0;
+  return u.as_uint32_t == 0;
 #else /* ENABLED (JERRY_NUMBER_TYPE_FLOAT64) */
-  union
-  {
-    uint64_t u64_value;
-    ecma_number_t float_value;
-  } u;
-
-  u.float_value = ecma_number;
-
-  return u.u64_value == 0;
+  return u.as_uint64_t == 0;
 #endif /* !ENABLED (JERRY_NUMBER_TYPE_FLOAT64) */
 } /* ecma_is_number_equal_to_positive_zero */
 


### PR DESCRIPTION
This change makes ecma_number_make_nan and ecma_number_make_infinity
always return constant value without any function call. Previously we
relied on compiler optimizations.

The ecma_number_t_accessor union is introduced to be able to access
float values as float and uint32_t (and doubles as double and uint64_t)
properly, without violating strict aliasing rules. There were many
copies of it, all of them were replaced to this new union.

Additionally ecma_number_make_nan should return QNaN instead of SNaN,
same value as C99 nan(""). Unfortunately calling nan("") here isn't
always optimal, because compilers sometimes generate constant returns,
sometimes function calls.

Before this change ecma_number_make_nan returned SNaN:
- double: 0x7FF0 0000 0000 0001 (sign:0, exponent: all 1 bits, fraction: 0...01)
- float: 0x7F8 00001 (sign:0, exponent: all 1 bits, fraction: 0...01)

After this change ecma_number_make_nan returns QNaN:
- double: 0x7FF8 0000 0000 0000 (sign:0, exponent: all 1 bits, fraction: 10..0)
- float: 0x7FC0 0000 (sign:0, exponent: all 1 bits, fraction: 10...0)
