### PR TITLE
Fix assignment expression pre-scanning for arrow functions.

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -1018,7 +1018,7 @@ scanner_scan_primary_expression_end (parser_context_t *context_p, /**< context *
     {
       scanner_pop_literal_pool (context_p, scanner_context_p);
       parser_stack_pop_uint8 (context_p);
-      scanner_context_p->mode = SCAN_MODE_POST_PRIMARY_EXPRESSION;
+      scanner_context_p->mode = SCAN_MODE_PRIMARY_EXPRESSION_END;
       return SCAN_KEEP_TOKEN;
     }
     case SCAN_STACK_CLASS_EXTENDS:

--- a/tests/jerry/es2015/regression-test-issue-3656.js
+++ b/tests/jerry/es2015/regression-test-issue-3656.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+$ => $++
+[ ]


### PR DESCRIPTION
Fixes #3656.