### PR TITLE
Update Travis build for OSx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
       env:
         - OPTS="--quiet --jerry-tests --jerry-test-suite --unittests"
       os: osx
+      osx_image: xcode11.4
       addons:
         homebrew:
           packages: [cmake, cppcheck, vera++]

--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -2043,7 +2043,7 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
 #endif /* ENABLED (JERRY_ES2015) */
 
       parser_emit_cbc_literal_value (context_p,
-                                     opcode,
+                                     (uint16_t) opcode,
                                      function_map_p[1].map_to,
                                      scanner_decode_map_to (function_map_p));
       continue;


### PR DESCRIPTION
So far Travis doesn't support 10.15 (Catalina), but it does support a newer version (10.14, Mojave) than what we've been using (10.13, High Sierra).
This updates clang version too from 9.1.0 to 11.0.3. 

JerryScript-DCO-1.0-Signed-off-by: Daniella Barsony bella@inf.u-szeged.hu