### PR TITLE
Fix Reflect.getPrototypeOf for primitive arguments

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
@@ -77,8 +77,7 @@ ecma_builtin_reflect_dispatch_routine (uint16_t builtin_routine_id, /**< built-i
   JERRY_UNUSED (this_arg);
   JERRY_UNUSED (arguments_number);
 
-  if (!ecma_is_value_object (arguments_list[0])
-      && builtin_routine_id > ECMA_REFLECT_OBJECT_SET_PROTOTYPE_OF_UL)
+  if (!ecma_is_value_object (arguments_list[0]))
   {
     return ecma_raise_type_error (ECMA_ERR_MSG ("Argument is not an Object."));
   }

--- a/tests/jerry/es2015/reflect-getPrototypeOf.js
+++ b/tests/jerry/es2015/reflect-getPrototypeOf.js
@@ -15,3 +15,17 @@
 assert (Reflect['getPrototypeOf']({}) === Object.prototype);
 assert (Reflect['getPrototypeOf'](Object.create(null)) === null);
 assert (Reflect['getPrototypeOf'](Object.prototype) === null);
+
+try {
+  Reflect.getPrototypeOf();
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try {
+  Reflect.getPrototypeOf("str");
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
Fixes #3349.
