### PR TITLE
Make REPL option parser handle "-" option properly

### DIFF
--- a/jerry-main/cli.c
+++ b/jerry-main/cli.c
@@ -112,7 +112,7 @@ cli_consume_option (cli_state_t *state_p) /**< state of the command line option 
 
   state_p->arg = arg;
 
-  if (arg[0] != '-')
+  if (arg[0] != '-' || (arg[0] == '-' && arg[1] == '\0'))
   {
     return CLI_OPT_DEFAULT;
   }

--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -366,7 +366,7 @@ static const cli_opt_t main_opts[] =
   CLI_OPT_DEF (.id = OPT_NO_PROMPT, .longopt = "no-prompt",
                .help = "don't print prompt in REPL mode"),
   CLI_OPT_DEF (.id = CLI_OPT_DEFAULT, .meta = "FILE",
-               .help = "input JS file(s)")
+               .help = "input JS file(s) (If file is -, read standard input.)")
 };
 
 /**


### PR DESCRIPTION
REPL could read JS file from standard input when we passed "-" option,
but #1809 missed to add this function to the new option parser.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
