### PR TITLE
Correctly handle variables imported or exported by modules.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -105,6 +105,7 @@ typedef enum
   ECMA_PARSE_HAS_IMPL_SUPER = (1u << 4), /**< the current context has implicit parent class */
   ECMA_PARSE_HAS_STATIC_SUPER = (1u << 5), /**< the current context is a static class method */
   ECMA_PARSE_EVAL = (1u << 6), /**< eval is called */
+  ECMA_PARSE_MODULE = (1u << 7), /**< module is parsed */
 } ecma_parse_opts_t;
 
 /**

--- a/jerry-core/ecma/base/ecma-module.c
+++ b/jerry-core/ecma/base/ecma-module.c
@@ -818,7 +818,7 @@ ecma_module_parse (ecma_module_t *module_p) /**< module */
                                                 0,
                                                 (jerry_char_t *) source_p,
                                                 source_size,
-                                                JERRY_PARSE_STRICT_MODE,
+                                                ECMA_PARSE_STRICT_MODE | ECMA_PARSE_MODULE,
                                                 &bytecode_data_p);
 
   JERRY_CONTEXT (module_top_context_p) = module_p->context_p->parent_p;

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -586,11 +586,6 @@ parser_parse_class (parser_context_t *context_p, /**< context */
 {
   JERRY_ASSERT (context_p->token.type == LEXER_KEYW_CLASS);
 
-#if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
-  /* FIXME: Remove this hack after module classes are supported. */
-  uint16_t assign_opcode = CBC_ASSIGN_LET_CONST;
-#endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
-
   uint16_t class_ident_index = PARSER_MAXIMUM_NUMBER_OF_LITERALS;
 
   if (is_statement)
@@ -611,8 +606,6 @@ parser_parse_class (parser_context_t *context_p, /**< context */
 #if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
     if (context_p->status_flags & PARSER_MODULE_STORE_IDENT)
     {
-      assign_opcode = CBC_ASSIGN_SET_IDENT;
-
       context_p->module_identifier_lit_p = context_p->lit_object.literal_p;
       context_p->status_flags &= (uint32_t) ~(PARSER_MODULE_STORE_IDENT);
     }
@@ -672,7 +665,7 @@ parser_parse_class (parser_context_t *context_p, /**< context */
   if (is_statement)
   {
     parser_emit_cbc_literal (context_p,
-                             class_ident_index >= PARSER_REGISTER_START ? CBC_MOV_IDENT : assign_opcode,
+                             class_ident_index >= PARSER_REGISTER_START ? CBC_MOV_IDENT : CBC_ASSIGN_LET_CONST,
                              class_ident_index);
   }
 

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -78,8 +78,9 @@ typedef enum
   PARSER_IS_EVAL = (1u << 25),                /**< eval code */
 #endif /* ENABLED (JERRY_ES2015) */
 #if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
-  PARSER_MODULE_DEFAULT_CLASS_OR_FUNC = (1u << 26),  /**< parsing a function or class default export */
-  PARSER_MODULE_STORE_IDENT = (1u << 27),     /**< store identifier of the current export statement */
+  PARSER_IS_MODULE = (1u << 26),              /**< an export / import keyword is encountered */
+  PARSER_MODULE_DEFAULT_CLASS_OR_FUNC = (1u << 27),  /**< parsing a function or class default export */
+  PARSER_MODULE_STORE_IDENT = (1u << 28),     /**< store identifier of the current export statement */
 #endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
 #ifndef JERRY_NDEBUG
   PARSER_SCANNING_SUCCESSFUL = (1u << 30),    /**< scanning process was successful */

--- a/jerry-core/parser/js/js-parser-module.c
+++ b/jerry-core/parser/js/js-parser-module.c
@@ -435,6 +435,14 @@ parser_module_parse_import_clause (parser_context_t *context_p) /**< parser cont
       parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
     }
 
+#if ENABLED (JERRY_ES2015)
+    if (context_p->next_scanner_info_p->source_p == context_p->source_p)
+    {
+      JERRY_ASSERT (context_p->next_scanner_info_p->type == SCANNER_TYPE_ERR_REDECLARED);
+      parser_raise_error (context_p, PARSER_ERR_VARIABLE_REDECLARED);
+    }
+#endif /* ENABLED (JERRY_ES2015) */
+
     ecma_string_t *import_name_p = NULL;
     ecma_string_t *local_name_p = NULL;
 
@@ -453,6 +461,14 @@ parser_module_parse_import_clause (parser_context_t *context_p) /**< parser cont
       {
         parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
       }
+
+#if ENABLED (JERRY_ES2015)
+      if (context_p->next_scanner_info_p->source_p == context_p->source_p)
+      {
+        JERRY_ASSERT (context_p->next_scanner_info_p->type == SCANNER_TYPE_ERR_REDECLARED);
+        parser_raise_error (context_p, PARSER_ERR_VARIABLE_REDECLARED);
+      }
+#endif /* ENABLED (JERRY_ES2015) */
 
       lexer_construct_literal_object (context_p, &context_p->token.lit_location, LEXER_NEW_IDENT_LITERAL);
 

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1766,7 +1766,6 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
     context.status_flags = PARSER_IS_FUNCTION;
   }
 
-
 #if ENABLED (JERRY_ES2015)
   context.status_flags |= PARSER_GET_CLASS_PARSER_OPTS (parse_opts);
 #endif /* ENABLED (JERRY_ES2015) */
@@ -1865,6 +1864,7 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
   context.u.allocated_buffer_p = NULL;
   context.line = 1;
   context.column = 1;
+  context.token.flags = 0;
 
   parser_stack_init (&context);
 
@@ -1873,6 +1873,11 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
 #endif /* ENABLED (JERRY_DEBUGGER) */
 
 #if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
+  if (context.status_flags & PARSER_IS_MODULE)
+  {
+    context.status_flags |= PARSER_IS_STRICT;
+  }
+
   if (parse_opts & ECMA_PARSE_EVAL)
   {
     /* After this point this flag is set for non-direct evals as well. */
@@ -1906,6 +1911,12 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
 
       lexer_next_token (&context);
     }
+#if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
+    else if (parse_opts & ECMA_PARSE_MODULE)
+    {
+      scanner_create_variables (&context, SCANNER_CREATE_VARS_NO_OPTS);
+    }
+#endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
     else
     {
       JERRY_ASSERT (context.next_scanner_info_p->source_p == source_p

--- a/jerry-core/parser/js/js-scanner-internal.h
+++ b/jerry-core/parser/js/js-scanner-internal.h
@@ -63,7 +63,7 @@ typedef enum
  *
  *  SCANNER_LITERAL_IS_FUNC | SCANNER_LITERAL_IS_LET : function declared in this block, might be let or var
  *  SCANNER_LITERAL_IS_FUNC | SCANNER_LITERAL_IS_CONST : function declared in this block, must be let
- *  SCANNER_LITERAL_IS_LET | SCANNER_LITERAL_IS_CONST : catch block variable
+ *  SCANNER_LITERAL_IS_LET | SCANNER_LITERAL_IS_CONST : module import on global scope, catch block variable otherwise
  */
 
 /**
@@ -105,6 +105,9 @@ typedef enum
 #endif /* ENABLED (JERRY_ES2015) */
   SCANNER_LITERAL_POOL_NO_ARGUMENTS = (1 << 4), /**< arguments object should not be constructed */
   SCANNER_LITERAL_POOL_IN_WITH = (1 << 5), /**< literal pool is in a with statement */
+#if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
+  SCANNER_LITERAL_POOL_IN_EXPORT = (1 << 6), /**< the declared variables are exported by the module system */
+#endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
 } scanner_literal_pool_flags_t;
 
 /**
@@ -167,6 +170,7 @@ void scanner_append_argument (parser_context_t *context_p, scanner_context_t *sc
 bool scanner_scope_find_let_declaration (parser_context_t *context_p, lexer_lit_location_t *literal_p);
 void scanner_detect_invalid_var (parser_context_t *context_p, scanner_context_t *scanner_context_p,
                                  lexer_lit_location_t *var_literal_p);
+void scanner_detect_invalid_let (parser_context_t *context_p, lexer_lit_location_t *let_literal_p);
 #endif /* ENABLED (JERRY_ES2015) */
 void scanner_detect_eval_call (parser_context_t *context_p, scanner_context_t *scanner_context_p);
 

--- a/jerry-core/parser/js/js-scanner.h
+++ b/jerry-core/parser/js/js-scanner.h
@@ -145,6 +145,9 @@ typedef enum
   SCANNER_STREAM_TYPE_LET, /**< let declaration */
   SCANNER_STREAM_TYPE_CONST, /**< const declaration */
 #endif /* ENABLED (JERRY_ES2015) */
+#if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
+  SCANNER_STREAM_TYPE_IMPORT, /**< module import */
+#endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
   SCANNER_STREAM_TYPE_ARG, /**< argument declaration */
   /* Function types should be at the end. See the SCANNER_STREAM_TYPE_IS_FUNCTION macro. */
   SCANNER_STREAM_TYPE_ARG_FUNC, /**< argument declaration which is later initialized with a function */

--- a/tests/jerry/es2015/module-export-fail-test.js
+++ b/tests/jerry/es2015/module-export-fail-test.js
@@ -1,0 +1,17 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* This module is imported by failing tests. */
+export let a;

--- a/tests/jerry/fail/module-032.js
+++ b/tests/jerry/fail/module-032.js
@@ -1,0 +1,17 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let a;
+import { a } from "../es2015/module-export-fail-test.js";

--- a/tests/jerry/fail/module-033.js
+++ b/tests/jerry/fail/module-033.js
@@ -1,0 +1,17 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var a;
+import { a } from "../es2015/module-export-fail-test.js";

--- a/tests/jerry/fail/module-034.js
+++ b/tests/jerry/fail/module-034.js
@@ -1,0 +1,17 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { a } from "../es2015/module-export-fail-test.js";
+class a {};

--- a/tests/jerry/fail/module-035.js
+++ b/tests/jerry/fail/module-035.js
@@ -1,0 +1,17 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { a } from "../es2015/module-export-fail-test.js";
+function a() {}


### PR DESCRIPTION
Remove var declaration workarounds and correctly create / use variables for modules.

Still missing: create lexical environment for automatic module conversion.
(Or remove this feature overall.)