### PR TITLE
Fix vera++ rule to find expressions without space after parentheses

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1748,12 +1748,12 @@ typedef struct
 /**
  * Function callback descriptor of a %TypedArray% object getter
  */
-typedef ecma_number_t (*ecma_typedarray_getter_fn_t)(lit_utf8_byte_t *src);
+typedef ecma_number_t (*ecma_typedarray_getter_fn_t) (lit_utf8_byte_t *src);
 
 /**
  * Function callback descriptor of a %TypedArray% object setter
  */
-typedef void (*ecma_typedarray_setter_fn_t)(lit_utf8_byte_t *src, ecma_number_t value);
+typedef void (*ecma_typedarray_setter_fn_t) (lit_utf8_byte_t *src, ecma_number_t value);
 
 /**
  * Builtin id for the different types of TypedArray's

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1527,7 +1527,7 @@ uintptr_t JERRY_ATTR_NOINLINE
 ecma_get_current_stack_usage (void)
 {
   volatile int __sp;
-  return (uintptr_t) (JERRY_CONTEXT (stack_base) - (uintptr_t)&__sp);
+  return (uintptr_t) (JERRY_CONTEXT (stack_base) - (uintptr_t) &__sp);
 } /* ecma_get_current_stack_usage */
 
 #endif /* (JERRY_STACK_LIMIT != 0) */

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -53,7 +53,7 @@ ecma_init (void)
 
 #if (JERRY_STACK_LIMIT != 0)
   volatile int sp;
-  JERRY_CONTEXT (stack_base) = (uintptr_t)&sp;
+  JERRY_CONTEXT (stack_base) = (uintptr_t) &sp;
 #endif /* (JERRY_STACK_LIMIT != 0) */
 
 #if ENABLED (JERRY_ES2015_BUILTIN_PROMISE)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -234,9 +234,9 @@ ecma_builtin_helper_error_dispatch_call (ecma_standard_error_t error_type, const
 /**
  * Comparison callback function header for sorting helper routines.
  */
-typedef ecma_value_t (*ecma_builtin_helper_sort_compare_fn_t)(ecma_value_t lhs, /**< left value */
-                                                              ecma_value_t rhs, /**< right value */
-                                                              ecma_value_t compare_func); /**< compare function */
+typedef ecma_value_t (*ecma_builtin_helper_sort_compare_fn_t) (ecma_value_t lhs, /**< left value */
+                                                               ecma_value_t rhs, /**< right value */
+                                                               ecma_value_t compare_func); /**< compare function */
 
 ecma_value_t ecma_builtin_helper_array_heap_sort_helper (ecma_value_t *array_p,
                                                          uint32_t right,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -204,7 +204,7 @@ ecma_builtin_json_parse_string (ecma_json_token_t *token_p) /**< token argument 
 
   ecma_stringbuilder_append_raw (&result_builder,
                                  unappended_p,
-                                 (lit_utf8_size_t)(current_p - unappended_p));
+                                 (lit_utf8_size_t) (current_p - unappended_p));
   token_p->u.string_p = ecma_stringbuilder_finalize (&result_builder);
   token_p->current_p = current_p + 1;
   token_p->type = TOKEN_STRING;

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -43,15 +43,15 @@ typedef const ecma_builtin_property_descriptor_t *ecma_builtin_property_list_ref
 /**
  * Definition of built-in dispatch routine function pointer.
  */
-typedef ecma_value_t (*ecma_builtin_dispatch_routine_t)(uint16_t builtin_routine_id,
-                                                        ecma_value_t this_arg,
-                                                        const ecma_value_t arguments_list[],
-                                                        ecma_length_t arguments_number);
+typedef ecma_value_t (*ecma_builtin_dispatch_routine_t) (uint16_t builtin_routine_id,
+                                                         ecma_value_t this_arg,
+                                                         const ecma_value_t arguments_list[],
+                                                         ecma_length_t arguments_number);
 /**
  * Definition of built-in dispatch call function pointer.
  */
-typedef ecma_value_t (*ecma_builtin_dispatch_call_t)(const ecma_value_t arguments_list[],
-                                                     ecma_length_t arguments_number);
+typedef ecma_value_t (*ecma_builtin_dispatch_call_t) (const ecma_value_t arguments_list[],
+                                                      ecma_length_t arguments_number);
 /**
  * Definition of a builtin descriptor which contains the builtin object's:
  * - prototype objects's id (13-bits)

--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -228,7 +228,7 @@ ecma_op_container_free_weakmap_entries (ecma_object_t *object_p, /**< object poi
 
   for (uint32_t i = 0; i < entry_count; i += ECMA_CONTAINER_PAIR_SIZE)
   {
-    ecma_container_pair_t *entry_p = (ecma_container_pair_t *)(start_p + i);
+    ecma_container_pair_t *entry_p = (ecma_container_pair_t *) (start_p + i);
 
     if (ecma_is_value_empty (entry_p->key))
     {
@@ -287,7 +287,7 @@ ecma_op_container_free_map_entries (ecma_collection_t *container_p)
 
   for (uint32_t i = 0; i < entry_count; i += ECMA_CONTAINER_PAIR_SIZE)
   {
-    ecma_container_pair_t *entry_p = (ecma_container_pair_t *)(start_p + i);
+    ecma_container_pair_t *entry_p = (ecma_container_pair_t *) (start_p + i);
 
     if (ecma_is_value_empty (entry_p->key))
     {

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -62,7 +62,7 @@
 static inline jmem_heap_free_t *  JERRY_ATTR_ALWAYS_INLINE JERRY_ATTR_PURE
 jmem_heap_get_region_end (jmem_heap_free_t *curr_p) /**< current region */
 {
-  return (jmem_heap_free_t *)((uint8_t *) curr_p + curr_p->size);
+  return (jmem_heap_free_t *) ((uint8_t *) curr_p + curr_p->size);
 } /* jmem_heap_get_region_end */
 #endif /* !ENABLED (JERRY_SYSTEM_ALLOCATOR) */
 
@@ -516,7 +516,7 @@ jmem_heap_realloc_block (void *ptr, /**< memory region to reallocate */
     JMEM_VALGRIND_RESIZE_SPACE (block_p, old_size, new_size);
     JMEM_HEAP_STAT_FREE (old_size);
     JMEM_HEAP_STAT_ALLOC (new_size);
-    jmem_heap_insert_block ((jmem_heap_free_t *)((uint8_t *) block_p + aligned_new_size),
+    jmem_heap_insert_block ((jmem_heap_free_t *) ((uint8_t *) block_p + aligned_new_size),
                             jmem_heap_find_prev (block_p),
                             aligned_old_size - aligned_new_size);
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2271,7 +2271,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                     stack_top_p[-2] = stack_top_p[-3];
                     stack_top_p[-3] = result;
                   }
-                  opcode_data &= (uint32_t)~VM_OC_PUT_STACK;
+                  opcode_data &= (uint32_t) ~VM_OC_PUT_STACK;
                 }
                 else if (opcode_data & VM_OC_PUT_BLOCK)
                 {
@@ -2334,7 +2334,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                 stack_top_p[-2] = stack_top_p[-3];
                 stack_top_p[-3] = ecma_copy_value (result);
               }
-              opcode_data &= (uint32_t)~VM_OC_PUT_STACK;
+              opcode_data &= (uint32_t) ~VM_OC_PUT_STACK;
             }
             else if (opcode_data & VM_OC_PUT_BLOCK)
             {

--- a/jerry-ext/debugger/debugger-tcp.c
+++ b/jerry-ext/debugger/debugger-tcp.c
@@ -257,7 +257,7 @@ jerryx_debugger_tcp_configure_socket (jerryx_socket server_socket, /** < socket 
     return false;
   }
 
-  if (bind (server_socket, (struct sockaddr *)&addr, sizeof (struct sockaddr_in)) != 0)
+  if (bind (server_socket, (struct sockaddr *) &addr, sizeof (struct sockaddr_in)) != 0)
   {
     return false;
   }
@@ -309,7 +309,7 @@ jerryx_debugger_tcp_create (uint16_t port) /**< listening port */
   struct sockaddr_in addr;
   socklen_t sin_size = sizeof (struct sockaddr_in);
 
-  jerryx_socket tcp_socket = accept (server_socket, (struct sockaddr *)&addr, &sin_size);
+  jerryx_socket tcp_socket = accept (server_socket, (struct sockaddr *) &addr, &sin_size);
 
   jerryx_debugger_tcp_close_socket (server_socket);
 

--- a/jerry-libm/atanh.c
+++ b/jerry-libm/atanh.c
@@ -60,7 +60,7 @@ atanh (double x)
   ix = hx & 0x7fffffff;
 
   /* |x| > 1 */
-  if ((ix | ((unsigned int)(temp.as_int.lo | (-temp.as_int.lo)) >> 31)) > 0x3ff00000)
+  if ((ix | ((unsigned int) (temp.as_int.lo | (-temp.as_int.lo)) >> 31)) > 0x3ff00000)
   {
     return NAN;
   }

--- a/targets/mbedos5/source/jerry_port_mbed.c
+++ b/targets/mbedos5/source/jerry_port_mbed.c
@@ -79,7 +79,7 @@ jerry_port_get_current_time (void)
    * are within the mentioned 71 mins. Above that interval we can assume
    * that the milliseconds part of the time is negligibe.
    */
-  if (curr_time - last_time > (time_t)(((uint32_t)-1) / 1000000)) {
+  if (curr_time - last_time > (time_t) (((uint32_t) - 1) / 1000000)) {
     skew = 0;
   } else if (last_tick > curr_tick) {
     skew = (skew + 33) % 1000;

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -1025,7 +1025,7 @@ main (void)
     TEST_ASSERT (jerry_get_boolean_value (has_prop_js));
     jerry_release_value (has_prop_js);
     jerry_value_t parsed_data = jerry_get_property (parsed_json, key);
-    TEST_ASSERT (jerry_value_is_string (parsed_data)== true);
+    TEST_ASSERT (jerry_value_is_string (parsed_data) == true);
     jerry_size_t buff_size = jerry_get_string_size (parsed_data);
     JERRY_VLA (char, buff, buff_size + 1);
     jerry_string_to_char_buffer (parsed_data, (jerry_char_t *) buff, buff_size);

--- a/tests/unit-core/test-arraybuffer.c
+++ b/tests/unit-core/test-arraybuffer.c
@@ -92,7 +92,7 @@ test_read_with_offset (uint8_t offset) /**< offset for buffer read. */
 
   /* Try to copy more than the target buffer size. */
   jerry_length_t copied = jerry_arraybuffer_read (arraybuffer, offset, buffer, 20);
-  TEST_ASSERT (copied == (jerry_length_t)(15 - offset));
+  TEST_ASSERT (copied == (jerry_length_t) (15 - offset));
 
   for (uint8_t i = 0; i < copied; i++)
   {
@@ -132,7 +132,7 @@ static void test_write_with_offset (uint8_t offset) /**< offset for buffer write
 
   /* Intentionally copy more than the allowed space. */
   jerry_length_t copied = jerry_arraybuffer_write (arraybuffer, offset, buffer, 20);
-  TEST_ASSERT (copied == (jerry_length_t)(15 - offset));
+  TEST_ASSERT (copied == (jerry_length_t) (15 - offset));
 
   const jerry_char_t eval_test_arraybuffer[] = TEST_STRING_LITERAL (
     "for (var i = 0; i < offset; i++)"
@@ -340,7 +340,7 @@ main (void)
     double sum = 0;
     for (int i = 0; i < 20; i++)
     {
-      data[i] = (uint8_t)(i * 3);
+      data[i] = (uint8_t) (i * 3);
       sum += data[i];
     }
 

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -728,7 +728,7 @@ jerry_arg_to_double_or_bool_t (jerryx_arg_js_iterator_t *js_arg_iter_p,
    * the stack more times than there are actual stack values to ensure
    * that the restore function doesn't produce an error. */
   double_or_bool_t *destination = c_arg_p->dest;
-  uintptr_t *extra_info = (uintptr_t *)(c_arg_p->extra_info);
+  uintptr_t *extra_info = (uintptr_t *) (c_arg_p->extra_info);
   jerryx_arg_t conversion_function;
   jerry_value_t conversion_result;
   jerry_value_t restore_result;

--- a/tools/vera++/scripts/rules/jerry_typecast_space_parentheses.tcl
+++ b/tools/vera++/scripts/rules/jerry_typecast_space_parentheses.tcl
@@ -22,7 +22,7 @@ proc check_part_of_the_file {file line_num col_start col_end} {
     set line [getLine $file $line_num]
     set line [string range $line $col_start $col_end]
 
-    if {[regexp {\)\w} $line]} {
+    if {[regexp {\)[\w\(&~=]} $line]} {
         report $file $line_num "there should be exactly one space after right parentheses"
     }
 }


### PR DESCRIPTION
Regex didn't include some characters that may occur after ')'

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com