### PR TITLE
Support nested destructuring patterns in catch header

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1922,13 +1922,13 @@ parser_parse_try_statement_end (parser_context_t *context_p) /**< context */
 #endif /* ENABLED (JERRY_ES2015) */
 
       lexer_next_token (context_p);
+
+#ifndef JERRY_NDEBUG
+      JERRY_ASSERT (block_found);
+#endif /* !JERRY_NDEBUG */
 #if ENABLED (JERRY_ES2015)
     }
 #endif /* ENABLED (JERRY_ES2015) */
-
-#ifndef JERRY_NDEBUG
-    JERRY_ASSERT (block_found);
-#endif /* !JERRY_NDEBUG */
 
     if (context_p->token.type != LEXER_RIGHT_PAREN)
     {

--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -829,10 +829,8 @@ scanner_scan_primary_expression_end (parser_context_t *context_p, /**< context *
 
       lexer_next_token (context_p);
 
-      if (binding_type == SCANNER_BINDING_CATCH)
+      if (binding_type == SCANNER_BINDING_CATCH && context_p->stack_top_uint8 == SCAN_STACK_CATCH_STATEMENT)
       {
-        JERRY_ASSERT (context_p->stack_top_uint8 == SCAN_STACK_CATCH_STATEMENT);
-
         scanner_pop_binding_list (scanner_context_p);
 
         if (context_p->token.type != LEXER_RIGHT_PAREN)

--- a/tests/jerry/es2015/try-pattern.js
+++ b/tests/jerry/es2015/try-pattern.js
@@ -71,3 +71,19 @@ try {
 } catch (e) {
   assert(e instanceof ReferenceError)
 }
+
+try {
+  throw [{a : 5}];
+} catch([{a}]) {
+  assert(a === 5);
+}
+
+var catchReached = false;
+try {
+  throw [{}];
+  assert(false);
+} catch([{}]) {
+  catchReached = true;
+}
+
+assert(catchReached);


### PR DESCRIPTION
This patch fixes #3433.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
