### PR TITLE
Fix lazy property name listing for ArrayIndices.

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -947,8 +947,11 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
 
     ecma_collection_t *for_non_enumerable_p = separate_enumerable ? non_enum_collection_p : main_collection_p;
 
-    /* 'length' property is non-enumerable (ECMA-262 v5, 15) */
-    ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
+    if (!is_array_indices_only)
+    {
+      /* 'length' property is non-enumerable (ECMA-262 v5, 15) */
+      ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
+    }
   }
   else
   {

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2079,25 +2079,34 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
           }
           case ECMA_OBJECT_TYPE_FUNCTION:
           {
-            ecma_op_function_list_lazy_property_names (obj_p,
-                                                       opts,
-                                                       prop_names_p,
-                                                       skipped_non_enumerable_p);
+            if (!is_array_indices_only)
+            {
+              ecma_op_function_list_lazy_property_names (obj_p,
+                                                         opts,
+                                                         prop_names_p,
+                                                         skipped_non_enumerable_p);
+            }
             break;
           }
           case ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION:
           {
-            ecma_op_external_function_list_lazy_property_names (opts,
-                                                                prop_names_p,
-                                                                skipped_non_enumerable_p);
+            if (!is_array_indices_only)
+            {
+              ecma_op_external_function_list_lazy_property_names (opts,
+                                                                  prop_names_p,
+                                                                  skipped_non_enumerable_p);
+            }
             break;
           }
           case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
           {
-            ecma_op_bound_function_list_lazy_property_names (obj_p,
-                                                             opts,
-                                                             prop_names_p,
-                                                             skipped_non_enumerable_p);
+            if (!is_array_indices_only)
+            {
+              ecma_op_bound_function_list_lazy_property_names (obj_p,
+                                                               opts,
+                                                               prop_names_p,
+                                                               skipped_non_enumerable_p);
+            }
             break;
           }
           case ECMA_OBJECT_TYPE_CLASS:

--- a/tests/jerry/regression-test-issue-3648.js
+++ b/tests/jerry/regression-test-issue-3648.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var func = function () {};
+var boundFunc = func.bind();
+var externalFunc = print;
+var builtinFunc = unescape;
+
+[func, boundFunc, externalFunc, builtinFunc].forEach(function (e) {
+  assert (Array.prototype.sort.call(e) === e);
+})
+


### PR DESCRIPTION
This patch fixes #3648.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
