### PR TITLE
Fix for-of block context creation for empty destructuring pattern

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1189,12 +1189,12 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
       else
       {
         token_type = LEXER_KEYW_LET;
-        has_context = true;
+        has_context = (context_p->next_scanner_info_p->source_p == context_p->source_p);
         scanner_get_location (&start_location, context_p);
       }
     }
 
-    if (has_context && (context_p->next_scanner_info_p->source_p == context_p->source_p))
+    if (has_context)
     {
       has_context = parser_push_block_context (context_p, true);
     }

--- a/tests/jerry/es2015/regression-test-issue-3421.js
+++ b/tests/jerry/es2015/regression-test-issue-3421.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright 2014 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+for (let [] of [[],[]]);


### PR DESCRIPTION
This patch fixes #3421.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
