### PR TITLE
Tagged template object references should be released only in post_processing

### DIFF
--- a/jerry-core/parser/js/js-parser-tagged-template-literal.c
+++ b/jerry-core/parser/js/js-parser-tagged-template-literal.c
@@ -141,8 +141,6 @@ parser_tagged_template_literal_finalize (ecma_object_t *template_obj_p, /**< tem
 {
   parser_tagged_template_literal_freeze_array (template_obj_p);
   parser_tagged_template_literal_freeze_array (raw_strings_p);
-
-  ecma_deref_object (template_obj_p);
 } /* parser_tagged_template_literal_finalize */
 #endif /* ENABLED (JERRY_ES2015) */
 

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1614,6 +1614,14 @@ parser_post_processing (parser_context_t *context_p) /**< context */
     }
 
     tagged_base_p[-1] = (ecma_value_t) context_p->tagged_template_literal_cp;
+
+    ecma_collection_t *collection_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
+                                                                       context_p->tagged_template_literal_cp);
+
+    for (uint32_t i = 0; i < collection_p->item_count; i++)
+    {
+      ecma_free_value (collection_p->buffer_p[i]);
+    }
   }
 #endif /* ENABLED (JERRY_ES2015) */
 

--- a/tests/jerry/es2015/regression-test-issue-3483.js
+++ b/tests/jerry/es2015/regression-test-issue-3483.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function assertThrows(src) {
+  try {
+    eval(src);
+    assert(false);
+  } catch (e) {
+    assert(e instanceof SyntaxError);
+  }
+}
+
+assertThrows('Setting `o.bar` to');
+assertThrows('Setting `o.bar`; Setting `o.bar` to');
+assertThrows('Setting `o.bar`; Setting `o.bar`; Setting `o.bar` to');


### PR DESCRIPTION
This patch fixes #3483.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu