### PR TITLE
Sort function breakpoints before enabling them

### DIFF
--- a/jerry-debugger/jerry_client_main.py
+++ b/jerry-debugger/jerry_client_main.py
@@ -1089,9 +1089,15 @@ class JerryDebugger(object):
                     result += self._enable_breakpoint(breakpoint)
 
         else:
+            functions_to_enable = []
             for function in self.function_list.values():
                 if function.name == string:
-                    result += self._enable_breakpoint(function.lines[function.first_breakpoint_line])
+                    functions_to_enable.append(function)
+
+            functions_to_enable.sort(key=lambda x: x.line)
+
+            for function in functions_to_enable:
+                result += self._enable_breakpoint(function.lines[function.first_breakpoint_line])
 
         if not result and not pending:
             print("No breakpoint found, do you want to add a %spending breakpoint%s? (y or [n])" % \


### PR DESCRIPTION
Function breakpoints should be sorted before enabling then since the object enumeration order does not grant consistent result.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
