### PR TITLE
Fix third parameter of forEach callback function in Map and Set

### DIFF
--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -591,9 +591,9 @@ ecma_op_container_foreach (ecma_value_t this_arg, /**< this argument */
       }
     }
 
-    ecma_value_t call_args[] = { value, key_arg };
+    ecma_value_t call_args[] = { value, key_arg, this_arg };
 
-    ecma_value_t call_value = ecma_op_function_call (func_object_p, predicate_this_arg, call_args, 2);
+    ecma_value_t call_value = ecma_op_function_call (func_object_p, predicate_this_arg, call_args, 3);
 
     ecma_free_value (value);
 

--- a/tests/jerry/es2015/map-prototype-foreach.js
+++ b/tests/jerry/es2015/map-prototype-foreach.js
@@ -106,3 +106,13 @@ var object = {
 map.forEach (function (value, key) {
   assert (this._secret === 42);
 }, object);
+
+/* Test third argument of callback */
+map = new Map();
+map.set('foo', 42);
+map.set('bar', 84);
+
+map.forEach(function(value, key, thisArg) {
+  assert (typeof thisArg === "object");
+  assert (thisArg === map);
+});

--- a/tests/jerry/es2015/set.js
+++ b/tests/jerry/es2015/set.js
@@ -118,3 +118,11 @@ try {
 Set.prototype.add = add;
 
 assert(closed === true);
+
+/* Test third argument of callback */
+var s = new Set([1, 2, 3]);
+
+s.forEach(function(value, key, thisArg) {
+  assert (typeof thisArg === "object");
+  assert(thisArg === s);
+});


### PR DESCRIPTION
There was a problem with passing third parameter to callback.

This patch fixes #3564

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com