### PR TITLE
Fix JSON.parse when __proto__ property is used

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -98,7 +98,11 @@ vm_op_get_value (ecma_value_t object, /**< base object */
       {
         ecma_object_t *obj_p = ecma_get_object_from_value (object);
 
-        return ecma_builtin_object_object_get_prototype_of (obj_p);
+        ecma_value_t has_property = ecma_op_object_has_property (obj_p, property_name_p);
+        if (ecma_is_value_false (has_property))
+        {
+          return ecma_builtin_object_object_get_prototype_of (obj_p);
+        }
       }
 #endif /* ENABLED (JERRY_ES2015) */
     }

--- a/tests/jerry/es2015/json-parse-proto.js
+++ b/tests/jerry/es2015/json-parse-proto.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* JSON.parse should treat __proto__ as regular property name */
+
+var str1 = '{"__proto__": [] }';
+var obj1 = JSON.parse(str1);
+assert(Object.getPrototypeOf(obj1) === Object.prototype);
+assert(Array.isArray(obj1.__proto__));


### PR DESCRIPTION
JSON.parse should treat **\_\_proto__** as a normal property

###### Test Code
```js
var str = '{"__proto__": [] }';
var obj = JSON.parse(str);

print(JSON.stringify(obj));
print(Array.isArray(obj.__proto__));
```

###### Current output - before commit
```
{"__proto__":[]}
false
```
###### Expected Output
```
{"__proto__":[]}
true
```

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com