### PR TITLE
Don't continue parsing expressions after ternary operators.

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -3304,13 +3304,9 @@ parser_parse_initializer_by_next_char (parser_context_t *context_p, /**< context
 
 /**
  * Process ternary expression.
- *
- * @return true - continue with primary expression parsing
- *         false - otherwise
  */
-static bool
-parser_process_ternary_expression (parser_context_t *context_p, /**< context */
-                                   size_t grouping_level) /**< grouping level */
+static void
+parser_process_ternary_expression (parser_context_t *context_p) /**< context */
 {
   JERRY_ASSERT (context_p->token.type == LEXER_QUESTION_MARK);
 
@@ -3354,7 +3350,6 @@ parser_process_ternary_expression (parser_context_t *context_p, /**< context */
   parser_flush_cbc (context_p);
 
   parser_process_binary_opcodes (context_p, 0);
-  return grouping_level >= PARSER_GROUPING_LEVEL_INCREASE;
 } /* parser_process_ternary_expression */
 
 /**
@@ -3523,18 +3518,28 @@ process_unary_expression:
         continue;
       }
 
-      if (JERRY_UNLIKELY (context_p->token.type == LEXER_QUESTION_MARK)
-          && (grouping_level != PARSE_EXPR_LEFT_HAND_SIDE)
-          && parser_process_ternary_expression (context_p, grouping_level))
-      {
-        continue;
-      }
       break;
     }
 
     if (grouping_level == PARSE_EXPR_LEFT_HAND_SIDE)
     {
       break;
+    }
+
+    if (JERRY_UNLIKELY (context_p->token.type == LEXER_QUESTION_MARK))
+    {
+      parser_process_ternary_expression (context_p);
+
+      if (context_p->token.type == LEXER_RIGHT_PAREN)
+      {
+        goto process_unary_expression;
+      }
+    }
+    else if (LEXER_IS_BINARY_OP_TOKEN (context_p->token.type))
+    {
+      parser_append_binary_token (context_p);
+      lexer_next_token (context_p);
+      continue;
     }
 
     if (JERRY_UNLIKELY (context_p->token.type == LEXER_COMMA)
@@ -3544,12 +3549,6 @@ process_unary_expression:
       continue;
     }
 
-    if (LEXER_IS_BINARY_OP_TOKEN (context_p->token.type))
-    {
-      parser_append_binary_token (context_p);
-      lexer_next_token (context_p);
-      continue;
-    }
     break;
   }
 

--- a/tests/jerry/es2015/regresssion-test-issue-3841.js
+++ b/tests/jerry/es2015/regresssion-test-issue-3841.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval('$?$:$=>{ }?{ }:$')
+  assert(false)
+} catch (e) {
+  assert(e instanceof SyntaxError)
+}

--- a/tests/jerry/es2015/regresssion-test-issue-3842.js
+++ b/tests/jerry/es2015/regresssion-test-issue-3842.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval('while(0 ? 0 : ()=>{} | {})')
+  assert(false)
+} catch (e) {
+  assert(e instanceof SyntaxError)
+}


### PR DESCRIPTION
Further benefits: new code requires less checks.