### PR TITLE
Update ES6 Regexp accessors descriptors

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.inc.h
@@ -29,31 +29,31 @@ OBJECT_VALUE (LIT_MAGIC_STRING_CONSTRUCTOR,
 #if ENABLED (JERRY_ES2015)
 ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_FLAGS,
                     ecma_builtin_regexp_prototype_get_flags,
-                    ECMA_PROPERTY_FIXED)
+                    ECMA_PROPERTY_FLAG_CONFIGURABLE)
 
 ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_SOURCE,
                     ecma_builtin_regexp_prototype_get_source,
-                    ECMA_PROPERTY_FIXED)
+                    ECMA_PROPERTY_FLAG_CONFIGURABLE)
 
 ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_GLOBAL,
                     ecma_builtin_regexp_prototype_get_global,
-                    ECMA_PROPERTY_FIXED)
+                    ECMA_PROPERTY_FLAG_CONFIGURABLE)
 
 ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_IGNORECASE_UL,
                     ecma_builtin_regexp_prototype_get_ignorecase,
-                    ECMA_PROPERTY_FIXED)
+                    ECMA_PROPERTY_FLAG_CONFIGURABLE)
 
 ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_MULTILINE,
                     ecma_builtin_regexp_prototype_get_multiline,
-                    ECMA_PROPERTY_FIXED)
+                    ECMA_PROPERTY_FLAG_CONFIGURABLE)
 
 ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_UNICODE,
                     ecma_builtin_regexp_prototype_get_unicode,
-                    ECMA_PROPERTY_FIXED)
+                    ECMA_PROPERTY_FLAG_CONFIGURABLE)
 
 ACCESSOR_READ_ONLY (LIT_MAGIC_STRING_STICKY,
                     ecma_builtin_regexp_prototype_get_sticky,
-                    ECMA_PROPERTY_FIXED)
+                    ECMA_PROPERTY_FLAG_CONFIGURABLE)
 
 ROUTINE (LIT_GLOBAL_SYMBOL_REPLACE, ecma_builtin_regexp_prototype_symbol_replace, 2, 2)
 ROUTINE (LIT_GLOBAL_SYMBOL_SEARCH, ecma_builtin_regexp_prototype_symbol_search, 1, 1)
@@ -79,12 +79,12 @@ SIMPLE_VALUE (LIT_MAGIC_STRING_IGNORECASE_UL,
 SIMPLE_VALUE (LIT_MAGIC_STRING_MULTILINE,
               ECMA_VALUE_FALSE,
               ECMA_PROPERTY_FIXED)
-#endif /* ENABLED (JERRY_ES2015) */
 
 /* ECMA-262 v5, 15.10.7.5 */
 NUMBER_VALUE (LIT_MAGIC_STRING_LASTINDEX_UL,
               0,
               ECMA_PROPERTY_FLAG_WRITABLE)
+#endif /* ENABLED (JERRY_ES2015) */
 
 #if ENABLED (JERRY_BUILTIN_ANNEXB)
 ROUTINE (LIT_MAGIC_STRING_COMPILE, ecma_builtin_regexp_prototype_compile, 2, 1)

--- a/tests/jerry/es2015/regexp-accessors-descriptors.js
+++ b/tests/jerry/es2015/regexp-accessors-descriptors.js
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var t = new RegExp ("abc","g");
-t.lastIndex = -12;
-result = t.exec("abc   abc");
-assert(result[0] === "abc");
-assert(result.index === 0);
-assert(t.lastIndex === 3);
+var accessors = [ 'flags', 'global', 'ignoreCase', 'multiline', 'source', 'sticky', 'unicode' ]
 
-assert(RegExp.prototype.lastIndex === undefined)
+accessors.forEach(function(attr) {
+    var desc = Object.getOwnPropertyDescriptor(RegExp.prototype, attr);
+    assert(typeof desc.get === 'function')
+    assert(desc.set === undefined)
+    assert(desc.enumerable === false)
+    assert(desc.configurable === true)
+});


### PR DESCRIPTION
In ES6 accessors of built in object are by default configurable. [ES 6 21.2.6.1](http://www.ecma-international.org/ecma-262/6.0/#sec-lastindex)
Also lastIndex property of RegExp object is created when only used. [ES 6 17](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-standard-built-in-objects)

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com