### PR TITLE
Always mark the identifers which are propagated to upper level after argument parsing.

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -970,10 +970,7 @@ scanner_filter_arguments (parser_context_t *context_p, /**< context */
       lexer_lit_location_t *literal_location_p = scanner_add_custom_literal (context_p,
                                                                              prev_literal_pool_p,
                                                                              literal_p);
-      if (type & SCANNER_LITERAL_NO_REG)
-      {
-        type |= SCANNER_LITERAL_NO_REG;
-      }
+      type |= SCANNER_LITERAL_NO_REG;
 
 #if ENABLED (JERRY_ES2015)
       type |= SCANNER_LITERAL_IS_USED;

--- a/tests/jerry/es2015/function-pattern2.js
+++ b/tests/jerry/es2015/function-pattern2.js
@@ -76,3 +76,18 @@ Function("{a, x:b}","[c]", "{ 'dd':d, e = Math.cos(0)}",
   "assert(d === 4);" +
   "assert(e === 1);"
 )({a:1, b:3}, [3], {a:1, b:2, dd:4});
+
+function m()
+{
+  var prop_name = "x";
+  var def_val = 123;
+
+  function g({[prop_name]: a, b = def_val })
+  {
+    assert(a === 12);
+    assert(b === 123);
+  }
+
+  g({ x:12 })
+}
+m();


### PR DESCRIPTION
#3511 updates the same test, so the patch needs to be updated after either of them lands