### PR TITLE
Colon must be expected after computed property name in object destructuring

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -2831,10 +2831,14 @@ parser_parse_object_initializer (parser_context_t *context_p, /**< context */
     }
     else
     {
-      if (push_prop_opcode != CBC_EXT_INITIALIZER_PUSH_PROP
-          && (context_p->token.type == LEXER_RIGHT_BRACE
-              || context_p->token.type == LEXER_ASSIGN
-              || context_p->token.type == LEXER_COMMA))
+      if (push_prop_opcode == CBC_EXT_INITIALIZER_PUSH_PROP)
+      {
+        parser_raise_error (context_p, PARSER_ERR_COLON_EXPECTED);
+      }
+
+      if (context_p->token.type == LEXER_RIGHT_BRACE
+          || context_p->token.type == LEXER_ASSIGN
+          || context_p->token.type == LEXER_COMMA)
       {
         parser_reparse_as_common_identifier (context_p, start_line, start_column);
         lexer_next_token (context_p);

--- a/tests/jerry/es2015/regression-test-issue-3527.js
+++ b/tests/jerry/es2015/regression-test-issue-3527.js
@@ -1,0 +1,34 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function assertThrows(src) {
+  try {
+    eval(src);
+    assert(false);
+  } catch (e) {
+    assert(e instanceof SyntaxError);
+  }
+}
+
+assertThrows(`function $({
+  $: {
+      [$.$]
+  }
+}) {}`);
+
+assertThrows(`function $({
+  $: {
+      [$]
+  }
+}) {}`);


### PR DESCRIPTION
This patch fixes #3527.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
