### PR TITLE
Fix exception handling in ecma_op_create_promise_object

### DIFF
--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -551,6 +551,7 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
   {
     /* 10.a. */
     completion = JERRY_CONTEXT (error_value);
+    JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_EXCEPTION;
     status = ecma_op_function_call (ecma_get_object_from_value (funcs->reject),
                                     ECMA_VALUE_UNDEFINED,
                                     &completion,

--- a/tests/jerry/es2015/regression-test-issue-3376.js
+++ b/tests/jerry/es2015/regression-test-issue-3376.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+(function () {
+  new Promise(isFinite.toString)
+})();
+
+(function () {
+  [ ] = [ ]
+})
+({})


### PR DESCRIPTION
This patch fixes #3376.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
