### PR TITLE
[[Prototype]] object's reference count should be increased by jerry_get_prototype

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2785,6 +2785,9 @@ jerry_get_object_keys (const jerry_value_t obj_val) /**< object value */
 /**
  * Get the prototype of the specified object
  *
+ * Note:
+ *      returned value must be freed with jerry_release_value, when it is no longer needed.
+ *
  * @return prototype object or null value - if success
  *         value marked with error flag - otherwise
  */
@@ -2806,6 +2809,7 @@ jerry_get_prototype (const jerry_value_t obj_val) /**< object value */
   }
 
   ecma_object_t *proto_obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, obj_p->u2.prototype_cp);
+  ecma_ref_object (proto_obj_p);
 
   return ecma_make_object_value (proto_obj_p);
 } /* jerry_get_prototype */

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -683,9 +683,16 @@ main (void)
   jerry_release_value (prim_val);
 
   /* Test: jerry_get_prototype */
+  proto_val = jerry_get_prototype (jerry_create_undefined ());
+  TEST_ASSERT (jerry_value_is_error (proto_val));
+  jerry_value_t error = jerry_get_value_from_error (proto_val, true);
+  TEST_ASSERT (jerry_get_error_type (error) == JERRY_ERROR_TYPE);
+  jerry_release_value (error);
+
   proto_val = jerry_get_prototype (obj_val);
   TEST_ASSERT (!jerry_value_is_error (proto_val));
   TEST_ASSERT (jerry_value_is_object (proto_val));
+  jerry_release_value (proto_val);
   jerry_release_value (obj_val);
 
   /* Test: jerry_set_prototype */
@@ -695,7 +702,9 @@ main (void)
   TEST_ASSERT (jerry_value_is_boolean (res));
   TEST_ASSERT (jerry_get_boolean_value (res));
 
-  res = jerry_set_prototype (obj_val, jerry_create_object ());
+  jerry_value_t new_proto = jerry_create_object ();
+  res = jerry_set_prototype (obj_val, new_proto);
+  jerry_release_value (new_proto);
   TEST_ASSERT (!jerry_value_is_error (res));
   TEST_ASSERT (jerry_value_is_boolean (res));
   TEST_ASSERT (jerry_get_boolean_value (res));


### PR DESCRIPTION
This patch ensures that the implementation satisfies the requirements of the public API documentation.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
