### PR TITLE
Accessor functions should not have 'prototype' property

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1326,7 +1326,7 @@ ecma_op_lazy_instantiate_prototype_object (ecma_object_t *object_p) /**< the fun
                                            ECMA_OBJECT_TYPE_GENERAL);
       init_constructor = false;
     }
-    else if (byte_code_p->status_flags & CBC_CODE_FLAGS_ARROW_FUNCTION)
+    else if (byte_code_p->status_flags & (CBC_CODE_FLAGS_ARROW_FUNCTION | CBC_CODE_FLAGS_ACCESSOR))
     {
       return NULL;
     }
@@ -1616,7 +1616,7 @@ ecma_op_function_list_lazy_property_names (ecma_object_t *object_p, /**< functio
   bytecode_data_p = ecma_op_function_get_compiled_code ((ecma_extended_object_t *) object_p);
 
 #if ENABLED (JERRY_ES2015)
-  if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_ARROW_FUNCTION)
+  if (bytecode_data_p->status_flags & (CBC_CODE_FLAGS_ARROW_FUNCTION | CBC_CODE_FLAGS_ACCESSOR))
   {
     return;
   }

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -68,7 +68,6 @@
   <test id="built-ins/Function/prototype/bind/instance-name-non-string.js"><reason></reason></test>
   <test id="built-ins/Function/prototype/name.js"><reason></reason></test>
   <test id="built-ins/Function/prototype/Symbol.hasInstance/name.js"><reason></reason></test>
-  <test id="built-ins/Function/prototype/Symbol.hasInstance/this-val-poisoned-prototype.js"><reason></reason></test>
   <test id="built-ins/Function/StrictFunction_restricted-properties.js"><reason></reason></test>
   <test id="built-ins/GeneratorFunction/instance-name.js"><reason></reason></test>
   <test id="built-ins/GeneratorFunction/instance-restricted-properties.js"><reason></reason></test>


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
