### PR TITLE
Don't upload artifacts to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,3 @@ build:
   project: build\Jerry.sln
   parallel: true
   verbosity: minimal
-
-artifacts:
-  - path: build\bin\$(configuration)\
-    name: JerryScriptBinary


### PR DESCRIPTION
Uploaded JerryScript binaries aren't useful in practice
but this step regularly fails with an error message:
"Error uploading artifact the storage: Unable to connect to the remote server"

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
