### PR TITLE
Added missing logical operator in js-parser-expr

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -2135,7 +2135,7 @@ parser_parse_expression (parser_context_t *context_p, /**< context */
    *
    * If this is not done, it is possible to carry the flag over to the next expression.
    */
-  bool has_super_ref = (context_p->status_flags & PARSER_CLASS_SUPER_PROP_REFERENCE);
+  bool has_super_ref = (context_p->status_flags & PARSER_CLASS_SUPER_PROP_REFERENCE) != 0;
   context_p->status_flags &= (uint32_t) ~PARSER_CLASS_SUPER_PROP_REFERENCE;
 #endif
 


### PR DESCRIPTION
This fix is needed to build JerryScript 2.1 on a STM board. When building for STM board, the compiler reports a warning (conversion warning) by doing a bool check this can be resolved.

JerryScript-DCO-1.0-Signed-off-by: bence gabor kis kisbg@inf.u-szeged.hu

