### PR TITLE
Get the typedArray's length property properly in Array.prototype.concat

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -887,14 +887,6 @@ ecma_op_object_get_length (ecma_object_t *object_p, /**< the object */
     return ECMA_VALUE_EMPTY;
   }
 
-#if ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY)
-  if (ecma_object_is_typedarray (object_p))
-  {
-    *length_p = ecma_typedarray_get_length (object_p);
-    return ECMA_VALUE_EMPTY;
-  }
-#endif /* ENABLED (JERRY_ES2015_BUILTIN_TYPEDARRAY) */
-
   ecma_value_t len_value = ecma_op_object_get_by_magic_id (object_p, LIT_MAGIC_STRING_LENGTH);
   ecma_value_t len_number = ecma_op_to_length (len_value, length_p);
   ecma_free_value (len_value);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -20,8 +20,6 @@
   <test id="built-ins/ArrayBuffer/symbol-species-name.js"><reason></reason></test>
   <test id="built-ins/Array/from/Array.from-name.js"><reason></reason></test>
   <test id="built-ins/Array/of/name.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/concat/Array.prototype.concat_large-typed-array.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/concat/Array.prototype.concat_small-typed-array.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/copyWithin/name.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/entries/name.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/fill/name.js"><reason></reason></test>


### PR DESCRIPTION
We should use the "length" property instead of the internal arraybuffer's length

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu

