### PR TITLE
Fix 'arguments' and 'caller' properties lazy listing in ES2015 profile

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1814,18 +1814,24 @@ ecma_op_function_list_lazy_property_names (ecma_object_t *object_p, /**< functio
 
     /* 'prototype' property is non-enumerable (ECMA-262 v5, 13.2.18) */
     ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_PROTOTYPE));
+
+#if ENABLED (JERRY_ES2015)
+    bool append_caller_and_arguments = !(bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE);
+#else /* !ENABLED (JERRY_ES2015) */
+    bool append_caller_and_arguments = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE);
+#endif /* ENABLED (JERRY_ES2015) */
+
+    if (append_caller_and_arguments)
+    {
+      /* 'caller' property is non-enumerable (ECMA-262 v5, 13.2.5) */
+      ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_CALLER));
+
+      /* 'arguments' property is non-enumerable (ECMA-262 v5, 13.2.5) */
+      ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_ARGUMENTS));
+    }
 #if ENABLED (JERRY_ES2015)
   }
 #endif /* ENABLED (JERRY_ES2015) */
-
-  if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE)
-  {
-    /* 'caller' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-    ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_CALLER));
-
-    /* 'arguments' property is non-enumerable (ECMA-262 v5, 13.2.5) */
-    ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_ARGUMENTS));
-  }
 } /* ecma_op_function_list_lazy_property_names */
 
 /**

--- a/tests/jerry/es2015/function-properties.js
+++ b/tests/jerry/es2015/function-properties.js
@@ -35,7 +35,7 @@ var prototype_obj = { dummy:1, length:1, caller:null,
 var func = function() {};
 
 Object.setPrototypeOf(func, prototype_obj);
-assert(getProperties(func) == "dummy caller arguments");
+assert(getProperties(func) == "dummy");
 
 var bound_func = (function() {}).bind(null);
 Object.setPrototypeOf(bound_func, prototype_obj);

--- a/tests/jerry/es2015/regression-test-issue-3536.js
+++ b/tests/jerry/es2015/regression-test-issue-3536.js
@@ -1,0 +1,36 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class A {
+  constructor() {
+    var hasProp = $ => {}
+    Object.preventExtensions(hasProp);
+    assert(Object.isSealed(hasProp) === true);
+  }
+  super() {
+    $: $
+  }
+}
+class B extends A {
+  constructor() {
+    super() (super.super)
+  }
+}
+
+try {
+  new B;
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #3536.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
