### PR TITLE
Handle properties of builtin function separately from builtin objects

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -807,7 +807,15 @@ typedef struct
   uint8_t length_and_bitset_size; /**< length for built-in functions and
                                    *   bit set size for all built-ins */
   uint16_t routine_id; /**< routine id for built-in functions */
-  uint32_t instantiated_bitset[1]; /**< bit set for instantiated properties */
+  union
+  {
+    uint32_t instantiated_bitset[1]; /**< bit set for instantiated properties */
+    struct
+    {
+      uint16_t name; /**< name of the built-in functions */
+      uint16_t bitset; /**< bit set for instantiated properties of builtin functions */
+    } builtin_routine;
+  } u;
 } ecma_built_in_props_t;
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -88,7 +88,14 @@ ecma_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *obj_p, ecma_object_t *new_target_p,
                                  const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
 ecma_property_t *
+ecma_builtin_routine_try_to_instantiate_property (ecma_object_t *object_p, ecma_string_t *string_p);
+ecma_property_t *
 ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, ecma_string_t *string_p);
+void
+ecma_builtin_routine_list_lazy_property_names (ecma_object_t *object_p,
+                                                uint32_t opts,
+                                                ecma_collection_t *main_collection_p,
+                                                ecma_collection_t *non_enum_collection_p);
 void
 ecma_builtin_list_lazy_property_names (ecma_object_t *object_p,
                                        uint32_t opts,

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -245,7 +245,14 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
   {
     if (ecma_get_object_is_builtin (object_p))
     {
-      property_p = ecma_builtin_try_to_instantiate_property (object_p, property_name_p);
+      if (type == ECMA_OBJECT_TYPE_FUNCTION && ecma_builtin_function_is_routine (object_p))
+      {
+        property_p = ecma_builtin_routine_try_to_instantiate_property (object_p, property_name_p);
+      }
+      else
+      {
+        property_p = ecma_builtin_try_to_instantiate_property (object_p, property_name_p);
+      }
     }
     else if (type == ECMA_OBJECT_TYPE_FUNCTION)
     {
@@ -592,7 +599,14 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
   {
     if (ecma_get_object_is_builtin (object_p))
     {
-      property_p = ecma_builtin_try_to_instantiate_property (object_p, property_name_p);
+      if (type == ECMA_OBJECT_TYPE_FUNCTION && ecma_builtin_function_is_routine (object_p))
+      {
+        property_p = ecma_builtin_routine_try_to_instantiate_property (object_p, property_name_p);
+      }
+      else
+      {
+        property_p = ecma_builtin_try_to_instantiate_property (object_p, property_name_p);
+      }
     }
     else if (type == ECMA_OBJECT_TYPE_FUNCTION)
     {
@@ -1413,7 +1427,14 @@ ecma_op_object_put_with_receiver (ecma_object_t *object_p, /**< the object */
 
     if (ecma_get_object_is_builtin (object_p))
     {
-      property_p = ecma_builtin_try_to_instantiate_property (object_p, property_name_p);
+      if (type == ECMA_OBJECT_TYPE_FUNCTION && ecma_builtin_function_is_routine (object_p))
+      {
+        property_p = ecma_builtin_routine_try_to_instantiate_property (object_p, property_name_p);
+      }
+      else
+      {
+        property_p = ecma_builtin_try_to_instantiate_property (object_p, property_name_p);
+      }
     }
     else if (type == ECMA_OBJECT_TYPE_FUNCTION)
     {
@@ -2074,10 +2095,20 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
 
       if (obj_is_builtin)
       {
-        ecma_builtin_list_lazy_property_names (obj_p,
-                                               opts,
-                                               prop_names_p,
-                                               skipped_non_enumerable_p);
+        if (type == ECMA_OBJECT_TYPE_FUNCTION && ecma_builtin_function_is_routine (obj_p))
+        {
+          ecma_builtin_routine_list_lazy_property_names (obj_p,
+                                                          opts,
+                                                          prop_names_p,
+                                                          skipped_non_enumerable_p);
+        }
+        else
+        {
+          ecma_builtin_list_lazy_property_names (obj_p,
+                                                 opts,
+                                                 prop_names_p,
+                                                 skipped_non_enumerable_p);
+        }
       }
       else
       {


### PR DESCRIPTION
separate builtin function part to make code clear and to support 'name' property later

JerryScript-DCO-1.0-Signed-off-by: HyukWoo Park hyukwoo.park@samsung.com
