### PR TITLE
Fix the usage of escaped identifiers in scanner_scope_find_let_declaration

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -1009,6 +1009,8 @@ scanner_scope_find_let_declaration (parser_context_t *context_p, /**< context */
   {
     uint8_t *destination_p = (uint8_t *) scanner_malloc (context_p, literal_p->length);
 
+    lexer_convert_ident_to_utf8 (literal_p->char_p, destination_p, literal_p->length);
+
     name_p = ecma_new_ecma_string_from_utf8 (destination_p, literal_p->length);
     scanner_free (destination_p, literal_p->length);
   }

--- a/tests/jerry/regression-test-issue-3313.js
+++ b/tests/jerry/regression-test-issue-3313.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval("var" + "\u2029" + 'g\\u0065t: break get' );
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #3313.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
