### PR TITLE
Fix the build with enabled debugger on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,15 +17,15 @@ platform:
 
 environment:
   matrix:
-    - FEATURE_DEBUGGER: ON
-    - FEATURE_DEBUGGER: OFF
+    - JERRY_DEBUGGER: ON
+    - JERRY_DEBUGGER: OFF
 
 # Steps of a job.
 init:
   - cmake -version
 before_build:
-  - if "%PLATFORM%"=="Win32" cmake -G"Visual Studio 15 2017" -Bbuild -H. -DFEATURE_DEBUGGER=%FEATURE_DEBUGGER%
-  - if "%PLATFORM%"=="x64" cmake -G"Visual Studio 15 2017 Win64" -Bbuild -H. -DFEATURE_DEBUGGER=%FEATURE_DEBUGGER%
+  - if "%PLATFORM%"=="Win32" cmake -G"Visual Studio 15 2017" -Bbuild -H. -DJERRY_DEBUGGER=%JERRY_DEBUGGER%
+  - if "%PLATFORM%"=="x64" cmake -G"Visual Studio 15 2017 Win64" -Bbuild -H. -DJERRY_DEBUGGER=%JERRY_DEBUGGER%
 build:
   project: build\Jerry.sln
   parallel: true

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -50,7 +50,7 @@ target_link_libraries(${JERRY_EXT_NAME} jerry-core)
 
 set(JERRY_EXT_PKGCONFIG_LIBS)
 
-if(USING_MSVC AND FEATURE_DEBUGGER)
+if(USING_MSVC AND JERRY_DEBUGGER)
   target_link_libraries(${JERRY_EXT_NAME} ws2_32)
   set(JERRY_EXT_PKGCONFIG_LIBS -lws2_32)
 endif()

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -175,6 +175,8 @@ JERRY_BUILDOPTIONS = [
             OPTIONS_GC_MARK_LIMIT),
     Options('buildoption_test-single-source',
             ['--cmake-param=-DENABLE_ALL_IN_ONE_SOURCE=ON']),
+    Options('buildoption_test-jerry-debugger',
+            ['--jerry-debugger=on']),
 ]
 
 def get_arguments():


### PR DESCRIPTION
Changes:
- Typo fixed in cmake build system and appveyor config
- Added a new buildoption test

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
