### PR TITLE
Optimize array push/pop for fast-array cases

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -56,11 +56,14 @@ ecma_value_t *
 ecma_fast_array_extend (ecma_object_t *object_p, uint32_t new_lengt);
 
 bool
-ecma_fast_array_set_property (ecma_object_t *object_p, ecma_string_t *property_name_p, ecma_value_t value);
+ecma_fast_array_set_property (ecma_object_t *object_p, uint32_t index, ecma_value_t value);
 
 void
 ecma_array_object_delete_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
                                    ecma_property_value_t *prop_value_p);
+
+uint32_t
+ecma_delete_fast_array_properties (ecma_object_t *object_p, uint32_t new_length);
 
 ecma_collection_t *
 ecma_fast_array_get_property_names (ecma_object_t *object_p, uint32_t opts);

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1004,7 +1004,13 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
           return ecma_reject (is_throw);
         }
 
-        if (ecma_fast_array_set_property (object_p, property_name_p, value))
+        uint32_t index = ecma_string_get_array_index (property_name_p);
+
+        if (JERRY_UNLIKELY (index == ECMA_STRING_NOT_ARRAY_INDEX))
+        {
+          ecma_fast_array_convert_to_normal (object_p);
+        }
+        else if (ecma_fast_array_set_property (object_p, index, value))
         {
           return ECMA_VALUE_TRUE;
         }

--- a/jerry-core/vm/vm-utils.c
+++ b/jerry-core/vm/vm-utils.c
@@ -98,10 +98,8 @@ vm_get_backtrace (uint32_t max_depth) /**< maximum backtrace depth, 0 = unlimite
     str_p = ecma_concat_ecma_strings (str_p, line_str_p);
     ecma_deref_ecma_string (line_str_p);
 
-    ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (index);
-    ecma_fast_array_set_property (array_p, index_str_p, ecma_make_string_value (str_p));
+    ecma_fast_array_set_property (array_p, index, ecma_make_string_value (str_p));
     ecma_deref_ecma_string (str_p);
-    ecma_deref_ecma_string (index_str_p);
 
     context_p = context_p->prev_context_p;
     index++;


### PR DESCRIPTION
Performance results:
ARM: 1m19s -> 0m57s
Intel: 0m7,5s -> 0m5s

Binary size increase: 168 bytes

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
