### PR TITLE
Fix VLA error in strings unittest

### DIFF
--- a/tests/unit-core/test-api-strings.c
+++ b/tests/unit-core/test-api-strings.c
@@ -83,7 +83,7 @@ main (void)
   utf8_sz = jerry_get_utf8_string_size (args[0]);
   cesu8_sz = jerry_get_utf8_string_size (args[1]);
 
-  TEST_ASSERT (utf8_sz == cesu8_sz);
+  TEST_ASSERT (utf8_sz == cesu8_sz && utf8_sz > 0);
 
   JERRY_VLA (char, string_from_utf8_string, utf8_sz);
   JERRY_VLA (char, string_from_cesu8_string, cesu8_sz);


### PR DESCRIPTION
In the test-api-string.c there was an error if the unittests are built in release.
Full error message:
```
tests/unit-core/test-api-strings.c:89:20: error: variable-length array bound is unknown [-Werror=vla-larger-than=]
89 |   JERRY_VLA (char, string_from_cesu8_string, cesu8_sz);
```

The problem is that the compiler does not know if the buffer size is always greater than zero.
Added an extra check to the TEST_ASSERT a line above to resolve the error.