### PR TITLE
Rework the Reflect.defineProperty method

### DIFF
--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -594,38 +594,42 @@ ecma_op_from_property_descriptor (const ecma_property_descriptor_t *src_prop_des
   }
   else
   {
-    /* 4. */
+#if !ENABLED (JERRY_ES2015)
     JERRY_ASSERT (src_prop_desc_p->flags & (ECMA_PROP_IS_GET_DEFINED | ECMA_PROP_IS_SET_DEFINED));
-
-    /* a. */
-    if (src_prop_desc_p->get_p == NULL)
+#else /* ENABLED (JERRY_ES2015) */
+    if (src_prop_desc_p->flags & (ECMA_PROP_IS_GET_DEFINED | ECMA_PROP_IS_SET_DEFINED))
+#endif /* ENABLED (JERRY_ES2015) */
     {
-      prop_desc.value = ECMA_VALUE_UNDEFINED;
-    }
-    else
-    {
-      prop_desc.value = ecma_make_object_value (src_prop_desc_p->get_p);
-    }
+      /* a. */
+      if (src_prop_desc_p->get_p == NULL)
+      {
+        prop_desc.value = ECMA_VALUE_UNDEFINED;
+      }
+      else
+      {
+        prop_desc.value = ecma_make_object_value (src_prop_desc_p->get_p);
+      }
 
-    completion = ecma_op_object_define_own_property (obj_p,
-                                                     ecma_get_magic_string (LIT_MAGIC_STRING_GET),
-                                                     &prop_desc);
-    JERRY_ASSERT (ecma_is_value_true (completion));
+      completion = ecma_op_object_define_own_property (obj_p,
+                                                       ecma_get_magic_string (LIT_MAGIC_STRING_GET),
+                                                       &prop_desc);
+      JERRY_ASSERT (ecma_is_value_true (completion));
 
-    /* b. */
-    if (src_prop_desc_p->set_p == NULL)
-    {
-      prop_desc.value = ECMA_VALUE_UNDEFINED;
-    }
-    else
-    {
-      prop_desc.value = ecma_make_object_value (src_prop_desc_p->set_p);
-    }
+      /* b. */
+      if (src_prop_desc_p->set_p == NULL)
+      {
+        prop_desc.value = ECMA_VALUE_UNDEFINED;
+      }
+      else
+      {
+        prop_desc.value = ecma_make_object_value (src_prop_desc_p->set_p);
+      }
 
-    completion = ecma_op_object_define_own_property (obj_p,
-                                                     ecma_get_magic_string (LIT_MAGIC_STRING_SET),
-                                                     &prop_desc);
-    JERRY_ASSERT (ecma_is_value_true (completion));
+      completion = ecma_op_object_define_own_property (obj_p,
+                                                       ecma_get_magic_string (LIT_MAGIC_STRING_SET),
+                                                       &prop_desc);
+      JERRY_ASSERT (ecma_is_value_true (completion));
+    }
   }
 
   prop_desc.value = ecma_make_boolean_value (src_prop_desc_p->flags & ECMA_PROP_IS_ENUMERABLE);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -163,7 +163,6 @@
   <test id="built-ins/Promise/reject/name.js"><reason></reason></test>
   <test id="built-ins/Promise/resolve/name.js"><reason></reason></test>
   <test id="built-ins/Promise/symbol-species-name.js"><reason></reason></test>
-  <test id="built-ins/Proxy/defineProperty/trap-return-is-false.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/call-parameters.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/return-is-abrupt.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/return-trap-result.js"><reason></reason></test>
@@ -177,8 +176,6 @@
   <test id="built-ins/Reflect/apply/name.js"><reason></reason></test>
   <test id="built-ins/Reflect/construct/name.js"><reason></reason></test>
   <test id="built-ins/Reflect/defineProperty/name.js"><reason></reason></test>
-  <test id="built-ins/Reflect/defineProperty/return-abrupt-from-attributes.js"><reason></reason></test>
-  <test id="built-ins/Reflect/defineProperty/return-abrupt-from-result.js"><reason></reason></test>
   <test id="built-ins/Reflect/deleteProperty/name.js"><reason></reason></test>
   <test id="built-ins/Reflect/enumerate/does-not-iterate-over-symbol-properties.js"><reason></reason></test>
   <test id="built-ins/Reflect/enumerate/enumerate.js"><reason></reason></test>


### PR DESCRIPTION
Also a minor update to the FromPropertyDescriptor operation since in ES6 we can use a property
descriptor whitout any keys

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
