### PR TITLE
Fix the parsing/scanning of empty return statement

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -2914,6 +2914,7 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 
         if ((context_p->token.flags & LEXER_WAS_NEWLINE)
             || context_p->token.type == LEXER_SEMICOLON
+            || context_p->token.type == LEXER_EOS
             || context_p->token.type == LEXER_RIGHT_BRACE)
         {
 #if ENABLED (JERRY_ES2015)

--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -1579,6 +1579,7 @@ scanner_scan_statement (parser_context_t *context_p, /**< context */
 
       if (!(context_p->token.flags & LEXER_WAS_NEWLINE)
           && context_p->token.type != LEXER_SEMICOLON
+          && context_p->token.type != LEXER_EOS
           && context_p->token.type != LEXER_RIGHT_BRACE)
       {
         scanner_context_p->mode = SCAN_MODE_PRIMARY_EXPRESSION;

--- a/tests/jerry/regression-test-issue-3467.js
+++ b/tests/jerry/regression-test-issue-3467.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert(new Function("return")() === undefined);


### PR DESCRIPTION
This patch fixes #3467.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
