### PR TITLE
Fix integer overflow during byteLength calculation for %TypedArray%s

### DIFF
--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -998,7 +998,7 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
             return ECMA_VALUE_ERROR;
           }
 
-          if ((uint32_t) new_length > (UINT32_MAX >> element_size_shift))
+          if (new_length > (UINT32_MAX >> element_size_shift))
           {
             ret = ecma_raise_range_error (ECMA_ERR_MSG ("Maximum typedarray size is reached."));
           }
@@ -1006,7 +1006,7 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
           {
             new_byte_length = (ecma_length_t) new_length << element_size_shift;
 
-            if (new_byte_length + offset > buf_byte_length)
+            if (((ecma_number_t) new_byte_length + offset) > buf_byte_length)
             {
               ret = ecma_raise_range_error (ECMA_ERR_MSG ("Invalid length."));
             }

--- a/tests/jerry/es2015/regression-test-issue-3243.js
+++ b/tests/jerry/es2015/regression-test-issue-3243.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  (new Int8Array((new ArrayBuffer()), 1, Infinity)).reverse()
+  assert(false);
+} catch (e) {
+  assert (e instanceof RangeError);
+}


### PR DESCRIPTION
This patch fixes #3243.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
