### PR TITLE
Fix releasing the pattern string in regexp

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -381,16 +381,17 @@ ecma_op_create_regexp_from_pattern (ecma_object_t *regexp_obj_p, /**< RegExp obj
 
   const re_compiled_code_t *bc_p = NULL;
   ecma_value_t ret_value = re_compile_bytecode (&bc_p, pattern_str_p, flags);
-  ecma_deref_ecma_string (pattern_str_p);
 
   if (ECMA_IS_VALUE_ERROR (ret_value))
   {
+    ecma_deref_ecma_string (pattern_str_p);
     return ret_value;
   }
 
   JERRY_ASSERT (ecma_is_value_empty (ret_value));
 
   ecma_op_regexp_initialize (regexp_obj_p, bc_p, pattern_str_p, flags);
+  ecma_deref_ecma_string (pattern_str_p);
 
   return ecma_make_object_value (regexp_obj_p);
 } /* ecma_op_create_regexp_from_pattern */

--- a/tests/jerry/regression-test-issue-3748-3749.js
+++ b/tests/jerry/regression-test-issue-3748-3749.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* try to trigger the gc a few times*/
+for (var i = 0; i < 2; i++)
+{
+  new RegExp(32.2, "g")
+}


### PR DESCRIPTION
The release of the regexp pattern string during creating
was incorrect as it was dereferenced a bit to early.

Fixes: #3748
Fixes: #3749 