### PR TITLE
Update the RegExp.prototype.test function to support ES6 version

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -470,6 +470,7 @@ ecma_builtin_regexp_prototype_exec (ecma_value_t this_arg, /**< this argument */
  *
  * See also:
  *          ECMA-262 v5, 15.10.6.3
+ *          ECMA-262 v6, 21.2.5.13
  *
  * @return true  - if match is not null
  *         false - otherwise
@@ -480,12 +481,35 @@ static ecma_value_t
 ecma_builtin_regexp_prototype_test (ecma_value_t this_arg, /**< this argument */
                                     ecma_value_t arg) /**< routine's argument */
 {
+#if ENABLED (JERRY_ES2015)
+  if (!ecma_is_value_object (this_arg))
+  {
+    return ecma_raise_type_error (ECMA_ERR_MSG ("'this' value is not an object"));
+  }
+
+  ecma_string_t *arg_str_p = ecma_op_to_string (arg);
+
+  if (JERRY_UNLIKELY (arg_str_p == NULL))
+  {
+    return ECMA_VALUE_ERROR;
+  }
+
+  ecma_value_t result = ecma_op_regexp_exec (this_arg, arg_str_p);
+
+  ecma_deref_ecma_string (arg_str_p);
+
+  if (ECMA_IS_VALUE_ERROR (result))
+  {
+    return result;
+  }
+#else /* !ENABLED (JERRY_ES2015) */
   ecma_value_t result = ecma_builtin_regexp_prototype_exec (this_arg, arg);
 
   if (ECMA_IS_VALUE_ERROR (result))
   {
     return result;
   }
+#endif /* ENABLED (JERRY_ES2015) */
 
   ecma_value_t ret_value = ecma_make_boolean_value (!ecma_is_value_null (result));
   ecma_free_value (result);

--- a/tests/jerry/es2015/regexp-prototype-test.js
+++ b/tests/jerry/es2015/regexp-prototype-test.js
@@ -1,0 +1,24 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var str = 'something interesting';
+var regexp = new RegExp('o*');
+Object.defineProperty(regexp, 'exec', { 'get':  function () {throw 42}});
+
+try {
+  regexp.test(str);
+  assert(false);
+} catch (e) {
+  assert(e === 42);  
+}


### PR DESCRIPTION
The algorithm is based on ECMA-262 v6, 21.2.5.13

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu

