### PR TITLE
CBC_PUSH_THIS should not be mutated in array literal parsing.

### DIFF
--- a/tests/jerry/regression-test-issue-3650.js
+++ b/tests/jerry/regression-test-issue-3650.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var u = 5;
+assert ([this, u = u - 1].length === 2);
+assert (u === 4);


### PR DESCRIPTION
This patch fixes #3650, and slightly reverts the changes of #3594.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
