### PR TITLE
Fix argument validation for Number.prototype.toPrecision

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -632,9 +632,9 @@ ecma_builtin_number_prepare_conversion (ecma_number_t *this_num_p, /**< [out] th
   }
 
   if (mode == NUMBER_ROUTINE_TO_PRECISION &&
-      (arg_num < 1 || arg_num >= 22))
+      (ecma_number_is_nan (arg_num) || arg_num < 1 || arg_num >= 22))
   {
-    return ecma_raise_range_error (ECMA_ERR_MSG ("Precision digits must be between 0 and 21."));
+    return ecma_raise_range_error (ECMA_ERR_MSG ("Precision digits must be between 1 and 21."));
   }
 
   *arg_1_int32_p = ecma_number_to_int32 (arg_num);

--- a/tests/jerry/fail/regression-test-issue-3173.js
+++ b/tests/jerry/fail/regression-test-issue-3173.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var NISLFuzzingFunc = function(d, c) {
+    var a = d.toPrecision(c);
+};
+var NISLParameter0 = 59246;
+var NISLParameter1 = function(p) {
+};
+NISLFuzzingFunc(NISLParameter0, NISLParameter1);


### PR DESCRIPTION
This patch fixes #3173

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
