### PR TITLE
Fix for OSx build

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -573,7 +573,7 @@ parser_parse_var_statement (parser_context_t *context_p) /**< context */
         }
 #endif /* ENABLED (JERRY_ES2015) */
 
-        parser_emit_cbc_literal (context_p, opcode, index);
+        parser_emit_cbc_literal (context_p, (uint16_t) opcode, index);
       }
 #if ENABLED (JERRY_ES2015)
       else if (declaration_type == LEXER_KEYW_LET)


### PR DESCRIPTION
Had an error on OSx when trying to build jerry, stating: `implicit conversion loses integer precision: 'cbc_opcode_t' to 'uint16_t'`

Clang version: 11.0.3
OSx version: 10.15.4 (Catalina)

JerryScript-DCO-1.0-Signed-off-by: Daniella Barsony bella@inf.u-szeged.hu