### PR TITLE
Correct release of spread arguments

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -471,7 +471,7 @@ opfunc_spread_arguments (ecma_value_t *stack_top_p, /**< pointer to the current 
     {
       for (uint32_t k = i + 1; k < arguments_list_len; k++)
       {
-        ecma_free_value (*(++stack_top_p));
+        ecma_free_value (*stack_top_p++);
       }
 
       ecma_collection_free (buff_p);

--- a/tests/jerry/es2015/regression-test-issue-3860.js
+++ b/tests/jerry/es2015/regression-test-issue-3860.js
@@ -1,0 +1,53 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  Object (...1, {});
+  assert (false);
+} catch (ex) {
+  // expected error: "TypeError: object is not iterable"
+  assert (ex instanceof TypeError);
+}
+
+try {
+  Object (...1, {}, {});
+  assert (false);
+} catch (ex) {
+  // expected error: "TypeError: object is not iterable"
+  assert (ex instanceof TypeError);
+}
+
+try {
+  Object (...1, { "prop": 2 }, 1, { "prop": 2 });
+  assert (false);
+} catch (ex) {
+  // expected error: "TypeError: object is not iterable"
+  assert (ex instanceof TypeError);
+}
+
+try {
+  Object (...1, "str");
+  assert (false);
+} catch (ex) {
+  // expected error: "TypeError: object is not iterable"
+  assert (ex instanceof TypeError);
+}
+
+try {
+  Object (...[], { "prop": 2 }, 1, { "prop": 2 }, ...1);
+  assert (false);
+} catch (ex) {
+  // expected error: "TypeError: object is not iterable"
+  assert (ex instanceof TypeError);
+}


### PR DESCRIPTION
During the `opfunc_spread_arguments` argument release process
the stack pointer was incremented early resulting in a state where
one of the arguments was not freed causing a memory leak.

Fixes: #3860
Fixes: #3859
Fixes: #3858