### PR TITLE
Rework register reference in the vm.

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2100,7 +2100,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           if (literal_index < register_end)
           {
             *stack_top_p++ = ECMA_VALUE_REGISTER_REF;
-            *stack_top_p++ = literal_index;
+            *stack_top_p++ = ecma_make_integer_value (literal_index);
             *stack_top_p++ = ecma_fast_copy_value (VM_GET_REGISTER (frame_ctx_p, literal_index));
           }
           else
@@ -3754,6 +3754,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
         if (object == ECMA_VALUE_REGISTER_REF)
         {
+          property = (ecma_value_t) ecma_get_integer_from_value (property);
           ecma_fast_free_value (VM_GET_REGISTER (frame_ctx_p, property));
           VM_GET_REGISTER (frame_ctx_p, property) = result;
 
@@ -3807,24 +3808,13 @@ error:
 
     if (ECMA_IS_VALUE_ERROR (result))
     {
-      ecma_value_t *vm_stack_p = stack_top_p;
+      ecma_value_t *stack_bottom_p = VM_GET_REGISTERS (frame_ctx_p) + register_end + frame_ctx_p->context_depth;
 
-      for (vm_stack_p = VM_GET_REGISTERS (frame_ctx_p) + register_end + frame_ctx_p->context_depth;
-           vm_stack_p < stack_top_p;
-           vm_stack_p++)
+      while (stack_top_p > stack_bottom_p)
       {
-        if (*vm_stack_p == ECMA_VALUE_REGISTER_REF)
-        {
-          JERRY_ASSERT (vm_stack_p < stack_top_p);
-          vm_stack_p++;
-        }
-        else
-        {
-          ecma_free_value (*vm_stack_p);
-        }
+        ecma_fast_free_value (*(--stack_top_p));
       }
 
-      stack_top_p = VM_GET_REGISTERS (frame_ctx_p) + register_end + frame_ctx_p->context_depth;
 #if ENABLED (JERRY_DEBUGGER)
       const uint32_t dont_stop = (JERRY_DEBUGGER_VM_IGNORE_EXCEPTION
                                   | JERRY_DEBUGGER_VM_IGNORE


### PR DESCRIPTION
The aim is storing only ecma values on the vm stack.

Benchmark | Perf (sec) |
----: | ----: | 
3d-cube.js | 0.733 -> 0.722 : **+1.511%** | 
3d-morph.js | 0.709 -> 0.699 : **+1.385%** | 
3d-raytrace.js | 0.867 -> 0.860 : +0.750% | 
access-binary-trees.js | 0.449 -> 0.446 : +0.660% | 
access-fannkuch.js | 1.741 -> 1.718 : **+1.326%** | 
access-nbody.js | 0.983 -> 0.977 : +0.622% | 
bitops-3bit-bits-in-byte.js | 0.480 -> 0.472 : **+1.684%** | 
bitops-bits-in-byte.js | 0.647 -> 0.638 : **+1.478%** | 
bitops-bitwise-and.js | 0.810 -> 0.804 : +0.759% | 
bitops-nsieve-bits.js | 1.008 -> 0.990 : **+1.744%** | 
controlflow-recursive.js | 0.326 -> 0.316 : **+2.938%** | 
crypto-aes.js | 0.617 -> 0.611 : +0.959% | 
crypto-md5.js | 0.498 -> 0.493 : +0.881% | 
crypto-sha1.js | 0.514 -> 0.510 : +0.827% | 
date-format-tofte.js | 0.655 -> 0.654 : +0.154% | 
date-format-xparb.js | 0.484 -> 0.480 : +0.907% | 
math-cordic.js | 1.095 -> 1.081 : **+1.277%** | 
math-partial-sums.js | 0.623 -> 0.614 : **+1.329%** | 
math-spectral-norm.js | 0.465 -> 0.460 : **+1.002%** | 
string-base64.js | 0.897 -> 0.883 : **+1.549%** | 
string-fasta.js | 1.052 -> 1.048 : +0.352% | 
Geometric mean: | +1.149% | 

Binary (bytes) | master(aeb8431aff) | patch(06e42c1ad7) | Diff |
----: | ----: | ----: | ----: |
size | 132620 | 132620 | 0 bytes |
.rodata | 11754 | 11754 | 0 bytes |
.dynstr | 212 | 212 | 0 bytes |
.rel.plt | 160 | 160 | 0 bytes |
.interp | 25 | 25 | 0 bytes |
.dynsym | 416 | 416 | 0 bytes |
.gnu.hash | 212 | 212 | 0 bytes |
.text | 116112 | 116096 | -16 bytes |
.comment | 85 | 85 | 0 bytes |
.shstrtab | 226 | 226 | 0 bytes |
.data | 8 | 8 | 0 bytes |
.ARM.exidx | 8 | 8 | 0 bytes |
.rel.dyn | 16 | 16 | 0 bytes |
.init | 12 | 12 | 0 bytes |
.got | 96 | 96 | 0 bytes |
.plt | 268 | 268 | 0 bytes |
.note.ABI-tag | 32 | 32 | 0 bytes |
.gnu.version_r | 32 | 32 | 0 bytes |
.bss | 1575096 | 1575096 | 0 bytes |
.fini | 8 | 8 | 0 bytes |
.hash | 180 | 180 | 0 bytes |
.gnu.version | 52 | 52 | 0 bytes |
.fini_array | 4 | 4 | 0 bytes |
.init_array | 4 | 4 | 0 bytes |
.dynamic | 240 | 240 | 0 bytes |
.eh_frame | 4 | 4 | 0 bytes |
.ARM.attributes | 53 | 53 | 0 bytes |
