### PR TITLE
Optimize ecma_number_to_uint32

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -703,9 +703,7 @@ ecma_uint32_to_utf8_string (uint32_t value, /**< value to convert */
 uint32_t
 ecma_number_to_uint32 (ecma_number_t num) /**< ecma-number */
 {
-  if (ecma_number_is_nan (num)
-      || ecma_number_is_zero (num)
-      || ecma_number_is_infinity (num))
+  if (JERRY_UNLIKELY (ecma_number_is_zero (num) || !ecma_number_is_finite (num)))
   {
     return 0;
   }

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -334,6 +334,24 @@ ecma_number_is_infinity (ecma_number_t num) /**< ecma-number */
 } /* ecma_number_is_infinity */
 
 /**
+ * Check if number is finite
+ *
+ * @return true  - if number is finite
+ *         false - if number is NaN or infinity
+ */
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
+ecma_number_is_finite (ecma_number_t num) /**< ecma-number */
+{
+#if defined (__GNUC__) || defined (__clang__)
+  return __builtin_isfinite (num);
+#elif defined (WIN32)
+  return isfinite (num);
+#else
+  return !ecma_number_is_nan (num) && !ecma_number_is_infinity (num);
+#endif /* defined (__GNUC__) || defined (__clang__) */
+} /* ecma_number_is_finite */
+
+/**
  * Get fraction and exponent of the number
  *
  * @return shift of dot in the fraction

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -340,6 +340,7 @@ bool ecma_number_is_nan (ecma_number_t num);
 bool ecma_number_is_negative (ecma_number_t num);
 bool ecma_number_is_zero (ecma_number_t num);
 bool ecma_number_is_infinity (ecma_number_t num);
+bool ecma_number_is_finite (ecma_number_t num);
 ecma_number_t
 ecma_number_make_from_sign_mantissa_and_exponent (bool sign, uint64_t mantissa, int32_t exponent);
 ecma_number_t ecma_number_get_prev (ecma_number_t num);


### PR DESCRIPTION
The ecma_number_to_uint32 function is called many times, we can merge
ecma_number_is_nan and ecma_number_is_infinity checks to !ecma_number_is_finite
to let the compiler generate more optimal code for it.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu