### PR TITLE
Fix for-in/off block context initialization for empty destructuring patterns

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1216,7 +1216,8 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
         || context_p->token.type == LEXER_KEYW_CONST)
     {
       token_type = context_p->token.type;
-      has_context = (context_p->token.type != LEXER_KEYW_VAR);
+      has_context = context_p->next_scanner_info_p->source_p == context_p->source_p;
+      JERRY_ASSERT (!has_context || context_p->next_scanner_info_p->type == SCANNER_TYPE_BLOCK);
       scanner_get_location (&start_location, context_p);
 
       /* TODO: remove this after the pre-scanner supports strict mode detection. */

--- a/tests/jerry/es2015/regression-test-issue-3611.js
+++ b/tests/jerry/es2015/regression-test-issue-3611.js
@@ -1,0 +1,40 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var tcs = [
+  "for (const [] of $)",
+  "for (const [] in $)",
+  "for (let [] of $)",
+  "for (let [] in $)",
+  "for (const {} of $)",
+  "for (const {} in $)",
+  "for (let {} of $)",
+  "for (let {} in $)",
+];
+
+for (let e of tcs) {
+  try {
+    eval (e);
+    assert (false);
+  } catch (e) {
+    assert (e instanceof SyntaxError);
+  }
+
+  try {
+    eval (e + " {}");
+    assert (false);
+  } catch (e) {
+    assert (e instanceof ReferenceError);
+  }
+}


### PR DESCRIPTION
This patch fixes #3611.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

