### PR TITLE
Keywords must not contain escape sequences.

### DIFF
--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -288,8 +288,7 @@ typedef struct
 typedef struct
 {
   uint8_t type;                              /**< token type */
-  uint8_t literal_is_reserved;               /**< future reserved keyword
-                                              *   (when char_literal.type is LEXER_IDENT_LITERAL) */
+  uint8_t ident_is_strict_keyword;           /**< identifier is strict reserved keyword */
   uint8_t extra_value;                       /**< helper value for different purposes */
   uint8_t flags;                             /**< flag bits for the current token */
   parser_line_counter_t line;                /**< token start line */

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -1054,7 +1054,7 @@ parser_parse_function_expression (parser_context_t *context_p, /**< context */
       }
 #endif /* ENABLED (JERRY_DEBUGGER) */
 
-      if (context_p->token.literal_is_reserved
+      if (context_p->token.ident_is_strict_keyword
           || context_p->lit_object.type != LEXER_LITERAL_OBJECT_ANY)
       {
         status_flags |= PARSER_HAS_NON_STRICT_ARG;

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -637,7 +637,7 @@ void lexer_parse_string (parser_context_t *context_p);
 void lexer_expect_identifier (parser_context_t *context_p, uint8_t literal_type);
 void lexer_scan_identifier (parser_context_t *context_p, uint32_t ident_opts);
 ecma_char_t lexer_hex_to_character (parser_context_t *context_p, const uint8_t *source_p, int length);
-void lexer_convert_ident_to_utf8 (const uint8_t *source_p, uint8_t *destination_p, prop_length_t length);
+void lexer_convert_ident_to_cesu8 (const uint8_t *source_p, uint8_t *destination_p, prop_length_t length);
 void lexer_expect_object_literal_id (parser_context_t *context_p, uint32_t ident_opts);
 void lexer_construct_literal_object (parser_context_t *context_p, const lexer_lit_location_t *literal_p,
                                      uint8_t literal_type);

--- a/jerry-core/parser/js/js-parser-module.c
+++ b/jerry-core/parser/js/js-parser-module.c
@@ -367,7 +367,7 @@ parser_module_parse_export_clause (parser_context_t *context_p) /**< parser cont
     /* 15.2.3.1 The referenced binding cannot be a reserved word. */
     if (context_p->token.type != LEXER_LITERAL
         || context_p->token.lit_location.type != LEXER_IDENT_LITERAL
-        || context_p->token.literal_is_reserved)
+        || context_p->token.ident_is_strict_keyword)
     {
       parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
     }

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -852,6 +852,10 @@ parser_error_to_string (parser_error_t error) /**< error code */
     {
       return "Character cannot be part of an identifier.";
     }
+    case PARSER_ERR_INVALID_KEYWORD:
+    {
+      return "Escape sequences are not allowed in keywords.";
+    }
     case PARSER_ERR_INVALID_NUMBER:
     {
       return "Invalid number.";

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1729,7 +1729,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
                                     &context_p->token.lit_location,
                                     LEXER_IDENT_LITERAL);
 
-    if (context_p->token.literal_is_reserved
+    if (context_p->token.ident_is_strict_keyword
         || context_p->lit_object.type != LEXER_LITERAL_OBJECT_ANY)
     {
       context_p->status_flags |= PARSER_HAS_NON_STRICT_ARG;

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -48,6 +48,7 @@ typedef enum
   PARSER_ERR_INVALID_UNICODE_ESCAPE_SEQUENCE,         /**< invalid unicode escape sequence */
   PARSER_ERR_INVALID_IDENTIFIER_START,                /**< character cannot be start of an identifier */
   PARSER_ERR_INVALID_IDENTIFIER_PART,                 /**< character cannot be part of an identifier */
+  PARSER_ERR_INVALID_KEYWORD,                         /**< escape sequences are not allowed in keywords */
 
   PARSER_ERR_INVALID_NUMBER,                          /**< invalid number literal */
   PARSER_ERR_MISSING_EXPONENT,                        /**< missing exponent */

--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -1147,7 +1147,7 @@ scanner_scope_find_let_declaration (parser_context_t *context_p, /**< context */
   {
     uint8_t *destination_p = (uint8_t *) scanner_malloc (context_p, literal_p->length);
 
-    lexer_convert_ident_to_utf8 (literal_p->char_p, destination_p, literal_p->length);
+    lexer_convert_ident_to_cesu8 (literal_p->char_p, destination_p, literal_p->length);
 
     name_p = ecma_new_ecma_string_from_utf8 (destination_p, literal_p->length);
     scanner_free (destination_p, literal_p->length);

--- a/tests/jerry/keyword.js
+++ b/tests/jerry/keyword.js
@@ -1,0 +1,47 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function check_syntax_error(code)
+{
+  try {
+    eval(code)
+    assert(false)
+  } catch (e) {
+    assert(e instanceof SyntaxError)
+  }
+}
+
+function check_strict_syntax_error(code)
+{
+  "use strict"
+
+  try {
+    eval(code)
+    assert(false)
+  } catch (e) {
+    assert(e instanceof SyntaxError)
+  }
+}
+
+check_syntax_error("d\\u006f {} while (false)")
+check_syntax_error("\\u0076\\u0061\\u0072 var = 5")
+check_syntax_error("wit\\u0068 ({}) {}")
+check_syntax_error("\\u0066alse")
+check_syntax_error("type\\006ff 3.14")
+check_syntax_error("try {} fin\\u0061lly {}")
+check_syntax_error("f\\u0075nction f() {}")
+check_syntax_error("a instanc\\u0065of b")
+
+check_strict_syntax_error("\\u006c\\u0065\\u0074 _let = 5");
+check_strict_syntax_error("\\u0070rotecte\\u0064");


### PR DESCRIPTION
The ES5.1 standard is unclear about this rule.