### PR TITLE
Add missing assert entry in case of static super assignment

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1890,10 +1890,12 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
             /**
              * The bytecode order for super assignment should be one of this:
              *  - CBC_EXT_PUSH_SUPER, CBC_EXT_SUPER_PROP_ASSIGN.
+             *  - CBC_EXT_PUSH_STATIC_SUPER, CBC_EXT_SUPER_PROP_ASSIGN.
              *  - CBC_EXT_PUSH_CONSTRUCTOR_SUPER_PROP, CBC_EXT_SUPER_PROP_ASSIGN.
              * That is one ext opcode back (-1).
              */
             JERRY_ASSERT (byte_code_start_p[-1] == CBC_EXT_PUSH_SUPER
+                          || byte_code_start_p[-1] == CBC_EXT_PUSH_STATIC_SUPER
                           || byte_code_start_p[-1] == CBC_EXT_PUSH_CONSTRUCTOR_SUPER_PROP);
           }
 

--- a/tests/jerry/es2015/regression-test-issue-3458.js
+++ b/tests/jerry/es2015/regression-test-issue-3458.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class Animal {}
+class Dog extends Animal {
+  static explain () {
+    super.f = 8
+  }
+}
+
+assert (Dog.f === undefined);
+assert (Animal.f === undefined);
+
+Dog.explain ()
+
+assert (Animal.f === undefined);
+assert (Dog.f === 8);


### PR DESCRIPTION
In case of static super member assignments there was a missing
check to validate if the CBC opcode is of CBC_EXT_PUSH_STATIC_SUPER.

Fixes: #3458 