### PR TITLE
Fixed segmentation fault in scanner.

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -1760,16 +1760,13 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
     size_t stack_size = info_p->u16_arg * sizeof (parser_scope_stack);
     context_p->scope_stack_size = info_p->u16_arg;
 
-    if (stack_size == 0)
+    scope_stack_p = NULL;
+
+    if (stack_size > 0)
     {
-      if (!(option_flags & SCANNER_CREATE_VARS_IS_FUNCTION_ARGS))
-      {
-        scanner_release_next (context_p, sizeof (scanner_info_t) + 1);
-      }
-      return;
+      scope_stack_p = (parser_scope_stack *) parser_malloc (context_p, stack_size);
     }
 
-    scope_stack_p = (parser_scope_stack *) parser_malloc (context_p, stack_size);
     context_p->scope_stack_p = scope_stack_p;
     scope_stack_end_p = scope_stack_p + context_p->scope_stack_size;
   }
@@ -1820,6 +1817,8 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
       }
       continue;
     }
+
+    JERRY_ASSERT (context_p->scope_stack_size != 0);
 
     if (!(data_p[0] & SCANNER_STREAM_UINT16_DIFF))
     {

--- a/tests/jerry/es2015/regression-test-issue-3419.js
+++ b/tests/jerry/es2015/regression-test-issue-3419.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval ('Function("[]", 0)()');
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}

--- a/tests/jerry/es2015/regression-test-issue-3431.js
+++ b/tests/jerry/es2015/regression-test-issue-3431.js
@@ -1,0 +1,27 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval ('function g({["y"]: []}) {}; g({xy: {}})');
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
+
+try {
+  eval ('function g([], {}, [], {}) {}; g()');
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}


### PR DESCRIPTION
The register end index was not correctly calculated when
only holes presented in the arguments list of a function.

Fixes #3419, fixes #3431

JerryScript-DCO-1.0-Signed-off-by: László Langó lango@inf.u-szeged.hu