### PR TITLE
Correctly handle celestial plane codepoints in ES5.1.

### DIFF
--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -223,6 +223,8 @@ lit_code_point_is_identifier_start (lit_code_point_t code_point) /**< code point
     /* TODO: detect these ranges correctly. */
     return (code_point >= 0x10C80 && code_point <= 0x10CF2);
   }
+#else /* !ENABLED (JERRY_ES2015) */
+  JERRY_ASSERT (code_point <= LIT_UTF8_4_BYTE_CODE_POINT_MIN);
 #endif /* ENABLED (JERRY_ES2015) */
 
   return lit_char_is_unicode_letter ((ecma_char_t) code_point);
@@ -252,6 +254,8 @@ lit_code_point_is_identifier_part (lit_code_point_t code_point) /**< code point 
     /* TODO: detect these ranges correctly. */
     return (code_point >= 0x10C80 && code_point <= 0x10CF2);
   }
+#else /* !ENABLED (JERRY_ES2015) */
+  JERRY_ASSERT (code_point <= LIT_UTF8_4_BYTE_CODE_POINT_MIN);
 #endif /* ENABLED (JERRY_ES2015) */
 
   return (lit_char_is_unicode_letter ((ecma_char_t) code_point)

--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -201,7 +201,6 @@ typedef enum
 #define LEXER_NEWLINE_LS_PS_BYTE_1 0xe2
 #define LEXER_NEWLINE_LS_PS_BYTE_23(source) \
   ((source)[1] == LIT_UTF8_2_BYTE_CODE_POINT_MIN && ((source)[2] | 0x1) == 0xa9)
-#define LEXER_UTF8_4BYTE_START 0xf0
 
 #define LEXER_IS_LEFT_BRACKET(type) \
   ((type) == LEXER_LEFT_BRACE || (type) == LEXER_LEFT_PAREN || (type) == LEXER_LEFT_SQUARE)

--- a/tests/unit-core/test-api-errortype.c
+++ b/tests/unit-core/test-api-errortype.c
@@ -62,5 +62,17 @@ main (void)
     jerry_release_value (test_values[idx]);
   }
 
+  char test_source[] = "\xF0\x9D\x84\x9E";
+
+  jerry_value_t result = jerry_parse (NULL,
+                                      0,
+                                      (const jerry_char_t *) test_source,
+                                      sizeof (test_source) - 1,
+                                      JERRY_PARSE_NO_OPTS);
+  TEST_ASSERT (jerry_value_is_error (result));
+  TEST_ASSERT (jerry_get_error_type (result) == JERRY_ERROR_SYNTAX);
+
+  jerry_release_value (result);
+
   jerry_cleanup ();
 } /* main */


### PR DESCRIPTION
Fixes #3498.