### PR TITLE
Fix Math.trunc(x) if -1 < x < 0

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -177,12 +177,12 @@ ecma_builtin_math_object_trunc (ecma_number_t arg)
 
   if ((arg > 0) && (arg < 1))
   {
-    return (ecma_number_t) 0;
+    return (ecma_number_t) 0.0;
   }
 
   if ((arg < 0) && (arg > -1))
   {
-    return (ecma_number_t) -0;
+    return (ecma_number_t) -0.0;
   }
 
   return (ecma_number_t) arg - fmod (arg, 1);

--- a/tests/jerry/es2015/math-trunc.js
+++ b/tests/jerry/es2015/math-trunc.js
@@ -18,13 +18,18 @@ var m_zero = -p_zero;
 var p_inf = Infinity;
 var m_inf = -p_inf;
 
+function isSameZero (x, y)
+{
+  return x === 0 && (1 / x) === (1 / y);
+}
+
 assert (isNaN(Math['trunc'](NaN)));
-assert (Math['trunc'](p_zero) === p_zero);
-assert (Math['trunc'](m_zero) === m_zero);
+assert (isSameZero (Math['trunc'](p_zero), p_zero));
+assert (isSameZero (Math['trunc'](m_zero), m_zero));
 assert (Math['trunc'](p_inf) === p_inf);
 assert (Math['trunc'](m_inf) === m_inf);
-assert (Math['trunc'](0.5) === p_zero);
-assert (Math['trunc'](-0.5) === m_zero);
+assert (isSameZero (Math['trunc'](0.5), p_zero));
+assert (isSameZero (Math['trunc'](-0.5), m_zero));
 assert (Math['trunc'](1.2) === 1);
 assert (Math['trunc'](-1.5) === -1);
 assert (Math['trunc'](65.7) === 65);


### PR DESCRIPTION
Math.trunc(x) should be -0.0 if -1 < x < 0 (ES2015 20.2.2.35). The problem
was that -0 isn't -0.0, but +0.0 in C. There were a test case for it, but
it was incorrect, because +0.0 === -0.0 in JS.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
