### PR TITLE
Add missing release value to ecma_op_object_get_property_names

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2159,6 +2159,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
                 }
                 else
                 {
+                  ecma_deref_ecma_string (name_p);
                   continue;
                 }
 

--- a/tests/jerry/regression-test-issue-3523.js
+++ b/tests/jerry/regression-test-issue-3523.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var obj = {
+    sort: Array.prototype.sort,
+    $: 0
+}
+assert(obj.sort() === obj);


### PR DESCRIPTION
This patch fixes #3523.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

