### PR TITLE
Add missing end-of-string checks to RegExp parser in unicode mode

### DIFF
--- a/tests/jerry/es2015/regression-test-issue-3870.js
+++ b/tests/jerry/es2015/regression-test-issue-3870.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert (new RegExp("\ud800", "u").exec("\ud800")[0] === "\ud800");

--- a/tests/jerry/es2015/regression-test-issue-3871.js
+++ b/tests/jerry/es2015/regression-test-issue-3871.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  new RegExp('"\\u', 'u');
+  assert (false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
Fixes #3870.
Fixes #3871.