### PR TITLE
Fix PropertyDefinition parsing in ObjectInitializer

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -888,17 +888,26 @@ parser_reparse_as_common_identifier (parser_context_t *context_p, /**< context *
                                      parser_line_counter_t start_line, /**< start line */
                                      parser_line_counter_t start_column) /**< start column */
 {
+  /* context_p->token.lit_location.char_p is showing the character after the string start,
+     so it is not suitable for reparsing as identifier.
+     e.g.: { 'foo' } */
+  if (context_p->token.lit_location.type != LEXER_IDENT_LITERAL)
+  {
+    parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
+  }
+
   context_p->source_p = context_p->token.lit_location.char_p;
   context_p->line = start_line;
   context_p->column = start_column;
 
   lexer_next_token (context_p);
 
-  if (context_p->token.type != LEXER_LITERAL
-      || context_p->token.lit_location.type != LEXER_IDENT_LITERAL)
+  if (context_p->token.type != LEXER_LITERAL)
   {
     parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
   }
+
+  JERRY_ASSERT (context_p->token.lit_location.type == LEXER_IDENT_LITERAL);
 
   lexer_construct_literal_object (context_p,
                                   &context_p->token.lit_location,

--- a/tests/jerry/es2015/regression-test-issue-3822.js
+++ b/tests/jerry/es2015/regression-test-issue-3822.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`function f ({array, 'a', { value: 'foo', enumerable: true } : 36}){}`);
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+

--- a/tests/jerry/es2015/regression-test-issue-3823.js
+++ b/tests/jerry/es2015/regression-test-issue-3823.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`function f ({"aba,a"}){}`);
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+

--- a/tests/jerry/es2015/regression-test-issue-3824.js
+++ b/tests/jerry/es2015/regression-test-issue-3824.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`var a = {"foo//b", };`);
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+

--- a/tests/jerry/es2015/regression-test-issue-3825.js
+++ b/tests/jerry/es2015/regression-test-issue-3825.js
@@ -1,0 +1,34 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`var errorMessage = "toStringThrows"
+
+  var toStringThrows = {
+    "foo//bar/baz//foo"
+  }
+
+  try {
+    var obj = {};
+    obj[toStringThrows] = 3;
+    assert(false);
+  } catch (e) {
+    assert(e.message == errorMessage);
+  }
+  `);
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+


### PR DESCRIPTION
This patch fixes #3822.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
