### PR TITLE
Fix lexical binding set in VM_OC_COPY_TO_GLOBAL

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-3647.js
+++ b/tests/jerry/es2015/regression-test-issue-3647.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+f();
+let g;
+function f() {
+  assert(eval('function g() { return 5}; g')() === 5);
+}


### PR DESCRIPTION
This patch fixes #3647.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
