### PR TITLE
Properly handle primitive arguments in Object methods

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.h
@@ -15,7 +15,7 @@
 #ifndef ECMA_BUILTIN_OBJECT_H
 #define ECMA_BUILTIN_OBJECT_H
 
-ecma_value_t ecma_builtin_object_object_get_prototype_of (ecma_value_t arg);
+ecma_value_t ecma_builtin_object_object_get_prototype_of (ecma_object_t *obj_p);
 
 ecma_value_t ecma_builtin_object_object_set_prototype_of (ecma_value_t arg1,
                                                           ecma_value_t arg2);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
@@ -87,7 +87,7 @@ ecma_builtin_reflect_dispatch_routine (uint16_t builtin_routine_id, /**< built-i
   {
     case ECMA_REFLECT_OBJECT_GET_PROTOTYPE_OF_UL:
     {
-      return ecma_builtin_object_object_get_prototype_of (arguments_list[0]);
+      return ecma_builtin_object_object_get_prototype_of (ecma_get_object_from_value (arguments_list[0]));
     }
     case ECMA_REFLECT_OBJECT_SET_PROTOTYPE_OF_UL:
     {

--- a/tests/jerry/es2015/object-get-own-property-symbols.js
+++ b/tests/jerry/es2015/object-get-own-property-symbols.js
@@ -109,11 +109,3 @@ assert (props.indexOf(foo2) !== -1);
 assert (props.length === 2);
 assert (Object.getOwnPropertyDescriptor (object, foo).enumerable === true);
 assert (Object.getOwnPropertyDescriptor (object, foo2).enumerable === false);
-
-// Test non-object argument
-try {
-  Object.getOwnPropertySymbols ('hello');
-  assert (false);
-} catch (e) {
-  assert (e instanceof TypeError);
-}

--- a/tests/jerry/es2015/object-methods.js
+++ b/tests/jerry/es2015/object-methods.js
@@ -1,0 +1,48 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert (JSON.stringify (Object.getOwnPropertyNames("hello")) === '["0","1","2","3","4","length"]');
+
+var n = Object.assign(42, {a: "str"});
+assert (n instanceof Number);
+assert (n.valueOf() === 42);
+assert (n.a === "str");
+
+assert (JSON.stringify (Object.getOwnPropertySymbols("hello")) === '[]');
+
+assert (JSON.stringify (Object.keys("str")) === '["0","1","2"]');
+
+var d = Object.getOwnPropertyDescriptor("hello", '1');
+assert (d.value === "e");
+assert (d.writable === false);
+assert (d.enumerable === true);
+assert (d.configurable === false);
+
+assert (Object.seal(42) === 42);
+assert (Object.seal(undefined) === undefined);
+
+assert (Object.isSealed(42) === true);
+assert (Object.isSealed(undefined) === true);
+
+assert (Object.freeze(42) === 42);
+assert (Object.freeze(undefined) === undefined);
+
+assert (Object.isFrozen(42) === true);
+assert (Object.isFrozen(undefined) === true);
+
+assert (Object.preventExtensions(42) === 42);
+assert (Object.preventExtensions(undefined) === undefined);
+
+assert (Object.isExtensible(42) === false);
+assert (Object.isExtensible(undefined) === false);

--- a/tests/jerry/es5.1/object-methods.js
+++ b/tests/jerry/es5.1/object-methods.js
@@ -1,0 +1,89 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  Object.getOwnPropertyNames("hello");
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try
+{
+  Object.preventExtensions(42);
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try
+{
+  Object.isExtensible(42);
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try
+{
+  Object.seal(42);
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try
+{
+  Object.isSealed(42);
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try
+{
+  Object.freeze(42);
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try
+{
+  Object.isFrozen(42);
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try {
+  Object.keys("hello");
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try {
+  Object.getOwnPropertyNames("hello");
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try {
+  Object.getOwnPropertyDescriptor("hello", '1');
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}

--- a/tests/jerry/object-defineproperty.js
+++ b/tests/jerry/object-defineproperty.js
@@ -68,3 +68,12 @@ try {
 } catch (err) {
   assert (err === 234);
 }
+
+try {
+  Object.defineProperty(42, "prop", {
+      set: undefined
+  });
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}

--- a/tests/jerry/object-get-own-property-names.js
+++ b/tests/jerry/object-get-own-property-names.js
@@ -62,11 +62,3 @@ assert (props.indexOf("prop") !== -1);
 assert (props.indexOf("method") !== -1);
 
 assert (props.length === 2);
-
-// Test non-object argument
-try {
-  Object.getOwnPropertyNames("hello");
-  assert (false);
-} catch (e) {
-  assert (e instanceof TypeError);
-}

--- a/tests/jerry/object-is-extensible.js
+++ b/tests/jerry/object-is-extensible.js
@@ -20,23 +20,6 @@ assert (Object.isExtensible(empty) === true);
 Object.preventExtensions(empty);
 assert(Object.isExtensible(empty) === false);
 
-// Call on undefined should throw TypeError.
-try
-{
-    Object.isExtensible(undefined);
-    assert (false);
-} catch (e) {
-    assert (e instanceof TypeError);
-}
-
-try
-{
-    Object.preventExtensions(undefined);
-    assert (false);
-} catch (e) {
-    assert (e instanceof TypeError);
-}
-
 // Sealed objects are by definition non-extensible.
 var sealed = Object.seal({});
 assert (Object.isExtensible(sealed) === false);

--- a/tests/jerry/object-keys.js
+++ b/tests/jerry/object-keys.js
@@ -61,14 +61,6 @@ assert (props.indexOf("prop") !== -1);
 assert (props.indexOf("method") !== -1);
 assert (props.length === 2);
 
-// Test non-object argument
-try {
-  Object.keys("hello");
-  assert (false);
-} catch (e) {
-  assert (e instanceof TypeError);
-}
-
 var o = {};
 
 Object.defineProperty(o, 'a', {


### PR DESCRIPTION
ES2015 allows primitive arguments for most of the Object built-ins.
This change implements handling for these arguments in affected methods.