### PR TITLE
Change raw string length calculation method

### DIFF
--- a/jerry-core/parser/js/js-parser-tagged-template-literal.c
+++ b/jerry-core/parser/js/js-parser-tagged-template-literal.c
@@ -48,12 +48,12 @@ parser_tagged_template_literal_append_strings (parser_context_t *context_p, /**<
     ecma_builtin_helper_def_prop_by_index (template_obj_p,
                                            prop_idx,
                                            ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY),
-                                           ECMA_PROPERTY_FIXED);
+                                           ECMA_PROPERTY_FLAG_ENUMERABLE);
 
     ecma_builtin_helper_def_prop_by_index (raw_strings_p,
                                            prop_idx,
                                            ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY),
-                                           ECMA_PROPERTY_FIXED);
+                                           ECMA_PROPERTY_FLAG_ENUMERABLE);
     return;
   }
 
@@ -88,12 +88,12 @@ parser_tagged_template_literal_append_strings (parser_context_t *context_p, /**<
   ecma_builtin_helper_def_prop_by_index (template_obj_p,
                                          prop_idx,
                                          ecma_make_string_value (cooked_str_p),
-                                         ECMA_PROPERTY_FIXED);
+                                         ECMA_PROPERTY_FLAG_ENUMERABLE);
 
   ecma_builtin_helper_def_prop_by_index (raw_strings_p,
                                          prop_idx,
                                          ecma_make_string_value (raw_str_p),
-                                         ECMA_PROPERTY_FIXED);
+                                         ECMA_PROPERTY_FLAG_ENUMERABLE);
 
   ecma_deref_ecma_string (cooked_str_p);
   ecma_deref_ecma_string (raw_str_p);

--- a/tests/jerry/es2015/tagged-template-literal.js
+++ b/tests/jerry/es2015/tagged-template-literal.js
@@ -126,3 +126,14 @@ assert (String.raw`Hi\n${2+3}!` === "Hi\\n5!");
   var localNew = new getStr();
   assert(chainedCall === getStr() && chainedCall === localNew);
 })();
+
+var templateObject;
+
+(function(p) {
+  templateObject = p;
+})`str`;
+
+var desc = Object.getOwnPropertyDescriptor(templateObject, '0');
+assert(desc.writable === false);
+assert(desc.enumerable === true);
+assert(desc.configurable === false);


### PR DESCRIPTION
New method uses length of source to calculate raw string length - as discussed in #3736

Also bug with template literal was fixed. Template object should have
indexed properties enumerable.

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com