### PR TITLE
Improve AArch64 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,15 @@ matrix:
         apt:
           packages: [gcc-arm-linux-gnueabihf, libc6-dev-armhf-cross, qemu-user-static]
 
+    - name: "Linux/AArch64 Cross Build & Correctness Tests"
+      env:
+        - OPTS="--quiet --jerry-tests --jerry-test-suite --toolchain=cmake/toolchain_linux_aarch64.cmake --buildoptions=--linker-flag=-static"
+        - RUNTIME=qemu-aarch64-static
+        - TIMEOUT=300
+      addons:
+        apt:
+          packages: [gcc-aarch64-linux-gnu, libc6-dev-arm64-cross, qemu-user-static]
+
     - name: "OSX/x86-64 Build, Correctness & Unit Tests"
       env:
         - OPTS="--quiet --jerry-tests --jerry-test-suite --unittests"

--- a/cmake/toolchain_linux_aarch64.cmake
+++ b/cmake/toolchain_linux_aarch64.cmake
@@ -1,0 +1,18 @@
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)


### PR DESCRIPTION
- Adds a CMake toolchain file for AArch64 to help with cross compilation
- Tests the AArch64 build on Travis and runs the test suite using QEMU

JerryScript-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu
