### PR TITLE
Remove asserts from ecma_number_is_zero and is_inf

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -298,8 +298,6 @@ ecma_number_is_negative (ecma_number_t num) /**< ecma-number */
 bool
 ecma_number_is_zero (ecma_number_t num) /**< ecma-number */
 {
-  JERRY_ASSERT (!ecma_number_is_nan (num));
-
   bool is_zero = (num == ECMA_NUMBER_ZERO);
 
 #ifndef JERRY_NDEBUG
@@ -323,8 +321,6 @@ ecma_number_is_zero (ecma_number_t num) /**< ecma-number */
 bool
 ecma_number_is_infinity (ecma_number_t num) /**< ecma-number */
 {
-  JERRY_ASSERT (!ecma_number_is_nan (num));
-
   uint32_t biased_exp = ecma_number_get_biased_exponent_field (num);
   uint64_t fraction = ecma_number_get_fraction_field (num);
 


### PR DESCRIPTION
There is no reason to force the developer to call ecma_number_is_nan
check before all ecma_number_is_zero and ecma_number_is_infinity.
These functions work fine and return false if NaN is passed.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
