### PR TITLE
Use Python 3.6 in case of Zephyr target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,11 +120,13 @@ matrix:
       script: make -f ./targets/mbedos5/Makefile.travis script
 
     - name: "Zephyr/Arduino 101 Build Test"
+      language: python # NOTE: only way to ensure python>=2.7.10 on Trusty image
+      python: 3.6
       install: make -f ./targets/zephyr/Makefile.travis install-noapt
       script: make -f ./targets/zephyr/Makefile.travis script
       addons:
         apt:
-          packages: [gperf, dfu-util, device-tree-compiler, python3-ply, python3-pip]
+          packages: [gperf, dfu-util, device-tree-compiler]
 
     - name: "NuttX/STM32F4 Build Test"
       install: make -f targets/nuttx-stm32f4/Makefile.travis install-noapt

--- a/targets/zephyr/Makefile.travis
+++ b/targets/zephyr/Makefile.travis
@@ -23,7 +23,7 @@ all:
 
 # Install tools via apt.
 install-apt-get-deps:
-	sudo apt-get install -q -y gperf dfu-util device-tree-compiler python3-ply python3-pip
+	sudo apt-get install -q -y gperf dfu-util device-tree-compiler
 
 # Install Zephyr SDK.
 install-zephyr-sdk:
@@ -33,13 +33,13 @@ install-zephyr-sdk:
 # Fetch Zephyr Project repository and install python dependencies.
 install-zephyr:
 	git clone https://github.com/zephyrproject-rtos/zephyr.git ../zephyr -b v1.14-branch
-	pip3 install --user -U pip
-	pip3 install --user -U setuptools
-	pip3 install --user -r ../zephyr/scripts/requirements.txt
+	pip3 install -U pip
+	pip3 install -U setuptools
+	pip3 install -r ../zephyr/scripts/requirements.txt
 
 # Install recent CMake
 install-cmake:
-	pip install --user cmake
+	pip install cmake
 	cmake --version
 
 # Perform all the necessary (JerryScript-independent) installation steps.


### PR DESCRIPTION
PyYAML requires Python 2.7 or Python 3.4+.