### PR TITLE
Fix Date.prototype.toString() and toISOString()

### DIFF
--- a/tests/jerry/date-toisostring.js
+++ b/tests/jerry/date-toisostring.js
@@ -1,0 +1,54 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+    d = new Date (-8640000000000001)
+    assert (d == "Invalid Date")
+    d.toISOString()
+    assert(false);
+} catch (e) {
+    assert(e instanceof RangeError)
+}
+
+assert (new Date (-8640000000000000).toISOString() == "-271821-04-20T00:00:00.000Z")
+
+assert (new Date(-62167219200001).toISOString() == "-000001-12-31T23:59:59.999Z")
+assert (new Date(-62167219200000).toISOString() == "0000-01-01T00:00:00.000Z")
+
+assert (new Date(-61851600000001).toISOString() == "0009-12-31T23:59:59.999Z")
+assert (new Date(-61851600000000).toISOString() == "0010-01-01T00:00:00.000Z")
+
+assert (new Date(-59011459200001).toISOString() == "0099-12-31T23:59:59.999Z")
+assert (new Date(-59011459200000).toISOString() == "0100-01-01T00:00:00.000Z")
+
+assert (new Date(-30610224000001).toISOString() == "0999-12-31T23:59:59.999Z")
+assert (new Date(-30610224000000).toISOString() == "1000-01-01T00:00:00.000Z")
+
+assert (new Date(-1).toISOString() == "1969-12-31T23:59:59.999Z")
+assert (new Date(0).toISOString() == "1970-01-01T00:00:00.000Z")
+assert (new Date(1).toISOString() == "1970-01-01T00:00:00.001Z")
+
+assert (new Date(253402300799999).toISOString() == "9999-12-31T23:59:59.999Z")
+assert (new Date(253402300800000).toISOString() == "+010000-01-01T00:00:00.000Z")
+
+assert (new Date (8640000000000000).toISOString() == "+275760-09-13T00:00:00.000Z")
+
+try {
+    d = new Date (8640000000000001)
+    assert (d == "Invalid Date")
+    d.toISOString()
+    assert(false);
+} catch (e) {
+    assert(e instanceof RangeError)
+}

--- a/tests/jerry/date-tostring.js
+++ b/tests/jerry/date-tostring.js
@@ -142,3 +142,29 @@ assert (Date (2015, 1, 1) == (new Date ()).toString ());
 assert (Date (Number.NaN) == Date ());
 
 assert (new Date ("2015-07-08T11:29:05.023Z").toISOString() == "2015-07-08T11:29:05.023Z");
+
+// corner cases
+assert (new Date (-8640000000000001).toString() == "Invalid Date")
+assert (new Date (-8640000000000000).toString() == "Tue Apr 20 -271821 00:00:00 GMT+00:00")
+
+assert (new Date(-62167219200001).toString() == "Fri Dec 31 -0001 23:59:59 GMT+00:00")
+assert (new Date(-62167219200000).toString() == "Sat Jan 01 0000 00:00:00 GMT+00:00")
+
+assert (new Date(-61851600000001).toString() == "Thu Dec 31 0009 23:59:59 GMT+00:00")
+assert (new Date(-61851600000000).toString() == "Fri Jan 01 0010 00:00:00 GMT+00:00")
+
+assert (new Date(-59011459200001).toString() == "Thu Dec 31 0099 23:59:59 GMT+00:00")
+assert (new Date(-59011459200000).toString() == "Fri Jan 01 0100 00:00:00 GMT+00:00")
+
+assert (new Date(-30610224000001).toString() == "Tue Dec 31 0999 23:59:59 GMT+00:00")
+assert (new Date(-30610224000000).toString() == "Wed Jan 01 1000 00:00:00 GMT+00:00")
+
+assert (new Date(-1).toString() == "Wed Dec 31 1969 23:59:59 GMT+00:00")
+assert (new Date(0).toString() == "Thu Jan 01 1970 00:00:00 GMT+00:00")
+assert (new Date(1).toString() == "Thu Jan 01 1970 00:00:00 GMT+00:00")
+
+assert (new Date(253402300799999).toString() == "Fri Dec 31 9999 23:59:59 GMT+00:00")
+assert (new Date(253402300800000).toString() == "Sat Jan 01 10000 00:00:00 GMT+00:00")
+
+assert (new Date (8640000000000000).toString() == "Sat Sep 13 275760 00:00:00 GMT+00:00")
+assert (new Date (8640000000000001).toString() == "Invalid Date")


### PR DESCRIPTION
The implementation was incorrect for negative years and years bigger than 9999.
-1 was 000/ because the negative (year%10) was added to '0' character, years
bigger than 9999 was truncated to 4 digits.

ES5.1 15.9.1.15.1 defines extended years format with 6 digits, but toString()
and toISOString() sections don't mention anything about extended years. ES6
20.3.4.3 already clarifies that Date.prototype.toISOString() should use this
extended year format if it is necessary.

Changes:
- Date.prototype.toString() uses 4 digits for years by default, 5 or 6 if it
is necessary and put '-' sign for negative years, no sign for positive years.
Date.prototype.toString() was implementation dependent until ES9, but ES9
already specify exactly this format.
- Date.prototype.toISOString() uses fixed 4 digits for years 0 - 9999,
otherwise sign + 6 digits (extended years).
- Tests added for corner cases.
