### PR TITLE
Remove dead code from ecma_date_parse_year()

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -133,10 +133,6 @@ ecma_date_parse_year (const lit_utf8_byte_t **str_p, /**< pointer to the cesu8 s
     return parsed_year;
   }
 
-  if (is_year_sign_negative)
-  {
-    str_p--; /* Parse failed, revert already parsed '-' sign. */
-  }
   return ecma_number_make_nan ();
 } /* ecma_date_parse_year */
 


### PR DESCRIPTION
Code cleanup after #3314. Reverting already parsed '-' sign
after parse fail is unnecessary, because in this case the whole
date parse is failed.

Additionally this dead code was incorrect too, because it didn't
modify the original pointer to the string, but a local variable.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
