### PR TITLE
Refactor ecma_op_to_string

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -292,10 +292,11 @@ static_snapshot_error_unsupported_literal (snapshot_globals_t *globals_p, /**< s
 
   ecma_string_t *error_message_p = ecma_new_ecma_string_from_utf8 (error_prefix, sizeof (error_prefix) - 1);
 
-  literal = ecma_op_to_string (literal);
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (literal));
 
-  ecma_string_t *literal_string_p = ecma_get_string_from_value (literal);
+  ecma_string_t *literal_string_p = ecma_op_to_string (literal);
+  JERRY_ASSERT (literal_string_p != NULL);
+
   error_message_p = ecma_concat_ecma_strings (error_message_p, literal_string_p);
   ecma_deref_ecma_string (literal_string_p);
 

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -1288,7 +1288,13 @@ jerry_value_to_string (const jerry_value_t value) /**< input value */
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (error_value_msg_p)));
   }
 
-  return jerry_return (ecma_op_to_string (value));
+  ecma_string_t *str_p = ecma_op_to_string (value);
+  if (JERRY_UNLIKELY (str_p == NULL))
+  {
+    return ecma_create_error_reference_from_context ();
+  }
+
+  return jerry_return (ecma_make_string_value (str_p));
 } /* jerry_value_to_string */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -187,11 +187,11 @@ ecma_builtin_date_parse (ecma_value_t this_arg, /**< this argument */
   ecma_number_t date_num = ecma_number_make_nan ();
 
   /* Date Time String fromat (ECMA-262 v5, 15.9.1.15) */
-  ECMA_TRY_CATCH (date_str_value,
-                  ecma_op_to_string (arg),
-                  ret_value);
-
-  ecma_string_t *date_str_p = ecma_get_string_from_value (date_str_value);
+  ecma_string_t *date_str_p = ecma_op_to_string (arg);
+  if (JERRY_UNLIKELY (date_str_p == NULL))
+  {
+    return ECMA_VALUE_ERROR;
+  }
 
   ECMA_STRING_TO_UTF8_STRING (date_str_p, date_start_p, date_start_size);
 
@@ -403,7 +403,7 @@ ecma_builtin_date_parse (ecma_value_t this_arg, /**< this argument */
   ret_value = ecma_make_number_value (date_num);
 
   ECMA_FINALIZE_UTF8_STRING (date_start_p, date_start_size);
-  ECMA_FINALIZE (date_str_value);
+  ecma_deref_ecma_string (date_str_p);
 
   return ret_value;
 } /* ecma_builtin_date_parse */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -1185,14 +1185,12 @@ ecma_builtin_global_dispatch_routine (uint16_t builtin_routine_id, /**< built-in
     return ecma_builtin_global_object_is_finite (arg_num);
   }
 
-  ecma_value_t string_value = ecma_op_to_string (routine_arg_1);
+  ecma_string_t *str_p = ecma_op_to_string (routine_arg_1);
 
-  if (ECMA_IS_VALUE_ERROR (string_value))
+  if (JERRY_UNLIKELY (str_p == NULL))
   {
-    return string_value;
+    return ECMA_VALUE_ERROR;
   }
-
-  ecma_string_t *str_p = ecma_get_string_from_value (string_value);
 
   ecma_value_t ret_value;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-error.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-error.c
@@ -47,20 +47,18 @@ ecma_builtin_helper_error_dispatch_call (ecma_standard_error_t error_type, /**< 
   if (arguments_list_len != 0
       && !ecma_is_value_undefined (arguments_list_p[0]))
   {
-    ecma_value_t ret_value = ECMA_VALUE_EMPTY;
+    ecma_string_t *message_string_p = ecma_op_to_string (arguments_list_p[0]);
 
-    ECMA_TRY_CATCH (msg_str_value,
-                    ecma_op_to_string (arguments_list_p[0]),
-                    ret_value);
+    if (JERRY_UNLIKELY (message_string_p == NULL))
+    {
+      return ECMA_VALUE_ERROR;
+    }
 
-    ecma_string_t *message_string_p = ecma_get_string_from_value (msg_str_value);
     ecma_object_t *new_error_object_p = ecma_new_standard_error_with_message (error_type,
                                                                               message_string_p);
-    ret_value = ecma_make_object_value (new_error_object_p);
 
-    ECMA_FINALIZE (msg_str_value);
-
-    return ret_value;
+    ecma_deref_ecma_string (message_string_p);
+    return ecma_make_object_value (new_error_object_p);
   }
   else
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -738,14 +738,12 @@ ecma_builtin_json_parse (ecma_value_t this_arg, /**< 'this' argument */
 {
   JERRY_UNUSED (this_arg);
 
-  ecma_value_t text_value = ecma_op_to_string (arg1);
+  ecma_string_t *text_string_p = ecma_op_to_string (arg1);
 
-  if (ECMA_IS_VALUE_ERROR (text_value))
+  if (JERRY_UNLIKELY (text_string_p == NULL))
   {
-    return text_value;
+    return ECMA_VALUE_ERROR;
   }
-
-  ecma_string_t *text_string_p = ecma_get_string_from_value (text_value);
 
   ECMA_STRING_TO_UTF8_STRING (text_string_p, str_start_p, string_size);
   ecma_value_t result = ecma_builtin_json_parse_buffer (str_start_p, string_size);
@@ -1176,7 +1174,8 @@ ecma_builtin_json_serialize_property (ecma_json_stringify_context_t *context_p, 
     /* 5.b */
     else if (class_name == LIT_MAGIC_STRING_STRING_UL)
     {
-      result = ecma_op_to_string (value);
+      ecma_string_t *str_p = ecma_op_to_string (value);
+      result = ecma_make_string_value (str_p);
     }
     /* 5.c */
     else if (class_name == LIT_MAGIC_STRING_BOOLEAN_UL)
@@ -1236,9 +1235,8 @@ ecma_builtin_json_serialize_property (ecma_json_stringify_context_t *context_p, 
     /* 10.a */
     if (!ecma_number_is_nan (num_value) && !ecma_number_is_infinity (num_value))
     {
-      ecma_value_t result_value = ecma_op_to_string (value);
-      JERRY_ASSERT (ecma_is_value_string (result_value));
-      ecma_string_t *result_string_p = ecma_get_string_from_value (result_value);
+      ecma_string_t *result_string_p = ecma_op_to_string (value);
+      JERRY_ASSERT (result_string_p != NULL);
 
       ecma_stringbuilder_append (&context_p->result_builder, result_string_p);
       ecma_deref_ecma_string (result_string_p);
@@ -1406,25 +1404,25 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
         /* 4.b.iii.5.e */
         else if (ecma_is_value_number (value))
         {
-          ecma_value_t number_str_value = ecma_op_to_string (value);
-          JERRY_ASSERT (ecma_is_value_string (number_str_value));
-          item = number_str_value;
+          ecma_string_t *number_str_p = ecma_op_to_string (value);
+          JERRY_ASSERT (number_str_p != NULL);
+          item = ecma_make_string_value (number_str_p);
         }
         /* 4.b.iii.5.f */
         else if (ecma_is_value_object (value)
                  && (ecma_object_get_class_name (ecma_get_object_from_value (value)) == LIT_MAGIC_STRING_NUMBER_UL
                      || ecma_object_get_class_name (ecma_get_object_from_value (value)) == LIT_MAGIC_STRING_STRING_UL))
         {
-          ecma_value_t str_val = ecma_op_to_string (value);
+          ecma_string_t *str_p = ecma_op_to_string (value);
 
-          if (ECMA_IS_VALUE_ERROR (str_val))
+          if (JERRY_UNLIKELY (str_p == NULL))
           {
             ecma_collection_free (context.property_list_p);
             ecma_free_value (value);
-            return str_val;
+            return ECMA_VALUE_ERROR;
           }
 
-          item = str_val;
+          item = ecma_make_string_value (str_p);
         }
 
         ecma_free_value (value);
@@ -1474,15 +1472,15 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
     /* 5.b */
     else if (class_name == LIT_MAGIC_STRING_STRING_UL)
     {
-      ecma_value_t value = ecma_op_to_string (arg3);
+      ecma_string_t *value_str_p = ecma_op_to_string (arg3);
 
-      if (ECMA_IS_VALUE_ERROR (value))
+      if (JERRY_UNLIKELY (value_str_p == NULL))
       {
         ecma_collection_free (context.property_list_p);
-        return value;
+        return ECMA_VALUE_ERROR;
       }
 
-      space = value;
+      space = ecma_make_string_value (value_str_p);
     }
     else
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
@@ -89,29 +89,28 @@ ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /*
     return ecma_raise_type_error (ECMA_ERR_MSG ("Invalid argument of RegExp call."));
   }
 
-  ecma_string_t *pattern_string_p = NULL;
-  ecma_value_t ret_value = ecma_regexp_read_pattern_str_helper (pattern_value, &pattern_string_p);
-  if (ECMA_IS_VALUE_ERROR (ret_value))
+  ecma_string_t *pattern_string_p = ecma_regexp_read_pattern_str_helper (pattern_value);
+
+  if (pattern_string_p == NULL)
   {
-    return ret_value;
+    return ECMA_VALUE_ERROR;
   }
-  JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
   uint16_t flags = 0;
+  ecma_value_t ret_value = ECMA_VALUE_EMPTY;
+
   if (!ecma_is_value_undefined (flags_value))
   {
-    ecma_value_t flags_str_value = ecma_op_to_string (flags_value);
+    ecma_string_t *flags_string_p = ecma_op_to_string (flags_value);
 
-    if (ECMA_IS_VALUE_ERROR (flags_str_value))
+    if (JERRY_UNLIKELY (flags_string_p == NULL))
     {
       ecma_deref_ecma_string (pattern_string_p);
-      return flags_str_value;
+      return ECMA_VALUE_ERROR;
     }
 
-    ecma_string_t *flags_string_p = ecma_get_string_from_value (flags_str_value);
-    JERRY_ASSERT (flags_string_p != NULL);
     ret_value = ecma_regexp_parse_flags (flags_string_p, &flags);
-    ecma_free_value (flags_str_value); // implicit frees flags_string_p
+    ecma_deref_ecma_string (flags_string_p);
 
     if (ECMA_IS_VALUE_ERROR (ret_value))
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
@@ -140,7 +140,13 @@ ecma_builtin_string_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
   /* 2.b */
   else
   {
-    ret_value = ecma_op_to_string (arguments_list_p[0]);
+    ecma_string_t *str_p = ecma_op_to_string (arguments_list_p[0]);
+    if (JERRY_UNLIKELY (str_p == NULL))
+    {
+      return ECMA_VALUE_ERROR;
+    }
+
+    ret_value = ecma_make_string_value (str_p);
   }
 
   return ret_value;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-symbol.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-symbol.c
@@ -198,18 +198,16 @@ ecma_builtin_symbol_for (ecma_value_t this_arg, /**< this argument */
                          ecma_value_t key) /**< key string */
 {
   JERRY_UNUSED (this_arg);
-  ecma_value_t string_desc = ecma_op_to_string (key);
+  ecma_string_t *string_desc_p = ecma_op_to_string (key);
 
   /* 1. */
-  if (ECMA_IS_VALUE_ERROR (string_desc))
+  if (JERRY_UNLIKELY (string_desc_p == NULL))
   {
     /* 2. */
-    return string_desc;
+    return ECMA_VALUE_ERROR;
   }
-  /* 4-7. */
-  JERRY_ASSERT (ecma_is_value_string (string_desc));
 
-  return ecma_builtin_symbol_for_helper (string_desc);
+  return ecma_builtin_symbol_for_helper (ecma_make_string_value (string_desc_p));
 } /* ecma_builtin_symbol_for */
 
 /**

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -430,16 +430,16 @@ ecma_get_number (ecma_value_t value, /**< ecma value*/
 } /* ecma_get_number */
 
 /**
- * ToString operation helper function.
+ * ToString operation.
  *
  * See also:
  *          ECMA-262 v5, 9.8
  *
  * @return NULL - if the conversion fails
- *         ecma-string - otherwise
+ *         pointer to the string descriptor - otherwise
  */
-static ecma_string_t *
-ecma_to_op_string_helper (ecma_value_t value) /**< ecma value */
+ecma_string_t *
+ecma_op_to_string (ecma_value_t value) /**< ecma value */
 {
   ecma_check_value_type_is_spec_defined (value);
 
@@ -452,7 +452,7 @@ ecma_to_op_string_helper (ecma_value_t value) /**< ecma value */
       return NULL;
     }
 
-    ecma_string_t *ret_string_p = ecma_to_op_string_helper (prim_value);
+    ecma_string_t *ret_string_p = ecma_op_to_string (prim_value);
 
     ecma_free_value (prim_value);
 
@@ -506,31 +506,6 @@ ecma_to_op_string_helper (ecma_value_t value) /**< ecma value */
   }
 
   return ecma_get_magic_string (LIT_MAGIC_STRING_FALSE);
-} /* ecma_to_op_string_helper */
-
-/**
- * ToString operation.
- *
- * See also:
- *          ECMA-262 v5, 9.8
- *
- * @return ecma value
- *         Returned value must be freed with ecma_free_value
- */
-ecma_value_t
-ecma_op_to_string (ecma_value_t value) /**< ecma value */
-{
-  ecma_check_value_type_is_spec_defined (value);
-
-  ecma_string_t *string_p = ecma_to_op_string_helper (value);
-
-  if (JERRY_UNLIKELY (string_p == NULL))
-  {
-    /* Note: At this point the error has already been thrown. */
-    return ECMA_VALUE_ERROR;
-  }
-
-  return ecma_make_string_value (string_p);
 } /* ecma_op_to_string */
 
 /**
@@ -553,7 +528,7 @@ ecma_op_to_prop_name (ecma_value_t value) /**< ecma value */
   }
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_SYMBOL) */
 
-  return ecma_to_op_string_helper (value);
+  return ecma_op_to_string (value);
 } /* ecma_op_to_prop_name */
 
 /**

--- a/jerry-core/ecma/operations/ecma-conversion.h
+++ b/jerry-core/ecma/operations/ecma-conversion.h
@@ -46,7 +46,7 @@ ecma_value_t ecma_op_to_primitive (ecma_value_t value, ecma_preferred_type_hint_
 bool ecma_op_to_boolean (ecma_value_t value);
 ecma_value_t ecma_op_to_number (ecma_value_t value);
 ecma_value_t ecma_get_number (ecma_value_t value, ecma_number_t *number_p);
-ecma_value_t ecma_op_to_string (ecma_value_t value);
+ecma_string_t *ecma_op_to_string (ecma_value_t value);
 ecma_string_t *ecma_op_to_prop_name (ecma_value_t value);
 ecma_value_t ecma_op_to_object (ecma_value_t value);
 ecma_value_t ecma_op_to_integer (ecma_value_t value, ecma_number_t *number_p);

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -302,8 +302,8 @@ ecma_raise_standard_error_with_format (ecma_standard_error_t error_type, /**< er
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_SYMBOL) */
       else
       {
-        ecma_value_t str_val = ecma_op_to_string (arg_val);
-        arg_string_p = ecma_get_string_from_value (str_val);
+        arg_string_p = ecma_op_to_string (arg_val);
+        JERRY_ASSERT (arg_string_p != NULL);
       }
 
       /* Concat argument. */

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -1324,32 +1324,19 @@ cleanup_string:
  * @return empty value if success, error value otherwise
  *         Returned value must be freed with ecma_free_value.
  */
-ecma_value_t
-ecma_regexp_read_pattern_str_helper (ecma_value_t pattern_arg, /**< the RegExp pattern */
-                                     ecma_string_t **pattern_string_p) /**< [out] ptr to the pattern string ptr */
+ecma_string_t *
+ecma_regexp_read_pattern_str_helper (ecma_value_t pattern_arg) /**< the RegExp pattern */
 {
   if (!ecma_is_value_undefined (pattern_arg))
   {
-    ecma_value_t regexp_str_value = ecma_op_to_string (pattern_arg);
-    if (ECMA_IS_VALUE_ERROR (regexp_str_value))
+    ecma_string_t *pattern_string_p = ecma_op_to_string (pattern_arg);
+    if (JERRY_UNLIKELY (pattern_string_p == NULL) || !ecma_string_is_empty (pattern_string_p))
     {
-      return regexp_str_value;
+      return pattern_string_p;
     }
-
-    *pattern_string_p = ecma_get_string_from_value (regexp_str_value);
-    if (!ecma_string_is_empty (*pattern_string_p))
-    {
-      ecma_ref_ecma_string (*pattern_string_p);
-    }
-
-    ecma_free_value (regexp_str_value); // must be freed *after* ecma_ref_ecma_string
   }
 
-  if (!*pattern_string_p || ecma_string_is_empty (*pattern_string_p))
-  {
-    *pattern_string_p = ecma_get_magic_string (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP);
-  }
-  return ECMA_VALUE_EMPTY;
+  return ecma_get_magic_string (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP);
 } /* ecma_regexp_read_pattern_str_helper */
 
 /**

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -90,7 +90,7 @@ typedef struct
 ecma_value_t ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *bytecode_p);
 ecma_value_t ecma_op_create_regexp_object (ecma_string_t *pattern_p, uint16_t flags);
 ecma_value_t ecma_regexp_exec_helper (ecma_value_t regexp_value, ecma_value_t input_string, bool ignore_global);
-ecma_value_t ecma_regexp_read_pattern_str_helper (ecma_value_t pattern_arg, ecma_string_t **pattern_string_p);
+ecma_string_t *ecma_regexp_read_pattern_str_helper (ecma_value_t pattern_arg);
 ecma_char_t ecma_regexp_canonicalize (ecma_char_t ch, bool is_ignorecase);
 ecma_char_t ecma_regexp_canonicalize_char (ecma_char_t ch);
 ecma_value_t ecma_regexp_parse_flags (ecma_string_t *flags_str_p, uint16_t *flags_p);

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -50,14 +50,14 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   if (arguments_list_len > 0)
   {
-    prim_value = ecma_op_to_string (arguments_list_p[0]);
+    ecma_string_t *str_p = ecma_op_to_string (arguments_list_p[0]);
 
-    if (ECMA_IS_VALUE_ERROR (prim_value))
+    if (JERRY_UNLIKELY (str_p == NULL))
     {
-      return prim_value;
+      return ECMA_VALUE_ERROR;
     }
 
-    JERRY_ASSERT (ecma_is_value_string (prim_value));
+    prim_value = ecma_make_string_value (str_p);
   }
 
 #if ENABLED (JERRY_BUILTIN_STRING)

--- a/jerry-core/ecma/operations/ecma-symbol-object.c
+++ b/jerry-core/ecma/operations/ecma-symbol-object.c
@@ -55,15 +55,15 @@ ecma_op_create_symbol (const ecma_value_t *arguments_list_p, /**< list of argume
   }
   else
   {
-    string_desc = ecma_op_to_string (arguments_list_p[0]);
+    ecma_string_t *str_p = ecma_op_to_string (arguments_list_p[0]);
 
     /* 4. */
-    if (ECMA_IS_VALUE_ERROR (string_desc))
+    if (JERRY_UNLIKELY (str_p == NULL))
     {
-      return string_desc;
+      return ECMA_VALUE_ERROR;
     }
 
-    JERRY_ASSERT (ecma_is_value_string (string_desc));
+    string_desc = ecma_make_string_value (str_p);
   }
 
   /* 5. */

--- a/jerry-core/vm/opcodes-ecma-arithmetics.c
+++ b/jerry-core/vm/opcodes-ecma-arithmetics.c
@@ -132,9 +132,9 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
   if (ecma_is_value_string (left_value)
       || ecma_is_value_string (right_value))
   {
-    ecma_value_t str_left_value = ecma_op_to_string (left_value);
+    ecma_string_t *string1_p = ecma_op_to_string (left_value);
 
-    if (ECMA_IS_VALUE_ERROR (str_left_value))
+    if (JERRY_UNLIKELY (string1_p == NULL))
     {
       if (free_left_value)
       {
@@ -144,14 +144,12 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
       {
         ecma_free_value (right_value);
       }
-      return str_left_value;
+      return ECMA_VALUE_ERROR;
     }
 
-    ecma_string_t *string1_p = ecma_get_string_from_value (str_left_value);
+    ecma_string_t *string2_p = ecma_op_to_string (right_value);
 
-    ecma_value_t str_right_value = ecma_op_to_string (right_value);
-
-    if (ECMA_IS_VALUE_ERROR (str_right_value))
+    if (JERRY_UNLIKELY (string2_p == NULL))
     {
       if (free_right_value)
       {
@@ -162,10 +160,8 @@ opfunc_addition (ecma_value_t left_value, /**< left value */
         ecma_free_value (left_value);
       }
       ecma_deref_ecma_string (string1_p);
-      return str_right_value;
+      return ECMA_VALUE_ERROR;
     }
-
-    ecma_string_t *string2_p = ecma_get_string_from_value (str_right_value);
 
     string1_p = ecma_concat_ecma_strings (string1_p, string2_p);
     ret_value = ecma_make_string_value (string1_p);


### PR DESCRIPTION
Similar to the ecma_op_to_object rework, in this new method we
return directly with the pointer to the ecma string, and we don't
wrap the result into an ecma_value_t

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu