### PR TITLE
Improve property key query for Proxy objects

### DIFF
--- a/tests/jerry/es2015/proxy_own_keys.js
+++ b/tests/jerry/es2015/proxy_own_keys.js
@@ -16,6 +16,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+function array_check(result_array, expected_array) {
+  assert(result_array instanceof Array);
+  assert(result_array.length === expected_array.length);
+  for (var idx = 0; idx < expected_array.length; idx++) {
+    assert(result_array[idx] === expected_array[idx]);
+  }
+}
+
 var target = {};
 var handler = { ownKeys (target) {
   throw 42;
@@ -56,26 +64,29 @@ try {
 }
 
 // test basic functionality
+var symA = Symbol("smA");
+var symB = Symbol("smB");
 var target = { prop1: "prop1", prop2: "prop2"};
+target[symB] = "s3";
 var handler = {
   ownKeys: function(target) {
-    return ["foo", "bar"];
+    return ["foo", "bar", symA];
   }
 }
 
 var proxy = new Proxy(target, handler);
 
-assert(JSON.stringify(Reflect.ownKeys(proxy)) === '["foo","bar"]');
-assert(JSON.stringify(Object.getOwnPropertyNames(proxy)) === '["foo","bar"]');
-assert(JSON.stringify(Object.keys(proxy)) === '["foo","bar"]');
-assert(JSON.stringify(Object.getOwnPropertySymbols(proxy)) === '["foo","bar"]');
+array_check(Reflect.ownKeys(proxy), ["foo", "bar", symA]);
+array_check(Object.getOwnPropertyNames(proxy), ["foo", "bar"]);
+array_check(Object.keys(proxy), ["foo", "bar"]);
+array_check(Object.getOwnPropertySymbols(proxy), [symA]);
 
 handler.ownKeys = function(target) {return Object.getOwnPropertyNames(target);};
 
-assert(JSON.stringify(Reflect.ownKeys(proxy)) === '["prop1","prop2"]');
-assert(JSON.stringify(Object.getOwnPropertyNames(proxy)) === '["prop1","prop2"]');
-assert(JSON.stringify(Object.keys(proxy)) === '["prop1","prop2"]');
-assert(JSON.stringify(Object.getOwnPropertySymbols(proxy)) === '["prop1","prop2"]');
+array_check(Reflect.ownKeys(proxy), ["prop1", "prop2"]);
+array_check(Object.getOwnPropertyNames(proxy), ["prop1", "prop2"]);
+array_check(Object.keys(proxy), ["prop1", "prop2"]);
+array_check(Object.getOwnPropertySymbols(proxy), []);
 
 // test with no trap
 var target = { prop1: "prop1", prop2: "prop2"};

--- a/tests/jerry/es2015/regression-test-issue-3787.js
+++ b/tests/jerry/es2015/regression-test-issue-3787.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var symbol = Symbol("s");
+var obj = {demo: "3"};
+obj[symbol] = 3;
+
+var proxy = new Proxy(obj, []);
+var str = JSON.stringify(proxy);
+
+assert(str === '{"demo":"3"}');


### PR DESCRIPTION
Property key query for Proxy objects always returned all keys
even if no symbols were requested symbols were present in the
resulting array.

Fixes: #3787 