### PR TITLE
Improve ecma_typedarray_info_t

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1689,13 +1689,16 @@ typedef struct
  **/
 typedef struct
 {
-  ecma_object_t *typedarray_buffer_p; /**< pointer to the typedArray's arraybuffer */
-  lit_utf8_byte_t *buffer_p; /**< pointer to the arraybuffer's internal data buffer */
-  ecma_typedarray_type_t typedarray_id; /**< type of the typedArray */
-  uint32_t typedarray_length; /**< length of the typedArray */
-  ecma_length_t offset; /**< offset of the internal array buffer */
+  ecma_object_t *array_buffer_p; /**< pointer to the typedArray's [[ViewedArrayBuffer]] internal slot */
+  lit_utf8_byte_t *buffer_p; /**< pointer to the underlying raw data buffer.
+                              *   Note:
+                              *    - This address is increased by the [ByteOffset]] internal property.
+                              *    - This address must be used during indexed read/write operation. */
+  ecma_typedarray_type_t id; /**< [[TypedArrayName]] internal slot */
+  uint32_t length; /**< [[ByteLength]] internal slot */
+  ecma_length_t offset; /**< [[ByteOffset]] internal slot. */
   uint8_t shift; /**< the element size shift in the typedArray */
-  uint8_t element_size; /**< size of each element in the typedArray */
+  uint8_t element_size; /**< element size based on [[TypedArrayName]] in Table 49 */
 } ecma_typedarray_info_t;
 
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY) */

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -185,14 +185,12 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
         if (array_index != ECMA_STRING_NOT_ARRAY_INDEX)
         {
           ecma_typedarray_info_t info = ecma_typedarray_get_info (object_p);
-          ecma_typedarray_getter_fn_t getter_cb = ecma_get_typedarray_getter_fn (info.typedarray_id);
           ecma_value_t value = ECMA_VALUE_UNDEFINED;
 
-          if (array_index < info.typedarray_length)
+          if (array_index < info.length)
           {
-            ecma_length_t byte_pos = (array_index << info.shift) + info.offset;
-            lit_utf8_byte_t *src_buffer = ecma_arraybuffer_get_buffer (info.typedarray_buffer_p) + byte_pos;
-            ecma_number_t num = getter_cb (src_buffer);
+            ecma_length_t byte_pos = array_index << info.shift;
+            ecma_number_t num = ecma_get_typedarray_element (info.buffer_p + byte_pos, info.id);
             value = ecma_make_number_value (num);
           }
 
@@ -556,16 +554,14 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
         if (array_index != ECMA_STRING_NOT_ARRAY_INDEX)
         {
           ecma_typedarray_info_t info = ecma_typedarray_get_info (object_p);
-          ecma_typedarray_getter_fn_t getter_cb = ecma_get_typedarray_getter_fn (info.typedarray_id);
 
-          if (array_index >= info.typedarray_length)
+          if (array_index >= info.length)
           {
             return ECMA_VALUE_UNDEFINED;
           }
 
-          ecma_length_t byte_pos = (array_index << info.shift) + info.offset;
-          lit_utf8_byte_t *src_buffer = ecma_arraybuffer_get_buffer (info.typedarray_buffer_p) + byte_pos;
-          ecma_number_t num = getter_cb (src_buffer);
+          ecma_length_t byte_pos = array_index << info.shift;
+          ecma_number_t num = ecma_get_typedarray_element (info.buffer_p + byte_pos, info.id);
           return ecma_make_number_value (num);
         }
 
@@ -1091,16 +1087,14 @@ ecma_op_object_put (ecma_object_t *object_p, /**< the object */
           }
 
           ecma_typedarray_info_t info = ecma_typedarray_get_info (object_p);
-          ecma_typedarray_setter_fn_t setter_cb = ecma_get_typedarray_setter_fn (info.typedarray_id);
 
-          if (array_index >= info.typedarray_length)
+          if (array_index >= info.length)
           {
             return ecma_reject (is_throw);
           }
 
-          ecma_length_t byte_pos = (array_index << info.shift) + info.offset;
-          lit_utf8_byte_t *src_buffer = ecma_arraybuffer_get_buffer (info.typedarray_buffer_p) + byte_pos;
-          setter_cb (src_buffer, num_var);
+          ecma_length_t byte_pos = array_index << info.shift;
+          ecma_set_typedarray_element (info.buffer_p + byte_pos, num_var, info.id);
 
           return ECMA_VALUE_TRUE;
         }

--- a/tests/jerry/es2015/regression-test-issue-3204.js
+++ b/tests/jerry/es2015/regression-test-issue-3204.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function tc3204_1 () {
+  (new Int16Array(7029)).subarray(5812).reduce(function() { })
+})();
+
+(function tc3204_2 () {
+  (new (Uint8Array)((new (ArrayBuffer)("5")), EvalError.length)).reduceRight(function() { })
+})();
+
+(function tc3204_3 () {
+  var v0 = (((new ((new ((new Object).constructor)).constructor)).constructor)("")).split( )
+  var $ = (new Float64Array(7652)).subarray(1872).reduce((new (v0.filter.constructor)))
+})();


### PR DESCRIPTION
- The structure members have been renamed and the members got more detailed description.
- Updated the usage of the typedarray info structure in all occurrences to use absolute addressing from the underlying arraybuffer pointer.

This patch also fixes #3204.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
