### PR TITLE
Fix adding entries to the internal buffer of a Map object

### DIFF
--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -64,11 +64,14 @@ ecma_op_internal_buffer_append (ecma_collection_t *container_p, /**< internal co
 {
   JERRY_ASSERT (container_p != NULL);
 
-  ecma_collection_push_back (container_p, ecma_copy_value_if_not_object (key_arg));
-
   if (lit_id == LIT_MAGIC_STRING_WEAKMAP_UL || lit_id == LIT_MAGIC_STRING_MAP_UL)
   {
-    ecma_collection_push_back (container_p, ecma_copy_value_if_not_object (value_arg));
+    ecma_value_t values[] = { ecma_copy_value_if_not_object (key_arg), ecma_copy_value_if_not_object (value_arg) };
+    ecma_collection_append (container_p, values, 2);
+  }
+  else
+  {
+    ecma_collection_push_back (container_p, ecma_copy_value_if_not_object (key_arg));
   }
 
   ECMA_CONTAINER_SET_SIZE (container_p, ECMA_CONTAINER_GET_SIZE (container_p) + 1);


### PR DESCRIPTION
When appending the key/value pair separately, garbage collection could be
triggered before the value is added, which could cause problems during
marking. This patch changes insertion to add both values at the same
time, which prevents partial entries from being present in the internal
buffer.

Fixes #3804.