### PR TITLE
Fix from_index calculation for %TypedArray%.prototype.lastIndexOf

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1766,6 +1766,11 @@ ecma_builtin_typedarray_prototype_index_helper (ecma_value_t this_arg, /**< this
   int32_t increment = is_last_index_of ? -info.element_size : info.element_size;
   ecma_typedarray_getter_fn_t getter_cb = ecma_get_typedarray_getter_fn (info.id);
 
+  if (is_last_index_of && from_index == info.length)
+  {
+    from_index--;
+  }
+
   for (int32_t position = (int32_t) from_index * info.element_size;
        (is_last_index_of ? position >= 0 : (uint32_t) position < limit);
        position += increment)

--- a/tests/jerry/es2015/regression-test-issue-3237.js
+++ b/tests/jerry/es2015/regression-test-issue-3237.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+var arrayBufferVar1 = new ArrayBuffer(12, 8);
+var arrayVar1 = new Uint8Array(arrayBufferVar1, 9);
+assert(arrayVar1.lastIndexOf(15, -Math.LOG10E) === -1);


### PR DESCRIPTION
This patch fixes #3237.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

