### PR TITLE
Fix error type when creating TypedArray with detached ArrayBuffer

### DIFF
--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -969,7 +969,7 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
       }
       else if (ecma_arraybuffer_is_detached (arraybuffer_p))
       {
-        ret = ecma_raise_range_error (ECMA_ERR_MSG ("Invalid detached ArrayBuffer."));
+        ret = ecma_raise_type_error (ECMA_ERR_MSG ("Invalid detached ArrayBuffer."));
       }
       else
       {

--- a/tests/unit-core/test-typedarray.c
+++ b/tests/unit-core/test-typedarray.c
@@ -400,6 +400,81 @@ static void test_property_by_index (test_entry_t test_entries[])
   }
 } /* test_property_by_index */
 
+static void
+test_detached_arraybuffer (void)
+{
+  static jerry_typedarray_type_t types[] =
+  {
+    JERRY_TYPEDARRAY_UINT8,
+    JERRY_TYPEDARRAY_UINT8CLAMPED,
+    JERRY_TYPEDARRAY_INT8,
+    JERRY_TYPEDARRAY_UINT16,
+    JERRY_TYPEDARRAY_INT16,
+    JERRY_TYPEDARRAY_UINT32,
+    JERRY_TYPEDARRAY_INT32,
+    JERRY_TYPEDARRAY_FLOAT32,
+    JERRY_TYPEDARRAY_FLOAT64,
+  };
+
+  /* Creating an TypedArray for a detached array buffer with a given length/offset is invalid */
+  {
+    uint8_t buf[1];
+    const uint32_t length = 1;
+    jerry_value_t arraybuffer = jerry_create_arraybuffer_external (length, buf, NULL);
+    TEST_ASSERT (!jerry_value_is_error (arraybuffer));
+    TEST_ASSERT (jerry_value_is_arraybuffer (arraybuffer));
+    TEST_ASSERT (jerry_get_arraybuffer_byte_length (arraybuffer) == length);
+
+    jerry_value_t is_detachable = jerry_is_arraybuffer_detachable (arraybuffer);
+    TEST_ASSERT (!jerry_value_is_error (is_detachable));
+    TEST_ASSERT (jerry_get_boolean_value (is_detachable));
+    jerry_release_value (is_detachable);
+
+    jerry_value_t res = jerry_detach_arraybuffer (arraybuffer);
+    TEST_ASSERT (!jerry_value_is_error (res));
+    jerry_release_value (res);
+
+    for (size_t idx = 0; idx < (sizeof (types) / sizeof (types[0])); idx++)
+    {
+      jerry_value_t typedarray = jerry_create_typedarray_for_arraybuffer_sz (types[idx], arraybuffer, 0, 4);
+      TEST_ASSERT (jerry_value_is_error (typedarray));
+      TEST_ASSERT (jerry_get_error_type (typedarray) == JERRY_ERROR_TYPE);
+      jerry_release_value (typedarray);
+    }
+
+    jerry_release_value (arraybuffer);
+  }
+
+  /* Creating an TypedArray for a detached array buffer without length/offset is valid */
+  {
+    uint8_t buf[1];
+    const uint32_t length = 1;
+    jerry_value_t arraybuffer = jerry_create_arraybuffer_external (length, buf, NULL);
+    TEST_ASSERT (!jerry_value_is_error (arraybuffer));
+    TEST_ASSERT (jerry_value_is_arraybuffer (arraybuffer));
+    TEST_ASSERT (jerry_get_arraybuffer_byte_length (arraybuffer) == length);
+
+    jerry_value_t is_detachable = jerry_is_arraybuffer_detachable (arraybuffer);
+    TEST_ASSERT (!jerry_value_is_error (is_detachable));
+    TEST_ASSERT (jerry_get_boolean_value (is_detachable));
+    jerry_release_value (is_detachable);
+
+    jerry_value_t res = jerry_detach_arraybuffer (arraybuffer);
+    TEST_ASSERT (!jerry_value_is_error (res));
+    jerry_release_value (res);
+
+    for (size_t idx = 0; idx < (sizeof (types) / sizeof (types[0])); idx++)
+    {
+      jerry_value_t typedarray = jerry_create_typedarray_for_arraybuffer (types[idx], arraybuffer);
+      TEST_ASSERT (jerry_value_is_error (typedarray));
+      TEST_ASSERT (jerry_get_error_type (typedarray) == JERRY_ERROR_TYPE);
+      jerry_release_value (typedarray);
+    }
+
+    jerry_release_value (arraybuffer);
+  }
+} /* test_detached_arraybuffer */
+
 int
 main (void)
 {
@@ -570,6 +645,8 @@ main (void)
       jerry_release_value (values[idx]);
     }
   }
+
+  test_detached_arraybuffer ();
 
   jerry_cleanup ();
 


### PR DESCRIPTION
Based on the ES2015 standard TypeError should be returned
when a TypedArray is created for a detached ArrayBuffer.

JerryScript-DCO-1.0-Signed-off-by: Dániel Vince vinced@inf.u-szeged.hu