### PR TITLE
Remove ECMA_OBJECT_TYPE_PSEUDO_ARRAY

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-map-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-map-iterator-prototype.c
@@ -51,7 +51,7 @@
 static ecma_value_t
 ecma_builtin_map_iterator_prototype_object_next (ecma_value_t this_val) /**< this argument */
 {
-  return ecma_op_container_iterator_next (this_val, ECMA_PSEUDO_MAP_ITERATOR);
+  return ecma_op_container_iterator_next (this_val, LIT_MAGIC_STRING_MAP_ITERATOR_UL);
 } /* ecma_builtin_map_iterator_prototype_object_next */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-map-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-map-prototype.c
@@ -165,7 +165,7 @@ ecma_builtin_map_prototype_object_entries (ecma_value_t this_arg) /**< this argu
                                             ECMA_ITERATOR_KEYS_VALUES,
                                             LIT_MAGIC_STRING_MAP_UL,
                                             ECMA_BUILTIN_ID_MAP_ITERATOR_PROTOTYPE,
-                                            ECMA_PSEUDO_MAP_ITERATOR);
+                                            LIT_MAGIC_STRING_MAP_ITERATOR_UL);
 } /* ecma_builtin_map_prototype_object_entries */
 
 /**
@@ -184,7 +184,7 @@ ecma_builtin_map_prototype_object_keys (ecma_value_t this_arg) /**< this argumen
                                             ECMA_ITERATOR_KEYS,
                                             LIT_MAGIC_STRING_MAP_UL,
                                             ECMA_BUILTIN_ID_MAP_ITERATOR_PROTOTYPE,
-                                            ECMA_PSEUDO_MAP_ITERATOR);
+                                            LIT_MAGIC_STRING_MAP_ITERATOR_UL);
 } /* ecma_builtin_map_prototype_object_keys */
 
 /**
@@ -203,7 +203,7 @@ ecma_builtin_map_prototype_object_values (ecma_value_t this_arg) /**< this argum
                                             ECMA_ITERATOR_VALUES,
                                             LIT_MAGIC_STRING_MAP_UL,
                                             ECMA_BUILTIN_ID_MAP_ITERATOR_PROTOTYPE,
-                                            ECMA_PSEUDO_MAP_ITERATOR);
+                                            LIT_MAGIC_STRING_MAP_ITERATOR_UL);
 } /* ecma_builtin_map_prototype_object_values */
 
 #endif /* ENABLED (JERRY_ES2015) */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-set-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-set-iterator-prototype.c
@@ -51,7 +51,7 @@
 static ecma_value_t
 ecma_builtin_set_iterator_prototype_object_next (ecma_value_t this_val) /**< this argument */
 {
-  return ecma_op_container_iterator_next (this_val, ECMA_PSEUDO_SET_ITERATOR);
+  return ecma_op_container_iterator_next (this_val, LIT_MAGIC_STRING_SET_ITERATOR_UL);
 } /* ecma_builtin_set_iterator_prototype_object_next */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-set-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-set-prototype.c
@@ -148,7 +148,7 @@ ecma_builtin_set_prototype_object_entries (ecma_value_t this_arg) /**< this argu
                                             ECMA_ITERATOR_KEYS_VALUES,
                                             LIT_MAGIC_STRING_SET_UL,
                                             ECMA_BUILTIN_ID_SET_ITERATOR_PROTOTYPE,
-                                            ECMA_PSEUDO_SET_ITERATOR);
+                                            LIT_MAGIC_STRING_SET_ITERATOR_UL);
 } /* ecma_builtin_set_prototype_object_entries */
 
 /**
@@ -167,7 +167,7 @@ ecma_builtin_set_prototype_object_keys (ecma_value_t this_arg) /**< this argumen
                                             ECMA_ITERATOR_KEYS,
                                             LIT_MAGIC_STRING_SET_UL,
                                             ECMA_BUILTIN_ID_SET_ITERATOR_PROTOTYPE,
-                                            ECMA_PSEUDO_SET_ITERATOR);
+                                            LIT_MAGIC_STRING_SET_ITERATOR_UL);
 } /* ecma_builtin_set_prototype_object_keys */
 
 /**
@@ -186,7 +186,7 @@ ecma_builtin_set_prototype_object_values (ecma_value_t this_arg) /**< this argum
                                             ECMA_ITERATOR_VALUES,
                                             LIT_MAGIC_STRING_SET_UL,
                                             ECMA_BUILTIN_ID_SET_ITERATOR_PROTOTYPE,
-                                            ECMA_PSEUDO_SET_ITERATOR);
+                                            LIT_MAGIC_STRING_SET_ITERATOR_UL);
 } /* ecma_builtin_set_prototype_object_values */
 
 #endif /* ENABLED (JERRY_ES2015) */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-iterator-prototype.c
@@ -58,16 +58,15 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   }
 
   ecma_object_t *obj_p = ecma_get_object_from_value (this_val);
-  ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
+  ecma_iterator_object_t *iterator_obj_p = (ecma_iterator_object_t *) obj_p;
 
   /* 3. */
-  if (ecma_get_object_type (obj_p) != ECMA_OBJECT_TYPE_PSEUDO_ARRAY
-      || ext_obj_p->u.pseudo_array.type != ECMA_PSEUDO_STRING_ITERATOR)
+  if (!ecma_object_class_is (obj_p, LIT_MAGIC_STRING_STRING_ITERATOR_UL))
   {
     return ecma_raise_type_error (ECMA_ERR_MSG ("Argument 'this' is not an iterator."));
   }
 
-  ecma_value_t iterated_value = ext_obj_p->u.pseudo_array.u2.iterated_value;
+  ecma_value_t iterated_value = iterator_obj_p->header.u.class_prop.u.iterated_value;
 
   /* 4 - 5 */
   if (ecma_is_value_empty (iterated_value))
@@ -80,12 +79,7 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   ecma_string_t *string_p = ecma_get_string_from_value (iterated_value);
 
   /* 6. */
-  ecma_length_t position = ext_obj_p->u.pseudo_array.u1.iterator_index;
-
-  if (JERRY_UNLIKELY (position == ECMA_ITERATOR_INDEX_LIMIT))
-  {
-    return ecma_raise_range_error (ECMA_ERR_MSG ("String iteration cannot be continued."));
-  }
+  ecma_length_t position = iterator_obj_p->index;
 
   /* 7. */
   ecma_length_t len = ecma_string_get_length (string_p);
@@ -94,7 +88,7 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   if (position >= len)
   {
     ecma_deref_ecma_string (string_p);
-    ext_obj_p->u.pseudo_array.u2.iterated_value = ECMA_VALUE_EMPTY;
+    iterator_obj_p->header.u.class_prop.u.iterated_value = ECMA_VALUE_EMPTY;
     return ecma_create_iter_result_object (ECMA_VALUE_UNDEFINED, ECMA_VALUE_TRUE);
   }
 
@@ -129,7 +123,7 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   }
 
   /* 13. */
-  ext_obj_p->u.pseudo_array.u1.iterator_index = (uint16_t) (position + result_size);
+  iterator_obj_p->index = position + result_size;
 
   /* 14. */
   ecma_value_t result = ecma_create_iter_result_object (ecma_make_string_value (result_str_p), ECMA_VALUE_FALSE);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1288,7 +1288,7 @@ ecma_builtin_string_prototype_object_iterator (ecma_value_t to_string) /**< this
 {
   return ecma_op_create_iterator_object (ecma_copy_value (to_string),
                                          ecma_builtin_get (ECMA_BUILTIN_ID_STRING_ITERATOR_PROTOTYPE),
-                                         ECMA_PSEUDO_STRING_ITERATOR,
+                                         LIT_MAGIC_STRING_STRING_ITERATOR_UL,
                                          0);
 } /* ecma_builtin_string_prototype_object_iterator */
 

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -359,11 +359,9 @@ ecma_builtin_typedarray_iterators_helper (ecma_value_t this_arg, /**< this argum
     return ecma_raise_type_error (ECMA_ERR_MSG ("Argument 'this' is not a TypedArray."));
   }
 
-  ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_ARRAY_ITERATOR_PROTOTYPE);
-
   return ecma_op_create_iterator_object (this_arg,
-                                         prototype_obj_p,
-                                         ECMA_PSEUDO_ARRAY_ITERATOR,
+                                         ecma_builtin_get (ECMA_BUILTIN_ID_ARRAY_ITERATOR_PROTOTYPE),
+                                         LIT_MAGIC_STRING_ARRAY_ITERATOR_UL,
                                          type);
 } /* ecma_builtin_typedarray_iterators_helper */
 

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -767,7 +767,7 @@ ecma_op_create_array_iterator (ecma_object_t *obj_p, /**< array object */
 
   return ecma_op_create_iterator_object (ecma_make_object_value (obj_p),
                                          prototype_obj_p,
-                                         ECMA_PSEUDO_ARRAY_ITERATOR,
+                                         LIT_MAGIC_STRING_ARRAY_ITERATOR_UL,
                                          (uint8_t) type);
 } /* ecma_op_create_array_iterator */
 #endif /* ENABLED (JERRY_ES2015) */

--- a/jerry-core/ecma/operations/ecma-container-object.h
+++ b/jerry-core/ecma/operations/ecma-container-object.h
@@ -45,8 +45,8 @@ void ecma_op_container_unref_weak (ecma_object_t *object_p, ecma_value_t ref_hol
 void ecma_op_container_remove_weak_entry (ecma_object_t *container_p, ecma_value_t key_arg);
 void ecma_op_container_free_entries (ecma_object_t *object_p);
 ecma_value_t ecma_op_container_create_iterator (ecma_value_t this_arg, uint8_t type, lit_magic_string_id_t lit_id,
-                                                ecma_builtin_id_t proto_id, ecma_pseudo_array_type_t iterator_type);
-ecma_value_t ecma_op_container_iterator_next (ecma_value_t this_val, ecma_pseudo_array_type_t iterator_type);
+                                                ecma_builtin_id_t proto_id, lit_magic_string_id_t iterator_type);
+ecma_value_t ecma_op_container_iterator_next (ecma_value_t this_val, lit_magic_string_id_t iterator_type);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-iterator-object.c
+++ b/jerry-core/ecma/operations/ecma-iterator-object.c
@@ -135,26 +135,23 @@ ecma_create_iter_result_object (ecma_value_t value, /**< value */
 ecma_value_t
 ecma_op_create_iterator_object (ecma_value_t iterated_value, /**< value from create iterator */
                                 ecma_object_t *prototype_obj_p, /**< prototype object */
-                                uint8_t iterator_type, /**< iterator type, see ecma_pseudo_array_type_t */
+                                lit_magic_string_id_t iterator_id, /**< iterator type */
                                 uint8_t extra_info) /**< extra information */
 {
-  /* 1. */
-  JERRY_ASSERT (iterator_type >= ECMA_PSEUDO_ARRAY_ITERATOR && iterator_type <= ECMA_PSEUDO_ARRAY__MAX);
-
   /* 2. */
   ecma_object_t *object_p = ecma_create_object (prototype_obj_p,
-                                                sizeof (ecma_extended_object_t),
-                                                ECMA_OBJECT_TYPE_PSEUDO_ARRAY);
+                                                sizeof (ecma_iterator_object_t),
+                                                ECMA_OBJECT_TYPE_CLASS);
 
-  ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) object_p;
-  ext_obj_p->u.pseudo_array.type = iterator_type;
+  ecma_iterator_object_t *iterator_obj_p = (ecma_iterator_object_t *) object_p;
+  iterator_obj_p->header.u.class_prop.class_id = iterator_id;
 
   /* 3. */
-  ext_obj_p->u.pseudo_array.u2.iterated_value = iterated_value;
+  iterator_obj_p->header.u.class_prop.u.iterated_value = iterated_value;
   /* 4. */
-  ext_obj_p->u.pseudo_array.u1.iterator_index = 0;
+  iterator_obj_p->index = 0;
   /* 5. */
-  ext_obj_p->u.pseudo_array.extra_info = extra_info;
+  iterator_obj_p->header.u.class_prop.extra_info = extra_info;
 
   /* 6. */
   return ecma_make_object_value (object_p);

--- a/jerry-core/ecma/operations/ecma-iterator-object.h
+++ b/jerry-core/ecma/operations/ecma-iterator-object.h
@@ -37,15 +37,9 @@ typedef enum
   ECMA_ITERATOR_THROW, /**< generator should perform a throw operation */
 } ecma_iterator_command_type_t;
 
-/**
- * Maximum value of [[%Iterator%NextIndex]] until it can be stored
- * in an ecma pseudo array object structure element.
- */
-#define ECMA_ITERATOR_INDEX_LIMIT UINT16_MAX
-
 ecma_value_t
 ecma_op_create_iterator_object (ecma_value_t iterated_value, ecma_object_t *prototype_obj_p,
-                                uint8_t iterator_type, uint8_t extra_info);
+                                lit_magic_string_id_t iterator_id, uint8_t extra_info);
 
 ecma_value_t
 ecma_create_iter_result_object (ecma_value_t value, ecma_value_t done);

--- a/jerry-core/ecma/operations/ecma-typedarray-object.h
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.h
@@ -29,6 +29,7 @@
  */
 
 uint8_t ecma_typedarray_helper_get_shift_size (ecma_typedarray_type_t typedarray_id);
+lit_magic_string_id_t ecma_get_typedarray_class_id (ecma_typedarray_type_t typedarray_id);
 ecma_typedarray_getter_fn_t ecma_get_typedarray_getter_fn (ecma_typedarray_type_t typedarray_id);
 ecma_typedarray_setter_fn_t ecma_get_typedarray_setter_fn (ecma_typedarray_type_t typedarray_id);
 ecma_number_t ecma_get_typedarray_element (lit_utf8_byte_t *src_p,

--- a/jerry-core/lit/lit-magic-strings.h
+++ b/jerry-core/lit/lit-magic-strings.h
@@ -46,11 +46,13 @@ typedef enum
   LIT_INTERNAL_MAGIC_STRING_PROMISE_PROPERTY_INDEX, /**< [[Index]] property */
   LIT_INTERNAL_MAGIC_STRING_PROMISE_PROPERTY_VALUE, /**< [[Values]] property */
   LIT_INTERNAL_MAGIC_STRING_PROMISE_PROPERTY_REMAINING_ELEMENT, /**< [[RemainingElement]] property */
-  LIT_INTERNAL_MAGIC_STRING_ITERATOR_NEXT_INDEX, /**< [[%Iterator%NextIndex]] property */
   LIT_INTERNAL_MAGIC_STRING_MAP_KEY, /**< Property key used when an object is a key in a map object */
   LIT_INTERNAL_MAGIC_API_INTERNAL, /**< Property key used to add non-visible JS properties from the public API  */
   LIT_INTERNAL_MAGIC_STRING_ARRAY_PROTOTYPE_VALUES, /**< %ArrayProto_values% intrinsic routine */
   LIT_INTERNAL_MAGIC_THIS_BINDING_VALUE, /**< FunctionEnvironmentRecord [[ThisBindingValue]] internal slot */
+  LIT_INTERNAL_MAGIC_STRING_TYPEDARRAY, /**< TypedArray which does NOT need extra space to store length and offset */
+  LIT_INTERNAL_MAGIC_STRING_TYPEDARRAY_WITH_INFO, /**< TypedArray which NEEDS extra space to store length and offset */
+  LIT_INTERNAL_MAGIC_STRING_MAPPED_ARGUMENTS, /**< Arguments object (10.6) */
   /* List of well known symbols */
   LIT_GLOBAL_SYMBOL_HAS_INSTANCE, /**< @@hasInstance well known symbol */
   LIT_GLOBAL_SYMBOL_IS_CONCAT_SPREADABLE, /**< @@isConcatSpreadable well known symbol */


### PR DESCRIPTION
All represented object types can be stored as ECMA_OBJECT_TYPE_CLASS.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
