### PR TITLE
Fix incorrect assertion in parser_parse_for_statement_start

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1372,15 +1372,13 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
                                                   : CBC_EXT_FOR_OF_GET_NEXT);
 #if ENABLED (JERRY_ES2015)
 #ifndef JERRY_NDEBUG
-        if (literal_index >= PARSER_REGISTER_START && has_context)
+        if (literal_index < PARSER_REGISTER_START
+            && has_context
+            && !scanner_literal_is_created (context_p, literal_index))
         {
           context_p->global_status_flags |= ECMA_PARSE_INTERNAL_FOR_IN_OFF_CONTEXT_ERROR;
         }
 #endif /* !JERRY_NDEBUG */
-
-        JERRY_ASSERT (literal_index >= PARSER_REGISTER_START
-                      || !has_context
-                      || scanner_literal_is_created (context_p, literal_index));
 
         uint16_t opcode = (has_context ? CBC_ASSIGN_LET_CONST : CBC_ASSIGN_SET_IDENT);
         parser_emit_cbc_literal (context_p, opcode, literal_index);

--- a/tests/jerry/es2015/regression-test-issue-3751.js
+++ b/tests/jerry/es2015/regression-test-issue-3751.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`for (let i in {
+            id_0: 1
+        })
+
+        (function() {
+                i
+        `);
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #3751.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
