### PR TITLE
Fix function argument handling issues caused by the parser.

### DIFF
--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -392,9 +392,10 @@ typedef struct
 #define PARSER_SCOPE_STACK_REGISTER_MASK 0x3fff
 
 /**
- * The scope stack item represents a lexical declaration (let/const)
+ * Function statements with the name specified
+ * in map_from should not be copied to global scope.
  */
-#define PARSER_SCOPE_STACK_IS_LEXICAL 0x4000
+#define PARSER_SCOPE_STACK_NO_FUNCTION_COPY 0x4000
 
 /**
  * The scope stack item represents a const declaration

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -742,7 +742,7 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
     while (stack_p < scope_stack_p)
     {
       if (literal_index == stack_p->map_from
-          && (stack_p->map_to & PARSER_SCOPE_STACK_IS_LEXICAL))
+          && (stack_p->map_to & PARSER_SCOPE_STACK_NO_FUNCTION_COPY))
       {
         copy_value = false;
         break;
@@ -758,7 +758,7 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
       {
         if (literal_index == stack_p->map_from)
         {
-          JERRY_ASSERT (!(stack_p->map_to & PARSER_SCOPE_STACK_IS_LEXICAL));
+          JERRY_ASSERT (!(stack_p->map_to & PARSER_SCOPE_STACK_NO_FUNCTION_COPY));
 
           uint16_t map_to = scanner_decode_map_to (stack_p);
           uint16_t opcode = ((map_to >= PARSER_REGISTER_START) ? CBC_ASSIGN_LITERAL_SET_IDENT

--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -3224,11 +3224,6 @@ scan_completed:
                 JERRY_DEBUG_MSG ("    LOCAL ");
                 break;
               }
-              case SCANNER_STREAM_TYPE_DESTRUCTURED_ARG:
-              {
-                JERRY_DEBUG_MSG ("    DESTRUCTURED_ARG ");
-                break;
-              }
 #endif /* ENABLED (JERRY_ES2015) */
 #if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
               case SCANNER_STREAM_TYPE_IMPORT:
@@ -3242,6 +3237,13 @@ scan_completed:
                 JERRY_DEBUG_MSG ("    ARG ");
                 break;
               }
+#if ENABLED (JERRY_ES2015)
+              case SCANNER_STREAM_TYPE_DESTRUCTURED_ARG:
+              {
+                JERRY_DEBUG_MSG ("    DESTRUCTURED_ARG ");
+                break;
+              }
+#endif /* ENABLED (JERRY_ES2015) */
               case SCANNER_STREAM_TYPE_ARG_FUNC:
               {
                 JERRY_DEBUG_MSG ("    ARG_FUNC ");

--- a/jerry-core/parser/js/js-scanner.h
+++ b/jerry-core/parser/js/js-scanner.h
@@ -148,12 +148,14 @@ typedef enum
   SCANNER_STREAM_TYPE_LET, /**< let declaration */
   SCANNER_STREAM_TYPE_CONST, /**< const declaration */
   SCANNER_STREAM_TYPE_LOCAL, /**< local declaration (e.g. catch block) */
-  SCANNER_STREAM_TYPE_DESTRUCTURED_ARG, /**< destructuring argument declaration */
 #endif /* ENABLED (JERRY_ES2015) */
 #if ENABLED (JERRY_ES2015_MODULE_SYSTEM)
   SCANNER_STREAM_TYPE_IMPORT, /**< module import */
 #endif /* ENABLED (JERRY_ES2015_MODULE_SYSTEM) */
   SCANNER_STREAM_TYPE_ARG, /**< argument declaration */
+#if ENABLED (JERRY_ES2015)
+  SCANNER_STREAM_TYPE_DESTRUCTURED_ARG, /**< destructuring argument declaration */
+#endif /* ENABLED (JERRY_ES2015) */
   /* Function types should be at the end. See the SCANNER_STREAM_TYPE_IS_FUNCTION macro. */
   SCANNER_STREAM_TYPE_ARG_FUNC, /**< argument declaration which
                                  *   is later initialized with a function */

--- a/tests/jerry/es2015/function-scope.js
+++ b/tests/jerry/es2015/function-scope.js
@@ -1,0 +1,67 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f1(a)
+{
+  assert(a === 2)
+  {
+    assert(a() === 1)
+    function a() { return 1 }
+  }
+  assert(a === 2)
+}
+f1(2)
+
+function f2([a])
+{
+  assert(a === 4)
+  {
+    assert(a() === 3)
+    function a() { return 3 }
+  }
+  assert(a === 4)
+}
+f2([4])
+
+function f3(a)
+{
+  assert(a() === 5)
+  {
+    assert(a() === 6)
+    function a() { return 6 }
+  }
+  assert(a() === 5)
+
+  function a() { return 5 }
+}
+f3(7)
+
+function f4(a)
+{
+  assert(a === 8)
+  {
+    eval("function a() { return 9 }")
+    assert(a() === 9)
+  }
+  assert(a() === 9)
+}
+f4(8)
+
+function f5(a, b = function() { return a }) {
+  function a() { return 9 }
+
+  assert(a() === 9)
+  assert(b() === 10)
+}
+f5(10)


### PR DESCRIPTION
1) Nested function declarations should not overwrite arguments.
2) Functions should be created in the correct scope.