### PR TITLE
Properly release callback result in ecma_builtin_typedarray_prototype_exec_routine

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -237,22 +237,23 @@ ecma_builtin_typedarray_prototype_exec_routine (ecma_value_t this_arg, /**< this
       return call_value;
     }
 
+    bool to_bool_result = ecma_op_to_boolean (call_value);
+    ecma_free_value (call_value);
+
     if (mode == TYPEDARRAY_ROUTINE_EVERY)
     {
-      if (!ecma_op_to_boolean (call_value))
+      if (!to_bool_result)
       {
         return ECMA_VALUE_FALSE;
       }
     }
     else if (mode == TYPEDARRAY_ROUTINE_SOME
-             && ecma_op_to_boolean (call_value))
+             && to_bool_result)
     {
       return ECMA_VALUE_TRUE;
     }
 
     byte_pos += info.element_size;
-
-    ecma_free_value (call_value);
   }
 
   if (mode == TYPEDARRAY_ROUTINE_EVERY)

--- a/tests/jerry/es2015/regression-test-issue-3262.js
+++ b/tests/jerry/es2015/regression-test-issue-3262.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert ((new Float64Array(Object('foobar').split())).every(function (p_0) { return p_0 }) === false);


### PR DESCRIPTION
This patch fixes #3262.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu