### PR TITLE
Fix the es2015-subset profile build on Windows

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -384,7 +384,7 @@ opfunc_append_to_spread_array (ecma_value_t *stack_top_p, /**< current stack top
  * @return NULL - if the operation failed
  *         pointer to the ecma-collection with the spreaded arguments, otherwise
  */
-ecma_collection_t * JERRY_ATTR_NOINLINE
+JERRY_ATTR_NOINLINE ecma_collection_t *
 opfunc_spread_arguments (ecma_value_t **stack_top_p, /**< [out] pointer to the current stack top */
                          uint8_t arguments_list_len) /**< number of arguments */
 {


### PR DESCRIPTION
JERRY_ATTR_NOINLINE define is __declspec(noinline) which should be placed
at the beginning of the declaration and caused build fail because it was
placed after the * character. Details can be found here:
https://docs.microsoft.com/en-us/cpp/cpp/declspec?view=vs-2019

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
