### PR TITLE
Compiled code should hold strong reference for the object in the tagged template literal collection

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -115,8 +115,6 @@ ecma_init_gc_info (ecma_object_t *object_p) /**< object */
   JERRY_CONTEXT (ecma_gc_objects_number)++;
   JERRY_CONTEXT (ecma_gc_new_objects)++;
 
-  JERRY_ASSERT (JERRY_CONTEXT (ecma_gc_new_objects) <= JERRY_CONTEXT (ecma_gc_objects_number));
-
   JERRY_ASSERT (object_p->type_flags_refs < ECMA_OBJECT_REF_ONE);
   object_p->type_flags_refs = (uint16_t) (object_p->type_flags_refs | ECMA_OBJECT_REF_ONE);
 
@@ -398,23 +396,6 @@ ecma_gc_mark_set_object (ecma_object_t *object_p) /**< object */
 #endif /* ENABLED (JERRY_ES2015_BUILTIN_SET) */
 
 #if ENABLED (JERRY_ES2015)
-
-/**
- * Mark tagged template literals of the compiled code.
- */
-static void
-ecma_gc_mark_tagged_template_literals (const ecma_compiled_code_t *byte_code_p)
-{
-  JERRY_ASSERT (byte_code_p->status_flags & CBC_CODE_FLAG_HAS_TAGGED_LITERALS);
-
-  ecma_collection_t *collection_p = ecma_compiled_code_get_tagged_template_collection (byte_code_p);
-
-  for (uint32_t i = 0; i < collection_p->item_count; i++)
-  {
-    ecma_gc_set_object_visited (ecma_get_object_from_value (collection_p->buffer_p[i]));
-  }
-} /* ecma_gc_mark_tagged_template_literals */
-
 /**
  * Mark objects referenced by inactive generator functions, async functions, etc.
  */
@@ -701,11 +682,6 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
 
 #if ENABLED (JERRY_ES2015)
           const ecma_compiled_code_t *byte_code_p = ecma_op_function_get_compiled_code (ext_func_p);
-
-          if (byte_code_p->status_flags & CBC_CODE_FLAG_HAS_TAGGED_LITERALS)
-          {
-            ecma_gc_mark_tagged_template_literals (byte_code_p);
-          }
 
           if (byte_code_p->status_flags & CBC_CODE_FLAGS_ARROW_FUNCTION)
           {

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1441,7 +1441,12 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
 #if ENABLED (JERRY_ES2015)
     if (bytecode_p->status_flags & CBC_CODE_FLAG_HAS_TAGGED_LITERALS)
     {
-      ecma_collection_destroy (ecma_compiled_code_get_tagged_template_collection (bytecode_p));
+      ecma_collection_t *collection_p = ecma_compiled_code_get_tagged_template_collection (bytecode_p);
+
+      /* Since the objects in the tagged template collection are not strong referenced anymore by the compiled code
+         we can treat them as 'new' objects. */
+      JERRY_CONTEXT (ecma_gc_new_objects) += collection_p->item_count;
+      ecma_collection_free (collection_p);
     }
 #endif /* ENABLED (JERRY_ES2015) */
 

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1658,14 +1658,6 @@ parser_post_processing (parser_context_t *context_p) /**< context */
   if (context_p->tagged_template_literal_cp != JMEM_CP_NULL)
   {
     base_p[-1] = (ecma_value_t) context_p->tagged_template_literal_cp;
-
-    ecma_collection_t *collection_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
-                                                                       context_p->tagged_template_literal_cp);
-
-    for (uint32_t i = 0; i < collection_p->item_count; i++)
-    {
-      ecma_free_value (collection_p->buffer_p[i]);
-    }
   }
 #endif /* ENABLED (JERRY_ES2015) */
 

--- a/tests/jerry/es2015/regression-test-issue-3866.js
+++ b/tests/jerry/es2015/regression-test-issue-3866.js
@@ -1,0 +1,34 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a;
+var b;
+var called = false;
+Promise.race([a, b]);
+Promise.race([b, a]);
+Promise.race([, b, a]);
+Promise.race().then(function() {}, function() {
+    let str;
+    function getStr() {
+        return $ `$`
+    }
+    var $ = getStr()
+}).catch(e => {
+  called = true;
+  assert (e instanceof TypeError);
+})
+
+function __checkAsync() {
+  assert(called);
+}


### PR DESCRIPTION
This patch fixes #3866.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
