### PR TITLE
Fix new.target invalidity check

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -119,16 +119,18 @@ parser_check_invalid_assign (parser_context_t *context_p) /**< context */
  */
 static void
 parser_check_invalid_new_target (parser_context_t *context_p, /**< parser context */
-                                     cbc_opcode_t opcode) /**< current opcode under parsing */
+                                 cbc_opcode_t opcode) /**< current opcode under parsing */
 {
-  JERRY_ASSERT ((opcode >= CBC_PRE_INCR && opcode <= CBC_POST_DECR)
-                || (opcode == CBC_ASSIGN
-                    && (context_p->token.type == LEXER_ASSIGN
-                        || LEXER_IS_BINARY_LVALUE_TOKEN (context_p->token.type))));
-
   /* new.target is an invalid left-hand side target */
   if (context_p->last_cbc_opcode == PARSER_TO_EXT_OPCODE (CBC_EXT_PUSH_NEW_TARGET))
   {
+    /* Make sure that the call side is a post/pre increment or an assignment expression.
+     * There should be no other ways the "new.target" expression should be here. */
+    JERRY_ASSERT ((opcode >= CBC_PRE_INCR && opcode <= CBC_POST_DECR)
+                  || (opcode == CBC_ASSIGN
+                      && (context_p->token.type == LEXER_ASSIGN
+                          || LEXER_IS_BINARY_LVALUE_TOKEN (context_p->token.type))));
+
     parser_raise_error (context_p, PARSER_ERR_NEW_TARGET_NOT_ALLOWED);
   }
 } /* parser_check_invalid_new_target */

--- a/tests/jerry/es2015/regression-test-issue-3519.js
+++ b/tests/jerry/es2015/regression-test-issue-3519.js
@@ -1,0 +1,24 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function method () {
+    [""] = $
+}
+
+try {
+  eval ("function mm () { [new.target] = 3; }");
+  assert (false);
+} catch (ex) {
+  assert (ex instanceof SyntaxError);
+}


### PR DESCRIPTION
Fixes #3519

Only check the assert if the new.target bytecode is detected.