### PR TITLE
Implement \u{hex} support.

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -1553,31 +1553,59 @@ jerry_append_number_to_buffer (uint8_t *buffer_p, /**< buffer */
 static bool
 ecma_string_is_valid_identifier (const ecma_string_t *string_p)
 {
-  bool result = false;
-
   ECMA_STRING_TO_UTF8_STRING (string_p, str_buffer_p, str_buffer_size);
 
-  if (lit_char_is_identifier_start (str_buffer_p))
+  const uint8_t *str_p = str_buffer_p;
+  const uint8_t *str_end_p = str_buffer_p + str_buffer_size;
+
+  while (str_p < str_end_p)
   {
-    const uint8_t *str_start_p = str_buffer_p;
-    const uint8_t *str_end_p = str_buffer_p + str_buffer_size;
+    lit_code_point_t code_point = *str_p;
+    lit_utf8_size_t utf8_length = 1;
 
-    result = true;
-
-    while (str_start_p < str_end_p)
+    if (JERRY_UNLIKELY (code_point >= LIT_UTF8_2_BYTE_MARKER))
     {
-      if (!lit_char_is_identifier_part (str_start_p))
+      utf8_length = lit_read_code_point_from_utf8 (str_p,
+                                                   (lit_utf8_size_t) (str_end_p - str_p),
+                                                   &code_point);
+
+#if ENABLED (JERRY_ES2015)
+      if ((code_point >= LIT_UTF16_HIGH_SURROGATE_MIN && code_point <= LIT_UTF16_HIGH_SURROGATE_MAX)
+          && str_p + 3 < str_end_p)
       {
-        result = false;
+        lit_code_point_t low_surrogate;
+        lit_read_code_point_from_utf8 (str_p + 3,
+                                       (lit_utf8_size_t) (str_end_p - (str_p + 3)),
+                                       &low_surrogate);
+
+        if (low_surrogate >= LIT_UTF16_LOW_SURROGATE_MIN && low_surrogate <= LIT_UTF16_LOW_SURROGATE_MAX)
+        {
+          code_point = lit_convert_surrogate_pair_to_code_point ((ecma_char_t) code_point,
+                                                                 (ecma_char_t) low_surrogate);
+          utf8_length = 2 * 3;
+        }
+      }
+#endif /* ENABLED (JERRY_ES2015) */
+    }
+
+    if (str_p == str_buffer_p)
+    {
+      if (!lit_code_point_is_identifier_start (code_point))
+      {
         break;
       }
-      lit_utf8_incr (&str_start_p);
     }
+    else if (!lit_code_point_is_identifier_part (code_point))
+    {
+      break;
+    }
+
+    str_p += utf8_length;
   }
 
   ECMA_FINALIZE_UTF8_STRING (str_buffer_p, str_buffer_size);
 
-  return result;
+  return str_p == str_end_p;
 } /* ecma_string_is_valid_identifier */
 
 #endif /* ENABLED (JERRY_SNAPSHOT_SAVE) */

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -461,16 +461,9 @@ ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *string
     if ((string_p[pos] & LIT_UTF8_4_BYTE_MASK) == LIT_UTF8_4_BYTE_MARKER)
     {
       /* Processing 4 byte unicode sequence. Always converted to two 3 byte long sequence. */
-      uint32_t character = ((((uint32_t) string_p[pos++]) & 0x7) << 18);
-      character |= ((((uint32_t) string_p[pos++]) & LIT_UTF8_LAST_6_BITS_MASK) << 12);
-      character |= ((((uint32_t) string_p[pos++]) & LIT_UTF8_LAST_6_BITS_MASK) << 6);
-      character |= (((uint32_t) string_p[pos++]) & LIT_UTF8_LAST_6_BITS_MASK);
-
-      JERRY_ASSERT (character >= 0x10000);
-      character -= 0x10000;
-
-      data_p += lit_char_to_utf8_bytes (data_p, (ecma_char_t) (0xd800 | (character >> 10)));
-      data_p += lit_char_to_utf8_bytes (data_p, (ecma_char_t) (0xdc00 | (character & LIT_UTF16_LAST_10_BITS_MASK)));
+      lit_four_byte_utf8_char_to_cesu8 (data_p, string_p + pos);
+      data_p += 3 * 2;
+      pos += 4;
     }
     else
     {
@@ -2683,10 +2676,10 @@ void
 ecma_stringbuilder_append_char (ecma_stringbuilder_t *builder_p, /**< string builder */
                                 const ecma_char_t c) /**< ecma char */
 {
-  const lit_utf8_size_t size = (lit_utf8_size_t) lit_char_get_utf8_length (c);
+  const lit_utf8_size_t size = (lit_utf8_size_t) lit_code_point_get_cesu8_length (c);
   lit_utf8_byte_t *dest_p = ecma_stringbuilder_grow (builder_p, size);
 
-  lit_char_to_utf8_bytes (dest_p, c);
+  lit_code_point_to_cesu8_bytes (dest_p, c);
 } /* ecma_stringbuilder_append_char */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -61,7 +61,7 @@ ecma_date_parse_date_chars (const lit_utf8_byte_t **str_p, /**< pointer to the c
 
   while (num_of_chars--)
   {
-    if (*str_p >= str_end_p || !lit_char_is_decimal_digit (lit_utf8_read_next (str_p)))
+    if (*str_p >= str_end_p || !lit_char_is_decimal_digit (lit_cesu8_read_next (str_p)))
     {
       return ecma_number_make_nan ();
     }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -150,7 +150,7 @@ ecma_builtin_global_object_parse_int (const lit_utf8_byte_t *string_buff, /**< r
   int sign = 1;
 
   /* 4. */
-  ecma_char_t current = lit_utf8_read_next (&string_curr_p);
+  ecma_char_t current = lit_cesu8_read_next (&string_curr_p);
   if (current == LIT_CHAR_MINUS)
   {
     sign = -1;
@@ -162,7 +162,7 @@ ecma_builtin_global_object_parse_int (const lit_utf8_byte_t *string_buff, /**< r
     start_p = string_curr_p;
     if (string_curr_p < string_end_p)
     {
-      current = lit_utf8_read_next (&string_curr_p);
+      current = lit_cesu8_read_next (&string_curr_p);
     }
   }
 
@@ -970,7 +970,7 @@ ecma_builtin_global_object_escape (lit_utf8_byte_t *input_start_p, /**< routine'
 
   while (input_curr_p < input_end_p)
   {
-    ecma_char_t chr = lit_utf8_read_next (&input_curr_p);
+    ecma_char_t chr = lit_cesu8_read_next (&input_curr_p);
 
     if (chr <= LIT_UTF8_1_BYTE_CODE_POINT_MAX)
     {
@@ -1005,7 +1005,7 @@ ecma_builtin_global_object_escape (lit_utf8_byte_t *input_start_p, /**< routine'
 
   while (input_curr_p < input_end_p)
   {
-    ecma_char_t chr = lit_utf8_read_next (&input_curr_p);
+    ecma_char_t chr = lit_cesu8_read_next (&input_curr_p);
 
     if (chr <= LIT_UTF8_1_BYTE_CODE_POINT_MAX)
     {
@@ -1091,7 +1091,7 @@ ecma_builtin_global_object_unescape (lit_utf8_byte_t *input_start_p, /**< routin
   while (input_curr_p < input_end_p)
   {
     /* 6. */
-    ecma_char_t chr = lit_utf8_read_next (&input_curr_p);
+    ecma_char_t chr = lit_cesu8_read_next (&input_curr_p);
 
     /* 7-8. */
     if (status == 0 && chr == LIT_CHAR_PERCENT)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -713,7 +713,7 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
 
       /* iterate original string and try to match at each position */
       bool searching = true;
-      ecma_char_t first_char = lit_utf8_read_next (&search_str_curr_p);
+      ecma_char_t first_char = lit_cesu8_read_next (&search_str_curr_p);
       while (searching)
       {
         /* match as long as possible */
@@ -722,14 +722,14 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
 
         if (match_len < search_len &&
             index + match_len < original_len &&
-            lit_utf8_read_next (&original_str_curr_p) == first_char)
+            lit_cesu8_read_next (&original_str_curr_p) == first_char)
         {
           const lit_utf8_byte_t *nested_search_str_curr_p = search_str_curr_p;
           match_len++;
 
           while (match_len < search_len &&
                  index + match_len < original_len &&
-                 lit_utf8_read_next (&original_str_curr_p) == lit_utf8_read_next (&nested_search_str_curr_p))
+                 lit_cesu8_read_next (&original_str_curr_p) == lit_cesu8_read_next (&nested_search_str_curr_p))
           {
             match_len++;
           }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1155,7 +1155,7 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_string_t *input_str
 
   while (input_str_curr_p < input_str_end_p)
   {
-    ecma_char_t character = lit_utf8_read_next (&input_str_curr_p);
+    ecma_char_t character = lit_cesu8_read_next (&input_str_curr_p);
     ecma_char_t character_buffer[LIT_MAXIMUM_OTHER_CASE_LENGTH];
     ecma_length_t character_length;
     lit_utf8_byte_t utf8_byte_buffer[LIT_CESU8_MAX_BYTES_IN_CODE_POINT];
@@ -1194,7 +1194,7 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_string_t *input_str
 
   while (input_str_curr_p < input_str_end_p)
   {
-    ecma_char_t character = lit_utf8_read_next (&input_str_curr_p);
+    ecma_char_t character = lit_cesu8_read_next (&input_str_curr_p);
     ecma_char_t character_buffer[LIT_MAXIMUM_OTHER_CASE_LENGTH];
     ecma_length_t character_length;
 

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -220,11 +220,11 @@ ecma_regexp_unicode_advance (const lit_utf8_byte_t **str_p, /**< reference to st
   JERRY_ASSERT (str_p != NULL);
   const lit_utf8_byte_t *current_p = *str_p;
 
-  lit_code_point_t ch = lit_utf8_read_next (&current_p);
+  lit_code_point_t ch = lit_cesu8_read_next (&current_p);
   if (lit_is_code_point_utf16_high_surrogate ((ecma_char_t) ch)
       && current_p < end_p)
   {
-    const ecma_char_t next_ch = lit_utf8_peek_next (current_p);
+    const ecma_char_t next_ch = lit_cesu8_peek_next (current_p);
     if (lit_is_code_point_utf16_low_surrogate (next_ch))
     {
       lit_utf8_incr (&current_p);
@@ -425,14 +425,14 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
 
         const bool is_ignorecase = re_ctx_p->flags & RE_FLAG_IGNORE_CASE;
         lit_code_point_t ch1 = re_get_char (&bc_p); /* Already canonicalized. */
-        lit_code_point_t ch2 = lit_utf8_read_next (&str_curr_p);
+        lit_code_point_t ch2 = lit_cesu8_read_next (&str_curr_p);
 
 #if ENABLED (JERRY_ES2015)
         if (re_ctx_p->flags & RE_FLAG_UNICODE
             && lit_is_code_point_utf16_high_surrogate (ch2)
             && str_curr_p < re_ctx_p->input_end_p)
         {
-          const ecma_char_t next_ch = lit_utf8_peek_next (str_curr_p);
+          const ecma_char_t next_ch = lit_cesu8_peek_next (str_curr_p);
           if (lit_is_code_point_utf16_low_surrogate (next_ch))
           {
             lit_utf8_incr (&str_curr_p);
@@ -460,7 +460,7 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
           return NULL; /* fail */
         }
 
-        const ecma_char_t ch = lit_utf8_read_next (&str_curr_p);
+        const ecma_char_t ch = lit_cesu8_read_next (&str_curr_p);
         JERRY_TRACE_MSG ("Period matching '.' to %u: ", (unsigned int) ch);
 
         if (lit_char_is_line_terminator (ch))
@@ -474,7 +474,7 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
             && lit_is_code_point_utf16_high_surrogate (ch)
             && str_curr_p < re_ctx_p->input_end_p)
         {
-          const ecma_char_t next_ch = lit_utf8_peek_next (str_curr_p);
+          const ecma_char_t next_ch = lit_cesu8_peek_next (str_curr_p);
           if (lit_is_code_point_utf16_low_surrogate (next_ch))
           {
             lit_utf8_incr (&str_curr_p);
@@ -501,7 +501,7 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
           return NULL; /* fail */
         }
 
-        if (lit_char_is_line_terminator (lit_utf8_peek_prev (str_curr_p)))
+        if (lit_char_is_line_terminator (lit_cesu8_peek_prev (str_curr_p)))
         {
           JERRY_TRACE_MSG ("match\n");
           break; /* tail merge */
@@ -526,7 +526,7 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
           return NULL; /* fail */
         }
 
-        if (lit_char_is_line_terminator (lit_utf8_peek_next (str_curr_p)))
+        if (lit_char_is_line_terminator (lit_cesu8_peek_next (str_curr_p)))
         {
           JERRY_TRACE_MSG ("match\n");
           break; /* tail merge */
@@ -539,10 +539,10 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
       case RE_OP_ASSERT_NOT_WORD_BOUNDARY:
       {
         const bool is_wordchar_left = ((str_curr_p > re_ctx_p->input_start_p)
-                                       && lit_char_is_word_char (lit_utf8_peek_prev (str_curr_p)));
+                                       && lit_char_is_word_char (lit_cesu8_peek_prev (str_curr_p)));
 
         const bool is_wordchar_right = ((str_curr_p < re_ctx_p->input_end_p)
-                                        && lit_char_is_word_char (lit_utf8_peek_next (str_curr_p)));
+                                        && lit_char_is_word_char (lit_cesu8_peek_next (str_curr_p)));
 
         if (op == RE_OP_ASSERT_WORD_BOUNDARY)
         {
@@ -659,7 +659,7 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
         else
         {
 #endif /* ENABLED (JERRY_ES2015) */
-          const ecma_char_t curr_ch = (ecma_char_t) ecma_regexp_canonicalize (lit_utf8_read_next (&str_curr_p),
+          const ecma_char_t curr_ch = (ecma_char_t) ecma_regexp_canonicalize (lit_cesu8_read_next (&str_curr_p),
                                                                               is_ignorecase);
 
           while (range_count-- > 0)
@@ -1115,7 +1115,7 @@ ecma_regexp_match (ecma_regexp_ctx_t *re_ctx_p, /**< RegExp matcher context */
               break;
             }
 
-            lit_utf8_read_prev (&str_curr_p);
+            lit_cesu8_read_prev (&str_curr_p);
             iter_count--;
           }
         }

--- a/jerry-core/lit/lit-char-helpers.h
+++ b/jerry-core/lit/lit-char-helpers.h
@@ -75,10 +75,8 @@ bool lit_char_is_line_terminator (ecma_char_t c);
 #define LIT_CHAR_UNDERSCORE  ((ecma_char_t) '_')  /* low line (underscore) */
 /* LIT_CHAR_BACKSLASH defined above */
 
-bool lit_char_is_identifier_start (const uint8_t *src_p);
-bool lit_char_is_identifier_part (const uint8_t *src_p);
-bool lit_char_is_identifier_start_character (ecma_char_t chr);
-bool lit_char_is_identifier_part_character (ecma_char_t chr);
+bool lit_code_point_is_identifier_start (lit_code_point_t code_point);
+bool lit_code_point_is_identifier_part (lit_code_point_t code_point);
 
 /*
  * Punctuator characters (ECMA-262 v5, 7.7)
@@ -215,8 +213,9 @@ bool lit_char_is_octal_digit (ecma_char_t c);
 bool lit_char_is_decimal_digit (ecma_char_t c);
 bool lit_char_is_hex_digit (ecma_char_t c);
 uint32_t lit_char_hex_to_int (ecma_char_t c);
-size_t lit_char_to_utf8_bytes (uint8_t *dst_p, ecma_char_t chr);
-size_t lit_char_get_utf8_length (ecma_char_t chr);
+size_t lit_code_point_to_cesu8_bytes (uint8_t *dst_p, lit_code_point_t code_point);
+size_t lit_code_point_get_cesu8_length (lit_code_point_t code_point);
+void lit_four_byte_utf8_char_to_cesu8 (uint8_t *dst_p, const uint8_t *source_p);
 
 /* read a hex encoded code point from a zero terminated buffer */
 bool lit_read_code_unit_from_hex (const lit_utf8_byte_t *buf_p, lit_utf8_size_t number_of_characters,

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -481,7 +481,7 @@ lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer wit
  * @return next code unit
  */
 ecma_char_t
-lit_utf8_read_next (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
+lit_cesu8_read_next (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
 {
   JERRY_ASSERT (*buf_p);
   ecma_char_t ch;
@@ -489,7 +489,7 @@ lit_utf8_read_next (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with cha
   *buf_p += lit_read_code_unit_from_utf8 (*buf_p, &ch);
 
   return ch;
-} /* lit_utf8_read_next */
+} /* lit_cesu8_read_next */
 
 /**
  * Decodes a unicode code unit from non-empty cesu-8-encoded buffer
@@ -497,7 +497,7 @@ lit_utf8_read_next (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with cha
  * @return previous code unit
  */
 ecma_char_t
-lit_utf8_read_prev (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
+lit_cesu8_read_prev (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
 {
   JERRY_ASSERT (*buf_p);
   ecma_char_t ch;
@@ -506,7 +506,7 @@ lit_utf8_read_prev (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with cha
   lit_read_code_unit_from_utf8 (*buf_p, &ch);
 
   return ch;
-} /* lit_utf8_read_prev */
+} /* lit_cesu8_read_prev */
 
 /**
  * Decodes a unicode code unit from non-empty cesu-8-encoded buffer
@@ -514,15 +514,15 @@ lit_utf8_read_prev (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with cha
  * @return next code unit
  */
 ecma_char_t
-lit_utf8_peek_next (const lit_utf8_byte_t *buf_p) /**< [in,out] buffer with characters */
+lit_cesu8_peek_next (const lit_utf8_byte_t *buf_p) /**< [in,out] buffer with characters */
 {
-  JERRY_ASSERT (buf_p);
+  JERRY_ASSERT (buf_p != NULL);
   ecma_char_t ch;
 
   lit_read_code_unit_from_utf8 (buf_p, &ch);
 
   return ch;
-} /* lit_utf8_peek_next */
+} /* lit_cesu8_peek_next */
 
 /**
  * Decodes a unicode code unit from non-empty cesu-8-encoded buffer
@@ -530,15 +530,15 @@ lit_utf8_peek_next (const lit_utf8_byte_t *buf_p) /**< [in,out] buffer with char
  * @return previous code unit
  */
 ecma_char_t
-lit_utf8_peek_prev (const lit_utf8_byte_t *buf_p) /**< [in,out] buffer with characters */
+lit_cesu8_peek_prev (const lit_utf8_byte_t *buf_p) /**< [in,out] buffer with characters */
 {
-  JERRY_ASSERT (buf_p);
+  JERRY_ASSERT (buf_p != NULL);
   ecma_char_t ch;
 
   lit_read_prev_code_unit_from_utf8 (buf_p, &ch);
 
   return ch;
-} /* lit_utf8_peek_prev */
+} /* lit_cesu8_peek_prev */
 
 /**
  * Increase cesu-8 encoded string pointer by one code unit.

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -46,7 +46,6 @@
 #define LIT_UTF8_2_BYTE_MARKER (0xC0)
 #define LIT_UTF8_3_BYTE_MARKER (0xE0)
 #define LIT_UTF8_4_BYTE_MARKER (0xF0)
-#define LIT_UTF8_5_BYTE_MARKER (0xF8)
 #define LIT_UTF8_EXTRA_BYTE_MARKER (0x80)
 
 #define LIT_UTF8_1_BYTE_MASK (0x80)
@@ -82,7 +81,7 @@
 /**
  * Byte values >= LIT_UTF8_FIRST_BYTE_MAX are not allowed in internal strings
  */
-#define LIT_UTF8_FIRST_BYTE_MAX LIT_UTF8_5_BYTE_MARKER
+#define LIT_UTF8_FIRST_BYTE_MAX (0xF8)
 
 /* validation */
 bool lit_is_valid_utf8_string (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t buf_size);
@@ -135,10 +134,10 @@ lit_utf8_size_t lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p,
 lit_utf8_size_t lit_read_prev_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p,
                                                    ecma_char_t *code_point);
 
-ecma_char_t lit_utf8_read_next (const lit_utf8_byte_t **buf_p);
-ecma_char_t lit_utf8_read_prev (const lit_utf8_byte_t **buf_p);
-ecma_char_t lit_utf8_peek_next (const lit_utf8_byte_t *buf_p);
-ecma_char_t lit_utf8_peek_prev (const lit_utf8_byte_t *buf_p);
+ecma_char_t lit_cesu8_read_next (const lit_utf8_byte_t **buf_p);
+ecma_char_t lit_cesu8_read_prev (const lit_utf8_byte_t **buf_p);
+ecma_char_t lit_cesu8_peek_next (const lit_utf8_byte_t *buf_p);
+ecma_char_t lit_cesu8_peek_prev (const lit_utf8_byte_t *buf_p);
 void lit_utf8_incr (const lit_utf8_byte_t **buf_p);
 void lit_utf8_decr (const lit_utf8_byte_t **buf_p);
 

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -637,8 +637,7 @@ bool lexer_check_yield_no_arg (parser_context_t *context_p);
 void lexer_parse_string (parser_context_t *context_p);
 void lexer_expect_identifier (parser_context_t *context_p, uint8_t literal_type);
 void lexer_scan_identifier (parser_context_t *context_p, uint32_t ident_opts);
-ecma_char_t lexer_hex_to_character (parser_context_t *context_p, const uint8_t *source_p, int length);
-void lexer_convert_ident_to_cesu8 (const uint8_t *source_p, uint8_t *destination_p, prop_length_t length);
+void lexer_convert_ident_to_cesu8 (uint8_t *destination_p, const uint8_t *source_p, prop_length_t length);
 void lexer_expect_object_literal_id (parser_context_t *context_p, uint32_t ident_opts);
 void lexer_construct_literal_object (parser_context_t *context_p, const lexer_lit_location_t *literal_p,
                                      uint8_t literal_type);
@@ -646,7 +645,9 @@ bool lexer_construct_number_object (parser_context_t *context_p, bool is_expr, b
 void lexer_convert_push_number_to_push_literal (parser_context_t *context_p);
 uint16_t lexer_construct_function_object (parser_context_t *context_p, uint32_t extra_status_flags);
 void lexer_construct_regexp_object (parser_context_t *context_p, bool parse_only);
-bool lexer_compare_identifiers (const uint8_t *left_p, const uint8_t *right_p, size_t size);
+bool lexer_compare_identifier_to_string (const lexer_lit_location_t *left_p, const uint8_t *right_p, size_t size);
+bool lexer_compare_identifiers (parser_context_t *context_p, const lexer_lit_location_t *left_p,
+                                const lexer_lit_location_t *right_p);
 bool lexer_current_is_literal (parser_context_t *context_p, const lexer_lit_location_t *right_ident_p);
 #if ENABLED (JERRY_ES2015)
 bool lexer_token_is_identifier (parser_context_t *context_p, const char *identifier_p,

--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -376,8 +376,7 @@ scanner_handle_bracket (parser_context_t *context_p, /**< context */
         arrow_source_p = NULL;
 #endif /* ENABLED (JERRY_ES2015) */
 
-        if (context_p->token.lit_location.length == 4
-            && lexer_compare_identifiers (context_p->token.lit_location.char_p, (const uint8_t *) "eval", 4))
+        if (lexer_compare_identifier_to_string (&context_p->token.lit_location, (const uint8_t *) "eval", 4))
         {
           scanner_context_p->active_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_NO_REG;
         }

--- a/jerry-core/parser/regexp/re-compiler.c
+++ b/jerry-core/parser/regexp/re-compiler.c
@@ -272,7 +272,7 @@ re_parse_char_class (re_compiler_ctx_t *re_ctx_p, /**< number of classes */
   const bool is_char_class = (re_ctx_p->current_token.type == RE_TOK_START_CHAR_CLASS
                               || re_ctx_p->current_token.type == RE_TOK_START_INV_CHAR_CLASS);
 
-  const ecma_char_t prev_char = lit_utf8_peek_prev (parser_ctx_p->input_curr_p);
+  const ecma_char_t prev_char = lit_cesu8_peek_prev (parser_ctx_p->input_curr_p);
   if (prev_char != LIT_CHAR_LEFT_SQUARE && prev_char != LIT_CHAR_CIRCUMFLEX)
   {
     lit_utf8_decr (&parser_ctx_p->input_curr_p);
@@ -286,7 +286,7 @@ re_parse_char_class (re_compiler_ctx_t *re_ctx_p, /**< number of classes */
       return ecma_raise_syntax_error (ECMA_ERR_MSG ("invalid character class, end of string"));
     }
 
-    lit_code_point_t ch = lit_utf8_read_next (&parser_ctx_p->input_curr_p);
+    lit_code_point_t ch = lit_cesu8_read_next (&parser_ctx_p->input_curr_p);
 
     if (ch == LIT_CHAR_RIGHT_SQUARE)
     {
@@ -318,7 +318,7 @@ re_parse_char_class (re_compiler_ctx_t *re_ctx_p, /**< number of classes */
         return ecma_raise_syntax_error (ECMA_ERR_MSG ("invalid character class, end of string after '\\'"));
       }
 
-      ch = lit_utf8_read_next (&parser_ctx_p->input_curr_p);
+      ch = lit_cesu8_read_next (&parser_ctx_p->input_curr_p);
 
       if (ch == LIT_CHAR_LOWERCASE_B)
       {
@@ -376,7 +376,7 @@ re_parse_char_class (re_compiler_ctx_t *re_ctx_p, /**< number of classes */
         parser_ctx_p->input_curr_p += 2;
         if (parser_ctx_p->input_curr_p < parser_ctx_p->input_end_p
             && is_range == false
-            && lit_utf8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
+            && lit_cesu8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
         {
           start = code_unit;
           continue;
@@ -396,7 +396,7 @@ re_parse_char_class (re_compiler_ctx_t *re_ctx_p, /**< number of classes */
         parser_ctx_p->input_curr_p += 4;
         if (parser_ctx_p->input_curr_p < parser_ctx_p->input_end_p
             && is_range == false
-            && lit_utf8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
+            && lit_cesu8_peek_next (parser_ctx_p->input_curr_p) == LIT_CHAR_MINUS)
         {
           start = code_unit;
           continue;
@@ -481,7 +481,7 @@ re_parse_char_class (re_compiler_ctx_t *re_ctx_p, /**< number of classes */
         && lit_is_code_point_utf16_high_surrogate (ch)
         && parser_ctx_p->input_curr_p < parser_ctx_p->input_end_p)
     {
-      const ecma_char_t next_ch = lit_utf8_peek_next (parser_ctx_p->input_curr_p);
+      const ecma_char_t next_ch = lit_cesu8_peek_next (parser_ctx_p->input_curr_p);
       if (lit_is_code_point_utf16_low_surrogate (next_ch))
       {
         ch = lit_convert_surrogate_pair_to_code_point ((ecma_char_t) ch, next_ch);

--- a/jerry-core/parser/regexp/re-parser.c
+++ b/jerry-core/parser/regexp/re-parser.c
@@ -315,7 +315,7 @@ re_parse_next_token (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context *
     return ret_value;
   }
 
-  ecma_char_t ch = lit_utf8_read_next (&parser_ctx_p->input_curr_p);
+  ecma_char_t ch = lit_cesu8_read_next (&parser_ctx_p->input_curr_p);
 
   switch (ch)
   {
@@ -348,7 +348,7 @@ re_parse_next_token (re_parser_ctx_t *parser_ctx_p, /**< RegExp parser context *
       }
 
       out_token_p->type = RE_TOK_CHAR;
-      ch = lit_utf8_read_next (&parser_ctx_p->input_curr_p);
+      ch = lit_cesu8_read_next (&parser_ctx_p->input_curr_p);
 
       if (ch == LIT_CHAR_LOWERCASE_B)
       {

--- a/tests/jerry/es2015/identifier-escape.js
+++ b/tests/jerry/es2015/identifier-escape.js
@@ -1,0 +1,36 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function check_syntax_error (code) {
+  try {
+    eval(code)
+    assert (false)
+  } catch (e) {
+    assert (e instanceof SyntaxError)
+  }
+}
+
+eval("\u{000010C80}: break \ud803\udc80")
+eval("\\u{10C80}: break \ud803\udc80")
+eval("$\u{000010C80}$: break $\ud803\udc80$")
+eval("$\\u{10C82}$: break $\ud803\udc82$")
+
+assert("\u{000010C80}".length === 2)
+assert("x\u{010C80}y".length === 4)
+assert("\u{10C80}" === "\ud803\u{dc80}")
+assert("\u{0}\x01" === "\u0000\u0001")
+
+/* Surrogate pairs are not combined if they passed as \u sequences. */
+check_syntax_error("\\u{10C80}: break \\ud803\\udc80");

--- a/tests/unit-core/test-strings.c
+++ b/tests/unit-core/test-strings.c
@@ -131,7 +131,7 @@ main (void)
 
     while (curr_p < end_p)
     {
-      code_units[code_units_count] = lit_utf8_peek_next (curr_p);
+      code_units[code_units_count] = lit_cesu8_peek_next (curr_p);
       saved_positions[code_units_count] = curr_p;
       code_units_count++;
       calculated_length++;
@@ -147,7 +147,7 @@ main (void)
       {
         ecma_length_t index = (ecma_length_t) rand () % code_units_count;
         curr_p = saved_positions[index];
-        TEST_ASSERT (lit_utf8_peek_next (curr_p) == code_units[index]);
+        TEST_ASSERT (lit_cesu8_peek_next (curr_p) == code_units[index]);
       }
     }
 
@@ -156,7 +156,7 @@ main (void)
     {
       TEST_ASSERT (code_units_count > 0);
       calculated_length--;
-      TEST_ASSERT (code_units[calculated_length] == lit_utf8_peek_prev (curr_p));
+      TEST_ASSERT (code_units[calculated_length] == lit_cesu8_peek_prev (curr_p));
       lit_utf8_decr (&curr_p);
     }
 
@@ -164,7 +164,7 @@ main (void)
 
     while (curr_p < end_p)
     {
-      ecma_char_t code_unit = lit_utf8_read_next (&curr_p);
+      ecma_char_t code_unit = lit_cesu8_read_next (&curr_p);
       TEST_ASSERT (code_unit == code_units[calculated_length]);
       calculated_length++;
     }
@@ -175,7 +175,7 @@ main (void)
     {
       TEST_ASSERT (code_units_count > 0);
       calculated_length--;
-      TEST_ASSERT (code_units[calculated_length] == lit_utf8_read_prev (&curr_p));
+      TEST_ASSERT (code_units[calculated_length] == lit_cesu8_read_prev (&curr_p));
     }
 
     TEST_ASSERT (calculated_length == 0);

--- a/tests/unit-core/test-unicode.c
+++ b/tests/unit-core/test-unicode.c
@@ -1,0 +1,61 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "jerryscript.h"
+#include "test-common.h"
+
+static bool
+test_syntax_error (char *script_p) /**< script */
+{
+  jerry_value_t parse_result = jerry_parse (NULL,
+                                            0,
+                                            (const jerry_char_t *) script_p,
+                                            strlen (script_p),
+                                            JERRY_PARSE_NO_OPTS);
+
+  bool result = false;
+
+  if (jerry_value_is_error (parse_result))
+  {
+    result = true;
+    TEST_ASSERT (jerry_get_error_type (parse_result) == JERRY_ERROR_SYNTAX);
+  }
+
+  jerry_release_value (parse_result);
+  return result;
+} /* test_syntax_error */
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  if (!test_syntax_error ("\\u{61}"))
+  {
+    TEST_ASSERT (!test_syntax_error ("\xF0\x90\xB2\x80: break \\u{10C80}"));
+    /* The \u surrogate pairs are ignored. The \u{hex} form must be used. */
+    TEST_ASSERT (test_syntax_error ("\xF0\x90\xB2\x80: break \\ud803\\udc80"));
+    /* The utf8 code point and the cesu8 surrogate pair must match. */
+    TEST_ASSERT (!test_syntax_error ("\xF0\x90\xB2\x80: break \xed\xa0\x83\xed\xb2\x80"));
+
+    TEST_ASSERT (!test_syntax_error ("$\xF0\x90\xB2\x80$: break $\\u{10C80}$"));
+    TEST_ASSERT (test_syntax_error ("$\xF0\x90\xB2\x80$: break $\\ud803\\udc80$"));
+    TEST_ASSERT (!test_syntax_error ("$\xF0\x90\xB2\x80$: break $\xed\xa0\x83\xed\xb2\x80$"));
+  }
+
+  jerry_cleanup ();
+
+  return 0;
+} /* main */

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -284,6 +284,7 @@ def create_binary(job, options):
         subprocess.check_output(build_cmd)
         ret = 0
     except subprocess.CalledProcessError as err:
+        print(err.output)
         ret = err.returncode
 
     BINARY_CACHE[binary_key] = (ret, build_dir_path)


### PR DESCRIPTION
A large rework because surrogate pairs must be combined.

Currently only the 0x10C80..0x10CF2 is accepted as valid identifier character from the non-basic plane.