### PR TITLE
Fix scanner_create_variables for empty destructuring patterns

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -1774,7 +1774,7 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
   }
   else
   {
-    JERRY_ASSERT (context_p->scope_stack_p != NULL);
+    JERRY_ASSERT (context_p->scope_stack_p != NULL || context_p->scope_stack_size == 0);
 
     scope_stack_p = context_p->scope_stack_p;
     scope_stack_end_p = scope_stack_p + context_p->scope_stack_size;

--- a/tests/jerry/es2015/regression-test-issue-3383.js
+++ b/tests/jerry/es2015/regression-test-issue-3383.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert (typeof Function('[]', 0) == "function");


### PR DESCRIPTION
This patch fixes #3383.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

