### PR TITLE
Fix the global error management on promise operations

### DIFF
--- a/jerry-core/ecma/operations/ecma-jobqueue.c
+++ b/jerry-core/ecma/operations/ecma-jobqueue.c
@@ -180,6 +180,7 @@ ecma_process_promise_reaction_job (void *obj_p) /**< the job to be operated */
     if (ECMA_IS_VALUE_ERROR (handler_result))
     {
       handler_result = JERRY_CONTEXT (error_value);
+      JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_EXCEPTION;
     }
 
     /* 7. */
@@ -254,6 +255,7 @@ ecma_process_promise_resolve_thenable_job (void *obj_p) /**< the job to be opera
   if (ECMA_IS_VALUE_ERROR (then_call_result))
   {
     then_call_result = JERRY_CONTEXT (error_value);
+    JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_EXCEPTION;
 
     ret = ecma_op_function_call (ecma_get_object_from_value (funcs->reject),
                                  ECMA_VALUE_UNDEFINED,

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -331,6 +331,7 @@ ecma_promise_resolve_handler (const ecma_value_t function, /**< the function its
   {
     /* 9. */
     then = JERRY_CONTEXT (error_value);
+    JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_EXCEPTION;
     ecma_reject_promise (promise, then);
   }
   else if (!ecma_op_is_callable (then))

--- a/tests/jerry/es2015/regression-test-issue-3409.js
+++ b/tests/jerry/es2015/regression-test-issue-3409.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a;
+Promise.race([a]).then(function() {[] = []});
+Promise.race().then(function() {}, function() { throw "'this' had incorrect value!"})
+
+var a = Promise.resolve('a');
+var b = Promise.reject('b');
+Promise.race([a, b]).then(function(x) {
+    var [a, b] = [1, 2];
+}, function(x) {});
+Promise.race([b, a]).then(function(x) {}, function(x) {});
+Promise.race([, b, a]).then(function(x) {}, function(x) {});
+Promise.race(a).then(function(x) {}, function(x) {
+    String(i.name === "TypeError");
+});

--- a/tests/jerry/es2015/regression-test-issue-3411.js
+++ b/tests/jerry/es2015/regression-test-issue-3411.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a;
+Promise.race([a]).then(function() {[] = []});
+Promise.race().then(function() {}, function() { throw "'this' had incorrect value!"})


### PR DESCRIPTION
This patch fixes #3409 and fixes #3411.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
