### PR TITLE
Allow lexical function declaration in labeled statements.

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -632,7 +632,8 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
 #if ENABLED (JERRY_ES2015)
   if ((parser_statement_flags[context_p->stack_top_uint8] & PARSER_STATM_SINGLE_STATM)
       && !(context_p->stack_top_uint8 == PARSER_STATEMENT_IF
-           || context_p->stack_top_uint8 == PARSER_STATEMENT_ELSE))
+           || context_p->stack_top_uint8 == PARSER_STATEMENT_ELSE
+           || context_p->stack_top_uint8 == PARSER_STATEMENT_LABEL))
   {
     parser_raise_error (context_p, PARSER_ERR_LEXICAL_SINGLE_STATEMENT);
   }

--- a/tests/jerry/es2015/regression-test-issue-3381.js
+++ b/tests/jerry/es2015/regression-test-issue-3381.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+a: function f() {return true;}
+
+assert (f() === true);


### PR DESCRIPTION
This patch fixes #3381.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

