### PR TITLE
Fix delete operation in Set objects

### DIFF
--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -573,7 +573,7 @@ ecma_op_container_delete (ecma_value_t this_arg, /**< this argument */
 
   ecma_deref_ecma_string (prop_name_p);
 
-  if (property_p == NULL)
+  if (property_p == NULL || ecma_is_value_empty (ECMA_PROPERTY_VALUE_PTR (property_p)->value))
   {
     return ECMA_VALUE_FALSE;
   }

--- a/tests/jerry/es2015/set.js
+++ b/tests/jerry/es2015/set.js
@@ -87,3 +87,7 @@ assert (set.size === 3);
 
 set.clear();
 assert(set.size === 0);
+
+set.add(3);
+assert(set.delete(3));
+assert(!set.delete(3));


### PR DESCRIPTION
Delete should return false if an element doesn't exist in a set.
ECMA_VALUE_EMPTY wasn't checked in case of a deleted property.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu