### PR TITLE
Fix Math.round(x) for big integer numbers

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -359,7 +359,8 @@ ecma_builtin_math_dispatch_routine (uint16_t builtin_routine_id, /**< built-in w
       {
         if (ecma_number_is_nan (x)
             || ecma_number_is_zero (x)
-            || ecma_number_is_infinity (x))
+            || ecma_number_is_infinity (x)
+            || fmod (x, 1.0) == 0)
         {
           /* Do nothing. */
         }

--- a/tests/jerry/math-round.js
+++ b/tests/jerry/math-round.js
@@ -35,3 +35,17 @@ assert (Math['round'](-0.7) === -1.0);
 assert (Math['round'](-1.2) === -1.0);
 assert (Math['round'](-1.7) === -2.0);
 assert (Math['round'](-1.5) === -1.0);
+
+assert (Math['round'](1) === 1);
+assert (Math['round'](-1) === -1);
+
+for (var n = 1; n <= 53; n++)
+{
+  var x = Math.pow(2, n)
+  assert (Math['round'](x - 1) === x - 1);
+  assert (Math['round'](x) === x);
+  assert (Math['round'](x + 1) === x + 1);
+  assert (Math['round'](-x - 1) === -x - 1);
+  assert (Math['round'](-x) === -x);
+  assert (Math['round'](-x + 1) === -x + 1);
+}


### PR DESCRIPTION
Math.round(x) should be x it x is already integer. (ES5 15.8.2.15)
The current implementation calculates with x +/- 0.5, which isn't
representable numbers if x >= 2^52.

A correct bug fix can be to follow the spec and simply
return the number itself if it is already integer.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu