### PR TITLE
Improve the performance of the interpreter.

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -851,7 +851,6 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       ecma_value_t ret_value = vm_run (bytecode_data_p,
                                        this_binding,
                                        local_env_p,
-                                       ECMA_PARSE_NO_OPTS,
                                        arguments_list_p,
                                        arguments_list_len);
 
@@ -914,7 +913,6 @@ ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
       ecma_value_t ret_value = vm_run (bytecode_data_p,
                                        arrow_func_p->this_binding,
                                        local_env_p,
-                                       ECMA_PARSE_NO_OPTS,
                                        arguments_list_p,
                                        arguments_list_len);
 

--- a/jerry-core/vm/vm-defines.h
+++ b/jerry-core/vm/vm-defines.h
@@ -43,13 +43,10 @@ typedef struct vm_frame_ctx_t
   const ecma_compiled_code_t *bytecode_header_p;      /**< currently executed byte-code data */
   uint8_t *byte_code_p;                               /**< current byte code pointer */
   uint8_t *byte_code_start_p;                         /**< byte code start pointer */
-  ecma_value_t *registers_p;                          /**< register start pointer */
   ecma_value_t *stack_top_p;                          /**< stack top pointer */
   ecma_value_t *literal_start_p;                      /**< literal list start pointer */
   ecma_object_t *lex_env_p;                           /**< current lexical environment */
-#if defined (JERRY_DEBUGGER) || ENABLED (JERRY_LINE_INFO)
   struct vm_frame_ctx_t *prev_context_p;              /**< previous context */
-#endif /* defined (JERRY_DEBUGGER) || ENABLED (JERRY_LINE_INFO) */
   ecma_value_t this_binding;                          /**< this binding */
   ecma_value_t block_result;                          /**< block result */
 #if ENABLED (JERRY_LINE_INFO) || ENABLED (JERRY_ES2015_MODULE_SYSTEM)
@@ -61,7 +58,18 @@ typedef struct vm_frame_ctx_t
   uint16_t context_depth;                             /**< current context depth */
   uint8_t is_eval_code;                               /**< eval mode flag */
   uint8_t call_operation;                             /**< perform a call or construct operation */
+  /* Registers start immediately after the frame context. */
 } vm_frame_ctx_t;
+
+/**
+ * Get register list corresponding to the frame context.
+ */
+#define VM_GET_REGISTERS(frame_ctx_p) ((ecma_value_t *) (frame_ctx_p + 1))
+
+/**
+ * Read or write a specific register.
+ */
+#define VM_GET_REGISTER(frame_ctx_p, i) (((ecma_value_t *) (frame_ctx_p + 1))[i])
 
 /**
  * @}

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -399,8 +399,7 @@ ecma_value_t vm_run_module (const ecma_compiled_code_t *bytecode_p, ecma_object_
 #endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
 
 ecma_value_t vm_run (const ecma_compiled_code_t *bytecode_header_p, ecma_value_t this_binding_value,
-                     ecma_object_t *lex_env_p, uint32_t parse_opts, const ecma_value_t *arg_list_p,
-                     ecma_length_t arg_list_len);
+                     ecma_object_t *lex_env_p, const ecma_value_t *arg_list_p, ecma_length_t arg_list_len);
 
 bool vm_is_strict_mode (void);
 bool vm_is_direct_eval_form_call (void);


### PR DESCRIPTION
Registers are stored immediately after the frame pointer and an argument is dropped from vm_run.

Benchmark | Stack (bytes) | Perf (sec) |
----: | ----: | ----: | 
3d-cube.js | 14128 -> 12808 : **+9.343%** | 0.740 -> 0.733 : +0.969% | 
3d-morph.js | 1432 -> 1432 : 0.000% | 0.743 -> 0.733 : **+1.404%** | 
3d-raytrace.js | 2664 -> 2472 : **+7.207%** | 0.873 -> 0.872 : +0.179% | 
access-binary-trees.js | 3304 -> 3040 : **+7.990%** | 0.459 -> 0.457 : +0.540% | 
access-fannkuch.js | 1504 -> 1504 : 0.000% | 1.824 -> 1.746 : **+4.284%** | 
access-nbody.js | 1504 -> 1504 : 0.000% | 1.010 -> 0.995 : **+1.463%** | 
bitops-3bit-bits-in-byte.js | 1464 -> 1464 : 0.000% | 0.475 -> 0.481 : -1.271% | 
bitops-bits-in-byte.js | 1464 -> 1464 : 0.000% | 0.649 -> 0.646 : +0.439% | 
bitops-bitwise-and.js | 1328 -> 1328 : 0.000% | 0.802 -> 0.803 : -0.030% | 
bitops-nsieve-bits.js | 1464 -> 1464 : 0.000% | 1.034 -> 1.013 : **+1.973%** | 
controlflow-recursive.js | 63624 -> 57480 : **+9.657%** | 0.316 -> 0.323 : -2.296% | 
crypto-aes.js | 2036 -> 1940 : **+4.715%** | 0.637 -> 0.621 : **+2.527%** | 
crypto-md5.js | 1752 -> 1608 : **+8.219%** | 0.501 -> 0.500 : +0.187% | 
crypto-sha1.js | 1544 -> 1544 : 0.000% | 0.517 -> 0.516 : +0.163% | 
date-format-tofte.js | 1968 -> 1872 : **+4.878%** | 0.661 -> 0.659 : +0.345% | 
date-format-xparb.js | 2368 -> 2296 : **+3.041%** | 0.489 -> 0.490 : -0.175% | 
math-cordic.js | 1464 -> 1464 : 0.000% | 1.099 -> 1.090 : +0.743% | 
math-partial-sums.js | 1424 -> 1424 : 0.000% | 0.664 -> 0.646 : **+2.725%** | 
math-spectral-norm.js | 1464 -> 1464 : 0.000% | 0.472 -> 0.467 : **+1.076%** | 
string-base64.js | 1480 -> 1480 : 0.000% | 0.909 -> 0.910 : -0.158% | 
string-fasta.js | 1448 -> 1448 : 0.000% | 1.066 -> 1.059 : +0.646% | 
Geometric mean: | +2.690% | +0.759% | 

Binary (bytes) | master(996bf76f59) | patch(6fc33aed8c) | Diff |
----: | ----: | ----: | ----: |
size | 132620 | 132620 | 0 bytes |
.rodata | 11866 | 11866 | 0 bytes |
.dynstr | 212 | 212 | 0 bytes |
.rel.plt | 160 | 160 | 0 bytes |
.interp | 25 | 25 | 0 bytes |
.dynsym | 416 | 416 | 0 bytes |
.gnu.hash | 212 | 212 | 0 bytes |
.text | 115208 | 115216 | +8 bytes |
.comment | 85 | 85 | 0 bytes |
.shstrtab | 226 | 226 | 0 bytes |
.data | 8 | 8 | 0 bytes |
.ARM.exidx | 8 | 8 | 0 bytes |
.rel.dyn | 16 | 16 | 0 bytes |
.init | 12 | 12 | 0 bytes |
.got | 96 | 96 | 0 bytes |
.plt | 268 | 268 | 0 bytes |
.note.ABI-tag | 32 | 32 | 0 bytes |
.gnu.version_r | 32 | 32 | 0 bytes |
.bss | 1575096 | 1575096 | 0 bytes |
.fini | 8 | 8 | 0 bytes |
.hash | 180 | 180 | 0 bytes |
.gnu.version | 52 | 52 | 0 bytes |
.fini_array | 4 | 4 | 0 bytes |
.init_array | 4 | 4 | 0 bytes |
.dynamic | 240 | 240 | 0 bytes |
.eh_frame | 4 | 4 | 0 bytes |
.ARM.attributes | 53 | 53 | 0 bytes |

Nice stack improvement, small performance, no memory change. Code is increased by 8 bytes.

This change should be needed for generators.