### PR TITLE
Fix appending elements for ecma collection

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-collection.c
@@ -174,9 +174,13 @@ ecma_collection_append (ecma_collection_t *collection_p, /**< value collection *
                         uint32_t count) /**< number of ecma values to append */
 {
   JERRY_ASSERT (collection_p != NULL);
-  if (collection_p->capacity - collection_p->item_count >= count)
+  JERRY_ASSERT (collection_p->capacity >= collection_p->item_count);
+
+  uint32_t free_count = collection_p->capacity - collection_p->item_count;
+
+  if (free_count < count)
   {
-    ecma_collection_reserve (collection_p, count);
+    ecma_collection_reserve (collection_p, count - free_count);
   }
 
   memcpy (collection_p->buffer_p + collection_p->item_count, buffer_p, count * sizeof (ecma_value_t));

--- a/tests/jerry/es2015/proxy_own_keys.js
+++ b/tests/jerry/es2015/proxy_own_keys.js
@@ -149,6 +149,21 @@ var proxy = new Proxy(target, handler);
 
 assert(JSON.stringify(Object.getOwnPropertyNames(proxy)) === '["a","a","a"]');
 
+// test with lots of keys
+var keyslist = [];
+
+var handler = {
+	ownKeys: function(target) {
+      for (var idx = 0; idx < 30; idx++) {
+        keyslist.push("K" + idx);
+      }
+      return keyslist;
+    }
+};
+
+var proxy = new Proxy(target, handler);
+assert(JSON.stringify(Object.getOwnPropertyNames(proxy)) === JSON.stringify(keyslist));
+
 // test when invariants gets violated
 var target = {
   "target_one": 1

--- a/tests/jerry/regression-test-issue-3711.js
+++ b/tests/jerry/regression-test-issue-3711.js
@@ -1,0 +1,42 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function func() {}
+
+var bound = func.bind();
+
+/* original test case from the issue report */
+if (function() {
+  return func.bind()(0, 0, 0, 0, 0, 0, 0)
+}());
+
+/* various versions of the issue report */
+
+/* call the bound function with a lots of args */
+for (var idx = 0; idx < 50; idx++) {
+    var args = new Array(idx);
+
+    bound.apply(undefined, args);
+
+    delete args;
+}
+
+/* bind the function with multiple args and invoke it */
+for (var idx = 0; idx < 25; idx++) {
+    var args = new Array(idx);
+
+    func.bind.apply(func, args).apply(undefined, args);
+
+    delete args;
+}


### PR DESCRIPTION
During ecma_collection_append the underlying collection
was not increased in the required case. This triggered
a buffer overflow when processing the bound function's arguments
during call or during the Proxy ownKeys method.

Fixes: #3711 