### PR TITLE
Add a few missing api version documentation

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -612,7 +612,7 @@ Possible values:
  - JERRY_PROMISE_STATE_FULFILLED - Promise is in "Fulfilled" state.
  - JERRY_PROMISE_STATE_REJECTED - Promise is in "Rejected" state.
 
-*New in version [NEXT VERSION]*.
+*New in version 2.2*.
 
 **See also**
 
@@ -3282,7 +3282,7 @@ jerry_get_promise_result (const jerry_value_t promise);
   - A TypeError is returned if the input argument was not a Promise object or
     the Promise support was not built into the library.
 
-*New in version [NEXT VERSION]*.
+*New in version 2.2*.
 
 **Example**
 
@@ -3348,7 +3348,7 @@ jerry_get_promise_state (const jerry_value_t promise);
   - `JERRY_PROMISE_STATE_NONE` is returned if the input argument was not a promise object or
     the Promise support was not built into the library.
 
-*New in version [NEXT VERSION]*.
+*New in version 2.2*.
 
 **Example**
 
@@ -4871,6 +4871,8 @@ jerry_has_internal_property (const jerry_value_t obj_val,
   - true, if the property exists
   - false, otherwise
 
+*New in version 2.2*.
+
 **Example**
 
 [doctest]: # ()
@@ -5013,6 +5015,8 @@ jerry_delete_internal_property (const jerry_value_t obj_val,
 - return value
   - true, if property was deleted successfully
   - false, otherwise
+
+*New in version 2.2*.
 
 **Example**
 
@@ -5173,6 +5177,8 @@ jerry_get_internal_property (const jerry_value_t obj_val,
   - value of property, if the internal property exists
   - undefined value, if the, if the internal does not property exists
   - thrown error, otherwise
+
+*New in version 2.2*.
 
 **Example**
 
@@ -5350,6 +5356,8 @@ jerry_set_internal_property (const jerry_value_t obj_val,
 - return value
   - true, if success
   - thrown error, otherwise
+
+*New in version 2.2*.
 
 **Example**
 
@@ -7584,6 +7592,8 @@ jerry_get_resource_name (jerry_value_t value);
   - resource name of the function object, if the given value is a function object
   - "<anonymous>", otherwise
 
+*New in version 2.2*.
+
 **Example**
 
 [doctest]: # (name="02.API-REFERENCE-jsresourcename.c")
@@ -8034,6 +8044,8 @@ jerry_is_arraybuffer_detachable (const jerry_value_t value);
   - boolean value if success
   - Error otherwise
 
+*New in version 2.2*.
+
 **Example**
 
 ```c
@@ -8074,6 +8086,8 @@ jerry_detach_arraybuffer (const jerry_value_t value);
 - return
   - null value if success
   - Error otherwise
+
+*New in version 2.2*.
 
 **Example**
 


### PR DESCRIPTION
A few api method/struct documentation did not have the
entry describing in which version it was introduced.
