### PR TITLE
Add runtime option "--call-on-exit [FUNCNAME]" to main-unix.c

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-2544.js
+++ b/tests/jerry/es2015/regression-test-issue-2544.js
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 Object.defineProperty(Array.prototype, 0, { get : function () { throw $; } });
-var asyncPassed = false;
-Promise.race([ , this]).then(Error).catch(function(err) { asyncPassed = (err instanceof ReferenceError); });
-new Promise(function() {
-  throw 5;
-}).then(Error).catch(function() { assert(asyncPassed); });
+var global_err = undefined;
+Promise.race([ , this]).then(Error).catch(function(err) { global_err = err; });
+
+function __checkAsync() {
+  assert(global_err instanceof ReferenceError);
+}

--- a/tools/runners/run-test-suite.py
+++ b/tools/runners/run-test-suite.py
@@ -127,7 +127,7 @@ def run_normal_tests(args, tests):
     test_cmd = get_platform_cmd_prefix()
     if args.runtime:
         test_cmd.append(args.runtime)
-    test_cmd.append(args.engine)
+    test_cmd.extend([args.engine, '--call-on-exit', '__checkAsync'])
 
     total = len(tests)
     tested = 0
@@ -161,6 +161,7 @@ def run_snapshot_tests(args, tests):
         generate_snapshot_cmd.append(args.runtime)
 
     execute_snapshot_cmd.extend([args.engine, '--exec-snapshot', 'js.snapshot'])
+    execute_snapshot_cmd.extend(['--call-on-exit', '__checkAsync'])
 
     # engine: jerry[.exe] -> snapshot generator: jerry-snapshot[.exe]
     engine = os.path.splitext(args.engine)


### PR DESCRIPTION
With this option you can call a function after the user script and promises have ran, to be able to do assertions that are executed just before the process would exit.

JerryScript-DCO-1.0-Signed-off-by: Daniel Balla dballa@inf.u-szeged.hu