### PR TITLE
Add new type which represents pointer with tag value

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -582,8 +582,8 @@ jerry_run (const jerry_value_t func_val) /**< function to run */
 
   ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) func_obj_p;
 
-  ecma_object_t *scope_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                            ext_func_p->u.function.scope_cp);
+  ecma_object_t *scope_p = ECMA_GET_NON_NULL_POINTER_FROM_POINTER_TAG (ecma_object_t,
+                                                                       ext_func_p->u.function.scope_cp);
 
   if (scope_p != ecma_get_global_environment ())
   {

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -619,8 +619,8 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
         if (!ecma_get_object_is_builtin (object_p))
         {
           ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-          ecma_gc_set_object_visited (ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                                       ext_func_p->u.function.scope_cp));
+          ecma_gc_set_object_visited (ECMA_GET_NON_NULL_POINTER_FROM_POINTER_TAG (ecma_object_t,
+                                                                                  ext_func_p->u.function.scope_cp));
 
 #if ENABLED (JERRY_ES2015)
           const ecma_compiled_code_t *byte_code_p = ecma_op_function_get_compiled_code (ext_func_p);

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -36,6 +36,15 @@
  */
 #define ECMA_NULL_POINTER JMEM_CP_NULL
 
+#if defined (JMEM_CAN_STORE_POINTER_VALUE_DIRECTLY)
+
+/**
+ * JMEM_ALIGNMENT_LOG aligned pointers can be stored directly in ecma_value_t
+ */
+#define ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
+
+#endif /* JMEM_CAN_STORE_POINTER_VALUE_DIRECTLY */
+
 /**
  * @}
  */
@@ -126,15 +135,6 @@ typedef uint32_t ecma_value_t;
  * Type for directly encoded integer numbers in JerryScript.
  */
 typedef int32_t ecma_integer_value_t;
-
-#if UINTPTR_MAX <= UINT32_MAX
-
-/**
- * JMEM_ALIGNMENT_LOG aligned pointers can be stored directly in ecma_value_t
- */
-#define ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
-
-#endif /* UINTPTR_MAX <= UINT32_MAX */
 
 /**
  * Mask for ecma types in ecma_value_t
@@ -845,7 +845,7 @@ typedef struct
      */
     struct
     {
-      ecma_value_t scope_cp; /**< function scope */
+      jmem_cpointer_tag_t scope_cp; /**< function scope */
       ecma_value_t bytecode_cp; /**< function byte code */
     } function;
 

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -35,6 +35,9 @@ JERRY_STATIC_ASSERT (ECMA_VALUE_SHIFT <= JMEM_ALIGNMENT_LOG,
 JERRY_STATIC_ASSERT (sizeof (jmem_cpointer_t) <= sizeof (ecma_value_t),
                      size_of_jmem_cpointer_t_must_be_less_or_equal_to_the_size_of_ecma_value_t);
 
+JERRY_STATIC_ASSERT (sizeof (jmem_cpointer_t) <= sizeof (jmem_cpointer_tag_t),
+                     size_of_jmem_cpointer_t_must_be_less_or_equal_to_the_size_of_jmem_cpointer_tag_t);
+
 #ifdef ECMA_VALUE_CAN_STORE_UINTPTR_VALUE_DIRECTLY
 
 JERRY_STATIC_ASSERT (sizeof (uintptr_t) <= sizeof (ecma_value_t),

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -33,6 +33,12 @@
 #define ECMA_GET_NON_NULL_POINTER(type, field) JMEM_CP_GET_NON_NULL_POINTER (type, field)
 
 /**
+ * Extract value of pointer from specified pointer-tag value
+ */
+#define ECMA_GET_NON_NULL_POINTER_FROM_POINTER_TAG(type, field) \
+  JMEM_CP_GET_NON_NULL_POINTER_FROM_POINTER_TAG (type, field)
+
+/**
  * Get value of pointer from specified compressed pointer.
  */
 #define ECMA_GET_POINTER(type, field) JMEM_CP_GET_POINTER (type, field)
@@ -45,10 +51,37 @@
                                                                                                non_compressed_pointer)
 
 /**
+ * Set value of pointer-tag value so that it will correspond
+ * to specified non_compressed_pointer along with tag
+ */
+#define ECMA_SET_NON_NULL_POINTER_TAG(field, non_compressed_pointer, tag) \
+  JMEM_CP_SET_NON_NULL_POINTER_TAG (field, non_compressed_pointer, tag)
+
+/**
  * Set value of compressed pointer so that it will correspond
  * to specified non_compressed_pointer.
  */
 #define ECMA_SET_POINTER(field, non_compressed_pointer) JMEM_CP_SET_POINTER (field, non_compressed_pointer)
+
+/**
+ * Get value of each tag bit from specified pointer-tag value
+ */
+#define ECMA_GET_FIRST_BIT_FROM_POINTER_TAG(field) \
+  JMEM_CP_GET_FIRST_BIT_FROM_POINTER_TAG (field) /**< get first tag bit from jmem_cpointer_tag_t **/
+#define ECMA_GET_SECOND_BIT_FROM_POINTER_TAG(field) \
+  JMEM_CP_GET_SECOND_BIT_FROM_POINTER_TAG (field) /**< get second tag bit from jmem_cpointer_tag_t **/
+#define ECMA_GET_THIRD_BIT_FROM_POINTER_TAG(field) \
+  JMEM_CP_GET_THIRD_BIT_FROM_POINTER_TAG (field) /**< get third tag bit from jmem_cpointer_tag_t **/
+
+/**
+ * Set value of each tag bit to specified pointer-tag value
+ */
+#define ECMA_SET_FIRST_BIT_TO_POINTER_TAG(field) \
+  JMEM_CP_SET_FIRST_BIT_TO_POINTER_TAG (field) /**< set first tag bit to jmem_cpointer_tag_t **/
+#define ECMA_SET_SECOND_BIT_TO_POINTER_TAG(field) \
+  JMEM_CP_SET_SECOND_BIT_TO_POINTER_TAG (field) /**< set second tag bit to jmem_cpointer_tag_t **/
+#define ECMA_SET_THIRD_BIT_TO_POINTER_TAG(field) \
+  JMEM_CP_SET_THIRD_BIT_TO_POINTER_TAG (field) /**< set third tag bit to jmem_cpointer_tag_t **/
 
 /**
  * Status flags for ecma_string_get_chars function

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -320,7 +320,7 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
   ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) func_p;
 
   /* 9. */
-  ECMA_SET_INTERNAL_VALUE_POINTER (ext_func_p->u.function.scope_cp, scope_p);
+  ECMA_SET_NON_NULL_POINTER_TAG (ext_func_p->u.function.scope_cp, scope_p, 0);
 
   /* 10., 11., 12. */
 
@@ -408,7 +408,7 @@ ecma_op_create_arrow_function_object (ecma_object_t *scope_p, /**< function's sc
 
   ecma_arrow_function_t *arrow_func_p = (ecma_arrow_function_t *) func_p;
 
-  ECMA_SET_INTERNAL_VALUE_POINTER (arrow_func_p->header.u.function.scope_cp, scope_p);
+  ECMA_SET_NON_NULL_POINTER_TAG (arrow_func_p->header.u.function.scope_cp, scope_p, 0);
 
 #if ENABLED (JERRY_SNAPSHOT_EXEC)
   if ((bytecode_data_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION))
@@ -932,8 +932,8 @@ ecma_op_function_call_simple (ecma_object_t *func_obj_p, /**< Function object */
   /* Entering Function Code (ECMA-262 v5, 10.4.3) */
   ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) func_obj_p;
 
-  ecma_object_t *scope_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                            ext_func_p->u.function.scope_cp);
+  ecma_object_t *scope_p = ECMA_GET_NON_NULL_POINTER_FROM_POINTER_TAG (ecma_object_t,
+                                                                       ext_func_p->u.function.scope_cp);
 
   /* 8. */
   ecma_value_t this_binding = this_arg_value;

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1224,14 +1224,14 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) func_p;
 
-          JERRY_ASSERT (frame_ctx_p->lex_env_p == ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                                                   ext_func_p->u.function.scope_cp));
+          JERRY_ASSERT (frame_ctx_p->lex_env_p ==
+                        ECMA_GET_NON_NULL_POINTER_FROM_POINTER_TAG (ecma_object_t, ext_func_p->u.function.scope_cp));
 
           ecma_object_t *name_lex_env = ecma_create_decl_lex_env (frame_ctx_p->lex_env_p);
 
           ecma_op_create_immutable_binding (name_lex_env, ecma_get_string_from_value (right_value), left_value);
 
-          ECMA_SET_INTERNAL_VALUE_POINTER (ext_func_p->u.function.scope_cp, name_lex_env);
+          ECMA_SET_NON_NULL_POINTER_TAG (ext_func_p->u.function.scope_cp, name_lex_env, 0);
 
           ecma_free_value (right_value);
           ecma_deref_object (name_lex_env);
@@ -1783,9 +1783,10 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           ecma_bytecode_ref ((ecma_compiled_code_t *) bytecode_p);
           ECMA_SET_INTERNAL_VALUE_POINTER (current_ext_func_obj_p->u.function.bytecode_cp,
                                            bytecode_p);
-          ECMA_SET_INTERNAL_VALUE_POINTER (current_ext_func_obj_p->u.function.scope_cp,
-                                           ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_object_t,
-                                                                            new_ext_func_obj_p->u.function.scope_cp));
+
+          ecma_object_t *scope_p = ECMA_GET_NON_NULL_POINTER_FROM_POINTER_TAG (ecma_object_t,
+                                                                               new_ext_func_obj_p->u.function.scope_cp);
+          ECMA_SET_NON_NULL_POINTER_TAG (current_ext_func_obj_p->u.function.scope_cp, scope_p, 0);
           ecma_deref_object (new_constructor_obj_p);
           continue;
         }


### PR DESCRIPTION
jmem_cpointer_tag_t is newly added to represent pointer along with tag value.
This new type is first applied to scope_cp to mark initailized function properties (length, name) later

JerryScript-DCO-1.0-Signed-off-by: HyukWoo Park hyukwoo.park@samsung.com