### PR TITLE
Fix property descriptor queries

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1858,6 +1858,8 @@ ecma_op_object_define_own_property (ecma_object_t *obj_p, /**< the object */
  *                                      [Enumerable], [Configurable]
  *                                    }.
  *
+ * The output property descriptor will always be initialized to an empty descriptor.
+ *
  * @return true - if property found
  *         false - otherwise
  */
@@ -1866,6 +1868,8 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
                                             ecma_string_t *property_name_p, /**< property name */
                                             ecma_property_descriptor_t *prop_desc_p) /**< property descriptor */
 {
+  *prop_desc_p = ecma_make_empty_property_descriptor ();
+
 #if ENABLED (JERRY_ES2015_BUILTIN_PROXY)
   if (ECMA_OBJECT_IS_PROXY (object_p))
   {
@@ -1884,8 +1888,6 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
   {
     return ECMA_VALUE_FALSE;
   }
-
-  *prop_desc_p = ecma_make_empty_property_descriptor ();
 
   uint32_t flags = ecma_is_property_enumerable (property) ? ECMA_PROP_IS_ENUMERABLE : ECMA_PROP_NO_OPTS;
   flags |= ecma_is_property_configurable (property) ? ECMA_PROP_IS_CONFIGURABLE: ECMA_PROP_NO_OPTS;

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -735,7 +735,7 @@ ecma_proxy_object_get_own_property_descriptor (ecma_object_t *obj_p, /**< proxy 
     /* .a */
     if (ecma_is_value_false (target_status))
     {
-      return ECMA_VALUE_UNDEFINED;
+      return ECMA_VALUE_FALSE;
     }
     /* .b */
     if (!(target_desc.flags & ECMA_PROP_IS_CONFIGURABLE))

--- a/tests/jerry/es2015/regression-test-issue-3837.js
+++ b/tests/jerry/es2015/regression-test-issue-3837.js
@@ -1,0 +1,33 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function dummy ()
+{
+  "D" + "a";
+}
+
+var p1Handler = { getOwnPropertyDescriptor: dummy };
+var p1 = new Proxy({}, p1Handler);
+
+function dummyString ()
+{
+  return "a";
+}
+
+var p2Handler = { deleteProperty: dummyString };
+var p2 = new Proxy(p1, p2Handler);
+
+var result = (delete p2[1]);
+
+assert (result);


### PR DESCRIPTION
When the getOwnPropertyDescriptor method was invoked the input property
descriptor was not cleared in every case. This could lead to problems when
the property descriptor is not set/modified by the getOwnPropertyDescriptor
call, resulting in a failure at a later state.

Related to this the Proxy getOwnPropertyDescriptor method incorrectly returned
"undefined" value in a single case.

Fixes: #3837 