### PR TITLE
Delay the variable construction in the function body.

### DIFF
--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -320,6 +320,14 @@ typedef struct
 
 /**
  * This item represents a function literal in the scope stack.
+ *
+ * When map_from == PARSER_SCOPE_STACK_FUNC:
+ *   map_to represents the literal reserved for a function literal
+ *   Note: the name of the function is the previous value in the scope stack
+ *
+ * When map_to == PARSER_SCOPE_STACK_FUNC:
+ *   map_from represents the name of the function literal following this literal
+ *   Note: only the name, the real mapping is somewhere else in the scope stack
  */
 #define PARSER_SCOPE_STACK_FUNC 0xffff
 
@@ -626,6 +634,7 @@ void parser_parse_super_class_context_end (parser_context_t *context_p);
 
 void scanner_release_next (parser_context_t *context_p, size_t size);
 void scanner_set_active (parser_context_t *context_p);
+void scanner_revert_active (parser_context_t *context_p);
 void scanner_release_active (parser_context_t *context_p, size_t size);
 void scanner_release_switch_cases (scanner_case_info_t *case_p);
 void scanner_seek (parser_context_t *context_p);

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1617,12 +1617,15 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
 #endif /* ENABLED (JERRY_ES2015) */
 
   JERRY_ASSERT (context_p->next_scanner_info_p->type == SCANNER_TYPE_FUNCTION);
-  scanner_create_variables (context_p, SCANNER_CREATE_VARS_NO_OPTS);
 
   if (context_p->token.type == end_type)
   {
+    scanner_create_variables (context_p, SCANNER_CREATE_VARS_NO_OPTS);
     return;
   }
+
+  scanner_create_variables (context_p, SCANNER_CREATE_VARS_IS_FUNCTION_ARGS);
+  scanner_set_active (context_p);
 
   while (true)
   {
@@ -1730,6 +1733,9 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
 
     parser_raise_error (context_p, error);
   }
+
+  scanner_revert_active (context_p);
+  scanner_create_variables (context_p, SCANNER_CREATE_VARS_IS_FUNCTION_BODY);
 } /* parser_parse_function_arguments */
 
 /**

--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -2632,12 +2632,11 @@ scan_completed:
 
           if (info_p->type == SCANNER_TYPE_FUNCTION)
           {
-            scanner_function_info_t *function_info_p = (scanner_function_info_t *) info_p;
-            data_p = (const uint8_t *) (function_info_p + 1);
+            data_p = (const uint8_t *) (info_p + 1);
 
             JERRY_DEBUG_MSG ("  FUNCTION: flags: 0x%x declarations: %d",
-                             (int) function_info_p->info.u8_arg,
-                             (int) function_info_p->info.u16_arg);
+                             (int) info_p->u8_arg,
+                             (int) info_p->u16_arg);
           }
           else
           {

--- a/jerry-core/parser/js/js-scanner.h
+++ b/jerry-core/parser/js/js-scanner.h
@@ -176,20 +176,14 @@ typedef enum
 } scanner_function_flags_t;
 
 /**
- * Scanner info for function statements.
- */
-typedef struct
-{
-  scanner_info_t info; /**< header */
-} scanner_function_info_t;
-
-/**
  * Option bits for scanner_create_variables function.
  */
 typedef enum
 {
   SCANNER_CREATE_VARS_NO_OPTS = 0, /**< no options */
   SCANNER_CREATE_VARS_IS_EVAL = (1 << 0), /**< create variables for script / direct eval */
+  SCANNER_CREATE_VARS_IS_FUNCTION_ARGS = (1 << 1), /**< create variables for function arguments */
+  SCANNER_CREATE_VARS_IS_FUNCTION_BODY = (1 << 2), /**< create variables for function body */
 } scanner_create_variables_flags_t;
 
 /**

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -949,7 +949,6 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         break;
       }
 
-#if ENABLED (JERRY_ES2015)
       case CBC_SET_VAR_FUNC:
       {
         uint32_t literal_index, value_index;
@@ -966,8 +965,6 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
         if (literal_index < register_end)
         {
-          JERRY_ASSERT (type == CBC_SET_VAR_FUNC);
-
           ecma_fast_free_value (frame_ctx_p->registers_p[literal_index]);
           frame_ctx_p->registers_p[literal_index] = lit_value;
           break;
@@ -978,7 +975,6 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         vm_set_var (frame_ctx_p->lex_env_p, name_p, is_strict, lit_value);
         break;
       }
-#endif /* ENABLED (JERRY_ES2015) */
 
 #if ENABLED (JERRY_SNAPSHOT_EXEC)
       case CBC_SET_BYTECODE_PTR:

--- a/tests/jerry/es2015/function-param-init2.js
+++ b/tests/jerry/es2015/function-param-init2.js
@@ -1,0 +1,65 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f(a, b = a)
+{
+  function a() { return 2; }
+
+  assert(a() === 2);
+  assert(b === 1)
+}
+f(1);
+
+function g(a, b = a)
+{
+  function a() { return 2; }
+
+  eval("assert(a() === 2)");
+  eval("assert(b === 1)");
+}
+g(1);
+
+var x = 1;
+function h(a = x) {
+  assert(x === undefined);
+  var x = 2;
+  assert(a === 1);
+  assert(x === 2);
+}
+h();
+
+x = function() { return 4; }
+let y = 6;
+
+function i(a = x() / 2, b = (y) + 2, c = typeof z) {
+  let y = 10;
+  let z = 11;
+
+  function x() { return 5; }
+
+  assert(a === 2);
+  assert(x() === 5);
+  assert(b === 8);
+  assert(c === "undefined");
+  assert(y === 10);
+  assert(z === 11);
+}
+i();
+
+var arguments = 10;
+function j(a = arguments[1])
+{
+  assert(a === 2);
+}
+j(undefined,2);


### PR DESCRIPTION
Local variables inside the function body should be constructed after the parameters are initialized. Furthermore arguments should be available during parameter initialization.