### PR TITLE
Rework the configuration macro of the debugger transport layer

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -800,7 +800,6 @@ EXCLUDE                = \
         jerry-core/ecma/base/ecma-globals.h \
         jerry-core/ecma/base/ecma-helpers.h \
         jerry-core/ecma/operations/ecma-exceptions.h \
-        jerry-core/include/jerryscript-debugger-transport.h \
         jerry-core/jcontext/jcontext.h \
         jerry-core/parser/js/byte-code.h \
         jerry-core/parser/js/common.h \

--- a/tools/srcgenerator.py
+++ b/tools/srcgenerator.py
@@ -69,6 +69,7 @@ def generate_jerry_core(output_dir, verbose=False):
         '--input={}/include/jerryscript.h'.format(JERRY_CORE),
         '--output={}/jerryscript.h'.format(output_dir),
         '--remove-include=config.h',
+        '--push-include={}/include/jerryscript-debugger-transport.h'.format(JERRY_CORE),
         '--push-include=jerryscript-config.h',
     ]
 


### PR DESCRIPTION
Similarly to the main debugger interface functions, with this patch the
`JERRY_DEBUGGER` configuration macro checks are now contained
inside the functions themselves.

This also fixes the issue of Doxygen not picking up the
documentation for the relevant functions.

JerryScript-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu

Related issues: #2469
