### PR TITLE
Fix attributes of length property for bound function

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -217,15 +217,15 @@ ecma_gc_mark_bound_function_object (ecma_object_t *object_p) /**< bound function
 {
   JERRY_ASSERT (ecma_get_object_type (object_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
 
-  ecma_extended_object_t *ext_function_p = (ecma_extended_object_t *) object_p;
+  ecma_bound_function_t *bound_func_p = (ecma_bound_function_t *) object_p;
 
-  ecma_object_t *target_func_obj_p;
-  target_func_obj_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_object_t,
-                                                       ext_function_p->u.bound_function.target_function);
+  ecma_object_t *target_func_p;
+  target_func_p = ECMA_GET_NON_NULL_POINTER_FROM_POINTER_TAG (ecma_object_t,
+                                                              bound_func_p->header.u.bound_function.target_function);
 
-  ecma_gc_set_object_visited (target_func_obj_p);
+  ecma_gc_set_object_visited (target_func_p);
 
-  ecma_value_t args_len_or_this = ext_function_p->u.bound_function.args_len_or_this;
+  ecma_value_t args_len_or_this = bound_func_p->header.u.bound_function.args_len_or_this;
 
   if (!ecma_is_value_integer_number (args_len_or_this))
   {
@@ -238,7 +238,7 @@ ecma_gc_mark_bound_function_object (ecma_object_t *object_p) /**< bound function
   }
 
   ecma_integer_value_t args_length = ecma_get_integer_from_value (args_len_or_this);
-  ecma_value_t *args_p = (ecma_value_t *) (ext_function_p + 1);
+  ecma_value_t *args_p = (ecma_value_t *) (bound_func_p + 1);
 
   JERRY_ASSERT (args_length > 0);
 
@@ -1311,9 +1311,10 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
     }
     case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
     {
-      ecma_extended_object_t *ext_function_p = (ecma_extended_object_t *) object_p;
+      ext_object_size = sizeof (ecma_bound_function_t);
+      ecma_bound_function_t *bound_func_p = (ecma_bound_function_t *) object_p;
 
-      ecma_value_t args_len_or_this = ext_function_p->u.bound_function.args_len_or_this;
+      ecma_value_t args_len_or_this = bound_func_p->header.u.bound_function.args_len_or_this;
 
       if (!ecma_is_value_integer_number (args_len_or_this))
       {
@@ -1322,7 +1323,7 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
       }
 
       ecma_integer_value_t args_length = ecma_get_integer_from_value (args_len_or_this);
-      ecma_value_t *args_p = (ecma_value_t *) (ext_function_p + 1);
+      ecma_value_t *args_p = (ecma_value_t *) (bound_func_p + 1);
 
       for (ecma_integer_value_t i = 0; i < args_length; i++)
       {

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -897,7 +897,7 @@ typedef struct
      */
     struct
     {
-      ecma_value_t target_function; /**< target function */
+      jmem_cpointer_tag_t target_function; /**< target function */
       ecma_value_t args_len_or_this; /**< length of arguments or this value */
     } bound_function;
 
@@ -946,6 +946,17 @@ typedef struct
  */
 #define ECMA_REGEXP_PROTO_COMPILED_CODE_SIZE \
   (JERRY_ALIGNUP (sizeof (ecma_compiled_code_t), JMEM_ALIGNMENT) + sizeof (ecma_value_t))
+
+/**
+ * Description of bound function objects.
+ */
+typedef struct
+{
+  ecma_extended_object_t header; /**< extended object header */
+#if ENABLED (JERRY_ES2015)
+  ecma_integer_value_t target_length; /**< length of target function */
+#endif /* ENABLED (JERRY_ES2015) */
+} ecma_bound_function_t;
 
 #if ENABLED (JERRY_SNAPSHOT_EXEC)
 

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -99,7 +99,8 @@ ecma_op_external_function_list_lazy_property_names (uint32_t opts,
                                                     ecma_collection_t *non_enum_collection_p);
 
 void
-ecma_op_bound_function_list_lazy_property_names (uint32_t opts,
+ecma_op_bound_function_list_lazy_property_names (ecma_object_t *object_p,
+                                                 uint32_t opts,
                                                  ecma_collection_t *main_collection_p,
                                                  ecma_collection_t *non_enum_collection_p);
 

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1997,7 +1997,8 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
           }
           case ECMA_OBJECT_TYPE_BOUND_FUNCTION:
           {
-            ecma_op_bound_function_list_lazy_property_names (opts,
+            ecma_op_bound_function_list_lazy_property_names (obj_p,
+                                                             opts,
                                                              prop_names_p,
                                                              skipped_non_enumerable_p);
             break;

--- a/tests/jerry/es2015/length-property.js
+++ b/tests/jerry/es2015/length-property.js
@@ -105,8 +105,10 @@ var builtin_typedArrays = [
   /* test length property of function objects */
   var normal_func = function () {};
   var arrow_func = () => {};
+  var bound_func = normal_func.bind({});
+  var nested_bound_func = arrow_func.bind().bind(1);
 
-  var functions = [normal_func, arrow_func];
+  var functions = [normal_func, arrow_func, bound_func, nested_bound_func];
 
   for (func of functions) {
     var desc = Object.getOwnPropertyDescriptor(func, 'length');
@@ -120,4 +122,20 @@ var builtin_typedArrays = [
     assert(delete func.length);
     assert(func.hasOwnProperty('length') === false);
   }
+})();
+
+(function() {
+  /* changing the length of f affects the bound function */
+  function f(a,b,c) {}
+  Object.defineProperty(f, "length", { value: 30 });
+  var g = f.bind(1,2)
+  assert(g.length === 29);
+})();
+
+(function() {
+  /* changing the length of f does not affect the bound function */
+  function f(a,b,c) {}
+  var g = f.bind(1,2)
+  Object.defineProperty(f, "length", { value: 30 });
+  assert(g.length === 2);
 })();


### PR DESCRIPTION
fix length property of bound function objects to be configurable (ECMA-262 v6, 19.2.4.1)
resolve #3615 

JerryScript-DCO-1.0-Signed-off-by: HyukWoo Park hyukwoo.park@samsung.com