### PR TITLE
Remove ECMA_OBJECT_TYPE_ARROW

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -627,9 +627,6 @@ typedef enum
   ECMA_OBJECT_TYPE_PSEUDO_ARRAY  = 3, /**< Array-like object, such as Arguments object (10.6) */
   /* Note: these 4 types must be in this order. See IsCallable operation.  */
   ECMA_OBJECT_TYPE_FUNCTION = 4, /**< Function objects (15.3), created through 13.2 routine */
-#if ENABLED (JERRY_ES2015)
-  ECMA_OBJECT_TYPE_ARROW_FUNCTION = 5, /**< arrow function objects */
-#endif /* ENABLED (JERRY_ES2015) */
   ECMA_OBJECT_TYPE_BOUND_FUNCTION = 6, /**< Function objects (15.3), created through 15.3.4.5 routine */
   ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION = 7, /**< External (host) function object */
   /* Types between 13-15 cannot have a built-in flag. See ecma_lexical_environment_type_t. */
@@ -959,10 +956,8 @@ typedef struct
  */
 typedef struct
 {
-  ecma_object_t object; /**< object header */
+  ecma_extended_object_t header; /**< extended object header */
   ecma_value_t this_binding; /**< value of 'this' binding */
-  jmem_cpointer_t scope_cp; /**< function scope */
-  jmem_cpointer_t bytecode_cp; /**< function byte code */
 } ecma_arrow_function_t;
 
 #if ENABLED (JERRY_SNAPSHOT_EXEC)

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -27,8 +27,6 @@
  * @{
  */
 
-bool ecma_is_normal_or_arrow_function (ecma_object_type_t type);
-
 #if ENABLED (JERRY_LINE_INFO) || ENABLED (JERRY_ES2015_MODULE_SYSTEM)
 ecma_value_t ecma_op_resource_name (const ecma_compiled_code_t *bytecode_header_p);
 #endif /* ENABLED (JERRY_LINE_INFO) || ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
@@ -84,8 +82,6 @@ ecma_object_t *
 ecma_op_create_arrow_function_object (ecma_object_t *scope_p, const ecma_compiled_code_t *bytecode_data_p,
                                       ecma_value_t this_binding);
 
-const ecma_compiled_code_t *
-ecma_op_arrow_function_get_compiled_code (ecma_arrow_function_t *arrow_function_p);
 #endif /* ENABLED (JERRY_ES2015) */
 
 ecma_value_t


### PR DESCRIPTION
Until now arrow functions had a separate type, but most of the time they can be handled similar to single functions.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
