### PR TITLE
Local functions should not be created globally.

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -1789,6 +1789,9 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
     if (type != SCANNER_STREAM_TYPE_ARG_FUNC)
     {
       if (func_init_opcode == CBC_INIT_LOCAL
+#if ENABLED (JERRY_ES2015)
+          && type != SCANNER_STREAM_TYPE_FUNC_LOCAL
+#endif /* ENABLED (JERRY_ES2015) */
           && (option_flags & SCANNER_CREATE_VARS_IS_EVAL))
       {
         func_init_opcode = CBC_CREATE_VAR_FUNC_EVAL;

--- a/tests/jerry/es2015/let11.js
+++ b/tests/jerry/es2015/let11.js
@@ -1,0 +1,18 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let b = 5;
+eval('function b() { return 8; }; assert(b() === 8);');
+assert(b === 5);


### PR DESCRIPTION
Fixes #3286.

Note: I don't want to add the original test case because it prints newlines to the screen. Also my test has assertions as well.