### PR TITLE
Remove the unused `ecma_op_check_object_type_is_class` declaration

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -798,7 +798,6 @@ RECURSIVE              = YES
 # who are familiar with the undocumented parts.
 EXCLUDE                = \
         jerry-core/ecma/base/ecma-globals.h \
-        jerry-core/ecma/base/ecma-helpers.h \
         jerry-core/ecma/operations/ecma-exceptions.h \
         jerry-core/include/jerryscript-debugger-transport.h \
         jerry-core/jcontext/jcontext.h \

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -436,7 +436,6 @@ uint8_t ecma_get_object_builtin_id (ecma_object_t *object_p);
 ecma_lexical_environment_type_t JERRY_ATTR_PURE ecma_get_lex_env_type (const ecma_object_t *object_p);
 ecma_object_t JERRY_ATTR_PURE *ecma_get_lex_env_binding_object (const ecma_object_t *object_p);
 ecma_object_t *ecma_clone_decl_lexical_environment (ecma_object_t *lex_env_p, bool copy_values);
-ecma_extended_object_t *ecma_op_check_object_type_is_class (ecma_value_t this);
 
 ecma_property_value_t *
 ecma_create_named_data_property (ecma_object_t *object_p, ecma_string_t *name_p, uint8_t prop_attributes,


### PR DESCRIPTION
Removes the unused `ecma_op_check_object_type_is_class` function
declaration from `ecma-helpers.h`. This also makes the file pass
the Doxygen check.

JerryScript-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu

Related issues: #2469