### PR TITLE
Fix assignment lookahead in parser_process_group_expression

### DIFF
--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -116,7 +116,6 @@ typedef enum
   PARSER_PATTERN_REST_ELEMENT = (1u << 7),     /**< parse rest array initializer */
   PARSER_PATTERN_ARGUMENTS = (1u << 8),        /**< parse arguments binding */
   PARSER_PATTERN_ARRAY = (1u << 9),            /**< array pattern is being parsed */
-  PARSER_PATTERN_GROUP_EXPR = (1u << 10),      /**< group expression is being assigned */
 } parser_pattern_flags_t;
 
 /**

--- a/tests/jerry/es2015/regression-test-issue-3819.js
+++ b/tests/jerry/es2015/regression-test-issue-3819.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  typeof (global.v2) = 123;
+  assert (false);
+} catch (e) {
+  assert (e instanceof ReferenceError);
+}

--- a/tests/jerry/es2015/regression-test-issue-3820.js
+++ b/tests/jerry/es2015/regression-test-issue-3820.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  (isNaN(parseFloat("."))) = 'abcd';
+  assert (false);
+} catch (e) {
+  assert (e instanceof ReferenceError);
+}

--- a/tests/jerry/regression-test-issue-3815.js
+++ b/tests/jerry/regression-test-issue-3815.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function a() {}
+
+try {
+  (a()) = a
+  assert (false);
+} catch (e) {
+  assert (e instanceof ReferenceError);
+}


### PR DESCRIPTION
This patch fixes #3815.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
