### PR TITLE
Set post-processing mode after an arrow expression scanning is completed

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -810,6 +810,7 @@ scanner_scan_primary_expression_end (parser_context_t *context_p, /**< context *
     case SCAN_STACK_ARROW_EXPRESSION:
     {
       parser_stack_pop_uint8 (context_p);
+      scanner_context_p->mode = SCAN_MODE_POST_PRIMARY_EXPRESSION;
       return SCAN_KEEP_TOKEN;
     }
 #endif /* ENABLED (JERRY_ES2015_ARROW_FUNCTION) */

--- a/tests/jerry/fail/regression-test-issue-3214.js
+++ b/tests/jerry/fail/regression-test-issue-3214.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var $ = { $ ( ){ } } = { g ( ) { ( ) => m ++ ( ) } }  = class extends C { constructor ( ) { super () } }


### PR DESCRIPTION
Fixes #3214.