### PR TITLE
Fix the lazy listing of builtin property names

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -962,7 +962,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
     uint32_t *bitset_p = built_in_props_p->instantiated_bitset;
 
     ecma_collection_t *for_non_enumerable_p = (separate_enumerable ? non_enum_collection_p
-                                                                          : main_collection_p);
+                                                                   : main_collection_p);
 
     while (curr_property_p->magic_string_id != LIT_MAGIC_STRING__COUNT)
     {
@@ -995,7 +995,16 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
       {
         ecma_value_t name = ecma_make_magic_string_value ((lit_magic_string_id_t) curr_property_p->magic_string_id);
 
-        ecma_collection_push_back (for_non_enumerable_p, name);
+#if ENABLED (JERRY_ES2015)
+        if (curr_property_p->attributes & ECMA_PROPERTY_FLAG_ENUMERABLE)
+        {
+          ecma_collection_push_back (main_collection_p, name);
+        }
+        else
+#endif /* ENABLED (JERRY_ES2015) */
+        {
+          ecma_collection_push_back (for_non_enumerable_p, name);
+        }
       }
 
       curr_property_p++;

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2438,6 +2438,7 @@ ecma_object_check_class_name_is_object (ecma_object_t *obj_p) /**< object */
 #endif /* ENABLED (JERRY_NUMBER_TYPE_FLOAT64) */
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY) */
 #if ENABLED (JERRY_ES2015)
+          || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_ARRAY_PROTOTYPE_UNSCOPABLES)
           || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_ARRAY_ITERATOR_PROTOTYPE)
           || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_ITERATOR_PROTOTYPE)
           || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_STRING_ITERATOR_PROTOTYPE)

--- a/tests/jerry/es2015/regression-test-issue-3606.js
+++ b/tests/jerry/es2015/regression-test-issue-3606.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+var expected = '{"values":true,"keys":true,"findIndex":true,"find":true,"fill":true,"entries":true,"copyWithin":true}';
+assert(JSON.stringify(Array.prototype[Symbol.unscopables]) === expected);


### PR DESCRIPTION
This patch fixes #3606.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
