### PR TITLE
Fix Array.slice when using fast arrays

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -869,6 +869,15 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t arg1, /**< start */
 
     if (ext_from_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
     {
+      if (JERRY_UNLIKELY (obj_p->u1.property_list_cp == JMEM_CP_NULL))
+      {
+        /**
+         * Very unlikely case: the buffer copied from is a fast buffer and the property list was deleted.
+         * There is no need to do any copy.
+         */
+        return new_array;
+      }
+
       ecma_extended_object_t *ext_to_obj_p = (ecma_extended_object_t *) new_array_p;
 
 #if ENABLED (JERRY_ES2015)

--- a/tests/jerry/es2015/regression-test-issue-3637.js
+++ b/tests/jerry/es2015/regression-test-issue-3637.js
@@ -1,0 +1,24 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = [1, 2, 3, 4];
+var b = a.slice(0, { valueOf: function(){ a.length = 0; return 100; } });
+
+assert(b.length === 4);
+
+var c = [1, 2, 3, 4];
+c.prop = 4
+var d = c.slice(0, { valueOf: function(){ c.length = 0; return 100; } });
+
+assert(d.length === 4);

--- a/tests/jerry/es5.1/regression-test-issue-3637.js
+++ b/tests/jerry/es5.1/regression-test-issue-3637.js
@@ -1,0 +1,24 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = [1, 2, 3, 4];
+var b = a.slice(0, { valueOf: function(){ a.length = 0; return 100; } });
+
+assert(b.length === 0);
+
+var c = [1, 2, 3, 4];
+c.prop = 4
+var d = c.slice(0, { valueOf: function(){ c.length = 0; return 100; } });
+
+assert(d.length === 0);


### PR DESCRIPTION
When a fast array was used during the Array.slice call and
the input array's properties were removed the property
list was used incorrectly.

Fixes: #3637
