### PR TITLE
There is no block info after invalid if-function construct.

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -642,8 +642,11 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
     if (context_p->stack_top_uint8 == PARSER_STATEMENT_IF
         || context_p->stack_top_uint8 == PARSER_STATEMENT_ELSE)
     {
-      JERRY_ASSERT (context_p->next_scanner_info_p->source_p == context_p->source_p);
-      parser_push_block_context (context_p, true);
+      /* There must be a parser error later if this check fails. */
+      if (context_p->next_scanner_info_p->source_p == context_p->source_p)
+      {
+        parser_push_block_context (context_p, true);
+      }
     }
     else if (context_p->stack_top_uint8 == PARSER_STATEMENT_LABEL)
     {

--- a/tests/jerry/fail/regression-test-issue-3714.js
+++ b/tests/jerry/fail/regression-test-issue-3714.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function $() {
+    if ($)
+    function
+}


### PR DESCRIPTION
Fixes #3713.