### PR TITLE
Fix undefined references build error on Windows

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -463,7 +463,7 @@ ecma_make_float_value (ecma_number_t *ecma_num_p) /**< pointer to the float numb
  *
  * @return ecma-value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_make_nan_value (void)
 {
   return ecma_create_float_number (ecma_number_make_nan ());


### PR DESCRIPTION
We should emit symbol for ecma_make_nan_value (void), because
it is used by unit-core/test-to-integer.c and test-to-length.c.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
