### PR TITLE
Fix parseFloat for non-infinity values

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -934,19 +934,18 @@ ecma_number_parse_float (const lit_utf8_byte_t *string_buff, /**< routine's firs
     }
   }
 
-  const lit_utf8_byte_t *infinity_str_p = lit_get_magic_string_utf8 (LIT_MAGIC_STRING_INFINITY_UL);
-  lit_utf8_byte_t *infinity_str_curr_p = (lit_utf8_byte_t *) infinity_str_p;
-  lit_utf8_byte_t *infinity_str_end_p = infinity_str_curr_p + sizeof (*infinity_str_p);
-
   /* Check if string is equal to "Infinity". */
-  while (str_curr_p < str_end_p
-         && *str_curr_p++ == *infinity_str_curr_p++)
+  const lit_utf8_byte_t *infinity_str_p = lit_get_magic_string_utf8 (LIT_MAGIC_STRING_INFINITY_UL);
+  const lit_utf8_size_t infinity_length = lit_get_magic_string_size (LIT_MAGIC_STRING_INFINITY_UL);
+
+  /* The input string should be at least the length of "Infinity" to be correctly processed as
+   * the infinity value.
+   */
+  if (string_buff_size >= infinity_length
+      && memcmp (infinity_str_p, str_curr_p, infinity_length) == 0)
   {
-    if (infinity_str_curr_p == infinity_str_end_p)
-    {
-      /* String matched Infinity. */
-      return ecma_make_number_value (ecma_number_make_infinity (sign));
-    }
+    /* String matched Infinity. */
+    return ecma_make_number_value (ecma_number_make_infinity (sign));
   }
 
   /* Reset to starting position. */

--- a/tests/jerry/regression-test-issue-3761.js
+++ b/tests/jerry/regression-test-issue-3761.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var result = parseFloat ("IE");
+assert (isNaN (result));


### PR DESCRIPTION
The parseFloat method performed the "Infinity" string check incorrectly.

Fixes: #3761 