### PR TITLE
General GC optimizations

### DIFF
--- a/docs/01.CONFIGURATION.md
+++ b/docs/01.CONFIGURATION.md
@@ -211,6 +211,17 @@ A value of 0 will use the default value.
 | CMake:  | `-DJERRY_GC_LIMIT=(int)`                     |
 | Python: | `--gc-limit=(int)`                           |
 
+### GC mark recursion limit
+
+This option can be used to adjust the maximum recursion depth during the GC mark phase. The provided value should be an integer, which represents the allowed number of recursive calls. Increasing the depth of the recursion reduces the time of GC cycles, however increases stack usage.
+A value of 0 will prevent any recursive GC calls.
+
+| Options |                                                   |
+|---------|---------------------------------------------------|
+| C:      | `-DJERRY_GC_MARK_LIMIT=(int)`                     |
+| CMake:  | `-DJERRY_GC_MARK_LIMIT=(int)`                     |
+| Python: | `--gc-mark-limit=(int)`                           |
+
 ### Stack limit
 
 This option can be used to cap the stack usage of the engine, and prevent stack overflows due to recursion. The provided value should be an integer, which represents the allowed stack usage in kilobytes.
@@ -296,7 +307,7 @@ These files can be directly compiled with an application using the JerryScript A
 For example with the following command:
 
 ```sh
-$ gcc -Wall -o demo_app demo_app.c gen_src/jerryscript.c gen_src/jerryscript-port-default.c jerryscript-libm.c -Igen_src/ 
+$ gcc -Wall -o demo_app demo_app.c gen_src/jerryscript.c gen_src/jerryscript-port-default.c jerryscript-libm.c -Igen_src/
 ```
 
 Please note that the headers must be available on the include path.

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -41,6 +41,7 @@ set(JERRY_VM_EXEC_STOP              OFF     CACHE BOOL   "Enable VM execution st
 set(JERRY_GLOBAL_HEAP_SIZE          "(512)" CACHE STRING "Size of memory heap, in kilobytes")
 set(JERRY_GC_LIMIT                  "(0)"   CACHE STRING "Heap usage limit to trigger garbage collection")
 set(JERRY_STACK_LIMIT               "(0)"   CACHE STRING "Maximum stack usage size, in kilobytes")
+set(JERRY_GC_MARK_LIMIT             "(8)"   CACHE STRING "Maximum depth of recursion during GC mark phase")
 
 # Option overrides
 if(USING_MSVC)
@@ -104,6 +105,7 @@ message(STATUS "JERRY_VM_EXEC_STOP             " ${JERRY_VM_EXEC_STOP})
 message(STATUS "JERRY_GLOBAL_HEAP_SIZE         " ${JERRY_GLOBAL_HEAP_SIZE})
 message(STATUS "JERRY_GC_LIMIT                 " ${JERRY_GC_LIMIT})
 message(STATUS "JERRY_STACK_LIMIT              " ${JERRY_STACK_LIMIT})
+message(STATUS "JERRY_GC_MARK_LIMIT            " ${JERRY_GC_MARK_LIMIT})
 
 # Include directories
 set(INCLUDE_CORE_PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
@@ -304,6 +306,9 @@ set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_GLOBAL_HEAP_SIZE=${JERRY_GLOBAL_HEAP_SI
 
 # Maximum size of stack memory usage
 set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_STACK_LIMIT=${JERRY_STACK_LIMIT})
+
+# Maximum depth of recursion during GC mark phase
+set(DEFINES_JERRY ${DEFINES_JERRY} JERRY_GC_MARK_LIMIT=${JERRY_GC_MARK_LIMIT})
 
 ## This function is to read "config.h" for default values
 function(read_set_defines FILE PREFIX OUTPUTVAR)

--- a/jerry-core/config.h
+++ b/jerry-core/config.h
@@ -234,6 +234,15 @@
 #endif /* !defined (JERRY_STACK_LIMIT) */
 
 /**
+ * Maximum depth of recursion during GC mark phase
+ *
+ * Default value: 8
+ */
+#ifndef JERRY_GC_MARK_LIMIT
+# define JERRY_GC_MARK_LIMIT (8)
+#endif /* !defined (JERRY_GC_MARK_LIMIT) */
+
+/**
  * Enable/Disable property lookup cache.
  *
  * Allowed values:
@@ -635,6 +644,9 @@
 #endif
 #if !defined (JERRY_STACK_LIMIT) || (JERRY_STACK_LIMIT < 0)
 # error "Invalid value for 'JERRY_STACK_LIMIT' macro."
+#endif
+#if !defined (JERRY_GC_MARK_LIMIT) || (JERRY_GC_MARK_LIMIT < 0)
+# error "Invalid value for 'JERRY_GC_MARK_LIMIT' macro."
 #endif
 #if !defined (JERRY_LCACHE) \
 || ((JERRY_LCACHE != 0) && (JERRY_LCACHE != 1))

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -714,14 +714,29 @@ typedef enum
 #endif /* ENABLED (JERRY_DEBUGGER) */
 
 /**
- * Value for increasing or decreasing the object reference counter.
+ * Bitshift index for an ecma-object reference count field
  */
-#define ECMA_OBJECT_REF_ONE (1u << 6)
+#define ECMA_OBJECT_REF_SHIFT 6
 
 /**
- * Maximum value of the object reference counter (1023).
+ * Bitmask for an ecma-object reference count field
  */
-#define ECMA_OBJECT_MAX_REF (0x3ffu << 6)
+#define ECMA_OBJECT_REF_MASK (((1u << 10) - 1) << ECMA_OBJECT_REF_SHIFT)
+
+/**
+ * Value for increasing or decreasing the object reference counter.
+ */
+#define ECMA_OBJECT_REF_ONE (1u << ECMA_OBJECT_REF_SHIFT)
+
+/**
+ * Represents non-visited white object
+ */
+#define ECMA_OBJECT_NON_VISITED (0x3ffu << ECMA_OBJECT_REF_SHIFT)
+
+/**
+ * Maximum value of the object reference counter (1022).
+ */
+#define ECMA_OBJECT_MAX_REF (ECMA_OBJECT_NON_VISITED - ECMA_OBJECT_REF_ONE)
 
 /**
  * Description of ECMA-object or lexical environment
@@ -733,7 +748,7 @@ typedef struct
                      depending on ECMA_OBJECT_FLAG_BUILT_IN_OR_LEXICAL_ENV
       flags : 2 bit : ECMA_OBJECT_FLAG_BUILT_IN_OR_LEXICAL_ENV,
                       ECMA_OBJECT_FLAG_EXTENSIBLE or ECMA_OBJECT_FLAG_NON_CLOSURE
-      refs : 10 bit (max 1023) */
+      refs : 10 bit (max 1022) */
   uint16_t type_flags_refs;
 
   /** next in the object chain maintained by the garbage collector */

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -54,8 +54,8 @@ JERRY_STATIC_ASSERT (ECMA_OBJECT_FLAG_EXTENSIBLE == (ECMA_OBJECT_FLAG_BUILT_IN_O
 JERRY_STATIC_ASSERT (ECMA_OBJECT_REF_ONE == (ECMA_OBJECT_FLAG_EXTENSIBLE << 1),
                      ecma_object_ref_one_must_follow_the_extensible_flag);
 
-JERRY_STATIC_ASSERT ((ECMA_OBJECT_MAX_REF | (ECMA_OBJECT_REF_ONE - 1)) == UINT16_MAX,
-                     ecma_object_max_ref_does_not_fill_the_remaining_bits);
+JERRY_STATIC_ASSERT (((ECMA_OBJECT_MAX_REF + ECMA_OBJECT_REF_ONE) | (ECMA_OBJECT_REF_ONE - 1)) == UINT16_MAX,
+                      ecma_object_max_ref_does_not_fill_the_remaining_bits);
 
 JERRY_STATIC_ASSERT (ECMA_PROPERTY_TYPE_DELETED == (ECMA_DIRECT_STRING_MAGIC << ECMA_PROPERTY_NAME_TYPE_SHIFT),
                      ecma_property_type_deleted_must_have_magic_string_name_type);

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -47,6 +47,10 @@ ecma_init (void)
   JERRY_CONTEXT (stack_base) = (uintptr_t)&sp;
 #endif /* (JERRY_STACK_LIMIT != 0) */
 
+#if (JERRY_GC_MARK_LIMIT != 0)
+  JERRY_CONTEXT (ecma_gc_mark_recursion_limit) = JERRY_GC_MARK_LIMIT;
+#endif /* (JERRY_GC_MARK_LIMIT != 0) */
+
 #if ENABLED (JERRY_ES2015_BUILTIN_PROMISE)
   ecma_job_queue_init ();
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_PROMISE) */

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -159,6 +159,9 @@ struct jerry_context_t
   uint32_t lit_magic_string_ex_count; /**< external magic strings count */
   uint32_t jerry_init_flags; /**< run-time configuration flags */
   uint32_t status_flags; /**< run-time flags (the top 8 bits are used for passing class parsing options) */
+#if (JERRY_GC_MARK_LIMIT != 0)
+  uint32_t ecma_gc_mark_recursion_limit; /**< GC mark recursion limit */
+#endif /* (JERRY_GC_MARK_LIMIT != 0) */
 
 #if ENABLED (JERRY_PROPRETY_HASHMAP)
   uint8_t ecma_prop_hashmap_alloc_state; /**< property hashmap allocation state: 0-4,

--- a/tools/build.py
+++ b/tools/build.py
@@ -128,6 +128,8 @@ def get_arguments():
                          help='memory usage limit to trigger garbage collection (in bytes)')
     coregrp.add_argument('--stack-limit', metavar='SIZE', type=int,
                          help='maximum stack usage (in kilobytes)')
+    coregrp.add_argument('--gc-mark-limit', metavar='SIZE', type=int,
+                         help='maximum depth of recursion during GC mark phase')
     coregrp.add_argument('--mem-stats', metavar='X', choices=['ON', 'OFF'], type=str.upper,
                          help=devhelp('enable memory statistics (%(choices)s)'))
     coregrp.add_argument('--mem-stress-test', metavar='X', choices=['ON', 'OFF'], type=str.upper,
@@ -214,6 +216,9 @@ def generate_build_options(arguments):
     build_options_append('JERRY_SYSTEM_ALLOCATOR', arguments.system_allocator)
     build_options_append('JERRY_VALGRIND', arguments.valgrind)
     build_options_append('JERRY_VM_EXEC_STOP', arguments.vm_exec_stop)
+
+    if arguments.gc_mark_limit is not None:
+        build_options.append('-D%s=%s' % ('JERRY_GC_MARK_LIMIT', arguments.gc_mark_limit))
 
     # jerry-main options
     build_options_append('ENABLE_LINK_MAP', arguments.link_map)

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -38,6 +38,7 @@ OPTIONS_PROFILE_MIN = ['--profile=minimal']
 OPTIONS_PROFILE_ES51 = [] # NOTE: same as ['--profile=es5.1']
 OPTIONS_PROFILE_ES2015 = ['--profile=es2015-subset']
 OPTIONS_STACK_LIMIT = ['--stack-limit=96']
+OPTIONS_GC_MARK_LIMIT = ['--gc-mark-limit=16']
 OPTIONS_DEBUG = ['--debug']
 OPTIONS_SNAPSHOT = ['--snapshot-save=on', '--snapshot-exec=on', '--jerry-cmdline-snapshot=on']
 OPTIONS_UNITTESTS = ['--unittests=on', '--jerry-cmdline=off', '--error-messages=on',
@@ -75,22 +76,23 @@ JERRY_UNITTESTS_OPTIONS = [
 # Test options for jerry-tests
 JERRY_TESTS_OPTIONS = [
     Options('jerry_tests-es2015_subset-debug',
-            OPTIONS_COMMON + OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES2015 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT),
     Options('jerry_tests-es5.1',
-            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_STACK_LIMIT),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT),
     Options('jerry_tests-es5.1-snapshot',
-            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_STACK_LIMIT,
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT,
             ['--snapshot']),
     Options('jerry_tests-es5.1-debug',
-            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT),
     Options('jerry_tests-es5.1-debug-snapshot',
-            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT,
-            ['--snapshot']),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_SNAPSHOT + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT
+            + OPTIONS_GC_MARK_LIMIT, ['--snapshot']),
     Options('jerry_tests-es5.1-debug-cpointer_32bit',
-            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT
             + ['--cpointer-32bit=on', '--mem-heap=1024']),
     Options('jerry_tests-es5.1-debug-external_context',
-            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + ['--external-context=on']),
+            OPTIONS_COMMON + OPTIONS_PROFILE_ES51 + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT
+            + ['--external-context=on']),
 ]
 
 # Test options for jerry-test-suite
@@ -169,6 +171,8 @@ JERRY_BUILDOPTIONS = [
             ['--jerry-cmdline-snapshot=on']),
     Options('buildoption_test-recursion_limit',
             OPTIONS_STACK_LIMIT),
+    Options('buildoption_test-gc-mark_limit',
+            OPTIONS_GC_MARK_LIMIT),
     Options('buildoption_test-single-source',
             ['--cmake-param=-DENABLE_ALL_IN_ONE_SOURCE=ON']),
 ]


### PR DESCRIPTION
- Enable recursive GC marking with a limited recursion count
- No need to decrease the reference count of the gray objects anymore
- Bound function object marking is separated into a helper function

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
