### PR TITLE
Fix fast array handling when doing put with receiver

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1193,6 +1193,12 @@ ecma_op_object_put_apply_receiver (ecma_value_t receiver, /**< receiver */
 
     return result;
   }
+
+  if (JERRY_UNLIKELY (ecma_op_object_is_fast_array (receiver_obj_p)))
+  {
+    ecma_fast_array_convert_to_normal (receiver_obj_p);
+  }
+
   /* 5.f.i */
   ecma_property_value_t *new_prop_value_p;
   new_prop_value_p = ecma_create_named_data_property (receiver_obj_p,

--- a/tests/jerry/es2015/regression-test-issue-3715.js
+++ b/tests/jerry/es2015/regression-test-issue-3715.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class B extends Array {
+    constructor() {
+        super();
+        super.f = 8;
+    }
+}
+var arg = new B()


### PR DESCRIPTION
During "put" with receiver the fast arrays were not converted to normal
objects to correctly set properties on it.

Fixes: #3715 