### PR TITLE
Fix global error management in ecma_builtin_string_prototype_object_split

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -902,6 +902,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
       if (ECMA_IS_VALUE_ERROR (match_result))
       {
         match_result = JERRY_CONTEXT (error_value);
+        JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_EXCEPTION;
       }
 
       ecma_free_value (match_result);
@@ -991,6 +992,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_to_string_val, /**
         if (ECMA_IS_VALUE_ERROR (match_result))
         {
           ecma_free_value (JERRY_CONTEXT (error_value));
+          JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_EXCEPTION;
         }
       }
       else

--- a/tests/jerry/es2015/regresssion-test-issue-3395.js
+++ b/tests/jerry/es2015/regresssion-test-issue-3395.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+for (var [] of [[], []])
+    String.prototype.split(RegExp.prototype)


### PR DESCRIPTION
This patch fixes #3395.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
