### PR TITLE
Fix Array.find and Array.findIndex omitting empty values.

### DIFF
--- a/tests/jerry/es2015/array-prototype-find-index.js
+++ b/tests/jerry/es2015/array-prototype-find-index.js
@@ -149,7 +149,14 @@ function func (element) {
 
 /* ES v6.0 22.1.3.9.8.c
    Checking behavior when the first element deletes the second */
-   function f() { delete arr[1]; };
-   var arr = [0, 1, 2, 3];
-   Object.defineProperty(arr, '0', { 'get' : f });
-   Array.prototype.findIndex.call(arr, func);
+function f() { delete arr[1]; };
+var arr = [0, 1, 2, 3];
+Object.defineProperty(arr, '0', { 'get' : f });
+Array.prototype.findIndex.call(arr, func);
+
+/* ES v6.0 22.1.3.9.8
+   Checking whether predicate is called also for empty elements */
+var count = 0;
+
+[,,,].findIndex(function() { count++; return false; });
+assert (count == 3);

--- a/tests/jerry/es2015/array-prototype-find.js
+++ b/tests/jerry/es2015/array-prototype-find.js
@@ -146,3 +146,10 @@ function f() { delete arr[1]; };
 var arr = [0, 1, 2, 3];
 Object.defineProperty(arr, '0', { 'get' : f });
 Array.prototype.find.call(arr, func);
+
+/* ES v6.0 22.1.3.8.8
+   Checking whether predicate is called also for empty elements */
+var count = 0;
+
+[,,,].find(function() { count++; return false; });
+assert (count == 3);


### PR DESCRIPTION
Empty values in array were omitted. Predicate should be called
for every element from 0 to length.

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com
