### PR TITLE
Check next token before reparsing identifiers in object assignments.

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -3075,13 +3075,19 @@ parser_parse_object_initializer (parser_context_t *context_p, /**< context */
         parser_raise_error (context_p, PARSER_ERR_COLON_EXPECTED);
       }
 
-      if (context_p->token.type == LEXER_RIGHT_BRACE
-          || context_p->token.type == LEXER_ASSIGN
-          || context_p->token.type == LEXER_COMMA)
+      if (context_p->token.type != LEXER_RIGHT_BRACE
+          && context_p->token.type != LEXER_ASSIGN
+          && context_p->token.type != LEXER_COMMA)
       {
-        parser_reparse_as_common_identifier (context_p, start_line, start_column);
-        lexer_next_token (context_p);
+        parser_raise_error (context_p, PARSER_ERR_OBJECT_ITEM_SEPARATOR_EXPECTED);
       }
+
+      parser_reparse_as_common_identifier (context_p, start_line, start_column);
+      lexer_next_token (context_p);
+
+      JERRY_ASSERT (context_p->token.type == LEXER_RIGHT_BRACE
+                    || context_p->token.type == LEXER_ASSIGN
+                    || context_p->token.type == LEXER_COMMA);
 
       if (flags & PARSER_PATTERN_ARGUMENTS)
       {

--- a/tests/jerry/fail/regression-test-issue-3735.js
+++ b/tests/jerry/fail/regression-test-issue-3735.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function $({ $ $() {}


### PR DESCRIPTION
Fixes #3735.