### PR TITLE
[DNM, WIP] targets: zephyr: Update for Zephyr 2.2

### DIFF
--- a/targets/zephyr/src/getline-zephyr.c
+++ b/targets/zephyr/src/getline-zephyr.c
@@ -14,7 +14,7 @@
  */
 
 #include <zephyr.h>
-#include <uart.h>
+#include <drivers/uart.h>
 #include <drivers/console/console.h>
 #include <drivers/console/uart_console.h>
 #include "getline-zephyr.h"

--- a/targets/zephyr/src/main-zephyr.c
+++ b/targets/zephyr/src/main-zephyr.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 
 #include <zephyr.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include "getline-zephyr.h"
 
 #include "jerryscript.h"


### PR DESCRIPTION
Zephyr 2.2 removed some deprecated compatibility headers, use the new
location.

JerryScript-DCO-1.0-Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org
