### PR TITLE
Add bounds check for copyWithin

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -2338,6 +2338,12 @@ ecma_builtin_array_prototype_object_copy_within (const ecma_value_t args[], /**<
     }
   }
 
+  if (target >= len || start >= end || end == 0)
+  {
+    ecma_ref_object (obj_p);
+    return ecma_make_object_value (obj_p);
+  }
+
   uint32_t count = JERRY_MIN (end - start, len - target);
 
   bool forward = true;

--- a/tests/jerry/es2015/regression-test-issue-3408.js
+++ b/tests/jerry/es2015/regression-test-issue-3408.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var array = [0, 0, obj, 0, 0];
+array.copyWithin(NaN, 67, 0);
+var obj


### PR DESCRIPTION
When certain inputs are given, we don't need to do anything in the operation,
beacuse it is unnecessary. Thats why we check these indeces.

Fixes #3408

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
