### PR TITLE
Fix incorrect assertion in parser_parse_for_statement_start

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -121,6 +121,13 @@ typedef enum
   ECMA_PARSE_GENERATOR_FUNCTION = (1u << 8), /**< generator function is parsed */
 
   /* These flags are internally used by the parser. */
+#ifndef JERRY_NDEBUG
+  /**
+   * This flag represents an error in for in/of statements, which cannot be set
+   * if the parsing is completed successfully.
+   */
+  ECMA_PARSE_INTERNAL_FOR_IN_OFF_CONTEXT_ERROR = (1u << 9),
+#endif /* !JERRY_NDEBUG */
 } ecma_parse_opts_t;
 
 /**

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1314,7 +1314,12 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
         parser_emit_cbc_ext (context_p, is_for_in ? CBC_EXT_FOR_IN_GET_NEXT
                                                   : CBC_EXT_FOR_OF_GET_NEXT);
 #if ENABLED (JERRY_ES2015)
-        JERRY_ASSERT (literal_index < PARSER_REGISTER_START || !has_context);
+#ifndef JERRY_NDEBUG
+        if (literal_index >= PARSER_REGISTER_START && has_context)
+        {
+          context_p->global_status_flags |= ECMA_PARSE_INTERNAL_FOR_IN_OFF_CONTEXT_ERROR;
+        }
+#endif /* !JERRY_NDEBUG */
 
         parser_emit_cbc_literal (context_p,
                                  has_context ? CBC_ASSIGN_LET_CONST : CBC_ASSIGN_SET_IDENT,

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2100,6 +2100,7 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
 
 #ifndef JERRY_NDEBUG
     JERRY_ASSERT (context.status_flags & PARSER_SCANNING_SUCCESSFUL);
+    JERRY_ASSERT (!(context.global_status_flags & ECMA_PARSE_INTERNAL_FOR_IN_OFF_CONTEXT_ERROR));
     context.status_flags &= (uint32_t) ~PARSER_SCANNING_SUCCESSFUL;
 #endif /* !JERRY_NDEBUG */
 

--- a/tests/jerry/es2015/regression-test-issue-3655.js
+++ b/tests/jerry/es2015/regression-test-issue-3655.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let str = 'for (let i of id_36) function testcase() { testcase';
+
+try {
+  eval (str);
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #3655.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu