### PR TITLE
Update the RegExp constructor to ECMA-262 v6

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -31,6 +31,7 @@
 #include "ecma-helpers.h"
 #include "ecma-init-finalize.h"
 #include "ecma-lex-env.h"
+#include "lit-char-helpers.h"
 #include "ecma-literal-storage.h"
 #include "ecma-objects.h"
 #include "ecma-objects-general.h"
@@ -1773,11 +1774,20 @@ jerry_create_regexp_sz (const jerry_char_t *pattern_p, /**< zero-terminated UTF-
     return jerry_throw (ecma_raise_common_error (ECMA_ERR_MSG ("Input must be a valid utf8 string")));
   }
 
+  ecma_object_t *regexp_obj_p = ecma_op_regexp_alloc (NULL);
+
+  if (JERRY_UNLIKELY (regexp_obj_p == NULL))
+  {
+    return ECMA_VALUE_ERROR;
+  }
+
   ecma_string_t *ecma_pattern = ecma_new_ecma_string_from_utf8 (pattern_p, pattern_size);
 
-  jerry_value_t ret_val = ecma_op_create_regexp_object (ecma_pattern, flags);
-
+  jerry_value_t ret_val = ecma_op_create_regexp_with_flags (regexp_obj_p,
+                                                            ecma_make_string_value (ecma_pattern),
+                                                            flags);
   ecma_deref_ecma_string (ecma_pattern);
+
   return ret_val;
 
 #else /* !ENABLED (JERRY_BUILTIN_REGEXP) */

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -1062,17 +1062,24 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
           ecma_dealloc_number (num_p);
           break;
         }
-
+#if ENABLED (JERRY_ES2015)
+        case LIT_INTERNAL_MAGIC_STRING_REGEXP_PROTO:
+        {
+          jmem_heap_free_block (ECMA_GET_INTERNAL_VALUE_POINTER (void, ext_object_p->u.class_prop.u.value),
+                                ECMA_REGEXP_PROTO_COMPILED_CODE_SIZE);
+          break;
+        }
+#endif /* ENABLED (JERRY_ES2015) */
         case LIT_MAGIC_STRING_REGEXP_UL:
         {
-          ecma_compiled_code_t *bytecode_p;
-          bytecode_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (ecma_compiled_code_t,
-                                                            ext_object_p->u.class_prop.u.value);
+          ecma_compiled_code_t *bytecode_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (ecma_compiled_code_t,
+                                                                                  ext_object_p->u.class_prop.u.value);
 
           if (bytecode_p != NULL)
           {
             ecma_bytecode_deref (bytecode_p);
           }
+
           break;
         }
 #if ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY)

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -940,6 +940,13 @@ typedef struct
                                      *   If regexp, the other flags must be RE_FLAG... */
 } ecma_compiled_code_t;
 
+/**
+ * The proper memory size for the RegExp.prototype. We have to align the header's size manually, because
+ * in the struct, it is aligned to 8 bytes during the compilation.
+ */
+#define ECMA_REGEXP_PROTO_COMPILED_CODE_SIZE \
+  (JERRY_ALIGNUP (sizeof (ecma_compiled_code_t), JMEM_ALIGNMENT) + sizeof (ecma_value_t))
+
 #if ENABLED (JERRY_SNAPSHOT_EXEC)
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1494,6 +1494,28 @@ ecma_compiled_code_get_tagged_template_collection (const ecma_compiled_code_t *b
 } /* ecma_compiled_code_get_tagged_template_collection */
 #endif /* ENABLED (JERRY_ES2015) */
 
+/**
+ * Helper function to check if the given value is a class
+ *
+ * @return pointer to the extended object - if 'this' is a class
+ *         NULL- otherwise
+ */
+ecma_extended_object_t *
+ecma_op_check_object_type_is_class (ecma_value_t this)  /**< this value */
+{
+  if (ecma_is_value_object (this))
+  {
+    ecma_object_t *obj_p = ecma_get_object_from_value (this);
+
+    if (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_CLASS)
+    {
+      return (ecma_extended_object_t *) obj_p;
+    }
+  }
+
+  return NULL;
+} /* ecma_op_check_object_type_is_class */
+
 #if ENABLED (JERRY_LINE_INFO) || ENABLED (JERRY_ES2015_MODULE_SYSTEM) || ENABLED (JERRY_ES2015)
 /**
  * Get the number of formal parameters of the compiled code

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -430,6 +430,7 @@ uint8_t ecma_get_object_builtin_id (ecma_object_t *object_p);
 ecma_lexical_environment_type_t JERRY_ATTR_PURE ecma_get_lex_env_type (const ecma_object_t *object_p);
 ecma_object_t JERRY_ATTR_PURE *ecma_get_lex_env_binding_object (const ecma_object_t *object_p);
 ecma_object_t *ecma_clone_decl_lexical_environment (ecma_object_t *lex_env_p, bool copy_values);
+ecma_extended_object_t *ecma_op_check_object_type_is_class (ecma_value_t this);
 
 ecma_property_value_t *
 ecma_create_named_data_property (ecma_object_t *object_p, ecma_string_t *name_p, uint8_t prop_attributes,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -814,7 +814,7 @@ ecma_builtin_helper_def_prop_by_index (ecma_object_t *obj_p, /**< object */
  */
 ecma_value_t
 ecma_builtin_helper_def_prop (ecma_object_t *obj_p, /**< object */
-                              ecma_string_t *index_p, /**< index string */
+                              ecma_string_t *name_p, /**< name string */
                               ecma_value_t value, /**< value */
                               uint32_t opts) /**< any combination of ecma_property_flag_t bits
                                               *   with the optional ECMA_IS_THROW flag */
@@ -826,7 +826,7 @@ ecma_builtin_helper_def_prop (ecma_object_t *obj_p, /**< object */
   prop_desc.value = value;
 
   return ecma_op_object_define_own_property (obj_p,
-                                             index_p,
+                                             name_p,
                                              &prop_desc);
 } /* ecma_builtin_helper_def_prop */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -60,7 +60,7 @@ bool
 ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, ecma_string_t *search_str_p, bool first_index,
                                        ecma_length_t start_pos, ecma_length_t *ret_index_p);
 ecma_value_t
-ecma_builtin_helper_def_prop (ecma_object_t *obj_p, ecma_string_t *index_p, ecma_value_t value, uint32_t opts);
+ecma_builtin_helper_def_prop (ecma_object_t *obj_p, ecma_string_t *name_p, ecma_value_t value, uint32_t opts);
 
 ecma_value_t
 ecma_builtin_helper_def_prop_by_index (ecma_object_t *obj_p, uint32_t index, ecma_value_t value, uint32_t opts);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -60,21 +60,23 @@ static ecma_value_t
 ecma_builtin_regexp_prototype_flags_helper (ecma_value_t this, /**< this value */
                                             uint16_t *flags_p) /**< [out] flags */
 {
-  if (!ecma_object_is_regexp_object (this))
+  ecma_extended_object_t *ext_obj_p = ecma_op_check_object_type_is_class (this);
+
+  if (ext_obj_p != NULL)
   {
-    return ecma_raise_type_error (ECMA_ERR_MSG ("Incompatible type"));
+    if (ext_obj_p->u.class_prop.class_id == LIT_MAGIC_STRING_REGEXP_UL
+        || ext_obj_p->u.class_prop.class_id == LIT_INTERNAL_MAGIC_STRING_REGEXP_PROTO)
+    {
+      re_compiled_code_t *bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t,
+                                                                  ext_obj_p->u.class_prop.u.value);
+
+      *flags_p = bc_p->header.status_flags;
+
+      return ECMA_VALUE_EMPTY;
+    }
   }
 
-  ecma_extended_object_t *re_obj_p = (ecma_extended_object_t *) ecma_get_object_from_value (this);
-  re_compiled_code_t *bc_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (re_compiled_code_t,
-                                                                  re_obj_p->u.class_prop.u.value);
-
-  if (bc_p != NULL)
-  {
-    *flags_p = bc_p->header.status_flags;
-  }
-
-  return ECMA_VALUE_EMPTY;
+  return ecma_raise_type_error (ECMA_ERR_MSG ("Incompatible type"));
 } /* ecma_builtin_regexp_prototype_flags_helper */
 
 /**
@@ -220,21 +222,21 @@ ecma_op_escape_regexp_pattern (ecma_string_t *pattern_str_p) /**< RegExp pattern
 static ecma_value_t
 ecma_builtin_regexp_prototype_get_source (ecma_value_t this_arg) /**< this argument */
 {
-  if (!ecma_object_is_regexp_object (this_arg))
+  ecma_extended_object_t *ext_obj_p = ecma_op_check_object_type_is_class (this_arg);
+
+  if (ext_obj_p != NULL)
   {
-    return ecma_raise_type_error (ECMA_ERR_MSG ("Incompatible type"));
+    if (ext_obj_p->u.class_prop.class_id == LIT_MAGIC_STRING_REGEXP_UL
+        || ext_obj_p->u.class_prop.class_id == LIT_INTERNAL_MAGIC_STRING_REGEXP_PROTO)
+    {
+      re_compiled_code_t *bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t,
+                                                                  ext_obj_p->u.class_prop.u.value);
+
+      return ecma_op_escape_regexp_pattern (ecma_get_string_from_value (bc_p->source));
+    }
   }
 
-  ecma_extended_object_t *re_obj_p = (ecma_extended_object_t *) ecma_get_object_from_value (this_arg);
-  re_compiled_code_t *bc_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (re_compiled_code_t,
-                                                                  re_obj_p->u.class_prop.u.value);
-
-  if (bc_p != NULL)
-  {
-    return ecma_op_escape_regexp_pattern (ecma_get_string_from_value (bc_p->source));
-  }
-
-  return ecma_make_string_value (ecma_get_magic_string (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP));
+  return ecma_raise_type_error (ECMA_ERR_MSG ("Incompatible type"));
 } /* ecma_builtin_regexp_prototype_get_source */
 
 /**
@@ -382,95 +384,47 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this argument
                                        ecma_value_t flags_arg) /**< flags */
 {
   if (!ecma_object_is_regexp_object (this_arg)
-      /* The builtin RegExp.prototype object does not have [[RegExpMatcher]] internal slot */
-      || ecma_get_object_from_value (this_arg) == ecma_builtin_get (ECMA_BUILTIN_ID_REGEXP_PROTOTYPE))
+#if !ENABLED (JERRY_ES2015)
+      || ecma_get_object_from_value (this_arg) == ecma_builtin_get (ECMA_BUILTIN_ID_REGEXP_PROTOTYPE)
+#endif /* !ENABLED (JERRY_ES2015) */
+      )
   {
     return ecma_raise_type_error (ECMA_ERR_MSG ("Incompatible type"));
   }
 
-  uint16_t flags = 0;
+  ecma_object_t *this_obj_p = ecma_get_object_from_value (this_arg);
+  ecma_ref_object (this_obj_p);
 
-  if (ecma_object_is_regexp_object (pattern_arg)
-      && ecma_get_object_from_value (pattern_arg) != ecma_builtin_get (ECMA_BUILTIN_ID_REGEXP_PROTOTYPE))
+  ecma_value_t status = ecma_builtin_helper_def_prop (this_obj_p,
+                                                      ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
+                                                      ecma_make_uint32_value (0),
+                                                      ECMA_PROPERTY_FLAG_WRITABLE | ECMA_PROP_IS_THROW);
+
+  JERRY_ASSERT (ecma_is_value_true (status));
+
+  if (ecma_object_is_regexp_object (pattern_arg))
   {
     if (!ecma_is_value_undefined (flags_arg))
     {
+      ecma_deref_object (this_obj_p);
       return ecma_raise_type_error (ECMA_ERR_MSG ("Invalid argument"));
     }
 
-    /* Compile from existing RegExp object. */
-    ecma_extended_object_t *target_p = (ecma_extended_object_t *) ecma_get_object_from_value (pattern_arg);
-    re_compiled_code_t *target_bc_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (re_compiled_code_t,
-                                                                           target_p->u.class_prop.u.value);
+    ecma_extended_object_t *pattern_obj_p = (ecma_extended_object_t *) ecma_get_object_from_value (pattern_arg);
+    re_compiled_code_t *bc_p = ECMA_GET_INTERNAL_VALUE_POINTER (re_compiled_code_t,
+                                                                pattern_obj_p->u.class_prop.u.value);
 
-    ecma_object_t *this_object_p = ecma_get_object_from_value (this_arg);
-    ecma_extended_object_t *current_p = (ecma_extended_object_t *) this_object_p;
-
-    re_compiled_code_t *current_bc_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (re_compiled_code_t,
-                                                                            current_p->u.class_prop.u.value);
-
-    JERRY_ASSERT (current_bc_p != NULL);
-    ecma_bytecode_deref ((ecma_compiled_code_t *) current_bc_p);
-
-    JERRY_ASSERT (target_bc_p != NULL);
-    ecma_bytecode_ref ((ecma_compiled_code_t *) target_bc_p);
-    ECMA_SET_INTERNAL_VALUE_POINTER (current_p->u.class_prop.u.value, target_bc_p);
-    ecma_regexp_initialize_props (this_object_p,
-                                  ecma_get_string_from_value (target_bc_p->source),
-                                  target_bc_p->header.status_flags);
-    return ecma_copy_value (this_arg);
+    return ecma_op_create_regexp_from_bytecode (this_obj_p, bc_p);
   }
 
-  ecma_string_t *pattern_string_p = ecma_regexp_read_pattern_str_helper (pattern_arg);
+  ecma_value_t ret_value = ecma_op_create_regexp_from_pattern (this_obj_p, pattern_arg, flags_arg);
 
-  /* Get source string. */
-  if (pattern_string_p == NULL)
+  if (ECMA_IS_VALUE_ERROR (ret_value))
   {
-    return ECMA_VALUE_ERROR;
+    ecma_deref_object (this_obj_p);
   }
 
-  /* Parse flags. */
-  if (!ecma_is_value_undefined (flags_arg))
-  {
-    ecma_string_t *flags_str_p = ecma_op_to_string (flags_arg);
-    if (JERRY_UNLIKELY (flags_str_p == NULL))
-    {
-      ecma_deref_ecma_string (pattern_string_p);
-      return ECMA_VALUE_ERROR;
-    }
-
-    ecma_value_t parsed_flags_val = ecma_regexp_parse_flags (flags_str_p, &flags);
-    ecma_deref_ecma_string (flags_str_p);
-
-    if (ECMA_IS_VALUE_ERROR (parsed_flags_val))
-    {
-      ecma_deref_ecma_string (pattern_string_p);
-      return parsed_flags_val;
-    }
-  }
-
-  /* Try to compile bytecode from new source. */
-  const re_compiled_code_t *new_bc_p = NULL;
-  ecma_value_t bc_val = re_compile_bytecode (&new_bc_p, pattern_string_p, flags);
-  if (ECMA_IS_VALUE_ERROR (bc_val))
-  {
-    ecma_deref_ecma_string (pattern_string_p);
-    return bc_val;
-  }
-
-  ecma_object_t *this_obj_p = ecma_get_object_from_value (this_arg);
-  ecma_value_t *bc_prop_p = &(((ecma_extended_object_t *) this_obj_p)->u.class_prop.u.value);
-
-  re_compiled_code_t *old_bc_p = ECMA_GET_INTERNAL_VALUE_ANY_POINTER (re_compiled_code_t, *bc_prop_p);
-
-  JERRY_ASSERT (old_bc_p != NULL);
-  ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
-
-  ECMA_SET_INTERNAL_VALUE_POINTER (*bc_prop_p, new_bc_p);
-  ecma_regexp_initialize_props (this_obj_p, pattern_string_p, flags);
-  ecma_deref_ecma_string (pattern_string_p);
-
-  return ecma_copy_value (this_arg);
+  return ret_value;
 } /* ecma_builtin_regexp_prototype_compile */
 
 #endif /* ENABLED (JERRY_BUILTIN_ANNEXB) */

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -501,8 +501,32 @@ ecma_instantiate_builtin (ecma_builtin_id_t obj_builtin_id) /**< built-in id */
       JERRY_ASSERT (obj_type == ECMA_OBJECT_TYPE_CLASS);
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
+#if ENABLED (JERRY_ES2015)
+      ext_object_p->u.class_prop.class_id = LIT_INTERNAL_MAGIC_STRING_REGEXP_PROTO;
+#else /* !ENABLED (JERRY_ES2015) */
       ext_object_p->u.class_prop.class_id = LIT_MAGIC_STRING_REGEXP_UL;
-      ext_object_p->u.class_prop.u.value = ECMA_NULL_POINTER;
+#endif /* ENABLED (JERRY_ES2015) */
+
+/* In the ECMA v6 version, we create a dummy bytecode for the RegExp prototype object for backwards compatibility,
+ * so we can use the existing methods to get the source and flags from the [[OriginalSource]] and [[OriginalFlags]]
+ * internal properties.
+ */
+#if ENABLED (JERRY_ES2015)
+      re_compiled_code_t *bc_p = (re_compiled_code_t *) jmem_heap_alloc_block (ECMA_REGEXP_PROTO_COMPILED_CODE_SIZE);
+
+      bc_p->header.status_flags = RE_FLAG_EMPTY;
+      bc_p->source = ecma_make_magic_string_value (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP);
+#else /* !ENABLED (JERRY_ES2015) */
+      const re_compiled_code_t *bc_p = NULL;
+      ecma_value_t ret_value = re_compile_bytecode (&bc_p,
+                                                    ecma_get_magic_string (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP),
+                                                    RE_FLAG_EMPTY);
+
+      JERRY_ASSERT (ecma_is_value_empty (ret_value));
+#endif /* ENABLED (JERRY_ES2015) */
+
+      ECMA_SET_INTERNAL_VALUE_POINTER (ext_object_p->u.class_prop.u.value, bc_p);
+
       break;
     }
 #endif /* ENABLED (JERRY_BUILTIN_REGEXP) */

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2506,6 +2506,14 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
     case ECMA_OBJECT_TYPE_CLASS:
     {
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
+
+#if ENABLED (JERRY_ES2015)
+      if (ext_object_p->u.class_prop.class_id == LIT_INTERNAL_MAGIC_STRING_REGEXP_PROTO)
+      {
+        return LIT_MAGIC_STRING_REGEXP_UL;
+      }
+#endif /* ENABLED (JERRY_ES2015) */
+
       return (lit_magic_string_id_t) ext_object_p->u.class_prop.class_id;
     }
     case ECMA_OBJECT_TYPE_PSEUDO_ARRAY:
@@ -2790,6 +2798,24 @@ ecma_op_species_constructor (ecma_object_t *this_value, /**< This Value */
   return species;
 } /* ecma_op_species_constructor */
 
+/**
+ * 7.3.18 Abstract operation Invoke when property name is a magic string
+ *
+ * @return ecma_value result of the invoked function or raised error
+ *         note: returned value must be freed with ecma_free_value
+ */
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+ecma_op_invoke_by_symbol_id (ecma_value_t object, /**< Object value */
+                             lit_magic_string_id_t symbol_id, /**< Symbol ID */
+                             ecma_value_t *args_p, /**< Argument list */
+                             ecma_length_t args_len) /**< Argument list length */
+{
+  ecma_string_t *symbol_p = ecma_op_get_global_symbol (symbol_id);
+  ecma_value_t ret_value = ecma_op_invoke (object, symbol_p, args_p, args_len);
+  ecma_deref_ecma_string (symbol_p);
+
+  return ret_value;
+} /* ecma_op_invoke_by_symbol_id */
 #endif /* ENABLED (JERRY_ES2015) */
 
 /**

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -77,6 +77,8 @@ bool ecma_object_is_regexp_object (ecma_value_t arg);
 ecma_value_t ecma_op_is_concat_spreadable (ecma_value_t arg);
 ecma_value_t ecma_op_is_regexp (ecma_value_t arg);
 ecma_value_t ecma_op_species_constructor (ecma_object_t *this_value, ecma_builtin_id_t default_constructor_id);
+ecma_value_t ecma_op_invoke_by_symbol_id (ecma_value_t object, lit_magic_string_id_t magic_string_id,
+                                          ecma_value_t *args_p, ecma_length_t args_len);
 #endif /* ENABLED (JERRY_ES2015) */
 ecma_value_t ecma_op_invoke (ecma_value_t object, ecma_string_t *property_name_p, ecma_value_t *args_p,
                              ecma_length_t args_len);

--- a/jerry-core/ecma/operations/ecma-regexp-object.h
+++ b/jerry-core/ecma/operations/ecma-regexp-object.h
@@ -97,22 +97,30 @@ typedef struct
   uint16_t flags;                              /**< RegExp flags */
 } ecma_regexp_ctx_t;
 
-ecma_value_t ecma_op_create_regexp_object_from_bytecode (re_compiled_code_t *bytecode_p);
-ecma_value_t ecma_op_create_regexp_object (ecma_string_t *pattern_p, uint16_t flags);
+ecma_object_t *ecma_op_regexp_alloc (ecma_object_t *new_target_obj_p);
 ecma_value_t ecma_regexp_exec_helper (ecma_object_t *regexp_object_p,
                                       ecma_string_t *input_string_p);
 ecma_string_t *ecma_regexp_read_pattern_str_helper (ecma_value_t pattern_arg);
 lit_code_point_t ecma_regexp_canonicalize (lit_code_point_t ch, bool is_ignorecase);
 lit_code_point_t ecma_regexp_canonicalize_char (lit_code_point_t ch);
 ecma_value_t ecma_regexp_parse_flags (ecma_string_t *flags_str_p, uint16_t *flags_p);
-void ecma_regexp_initialize_props (ecma_object_t *re_obj_p, ecma_string_t *source_p, uint16_t flags);
-
+void ecma_regexp_create_and_initialize_props (ecma_object_t *re_object_p,
+                                              ecma_string_t *source_p,
+                                              uint16_t flags);
 ecma_value_t ecma_regexp_replace_helper (ecma_value_t this_arg, ecma_value_t string_arg, ecma_value_t replace_arg);
 ecma_value_t ecma_regexp_search_helper (ecma_value_t regexp_arg, ecma_value_t string_arg);
 ecma_value_t ecma_regexp_split_helper (ecma_value_t this_arg, ecma_value_t string_arg, ecma_value_t limit_arg);
 ecma_value_t ecma_regexp_match_helper (ecma_value_t this_arg, ecma_value_t string_arg);
 
 ecma_value_t ecma_op_regexp_exec (ecma_value_t this_arg, ecma_string_t *str_p);
+
+ecma_value_t ecma_op_create_regexp_from_bytecode (ecma_object_t *regexp_obj_p, re_compiled_code_t *bc_p);
+ecma_value_t ecma_op_create_regexp_from_pattern (ecma_object_t *regexp_obj_p,
+                                                 ecma_value_t pattern_value,
+                                                 ecma_value_t flags_value);
+ecma_value_t ecma_op_create_regexp_with_flags (ecma_object_t *regexp_obj_p,
+                                               ecma_value_t pattern_value,
+                                               uint16_t flags);
 /**
  * @}
  * @}

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -51,6 +51,7 @@ typedef enum
   LIT_INTERNAL_MAGIC_API_INTERNAL, /**< Property key used to add non-visible JS properties from the public API  */
   LIT_INTERNAL_MAGIC_STRING_ARRAY_PROTOTYPE_VALUES, /**< %ArrayProto_values% intrinsic routine */
   LIT_INTERNAL_MAGIC_THIS_BINDING_VALUE, /**< FunctionEnvironmentRecord [[ThisBindingValue]] internal slot */
+  LIT_INTERNAL_MAGIC_STRING_REGEXP_PROTO, /**< RegExp object prototype */
   /* List of well known symbols */
   LIT_GLOBAL_SYMBOL_HAS_INSTANCE, /**< @@hasInstance well known symbol */
   LIT_GLOBAL_SYMBOL_IS_CONCAT_SPREADABLE, /**< @@isConcatSpreadable well known symbol */

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -440,16 +440,14 @@ vm_construct_literal_object (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
 #if ENABLED (JERRY_BUILTIN_REGEXP)
   if (!(bytecode_p->status_flags & CBC_CODE_FLAGS_FUNCTION))
   {
-    ecma_value_t ret_value;
-    ret_value = ecma_op_create_regexp_object_from_bytecode ((re_compiled_code_t *) bytecode_p);
+    ecma_object_t *regexp_obj_p = ecma_op_regexp_alloc (NULL);
 
-    if (ECMA_IS_VALUE_ERROR (ret_value))
+    if (JERRY_UNLIKELY (regexp_obj_p == NULL))
     {
-      /* TODO: throw exception instead of define an 'undefined' value. */
-      return ECMA_VALUE_UNDEFINED;
+      return ECMA_VALUE_ERROR;
     }
 
-    return ret_value;
+    return ecma_op_create_regexp_from_bytecode (regexp_obj_p, (re_compiled_code_t *) bytecode_p);;
   }
 #endif /* ENABLED (JERRY_BUILTIN_REGEXP) */
 

--- a/tests/jerry/es2015/regexp-construct.js
+++ b/tests/jerry/es2015/regexp-construct.js
@@ -14,11 +14,17 @@
 
 var r = RegExp ("a","gim");
 var r2 = RegExp (r,"gim");
+var r3 = RegExp (r);
 
 assert(r2.source === 'a');
 assert(r2.global === true);
 assert(r2.ignoreCase === true);
 assert(r2.multiline === true);
+
+assert(r3.source === 'a');
+assert(r3.global === true);
+assert(r3.ignoreCase === true);
+assert(r3.multiline === true);
 
 var obj = { get source() { throw 5 }, [Symbol.match] : true }
 


### PR DESCRIPTION
The following methods have been implemented:
- RegExpAlloc, based on ECMA-262 v6, 21.2.3.2.1
- RegExpInitialize, based on ECMA-262 v6, 22.2.3.2.2
- RegExpCreate, based on ECMA-262 v6, 21.2.3.2.3

Co-authored-by: Robert Fancsik frobert@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
