### PR TITLE
Fix invalid AssignmentExpression lookahead in parser_process_group_expression

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -3407,7 +3407,8 @@ parser_process_group_expression (parser_context_t *context_p, /**< context */
      with a single indentifier in it. e.g.: (a) = function () {} */
   if (JERRY_UNLIKELY (context_p->token.type == LEXER_ASSIGN
                       && PARSER_IS_PUSH_LITERALS_WITH_THIS (context_p->last_cbc_opcode)
-                      && context_p->last_cbc.literal_type == LEXER_IDENT_LITERAL))
+                      && context_p->last_cbc.literal_type == LEXER_IDENT_LITERAL
+                      && parser_is_assignment_expr (context_p)))
   {
     parser_stack_push_uint8 (context_p, LEXER_ASSIGN_GROUP_EXPR);
   }

--- a/tests/jerry/es2015/regression-test-issue-3845.js
+++ b/tests/jerry/es2015/regression-test-issue-3845.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`typeof (a) = 1 === 'undefined';`);
+  assert(false);
+} catch (e) {
+  assert(e instanceof ReferenceError);
+}
+


### PR DESCRIPTION
This patch fixes #3845.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
