### PR TITLE
Fix the handling of unresolvable reference in VM_OC_TYPEOF_IDENT

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2606,6 +2606,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             if (ref_base_lex_env_p == NULL)
             {
               ecma_free_value (JERRY_CONTEXT (error_value));
+              JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_EXCEPTION;
               result = ECMA_VALUE_UNDEFINED;
             }
             else if (ECMA_IS_VALUE_ERROR (result))

--- a/tests/jerry/es2015/regression-test-issue-3363.js
+++ b/tests/jerry/es2015/regression-test-issue-3363.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert (typeof x === 'undefined');
+let { t: [ { a: b } ] } = { t: [ { a: 'a' } ] };
+assert (b === 'a');


### PR DESCRIPTION
This patch fixes #3363.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
