### PR TITLE
Fix leaking char buffer in RegExp.prototype[@@replace]

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -2220,11 +2220,12 @@ ecma_regexp_replace_helper (ecma_value_t this_arg, /**< this argument */
                                  (lit_utf8_size_t) (string_end_p - source_position_p));
 
   result = ecma_make_string_value (ecma_stringbuilder_finalize (&replace_ctx.builder));
-  goto cleanup_results;
+  goto cleanup_chars;
 
 cleanup_builder:
   ecma_stringbuilder_destroy (&replace_ctx.builder);
 
+cleanup_chars:
   if (string_flags & ECMA_STRING_FLAG_MUST_BE_FREED)
   {
     jmem_heap_free_block ((void *) replace_ctx.string_p, replace_ctx.string_size);

--- a/tests/jerry/es2015/symbol-replace.js
+++ b/tests/jerry/es2015/symbol-replace.js
@@ -660,3 +660,11 @@ try {
 } catch (e) {
   assert (e === "abrupt @@replace")
 }
+
+class Regexplike2 {
+    exec() {
+        return {}
+    }
+}
+re = new Regexplike2();
+assert (replace.call (re, "1") === "undefined");


### PR DESCRIPTION
Fixes #3392.