### PR TITLE
[[HasOwnProperty]] should update the lex-env binding of arguments objects

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -402,9 +402,10 @@ inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_has_own_property (ecma_object_t *object_p, /**< the object */
                                  ecma_string_t *property_name_p) /**< property name */
 {
+  ecma_property_ref_t property_ref;
   ecma_property_t property = ecma_op_object_get_own_property (object_p,
                                                               property_name_p,
-                                                              NULL,
+                                                              &property_ref,
                                                               ECMA_PROPERTY_GET_NO_OPTIONS);
 
   return property != ECMA_PROPERTY_TYPE_NOT_FOUND && property != ECMA_PROPERTY_TYPE_NOT_FOUND_AND_STOP;

--- a/tests/jerry/regression-test-issue-3271.js
+++ b/tests/jerry/regression-test-issue-3271.js
@@ -1,0 +1,42 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function bar(a) {
+  assert(a[0] === 10);
+  a.hasOwnProperty(0);
+  assert(a[0] === 10);
+}
+
+function foo(a) {
+  assert(a === 20);
+  a = 10;
+  bar(arguments);
+}
+
+function barStrict(a) {
+  "use strict"
+  assert(a[0] === 20);
+  a.hasOwnProperty(0);
+  assert(a[0] === 20);
+}
+
+function fooStrict(a) {
+  "use strict"
+  assert(a === 20);
+  a = 10;
+  barStrict(arguments);
+}
+
+foo(20);
+fooStrict(20);


### PR DESCRIPTION
This patch fixes #3271.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
