### PR TITLE
Fix undefined references build error on Windows (x64)

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -1760,7 +1760,7 @@ ecma_compare_ecma_strings_longpath (const ecma_string_t *string1_p, /**< ecma-st
  * @return true - if strings are equal;
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_compare_ecma_strings (const ecma_string_t *string1_p, /**< ecma-string */
                            const ecma_string_t *string2_p) /**< ecma-string */
 {

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -289,7 +289,7 @@ ecma_is_value_float_number (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-number value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_is_value_integer_number (value)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -57,7 +57,7 @@ ecma_date_day (ecma_number_t time) /**< time value */
  *
  * @return time value within the day
  */
-inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_time_within_day (ecma_number_t time) /**< time value */
 {
   JERRY_ASSERT (!ecma_number_is_nan (time));

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -321,7 +321,7 @@ jmem_heap_alloc_block_internal (const size_t size) /**< required memory size */
  * @return NULL, if the required memory is 0
  *         pointer to allocated memory block, otherwise
  */
-inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
+extern inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_heap_alloc_block (const size_t size) /**< required memory size */
 {
   void *block_p = jmem_heap_gc_and_alloc_block (size, JMEM_PRESSURE_FULL);
@@ -666,7 +666,7 @@ jmem_heap_realloc_block (void *ptr, /**< memory region to reallocate */
 /**
  * Free memory block
  */
-inline void JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_heap_free_block (void *ptr, /**< pointer to beginning of data space of the block */
                       const size_t size) /**< size of allocated region */
 {

--- a/jerry-core/jmem/jmem-poolman.c
+++ b/jerry-core/jmem/jmem-poolman.c
@@ -55,7 +55,7 @@ jmem_pools_finalize (void)
  * @return pointer to allocated chunk, if allocation was successful,
  *         or NULL - if not enough memory.
  */
-inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
+extern inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_pools_alloc (size_t size) /**< size of the chunk */
 {
 #if ENABLED (JERRY_MEM_GC_BEFORE_EACH_ALLOC)
@@ -115,7 +115,7 @@ jmem_pools_alloc (size_t size) /**< size of the chunk */
 /**
  * Free the chunk
  */
-inline void JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_pools_free (void *chunk_p, /**< pointer to the chunk */
                  size_t size) /**< size of the chunk */
 {


### PR DESCRIPTION
We should emit function symbols for these jerry-core functions:
- ecma_compare_ecma_strings is used by test-stringbuilder.c
- ecma_is_value_number is used by test-literal-storage.c
- ecma_date_time_within_day is used by test-date-helpers.c
- jmem_heap_alloc_block is used by test-jmem.c
- jmem_heap_free_block is used by test-jmem.c
- jmem_pools_alloc is used by test-poolman.c
- jmem_pools_alloc is used by test-poolman.c

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu