### PR TITLE
Implement ecma_stringbuilder_create_raw method for stringbuilder

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -295,9 +295,8 @@ static void
 static_snapshot_error_unsupported_literal (snapshot_globals_t *globals_p, /**< snapshot globals */
                                            ecma_value_t literal) /**< literal form the literal pool */
 {
-  ecma_stringbuilder_t builder = ecma_stringbuilder_create ();
-
-  ecma_stringbuilder_append_raw (&builder, (lit_utf8_byte_t *) "Unsupported static snapshot literal: ", 37);
+  lit_utf8_byte_t *str_p = (lit_utf8_byte_t *) "Unsupported static snapshot literal: ";
+  ecma_stringbuilder_t builder = ecma_stringbuilder_create_raw (str_p, 37);
 
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (literal));
 

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -2529,6 +2529,29 @@ ecma_stringbuilder_create_from (ecma_string_t *string_p) /**< ecma string */
 } /* ecma_stringbuilder_create_from */
 
 /**
+ * Create a string builder from a raw string
+ *
+ * @return new string builder
+ */
+ecma_stringbuilder_t
+ecma_stringbuilder_create_raw (const lit_utf8_byte_t *data_p, /**< pointer to data */
+                               const lit_utf8_size_t data_size) /**< size of the data */
+{
+  const lit_utf8_size_t initial_size = data_size + (lit_utf8_size_t) sizeof (ecma_ascii_string_t);
+
+  ecma_stringbuilder_header_t *header_p = (ecma_stringbuilder_header_t *) jmem_heap_alloc_block (initial_size);
+  header_p->current_size = initial_size;
+#if ENABLED (JERRY_MEM_STATS)
+  jmem_stats_allocate_string_bytes (initial_size);
+#endif /* ENABLED (JERRY_MEM_STATS) */
+
+  memcpy (ECMA_STRINGBUILDER_STRING_PTR (header_p), data_p, data_size);
+
+  ecma_stringbuilder_t ret = {.header_p = header_p};
+  return ret;
+} /* ecma_stringbuilder_create_raw */
+
+/**
  * Grow the underlying buffer of a string builder
  *
  * @return pointer to the end of the data in the underlying buffer

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -320,6 +320,8 @@ ecma_string_t *ecma_string_trim (const ecma_string_t *string_p);
 
 ecma_stringbuilder_t ecma_stringbuilder_create (void);
 ecma_stringbuilder_t ecma_stringbuilder_create_from (ecma_string_t *string_p);
+ecma_stringbuilder_t ecma_stringbuilder_create_raw (const lit_utf8_byte_t *data_p,
+                                                    const lit_utf8_size_t data_size);
 lit_utf8_size_t ecma_stringbuilder_get_size (ecma_stringbuilder_t *builder_p);
 lit_utf8_byte_t *ecma_stringbuilder_get_data (ecma_stringbuilder_t *builder_p);
 void ecma_stringbuilder_revert (ecma_stringbuilder_t *builder_p, const lit_utf8_size_t size);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -477,9 +477,8 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_value, /**< this
     {
       if (!memcmp (curr_p, search_buf_p, search_size))
       {
-        replace_ctx.builder = ecma_stringbuilder_create ();
         const lit_utf8_size_t byte_offset = (lit_utf8_size_t) (curr_p - replace_ctx.string_p);
-        ecma_stringbuilder_append_raw (&replace_ctx.builder, replace_ctx.string_p, byte_offset);
+        replace_ctx.builder = ecma_stringbuilder_create_raw (replace_ctx.string_p, byte_offset);
 
         if (replace_ctx.replace_str_p == NULL)
         {

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -793,9 +793,7 @@ ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, /**< object *
 #if ENABLED (JERRY_ES2015)
     case ECMA_BUILTIN_PROPERTY_SYMBOL:
     {
-      ecma_stringbuilder_t builder = ecma_stringbuilder_create ();
-
-      ecma_stringbuilder_append_raw (&builder, (lit_utf8_byte_t *) "Symbol.", 7);
+      ecma_stringbuilder_t builder = ecma_stringbuilder_create_raw ((lit_utf8_byte_t *) "Symbol.", 7);
 
       lit_magic_string_id_t symbol_desc_id = (lit_magic_string_id_t) curr_property_p->value;
 

--- a/jerry-core/ecma/operations/ecma-symbol-object.c
+++ b/jerry-core/ecma/operations/ecma-symbol-object.c
@@ -128,10 +128,8 @@ ecma_get_symbol_descriptive_string (ecma_value_t symbol_value) /**< symbol to st
   ecma_string_t *symbol_p = ecma_get_symbol_from_value (symbol_value);
   ecma_string_t *string_desc_p = ecma_get_symbol_description (symbol_p);
 
-  ecma_stringbuilder_t builder = ecma_stringbuilder_create ();
-
   /* 5. */
-  ecma_stringbuilder_append_raw (&builder, (lit_utf8_byte_t *) ("Symbol("), 7);
+  ecma_stringbuilder_t builder = ecma_stringbuilder_create_raw ((lit_utf8_byte_t *) ("Symbol("), 7);
   ecma_stringbuilder_append (&builder, string_desc_p);
   ecma_stringbuilder_append_byte (&builder, LIT_CHAR_RIGHT_PAREN);
 


### PR DESCRIPTION
With this new method, we can create a stringbuilder from a raw string

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
