### PR TITLE
heap-buffer-overflow in ecma_date_parse_year

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -112,13 +112,8 @@ ecma_date_parse_year (const lit_utf8_byte_t **str_p, /**< pointer to the cesu8 s
   const lit_utf8_byte_t *str_start_p = *str_p;
   int32_t parsed_year = 0;
 
-  while (str_start_p - *str_p <= 6)
+  while ((str_start_p - *str_p < 6) && (str_start_p < str_end_p) && lit_char_is_decimal_digit (*str_start_p))
   {
-    if (*str_p >= str_end_p || !lit_char_is_decimal_digit (*str_start_p))
-    {
-      break;
-    }
-
     parsed_year = 10 * parsed_year + *str_start_p - LIT_CHAR_0;
     str_start_p++;
   }

--- a/tests/jerry/date-parse.js
+++ b/tests/jerry/date-parse.js
@@ -70,7 +70,8 @@ var wrongFormats = ["",
                     "Fri Jan 01 -1 00:00:00 GMT+0000",
                     "Fri Jan 01 -11 00:00:00 GMT+0000",
                     "Fri Jan 01 -111 00:00:00 GMT+0000",
-                    "Fri Jan 01 -1234567 00:00:00 GMT+0000"];
+                    "Fri Jan 01 -1234567 00:00:00 GMT+0000",
+                    "Thu Apr 10 1997"];
 
 for (i in wrongFormats) {
   var d = Date.parse(wrongFormats[i]);


### PR DESCRIPTION
If ecma_date_parse_year got an invalid date string, it could overread the input string.
The problem was that we compared the original str_p to str_end_p instead of str_start_p.
Additionally I simplified the parser loop.

Fixes #3388.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
