### PR TITLE
Fix iterator step calculation for bracketed property expressions

### DIFF
--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -112,6 +112,7 @@ typedef enum
   PARSER_PATTERN_LOCAL = (1u << 5),            /**< pattern is a local (catch parameter) declaration */
   PARSER_PATTERN_REST_ELEMENT = (1u << 6),     /**< parse rest array initializer */
   PARSER_PATTERN_ARGUMENTS = (1u << 7),        /**< parse arguments binding */
+  PARSER_PATTERN_ARRAY = (1u << 8),            /**< array pattern is being parsed */
 } parser_pattern_flags_t;
 
 /**

--- a/tests/jerry/es2015/regression-test-issue-3665.js
+++ b/tests/jerry/es2015/regression-test-issue-3665.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var idx1 = 32.6;
+var idx2 = 42.7;
+var obj = { [idx1] : { [idx2] : {}}};
+([obj[idx1][idx2]] = [5.7]);
+
+assert (obj[idx1][idx2] === 5.7);


### PR DESCRIPTION
This patch fixes #3665.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
