### PR TITLE
Foreach API methods should not iterate over internal objects

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -1142,7 +1142,8 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
           JERRY_ASSERT (ext_object_p->u.class_prop.class_id == LIT_MAGIC_STRING_UNDEFINED
                         || ext_object_p->u.class_prop.class_id == LIT_MAGIC_STRING_ARGUMENTS_UL
                         || ext_object_p->u.class_prop.class_id == LIT_MAGIC_STRING_BOOLEAN_UL
-                        || ext_object_p->u.class_prop.class_id == LIT_MAGIC_STRING_ERROR_UL);
+                        || ext_object_p->u.class_prop.class_id == LIT_MAGIC_STRING_ERROR_UL
+                        || ext_object_p->u.class_prop.class_id == LIT_INTERNAL_MAGIC_STRING_INTERNAL_OBJECT);
           break;
         }
       }

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -73,6 +73,7 @@ typedef enum
   LIT_INTERNAL_MAGIC_STRING_CLASS_THIS_BINDING, /**< the this binding of the class constructor */
   LIT_INTERNAL_MAGIC_STRING_WEAK_REFS, /**< Weak references to the current object */
   LIT_INTERNAL_MAGIC_STRING_CONTAINER, /**< Literal ID for internal container objects */
+  LIT_INTERNAL_MAGIC_STRING_INTERNAL_OBJECT, /**< Internal object ID for internal properties */
   LIT_MAGIC_STRING__COUNT /**< number of magic strings */
 } lit_magic_string_id_t;
 


### PR DESCRIPTION
The `jerry_objects_foreach` and `jerry_objects_foreach_by_native_info` methods
iterates over all objects. However in ES 2015 there are a few special objects
which should only be used internally thus these objects should not be accessed
by the API user.
