### PR TITLE
Fix the assertion for VM_OC_EVAL.

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2397,7 +2397,10 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         case VM_OC_EVAL:
         {
           JERRY_CONTEXT (status_flags) |= ECMA_STATUS_DIRECT_EVAL;
-          JERRY_ASSERT (*byte_code_p >= CBC_CALL && *byte_code_p <= CBC_CALL2_PROP_BLOCK);
+          JERRY_ASSERT ((*byte_code_p >= CBC_CALL && *byte_code_p <= CBC_CALL2_PROP_BLOCK)
+                        || (*byte_code_p == CBC_EXT_OPCODE
+                            && byte_code_p[1] >= CBC_EXT_SPREAD_CALL
+                            && byte_code_p[1] <= CBC_EXT_SPREAD_CALL_PROP_BLOCK));
           continue;
         }
         case VM_OC_CALL:

--- a/tests/jerry/es2015/regression-test-issue-3364.js
+++ b/tests/jerry/es2015/regression-test-issue-3364.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert(eval(...[0]) === 0);


### PR DESCRIPTION
Eval flag can be set for spreaded argument function calls as well.

This patch fixes #3364.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
