### PR TITLE
Remove abort-on-fail from the default port

### DIFF
--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -325,7 +325,6 @@ typedef enum
   OPT_EXEC_SNAP,
   OPT_EXEC_SNAP_FUNC,
   OPT_LOG_LEVEL,
-  OPT_ABORT_ON_FAIL,
   OPT_NO_PROMPT
 } main_opt_id_t;
 
@@ -364,8 +363,6 @@ static const cli_opt_t main_opts[] =
                .help = "execute specific function from input snapshot file(s)"),
   CLI_OPT_DEF (.id = OPT_LOG_LEVEL, .longopt = "log-level", .meta = "NUM",
                .help = "set log level (0-3)"),
-  CLI_OPT_DEF (.id = OPT_ABORT_ON_FAIL, .longopt = "abort-on-fail",
-               .help = "segfault on internal failure (instead of non-zero exit code)"),
   CLI_OPT_DEF (.id = OPT_NO_PROMPT, .longopt = "no-prompt",
                .help = "don't print prompt in REPL mode"),
   CLI_OPT_DEF (.id = CLI_OPT_DEFAULT, .meta = "FILE",
@@ -622,11 +619,6 @@ main (int argc,
                      argv[0], "Error: invalid value for --log-level: ", cli_state.arg);
 
         jerry_port_default_set_log_level ((jerry_log_level_t) log_level);
-        break;
-      }
-      case OPT_ABORT_ON_FAIL:
-      {
-        jerry_port_default_set_abort_on_fail (true);
         break;
       }
       case OPT_NO_PROMPT:

--- a/jerry-port/default/default-fatal.c
+++ b/jerry-port/default/default-fatal.c
@@ -18,59 +18,17 @@
 #include "jerryscript-port.h"
 #include "jerryscript-port-default.h"
 
-#ifndef DISABLE_EXTRA_API
-
-static bool abort_on_fail = false;
-
-/**
- * Sets whether 'abort' should be called instead of 'exit' upon exiting with
- * non-zero exit code in the default implementation of jerry_port_fatal.
- *
- * Note:
- *      This function is only available if the port implementation library is
- *      compiled without the DISABLE_EXTRA_API macro.
- */
-void jerry_port_default_set_abort_on_fail (bool flag) /**< new value of 'abort on fail' flag */
-{
-  abort_on_fail = flag;
-} /* jerry_port_default_set_abort_on_fail */
-
-/**
- * Check whether 'abort' should be called instead of 'exit' upon exiting with
- * non-zero exit code in the default implementation of jerry_port_fatal.
- *
- * @return true - if 'abort on fail' flag is set,
- *         false - otherwise
- *
- * Note:
- *      This function is only available if the port implementation library is
- *      compiled without the DISABLE_EXTRA_API macro.
- */
-bool jerry_port_default_is_abort_on_fail (void)
-{
-  return abort_on_fail;
-} /* jerry_port_default_is_abort_on_fail */
-
-#endif /* !DISABLE_EXTRA_API */
-
 /**
  * Default implementation of jerry_port_fatal. Calls 'abort' if exit code is
- * non-zero and "abort-on-fail" behaviour is enabled, 'exit' otherwise.
- *
- * Note:
- *      The "abort-on-fail" behaviour is only available if the port
- *      implementation library is compiled without the DISABLE_EXTRA_API macro.
+ * non-zero, 'exit' otherwise.
  */
 void jerry_port_fatal (jerry_fatal_code_t code) /**< cause of error */
 {
-#ifndef DISABLE_EXTRA_API
   if (code != 0
-      && code != ERR_OUT_OF_MEMORY
-      && abort_on_fail)
+      && code != ERR_OUT_OF_MEMORY)
   {
     abort ();
   }
-#endif /* !DISABLE_EXTRA_API */
 
   exit ((int) code);
 } /* jerry_port_fatal */

--- a/jerry-port/default/include/jerryscript-port-default.h
+++ b/jerry-port/default/include/jerryscript-port-default.h
@@ -31,9 +31,6 @@ extern "C"
  * @{
  */
 
-void jerry_port_default_set_abort_on_fail (bool flag);
-bool jerry_port_default_is_abort_on_fail (void);
-
 jerry_log_level_t jerry_port_default_get_log_level (void);
 void jerry_port_default_set_log_level (jerry_log_level_t level);
 


### PR DESCRIPTION
This flag provides no benefit, and removing it makes debugging easier. Abort is now always called when an assert fails.
