### PR TITLE
Fix setting integrity level, when object has Symbol properties

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -291,7 +291,12 @@ ecma_builtin_object_set_integrity_level (ecma_object_t *obj_p, /**< object */
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_PROXY) */
 
   /* 6. */
-  ecma_collection_t *props_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_CONVERT_FAST_ARRAYS);
+  uint32_t opts = ECMA_LIST_CONVERT_FAST_ARRAYS;
+#if ENABLED (JERRY_ES2015)
+  opts |= ECMA_LIST_SYMBOLS;
+#endif /* ENABLED (JERRY_ES2015) */
+
+  ecma_collection_t *props_p = ecma_op_object_get_property_names (obj_p, opts);
 
 #if ENABLED (JERRY_ES2015_BUILTIN_PROXY)
   if (props_p == NULL)
@@ -307,7 +312,7 @@ ecma_builtin_object_set_integrity_level (ecma_object_t *obj_p, /**< object */
     /* 8.a */
     for (uint32_t i = 0; i < props_p->item_count; i++)
     {
-      ecma_string_t *property_name_p = ecma_get_string_from_value (buffer_p[i]);
+      ecma_string_t *property_name_p = ecma_get_prop_name_from_value (buffer_p[i]);
 
       ecma_property_descriptor_t prop_desc;
       ecma_value_t status = ecma_op_object_get_own_property_descriptor (obj_p, property_name_p, &prop_desc);
@@ -349,7 +354,7 @@ ecma_builtin_object_set_integrity_level (ecma_object_t *obj_p, /**< object */
     /* 9.a */
     for (uint32_t i = 0; i < props_p->item_count; i++)
     {
-      ecma_string_t *property_name_p = ecma_get_string_from_value (buffer_p[i]);
+      ecma_string_t *property_name_p = ecma_get_prop_name_from_value (buffer_p[i]);
 
       /* 9.1 */
       ecma_property_descriptor_t prop_desc;

--- a/tests/jerry/es2015/object-freeze-with-symbol.js
+++ b/tests/jerry/es2015/object-freeze-with-symbol.js
@@ -1,0 +1,28 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var s1 = Symbol();
+var s2 = Symbol();
+var obj = {};
+
+obj[s1] = 1;
+Object.freeze(obj);
+
+obj[s1] = 2;
+obj[s2] = 3
+
+assert(obj[s1] === 1);
+assert(obj[s2] === undefined);
+assert(delete obj[s1] === false);

--- a/tests/jerry/es2015/object-seal-with-symbol.js
+++ b/tests/jerry/es2015/object-seal-with-symbol.js
@@ -1,0 +1,28 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var s1 = Symbol();
+var s2 = Symbol();
+var obj = {};
+
+obj[s1] = 1;
+Object.seal(obj);
+
+obj[s1] = 2;
+obj[s2] = 3
+
+assert(obj[s1] === 2);
+assert(obj[s2] === undefined);
+assert(delete obj[s1] === false);


### PR DESCRIPTION
Symbol type properties were not included when integrity level were changed. 

As it is in ES6, [SetIntegrityLevel](https://www.ecma-international.org/ecma-262/6.0/#sec-setintegritylevel) uses [OwnPropertyKeys](https://www.ecma-international.org/ecma-262/6.0/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys) that should also include Symbol type properties.
