### PR TITLE
Spread operator should not update the scanner context's binding type

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -220,17 +220,19 @@ scanner_scan_primary_expression (parser_context_t *context_p, /**< context */
     }
 #if ENABLED (JERRY_ES2015)
     case LEXER_THREE_DOTS:
+    {
+      /* Elision or spread arguments */
+      if (stack_top != SCAN_STACK_PAREN_EXPRESSION && stack_top != SCAN_STACK_ARRAY_LITERAL)
+      {
+        scanner_raise_error (context_p);
+      }
+      scanner_context_p->mode = SCAN_MODE_PRIMARY_EXPRESSION;
+      break;
+    }
 #endif /* ENABLED (JERRY_ES2015) */
     case LEXER_COMMA:
     {
-      /* Elision or spread arguments */
-#if ENABLED (JERRY_ES2015)
-      bool raise_error = (stack_top != SCAN_STACK_PAREN_EXPRESSION && stack_top != SCAN_STACK_ARRAY_LITERAL);
-#else /* !ENABLED (JERRY_ES2015) */
-      bool raise_error = stack_top != SCAN_STACK_ARRAY_LITERAL;
-#endif /* ENABLED (JERRY_ES2015) */
-
-      if (raise_error)
+      if (stack_top != SCAN_STACK_ARRAY_LITERAL)
       {
         scanner_raise_error (context_p);
       }

--- a/tests/jerry/es2015/regression-test-issue-3595.js
+++ b/tests/jerry/es2015/regression-test-issue-3595.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test if the native function as constructor is correctly invoked
+// when used as parent "class"
+
+var src = "({ $($) { a(...args) }";
+
+try {
+  eval (src);
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #3595.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
