### PR TITLE
Fix attributes of length property for function objects

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -249,6 +249,7 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
     }
     else if (type == ECMA_OBJECT_TYPE_FUNCTION)
     {
+#if !ENABLED (JERRY_ES2015)
       if (ecma_string_is_length (property_name_p))
       {
         if (options & ECMA_PROPERTY_GET_VALUE)
@@ -274,6 +275,7 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
 
         return ECMA_PROPERTY_TYPE_VIRTUAL;
       }
+#endif /* !ENABLED (JERRY_ES2015) */
 
       /* Get prototype physical property. */
       property_p = ecma_op_function_try_to_lazy_instantiate_property (object_p, property_name_p);
@@ -594,6 +596,7 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
     }
     else if (type == ECMA_OBJECT_TYPE_FUNCTION)
     {
+#if !ENABLED (JERRY_ES2015)
       if (ecma_string_is_length (property_name_p))
       {
         /* Get length virtual property. */
@@ -614,6 +617,7 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
 
         return ecma_make_uint32_value (len);
       }
+#endif /* !ENABLED (JERRY_ES2015) */
 
       /* Get prototype physical property. */
       property_p = ecma_op_function_try_to_lazy_instantiate_property (object_p, property_name_p);
@@ -1322,10 +1326,19 @@ ecma_op_object_put_with_receiver (ecma_object_t *object_p, /**< the object */
     }
     else if (type == ECMA_OBJECT_TYPE_FUNCTION)
     {
+#if ENABLED (JERRY_ES2015)
+      /* Uninitialized 'length' property is non-writable (ECMA-262 v6, 19.2.4.1) */
+      if ((ecma_string_is_length (property_name_p))
+          && (!ECMA_GET_FIRST_BIT_FROM_POINTER_TAG (((ecma_extended_object_t *) object_p)->u.function.scope_cp)))
+      {
+        return ecma_reject (is_throw);
+      }
+#else /* !ENABLED (JERRY_ES2015) */
       if (ecma_string_is_length (property_name_p))
       {
         return ecma_reject (is_throw);
       }
+#endif /* ENABLED (JERRY_ES2015) */
 
       /* Get prototype physical property. */
       property_p = ecma_op_function_try_to_lazy_instantiate_property (object_p, property_name_p);

--- a/tests/jerry/es2015/length-property.js
+++ b/tests/jerry/es2015/length-property.js
@@ -100,3 +100,24 @@ var builtin_typedArrays = [
     assert(ta.hasOwnProperty('length') === false);
   }
 })();
+
+(function () {
+  /* test length property of function objects */
+  var normal_func = function () {};
+  var arrow_func = () => {};
+
+  var functions = [normal_func, arrow_func];
+
+  for (func of functions) {
+    var desc = Object.getOwnPropertyDescriptor(func, 'length');
+    assert(desc.writable === false);
+    assert(desc.enumerable === false);
+    assert(desc.configurable === true);
+  }
+
+  for (func of functions) {
+    assert(func.hasOwnProperty('length') === true);
+    assert(delete func.length);
+    assert(func.hasOwnProperty('length') === false);
+  }
+})();

--- a/tests/jerry/es2015/regression-test-issue-3267.js
+++ b/tests/jerry/es2015/regression-test-issue-3267.js
@@ -14,7 +14,7 @@
 
 var hasProp = $ => { }
 Object.preventExtensions(hasProp);
-assert (Object.isSealed(hasProp));
+assert (Object.isSealed(hasProp) === false);
 
 var keys = Object.getOwnPropertyNames(hasProp);
 assert (keys.length === 1);

--- a/tests/jerry/es2015/regression-test-issue-3536.js
+++ b/tests/jerry/es2015/regression-test-issue-3536.js
@@ -16,7 +16,7 @@ class A {
   constructor() {
     var hasProp = $ => {}
     Object.preventExtensions(hasProp);
-    assert(Object.isSealed(hasProp) === true);
+    assert(Object.isSealed(hasProp) === false);
   }
   super() {
     $: $


### PR DESCRIPTION
length property of function objects should be configurable in ES2015.
Instead of lazy initialization, length property is added directly
when allocating each function object.

JerryScript-DCO-1.0-Signed-off-by: HyukWoo Park hyukwoo.park@samsung.com