### PR TITLE
Extend the API documentation for jerry_create_string_* functions

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -4068,7 +4068,7 @@ jerry_value_t
 jerry_create_string (const jerry_char_t *str_p);
 ```
 
-- `str_p` - pointer to string
+- `str_p` - non-null pointer to string
 - return value - value of the created string
 
 **Example**
@@ -4107,7 +4107,7 @@ jerry_create_string_sz (const jerry_char_t *str_p,
                         jerry_size_t str_size)
 ```
 
-- `str_p` - pointer to string
+- `str_p` - non-null pointer to string
 - `str_size` - size of the string
 - return value - value of the created string
 
@@ -4138,8 +4138,9 @@ jerry_create_string_sz (const jerry_char_t *str_p,
 
 Create string from a valid UTF8 string.
 
-*Note*: The difference from [jerry_create_string](#jerry_create_string) is that it accepts utf-8 string instead of cesu-8 string.
-*Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+*Note*:
+ - The difference from [jerry_create_string](#jerry_create_string) is that it accepts utf-8 string instead of cesu-8 string.
+ - Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
 is no longer needed.
 
 **Prototype**
@@ -4149,7 +4150,7 @@ jerry_value_t
 jerry_create_string_from_utf8 (const jerry_char_t *str_p);
 ```
 
-- `str_p` - pointer to string
+- `str_p` - non-null pointer to string
 - return value - value of the created string
 
 *New in version 2.0*.
@@ -4179,19 +4180,20 @@ jerry_create_string_from_utf8 (const jerry_char_t *str_p);
 
 Create string from a valid UTF8 string.
 
-*Note*: The difference from [jerry_create_string_sz](#jerry_create_string_sz) is that it accepts utf-8 string instead of cesu-8 string.
-*Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+*Note*:
+ - The difference from [jerry_create_string_sz](#jerry_create_string_sz) is that it accepts utf-8 string instead of cesu-8 string.
+ - Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
 is no longer needed.
 
 **Prototype**
 
 ```c
 jerry_value_t
-jerry_create_string_sz (const jerry_char_t *str_p,
-                        jerry_size_t str_size)
+jerry_create_string_sz_from_utf8 (const jerry_char_t *str_p,
+                                  jerry_size_t str_size)
 ```
 
-- `str_p` - pointer to string
+- `str_p` - non-null pointer to string
 - `str_size` - size of the string
 - return value - value of the created string
 
@@ -7632,7 +7634,7 @@ Get if the ArrayBuffer is detachable.
 **Prototype**
 
 ```c
-jerry_value_t 
+jerry_value_t
 jerry_is_arraybuffer_detachable (const jerry_value_t value);
 ```
 
@@ -7673,7 +7675,7 @@ This operation requires the ArrayBuffer to be external that created by
 **Prototype**
 
 ```c
-jerry_value_t 
+jerry_value_t
 jerry_detach_arraybuffer (const jerry_value_t value);
 ```
 

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -247,13 +247,15 @@ convert_code_point_to_high_surrogate (lit_code_point_t code_point) /**< code poi
  * Calculate size of a zero-terminated utf-8 string
  *
  * NOTE:
- *   string should not contain zero characters in the middel
+ *   - string cannot be NULL
+ *   - string should not contain zero characters in the middle
  *
  * @return size of a string
  */
 lit_utf8_size_t
 lit_zt_utf8_string_size (const lit_utf8_byte_t *utf8_str_p) /**< zero-terminated utf-8 string */
 {
+  JERRY_ASSERT (utf8_str_p != NULL);
   return (lit_utf8_size_t) strlen ((const char *) utf8_str_p);
 } /* lit_zt_utf8_string_size */
 


### PR DESCRIPTION
 - The given string pointer cannot be NULL
 - Fixed API prototype for jerry_create_string_sz_from_utf8
 - Assert is added for non-NULL pointer in lit_zt_utf8_string_size

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
