### PR TITLE
Improve example REPL to exit if there is nothing on the stdin

### DIFF
--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -861,7 +861,7 @@ main (int argc,
       /* Read a line */
       while (true)
       {
-        if (fread (source_buffer_tail, 1, 1, stdin) != 1 && len == 0)
+        if (fread (source_buffer_tail, 1, 1, stdin) != 1)
         {
           is_done = true;
           break;


### PR DESCRIPTION
When reading from the stdin a '\n' character or an empty line/file
was expected to end the read. However, in case of an input which is not terminated
with a newline a buffer overflow will occur.

Test case:
```sh
$ echo -n "print('a')" | ./build/bin/jerry
```