### PR TITLE
Fix ReferenceError for let/const variables in of/in for loop

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -2108,7 +2108,7 @@ scanner_scan_statement_end (parser_context_t *context_p, /**< context */
         while ((literal_p = (lexer_lit_location_t *) parser_list_iterator_next (&literal_iterator)) != NULL)
         {
           if ((literal_p->type & (SCANNER_LITERAL_IS_LET | SCANNER_LITERAL_IS_CONST))
-              && literal_p->type & SCANNER_LITERAL_NO_REG)
+              && (literal_p->type & SCANNER_LITERAL_IS_USED))
           {
             literal_p->type |= SCANNER_LITERAL_EARLY_CREATE;
           }

--- a/tests/jerry/es2015/for-let-reference-error.js
+++ b/tests/jerry/es2015/for-let-reference-error.js
@@ -1,0 +1,30 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+function check_reference_error (code)
+{
+  try {
+    eval (code)
+    assert (false)
+  } catch (e) {
+    assert (e instanceof ReferenceError)
+  }
+}
+
+check_reference_error("for (let x of [x]) {}")
+check_reference_error("for (const x of [x]) {}")
+
+check_reference_error("for (let x in {x}) {}")
+check_reference_error("for (const x in {x}) {}")

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -422,12 +422,8 @@
   <test id="language/statements/continue/labeled-continue.js"><reason></reason></test>
   <test id="language/statements/continue/nested-let-bound-for-loops-labeled-continue.js"><reason></reason></test>
   <test id="language/statements/continue/simple-and-labeled.js"><reason></reason></test>
-  <test id="language/statements/for-in/const-bound-names-fordecl-tdz-for-in.js"><reason></reason></test>
-  <test id="language/statements/for-in/let-bound-names-fordecl-tdz-for-in.js"><reason></reason></test>
   <test id="language/statements/for-of/body-dstr-assign-error.js"><reason></reason></test>
   <test id="language/statements/for-of/body-dstr-assign.js"><reason></reason></test>
-  <test id="language/statements/for-of/const-bound-names-fordecl-tdz-for-of.js"><reason></reason></test>
-  <test id="language/statements/for-of/let-bound-names-fordecl-tdz-for-of.js"><reason></reason></test>
   <test id="language/statements/for/S12.6.3_A9.1.js"><reason></reason></test>
   <test id="language/statements/for/S12.6.3_A9.js"><reason></reason></test>
   <test id="language/statements/function/13.2-30-s.js"><reason></reason></test>


### PR DESCRIPTION
ReferenceError should be thrown when variable is used before assignment.

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com

