### PR TITLE
Fix several function name related issues

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2690,6 +2690,11 @@ parser_compiled_code_set_function_name (parser_context_t *context_p, /**< contex
 
   lexer_literal_t *name_lit_p = (lexer_literal_t *) PARSER_GET_LITERAL (name_index);
 
+  if (name_lit_p->type != LEXER_IDENT_LITERAL && name_lit_p->type != LEXER_STRING_LITERAL)
+  {
+    return;
+  }
+
   uint8_t *name_buffer_p = (uint8_t *) name_lit_p->u.char_p;
   uint32_t name_length = name_lit_p->prop.length;
 

--- a/tests/jerry/es2015/function-name.js
+++ b/tests/jerry/es2015/function-name.js
@@ -285,3 +285,13 @@ assert(Object.getOwnPropertyDescriptor(Array, Symbol.species).get.name === 'get 
 assert(Object.getOwnPropertyDescriptor(String.prototype, Symbol.iterator).value.name === '[Symbol.iterator]');
 assert(Object.getOwnPropertyDescriptor(Object.prototype, '__proto__').get.name === 'get __proto__');
 assert(Object.getOwnPropertyDescriptor(Object.prototype, '__proto__').set.name === 'set __proto__');
+
+let arFunc;
+let array = [];
+array['original'] = array;
+array['original'][arFunc = ()=>{ }]=function(){}
+assertNameNotExists(array[arFunc]);
+
+var o = { 0 : class {} };
+
+assertMethodName(o['0'], '0');


### PR DESCRIPTION
 - For non-computed name script functions only identifier/string literal should be set as name
 - Implicit class constructor names with non string function name should be ToString-ed

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
