### PR TITLE
Support strict mode detection in the pre-scanner.

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -3042,6 +3042,42 @@ lexer_current_is_literal (parser_context_t *context_p, /**< context */
   return lexer_compare_identifiers (context_p, left_ident_p, right_ident_p);
 } /* lexer_current_is_literal */
 
+/**
+ * Compares the current string token to "use strict".
+ *
+ * Note:
+ *   Escape sequences are not allowed.
+ *
+ * @return true if "use strict" is found, false otherwise
+ */
+inline bool JERRY_ATTR_ALWAYS_INLINE
+lexer_string_is_use_strict (parser_context_t *context_p) /**< context */
+{
+  JERRY_ASSERT (context_p->token.type == LEXER_LITERAL
+                && context_p->token.lit_location.type == LEXER_STRING_LITERAL);
+
+  return (context_p->token.lit_location.length == 10
+          && !context_p->token.lit_location.has_escape
+          && memcmp (context_p->token.lit_location.char_p, "use strict", 10) == 0);
+} /* lexer_string_is_use_strict */
+
+/**
+ * Checks whether the string before the current token is a directive or a string literal.
+ *
+ * @return true if the string is a directive, false otherwise
+ */
+inline bool JERRY_ATTR_ALWAYS_INLINE
+lexer_string_is_directive (parser_context_t *context_p) /**< context */
+{
+  return (context_p->token.type == LEXER_SEMICOLON
+          || context_p->token.type == LEXER_RIGHT_BRACE
+          || ((context_p->token.flags & LEXER_WAS_NEWLINE)
+              && !LEXER_IS_BINARY_OP_TOKEN (context_p->token.type)
+              && context_p->token.type != LEXER_LEFT_PAREN
+              && context_p->token.type != LEXER_LEFT_SQUARE
+              && context_p->token.type != LEXER_DOT));
+} /* lexer_string_is_directive */
+
 #if ENABLED (JERRY_ES2015)
 
 /**

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -649,6 +649,8 @@ bool lexer_compare_identifier_to_string (const lexer_lit_location_t *left_p, con
 bool lexer_compare_identifiers (parser_context_t *context_p, const lexer_lit_location_t *left_p,
                                 const lexer_lit_location_t *right_p);
 bool lexer_current_is_literal (parser_context_t *context_p, const lexer_lit_location_t *right_ident_p);
+bool lexer_string_is_use_strict (parser_context_t *context_p);
+bool lexer_string_is_directive (parser_context_t *context_p);
 #if ENABLED (JERRY_ES2015)
 bool lexer_token_is_identifier (parser_context_t *context_p, const char *identifier_p,
                                 size_t identifier_length);

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -937,6 +937,10 @@ parser_error_to_string (parser_error_t error) /**< error code */
       return "Arguments is not allowed to be used here in strict mode.";
     }
 #if ENABLED (JERRY_ES2015)
+    case PARSER_ERR_USE_STRICT_NOT_ALLOWED:
+    {
+      return "The 'use strict' directive is not allowed for functions with non-simple arguments.";
+    }
     case PARSER_ERR_YIELD_NOT_ALLOWED:
     {
       return "Incorrect use of yield keyword.";

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -75,6 +75,7 @@ typedef enum
   PARSER_ERR_EVAL_NOT_ALLOWED,                        /**< eval is not allowed here in strict mode */
   PARSER_ERR_ARGUMENTS_NOT_ALLOWED,                   /**< arguments is not allowed here in strict mode */
 #if ENABLED (JERRY_ES2015)
+  PARSER_ERR_USE_STRICT_NOT_ALLOWED,                  /**< use strict directive is not allowed */
   PARSER_ERR_YIELD_NOT_ALLOWED,                       /**< yield keyword is not allowed */
 #endif /* ENABLED (JERRY_ES2015) */
   PARSER_ERR_DELETE_IDENT_NOT_ALLOWED,                /**< identifier delete is not allowed in strict mode */

--- a/tests/jerry/es2015/directive.js
+++ b/tests/jerry/es2015/directive.js
@@ -1,0 +1,35 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function check_syntax_error (code)
+{
+  try {
+    eval (code)
+    assert (false)
+  } catch (e) {
+    assert (e instanceof SyntaxError)
+  }
+}
+
+eval("function f(a, b = 4) { }")
+check_syntax_error ("function f(a, b = 4) { 'use strict' }")
+
+eval('function f(...a) { }')
+check_syntax_error ('function f(...a) { "use strict" }')
+
+eval("({ f([a,b]) { } })")
+check_syntax_error ("({ f([a,b]) { 'use strict' } })")
+
+eval("function f(a, b = 4) { 'directive1'\n'directive2'\n }")
+check_syntax_error ("function f(a, b = 4) { 'directive1'\n'directive2'\n'use strict' }")


### PR DESCRIPTION
Furthermode an error is thrown when 'use strict' is used in a function with non-simple arguments
and function arguments are not moved to lexical environment when unmapped arguments are present.