### PR TITLE
Add documentation about x86 and floating-point operations

### DIFF
--- a/docs/01.CONFIGURATION.md
+++ b/docs/01.CONFIGURATION.md
@@ -302,3 +302,21 @@ $ gcc -Wall -o demo_app demo_app.c gen_src/jerryscript.c gen_src/jerryscript-por
 Please note that the headers must be available on the include path.
 
 In addition there is a `-DENABLE_ALL_IN_ONE_SOURCE=ON` CMake option to use this kind of sources during the build.
+
+# Target specific information
+
+## x86 with GCC
+
+When building for Intel 32 bit architecture it is possible that the GCC uses conservative options, thus assuming the most
+basic floating-point support (that is it does not generate SSE or others instructions).
+However this could lead to loss off precision and/or different results than what is required by the JavaScript standard
+in regards of floating-point values and arithmetic.
+
+To resolve this precision problem it is advised to use at least SSE2.
+To do this with GCC please provide the `-mfpmath=sse -msse2` options during build.
+
+These options can also be specified via the `build.py` script:
+
+```sh
+$ ./tools/build.py --compile-flag=-mfpmath=sse --compile-flag=-msse2 --compile-flag=-m32
+```


### PR DESCRIPTION
If JerrScript is compiled for x86 then it is possible that the
floating-point operations are not correct for the JS standard.

Reproduction example:

```
$ ./tools/build.py --compile-flag=-m32  --compile-flag=-std=gnu99
$ echo "0.42018199893505187" | ./build/bin/jerry
jerry> 0.420181998935051836951970472000539302825927734463817841970...
```

To "fix" this the users should be advised to use at least SSE2
during build for this platform.

```
$ ./tools/build.py --compile-flag=-m32 --compile-flag=-std=gnu99 \
    --compile-flag=-mfpmath=sse --compile-flag=-msse2
$ echo "0.42018199893505187" | ./build/bin/jerry
jerry> 0.42018199893505187
```

JerryScript-DCO-1.0-Signed-off-by: Dániel Vince vinced@inf.u-szeged.hu