### PR TITLE
Early return when the scanner throws an error while parsing an invalid function identifier

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -455,6 +455,18 @@ scanner_pop_literal_pool (parser_context_t *context_p, /**< context */
 {
   scanner_literal_pool_t *literal_pool_p = scanner_context_p->active_literal_pool_p;
   scanner_literal_pool_t *prev_literal_pool_p = literal_pool_p->prev_p;
+
+  if (literal_pool_p->source_p == NULL)
+  {
+    JERRY_ASSERT (literal_pool_p->status_flags & SCANNER_LITERAL_POOL_FUNCTION);
+    JERRY_ASSERT (literal_pool_p->literal_pool.data.first_p == NULL
+                  && literal_pool_p->literal_pool.data.last_p == NULL);
+
+    scanner_context_p->active_literal_pool_p = literal_pool_p->prev_p;
+    scanner_free (literal_pool_p, sizeof (scanner_literal_pool_t));
+    return;
+  }
+
   parser_list_iterator_t literal_iterator;
   lexer_lit_location_t *literal_p;
   bool is_function = (literal_pool_p->status_flags & SCANNER_LITERAL_POOL_FUNCTION) != 0;

--- a/tests/jerry/es2015/regression-test-issue-3454.js
+++ b/tests/jerry/es2015/regression-test-issue-3454.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+"use strict"
+try {
+  eval("var $ = function yield() {}");
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
Fixes #3454

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu