### PR TITLE
Fix built-in RegExp allocation with default constructor

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -210,31 +210,13 @@ ecma_object_t *
 ecma_op_regexp_alloc (ecma_object_t *ctr_obj_p) /**< constructor object pointer */
 {
 #if ENABLED (JERRY_ES2015)
-  bool default_alloc = false;
-
   if (ctr_obj_p == NULL)
   {
-    ecma_object_t *re_prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_REGEXP_PROTOTYPE);
-
-    ecma_value_t ctr_value = ecma_op_object_get_by_magic_id (re_prototype_obj_p, LIT_MAGIC_STRING_CONSTRUCTOR);
-
-    if (ECMA_IS_VALUE_ERROR (ctr_value))
-    {
-      return NULL;
-    }
-
-    ctr_obj_p = ecma_get_object_from_value (ctr_value);
-
-    default_alloc = true;
+    ctr_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_REGEXP);
   }
 
   ecma_object_t *proto_obj_p = ecma_op_get_prototype_from_constructor (ctr_obj_p,
                                                                        ECMA_BUILTIN_ID_REGEXP_PROTOTYPE);
-
-  if (default_alloc)
-  {
-    ecma_deref_object (ctr_obj_p);
-  }
 
   if (JERRY_UNLIKELY (proto_obj_p == NULL))
   {

--- a/tests/jerry/es2015/regression-test-issue-3880.js
+++ b/tests/jerry/es2015/regression-test-issue-3880.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+RegExp.prototype.constructor = ""
+var r = /a/;
+assert (r.test ("a"));
+
+RegExp.prototype.constructor = {}
+r = /b/;
+assert (r.test ("b"));


### PR DESCRIPTION
Fixes #3880.
Fixes #3881.
