### PR TITLE
Raw string length should be adjusted when UTF8 string is converted to CESU8

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -915,7 +915,7 @@ lexer_parse_string (parser_context_t *context_p, /**< context */
                     lexer_string_options_t opts) /**< options */
 {
 #if ENABLED (JERRY_ES2015)
-  size_t raw_length_dec = 0;
+  int32_t raw_length_adjust = 0;
 #else /* ENABLED (JERRY_ES2015) */
   JERRY_UNUSED (opts);
 #endif /* ENABLED (JERRY_ES2015) */
@@ -972,7 +972,7 @@ lexer_parse_string (parser_context_t *context_p, /**< context */
             && *source_p == LIT_CHAR_LF)
         {
 #if ENABLED (JERRY_ES2015)
-          raw_length_dec++;
+          raw_length_adjust--;
 #endif /* ENABLED (JERRY_ES2015) */
           source_p++;
         }
@@ -1121,7 +1121,7 @@ lexer_parse_string (parser_context_t *context_p, /**< context */
              source_p + 1 < source_end_p &&
              source_p[1] == LIT_CHAR_LEFT_BRACE)
     {
-      raw_length_dec++;
+      raw_length_adjust--;
       source_p++;
       break;
     }
@@ -1135,6 +1135,9 @@ lexer_parse_string (parser_context_t *context_p, /**< context */
       length += 2 * 3;
       has_escape = true;
       source_p += 4;
+#if ENABLED (JERRY_ES2015)
+      raw_length_adjust += 2;
+#endif /* ENABLED (JERRY_ES2015) */
       column++;
       continue;
     }
@@ -1158,7 +1161,7 @@ lexer_parse_string (parser_context_t *context_p, /**< context */
             && *source_p == LIT_CHAR_LF)
         {
           source_p++;
-          raw_length_dec++;
+          raw_length_adjust--;
         }
         line++;
         column = 1;
@@ -1206,7 +1209,7 @@ lexer_parse_string (parser_context_t *context_p, /**< context */
 #if ENABLED (JERRY_ES2015)
   if (opts & LEXER_STRING_RAW)
   {
-    length = (size_t) (source_p - string_start_p) - raw_length_dec;
+    length = (size_t) ((source_p - string_start_p) + raw_length_adjust);
   }
 #endif /* ENABLED (JERRY_ES2015) */
 

--- a/tests/jerry/es2015/regression-test-issue-3812.js
+++ b/tests/jerry/es2015/regression-test-issue-3812.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f (a) {
+  assert(a[0] === '𞹴');
+}
+
+f`𞹴`;


### PR DESCRIPTION
This patch fixes #3812.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
