### PR TITLE
Make run-test-suite.py work with python3 too

### DIFF
--- a/tools/runners/run-test-suite.py
+++ b/tools/runners/run-test-suite.py
@@ -70,7 +70,7 @@ def get_tests(test_dir, test_list, skip_list):
                 return False
         return True
 
-    return filter(filter_tests, tests)
+    return [test for test in tests if filter_tests(test)]
 
 
 def get_platform_cmd_prefix():
@@ -80,7 +80,11 @@ def get_platform_cmd_prefix():
 
 
 def execute_test_command(test_cmd):
-    process = subprocess.Popen(test_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+    kwargs = {}
+    if sys.version_info.major >= 3:
+        kwargs['encoding'] = 'unicode_escape'
+        kwargs['text'] = True
+    process = subprocess.Popen(test_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
     stdout = process.communicate()[0]
     return (process.returncode, stdout)
 


### PR DESCRIPTION
Changes:
- Use list comprehension instead of filter in get_tests
to ensure returning list instead of iterable object
- Fix unicode decoding issues with Popen call

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
