### PR TITLE
Fix regexp flag handling in case of regexp like object

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-3760.js
+++ b/tests/jerry/es2015/regression-test-issue-3760.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var split = RegExp.prototype[Symbol.split];
+
+try {
+  split.call({[Symbol.match]: "g"});
+  assert(false);
+} catch (ex) {
+  assert(ex instanceof SyntaxError);
+}


### PR DESCRIPTION
The regexp flag should be correctly referenced and released
if an existing regexp like object is used for constructing a new one.

Fixes: #3760 