### PR TITLE
Fix python build `--mem-heap` document

### DIFF
--- a/docs/01.CONFIGURATION.md
+++ b/docs/01.CONFIGURATION.md
@@ -194,7 +194,7 @@ The default value is 512.
 |---------|----------------------------------------------|
 | C:      | `-DJERRY_GLOBAL_HEAP_SIZE=(int)`             |
 | CMake:  | `--DJERRY_GLOBAL_HEAP_SIZE=(int)`            |
-| Python: | `--heap-size=(int)`                          |
+| Python: | `--mem-heap=(int)`                           |
 
 ### Garbage collection limit
 


### PR DESCRIPTION
`--heap-size` has been renamed to `--mem-heap`.

JerryScript-DCO-1.0-Signed-off-by: legendecas legendecas@gmail.com