### PR TITLE
Fix literal object initialization in CBC_INIT_LOCAL

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -993,15 +993,25 @@ vm_init_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         ecma_string_t *name_p = ecma_get_string_from_value (literal_start_p[literal_index]);
 
         JERRY_ASSERT (ecma_get_lex_env_type (frame_ctx_p->lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_DECLARATIVE);
-        JERRY_ASSERT (ecma_find_named_property (frame_ctx_p->lex_env_p, name_p) == NULL);
 
+        ecma_property_t *prop_p = ecma_find_named_property (frame_ctx_p->lex_env_p, name_p);
         ecma_property_value_t *property_value_p;
-        property_value_p = ecma_create_named_data_property (frame_ctx_p->lex_env_p,
-                                                            name_p,
-                                                            ECMA_PROPERTY_FLAG_WRITABLE,
-                                                            NULL);
 
-        JERRY_ASSERT (property_value_p->value == ECMA_VALUE_UNDEFINED);
+        if (prop_p == NULL)
+        {
+          property_value_p = ecma_create_named_data_property (frame_ctx_p->lex_env_p,
+                                                              name_p,
+                                                              ECMA_PROPERTY_FLAG_WRITABLE,
+                                                              NULL);
+
+          JERRY_ASSERT (property_value_p->value == ECMA_VALUE_UNDEFINED);
+        }
+        else
+        {
+          property_value_p = ECMA_PROPERTY_VALUE_PTR (prop_p);
+          ecma_free_value_if_not_object (property_value_p->value);
+        }
+
         property_value_p->value = lit_value;
 
         if (value_index >= register_end)

--- a/tests/jerry/es2015/regression-test-issue-3396.js
+++ b/tests/jerry/es2015/regression-test-issue-3396.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function i($, b = (eval("var x = {}"))) {
+  function x() {}
+  assert (typeof x === "function");
+  eval();
+}
+
+i();


### PR DESCRIPTION
Due to default arguments the lexical binding may exists before the literal object initialization.

This patch fixes #3396.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
