### PR TITLE
Fix assignment opcode transformation for CBC_PUSH_THIS_LITERAL

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -2156,6 +2156,13 @@ parser_append_binary_single_assignment_token (parser_context_t *context_p, /**< 
     parser_stack_push_uint16 (context_p, literal_index);
     parser_stack_push_uint8 (context_p, assign_ident_opcode);
   }
+  else if (context_p->last_cbc_opcode == CBC_PUSH_THIS_LITERAL)
+  {
+    context_p->last_cbc_opcode = CBC_PUSH_THIS;
+    parser_flush_cbc (context_p);
+    parser_stack_push_uint16 (context_p, context_p->last_cbc.literal_index);
+    parser_stack_push_uint8 (context_p, assign_ident_opcode);
+  }
   else if (context_p->last_cbc_opcode == CBC_PUSH_PROP)
   {
     JERRY_ASSERT (CBC_SAME_ARGS (CBC_PUSH_PROP, CBC_ASSIGN));
@@ -2248,6 +2255,12 @@ parser_append_binary_token (parser_context_t *context_p) /**< context */
     else if (PARSER_IS_PUSH_PROP (context_p->last_cbc_opcode))
     {
       context_p->last_cbc_opcode = PARSER_PUSH_PROP_TO_PUSH_PROP_REFERENCE (context_p->last_cbc_opcode);
+    }
+    else if (context_p->last_cbc_opcode == CBC_PUSH_THIS_LITERAL)
+    {
+      context_p->last_cbc_opcode = CBC_PUSH_THIS;
+      parser_flush_cbc (context_p);
+      context_p->last_cbc_opcode = CBC_PUSH_IDENT_REFERENCE;
     }
     else
     {

--- a/tests/jerry/regression-test-issue-3477.js
+++ b/tests/jerry/regression-test-issue-3477.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function _p(arg1, arg2) {
+  return arg1 ? arg1 : arg2;
+}
+
+var _ref;
+var constructor = _p(this, (_ref = Object.getPrototypeOf(function (){})).call({}));
+assert(constructor === this);
+
+try {
+  _p(this, (_ref += Object.getPrototypeOf(function (){})).call({}));
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #3477.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
