### PR TITLE
Builtin objects finalization should handle function properties with tagged template literal collection

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -906,7 +906,7 @@ ecma_gc_free_executable_object (ecma_object_t *object_p) /**< object */
 /**
  * Free properties of an object
  */
-static void
+void
 ecma_gc_free_properties (ecma_object_t *object_p) /**< object */
 {
   jmem_cpointer_t prop_iter_cp = object_p->u1.property_list_cp;

--- a/jerry-core/ecma/base/ecma-gc.h
+++ b/jerry-core/ecma/base/ecma-gc.h
@@ -29,6 +29,7 @@
 void ecma_init_gc_info (ecma_object_t *object_p);
 void ecma_ref_object (ecma_object_t *object_p);
 void ecma_deref_object (ecma_object_t *object_p);
+void ecma_gc_free_properties (ecma_object_t *object_p);
 void ecma_gc_run (void);
 void ecma_free_unused_memory (jmem_pressure_t pressure);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -539,7 +539,22 @@ ecma_finalize_builtins (void)
   {
     if (JERRY_CONTEXT (ecma_builtin_objects)[id] != JMEM_CP_NULL)
     {
-      ecma_deref_object (ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[id]));
+      ecma_object_t *obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[id]);
+      ecma_deref_object (obj_p);
+
+#if ENABLED (JERRY_ES2015)
+      /* Note: In ES2015 a function object may contain tagged template literal collection. Whenever
+         this function is assigned to a builtin function or function routine during the GC it may cause unresolvable
+         circle since one part of the circle is a weak reference (marked by GC) and the other part is hard reference
+         (reference count). In this case when the function which contains the tagged template literal collection
+         is getting GC marked the arrays in the collection are still holding weak references to properties/prototypes
+         which prevents these objects from getting freed. Releasing the property list and the prototype reference
+         manually eliminates the existence of the unresolvable circle described above. */
+      ecma_gc_free_properties (obj_p);
+      obj_p->u1.property_list_cp = JMEM_CP_NULL;
+      obj_p->u2.prototype_cp = JMEM_CP_NULL;
+#endif /* ENABLED (JERRY_ES2015) */
+
       JERRY_CONTEXT (ecma_builtin_objects)[id] = JMEM_CP_NULL;
     }
   }

--- a/tests/jerry/es2015/regression-test-issue-3893.js
+++ b/tests/jerry/es2015/regression-test-issue-3893.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Object.prototype.toString = function () {
+  return a`` ;
+};


### PR DESCRIPTION
This patch fixes #3893.

Co-authored-by: Dániel Bátyai dbatyai@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
