### PR TITLE
Fix array-indexed property name calculation for fast access mode arrays in property name listing

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -301,6 +301,18 @@ ecma_fast_array_set_property (ecma_object_t *object_p, /**< fast access mode arr
   return true;
 } /* ecma_fast_array_set_property */
 
+/**
+ * Get the number of array holes in a fast access array object
+ *
+ * @return number of array holes in a fast access array object
+ */
+inline uint32_t JERRY_ATTR_ALWAYS_INLINE
+ecma_fast_array_get_hole_count (ecma_object_t *obj_p) /**< fast access mode array object */
+{
+  JERRY_ASSERT (ecma_op_object_is_fast_array (obj_p));
+
+  return ((ecma_extended_object_t *) obj_p)->u.array.u.hole_count >> ECMA_FAST_ARRAY_HOLE_SHIFT;
+} /* ecma_fast_array_get_hole_count */
 
 /**
  * Extend the underlying buffer of a fast mode access array for the given new length

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -74,6 +74,9 @@ ecma_op_object_is_fast_array (ecma_object_t *object_p);
 bool
 ecma_op_array_is_fast_array (ecma_extended_object_t *array_p);
 
+uint32_t
+ecma_fast_array_get_hole_count (ecma_object_t *obj_p);
+
 ecma_value_t *
 ecma_fast_array_extend (ecma_object_t *object_p, uint32_t new_lengt);
 

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2015,7 +2015,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
       ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) prototype_chain_iter_p;
 
       uint32_t length = ext_obj_p->u.array.length;
-      array_index_named_properties_count = length;
+      array_index_named_properties_count = length - ecma_fast_array_get_hole_count (prototype_chain_iter_p);
 
       ecma_value_t *values_p = ECMA_GET_NON_NULL_POINTER (ecma_value_t, prop_iter_cp);
 

--- a/tests/jerry/regression-test-issue-3532.js
+++ b/tests/jerry/regression-test-issue-3532.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var reached = false;
+
+function dConstr () {}
+dConstr.prototype = [, ]
+for (var $ in new dConstr()) {
+  reached = true;
+}
+
+assert(!reached);


### PR DESCRIPTION
This patch fixes #3532.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
