### PR TITLE
Fix ecma_op_get_value_lex_env_base for let/const declarations

### DIFF
--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -61,7 +61,17 @@ ecma_op_get_value_lex_env_base (ecma_object_t *lex_env_p, /**< lexical environme
         if (property_p != NULL)
         {
           *ref_base_lex_env_p = lex_env_p;
-          return ecma_copy_value (ECMA_PROPERTY_VALUE_PTR (property_p)->value);
+          ecma_property_value_t *property_value_p = ECMA_PROPERTY_VALUE_PTR (property_p);
+
+#if ENABLED (JERRY_ES2015)
+          if (JERRY_UNLIKELY (property_value_p->value == ECMA_VALUE_UNINITIALIZED))
+          {
+            return ecma_raise_reference_error (ECMA_ERR_MSG ("Variables declared by let/const must be"
+                                                             " initialized before reading their value."));
+          }
+#endif /* ENABLED (JERRY_ES2015) */
+
+          return ecma_fast_copy_value (property_value_p->value);
         }
         break;
       }

--- a/tests/jerry/es2015/regression-test-issue-3306.js
+++ b/tests/jerry/es2015/regression-test-issue-3306.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  typeof(a);
+  let a;
+  assert (false);
+} catch (e) {
+  assert (e instanceof ReferenceError);
+}


### PR DESCRIPTION
This patch fixes #3306.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
