### PR TITLE
Fix fast array array hole initialization

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -86,6 +86,7 @@ ecma_op_new_array_object (ecma_length_t length) /**< length of the new array */
 
   ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) object_p;
   ext_obj_p->u.array.length = length;
+  ext_obj_p->u.array.u.hole_count = 0;
   ext_obj_p->u.array.u.length_prop = ECMA_PROPERTY_FLAG_WRITABLE | ECMA_PROPERTY_TYPE_VIRTUAL;
 
   return object_p;


### PR DESCRIPTION
This patch eliminates the valgrind error: "Conditional jump or move depends on uninitialised value(s)".

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

