### PR TITLE
Add missing release value call to Array.prototype.pop fast path.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -428,6 +428,7 @@ ecma_builtin_array_prototype_object_pop (ecma_object_t *obj_p, /**< array object
   {
     if (!ecma_get_object_extensible (obj_p))
     {
+      ecma_free_value (get_value);
       return ecma_raise_type_error (ECMA_ERR_MSG ("Invalid argument type."));
     }
 

--- a/tests/jerry/es2015/regression-test-issue-3534.js
+++ b/tests/jerry/es2015/regression-test-issue-3534.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var array = [$, Infinity]
+Reflect.preventExtensions(array);
+
+try {
+  var $ = array.pop()
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #3534.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
