### PR TITLE
Allow to create ArrayBuffer with empty external user data

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3707,7 +3707,7 @@ jerry_create_arraybuffer_external (const jerry_length_t size
 - `free_cb` - the callback function called when the object is released
 - return value
   - the new ArrayBuffer as a `jerry_value_t`
-  - if the `size` is zero or `buffer_p` is a null pointer will return RangeError
+  - if the `size` is zero or `buffer_p` is a null pointer this will return an empty ArrayBuffer.
 
 *New in version 2.0*.
 

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -3446,7 +3446,7 @@ jerry_create_arraybuffer (const jerry_length_t size) /**< size of the ArrayBuffe
  *     * the size is specified in bytes.
  *     * the buffer passed should be at least the specified bytes big.
  *     * if the typed arrays are disabled this will return a TypeError.
- *     * if the size is zero or the buffer_p is a null pointer this will return a RangeError.
+ *     * if the size is zero or buffer_p is a null pointer this will return an empty ArrayBuffer.
  *
  * @return value of the construced ArrayBuffer object
  */
@@ -3458,14 +3458,19 @@ jerry_create_arraybuffer_external (const jerry_length_t size, /**< size of the b
   jerry_assert_api_available ();
 
 #if ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY)
-  if (size == 0 || buffer_p == NULL)
+  ecma_object_t *arraybuffer;
+
+  if (JERRY_UNLIKELY (size == 0 || buffer_p == NULL))
   {
-    return jerry_throw (ecma_raise_range_error (ECMA_ERR_MSG ("invalid buffer size or storage reference")));
+    arraybuffer = ecma_arraybuffer_new_object_external (0, NULL, (ecma_object_native_free_callback_t) free_cb);
+  }
+  else
+  {
+    arraybuffer = ecma_arraybuffer_new_object_external (size,
+                                                        buffer_p,
+                                                        (ecma_object_native_free_callback_t) free_cb);
   }
 
-  ecma_object_t *arraybuffer = ecma_arraybuffer_new_object_external (size,
-                                                                     buffer_p,
-                                                                     (ecma_object_native_free_callback_t) free_cb);
   return jerry_return (ecma_make_object_value (arraybuffer));
 #else /* !ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY) */
   JERRY_UNUSED (size);

--- a/tests/unit-core/test-arraybuffer.c
+++ b/tests/unit-core/test-arraybuffer.c
@@ -250,6 +250,23 @@ main (void)
     jerry_release_value (arraybuffer);
   }
 
+  /* Test zero length external ArrayBuffer */
+  {
+    const uint32_t length = 0;
+    jerry_value_t arraybuffer = jerry_create_arraybuffer_external (length, NULL, NULL);
+    TEST_ASSERT (!jerry_value_is_error (arraybuffer));
+    TEST_ASSERT (jerry_value_is_arraybuffer (arraybuffer));
+    TEST_ASSERT (jerry_get_arraybuffer_byte_length (arraybuffer) == length);
+
+    uint8_t data[20];
+    memset (data, 11, 20);
+
+    jerry_length_t bytes_written = jerry_arraybuffer_write (arraybuffer, 0, data, 20);
+    TEST_ASSERT (bytes_written == 0);
+
+    jerry_release_value (arraybuffer);
+  }
+
   /* Test ArrayBuffer with buffer allocated externally */
   {
     const uint32_t buffer_size = 15;
@@ -344,14 +361,6 @@ main (void)
     jerry_release_value (res);
 
     jerry_release_value (buffer);
-  }
-
-  /* Test ArrayBuffer external with invalid arguments */
-  {
-    jerry_value_t input_buffer = jerry_create_arraybuffer_external (0, NULL, NULL);
-    TEST_ASSERT (jerry_value_is_error (input_buffer));
-    TEST_ASSERT (jerry_get_error_type (input_buffer) == JERRY_ERROR_RANGE);
-    jerry_release_value (input_buffer);
   }
 
   /* Test ArrayBuffer detach */


### PR DESCRIPTION
This patch helps to unify the behavior of `jerry_create_arraybuffer(0)` and `jerry_create_arraybuffer_external(0, NULL, NULL)`. The latter one is useful on systems where the ArrayBuffer creation is based on network communication. For example, if there is no received data (empty external user data), an empty ArrayBuffer could be created.