### PR TITLE
Remove arguments and caller properties from ArrowFunction

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1525,10 +1525,11 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
     bytecode_data_p = ecma_op_function_get_compiled_code ((ecma_extended_object_t *) object_p);
 
 #if ENABLED (JERRY_ESNEXT)
-    if (!(bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE))
+    if (!(bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE)
+        && !(CBC_FUNCTION_GET_TYPE (bytecode_data_p->status_flags) == CBC_FUNCTION_ARROW))
     {
       ecma_property_t *value_prop_p;
-      /* The property_name_p argument contans the name. */
+      /* The property_name_p argument contains the name. */
       ecma_property_value_t *value_p = ecma_create_named_data_property (object_p,
                                                                         property_name_p,
                                                                         ECMA_PROPERTY_FIXED,
@@ -1542,7 +1543,7 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
       ecma_object_t *thrower_p = ecma_builtin_get (ECMA_BUILTIN_ID_TYPE_ERROR_THROWER);
 
       ecma_property_t *caller_prop_p;
-      /* The property_name_p argument contans the name. */
+      /* The property_name_p argument contains the name. */
       ecma_create_named_accessor_property (object_p,
                                            property_name_p,
                                            thrower_p,

--- a/tests/jerry/es.next/arrow-function.js
+++ b/tests/jerry/es.next/arrow-function.js
@@ -184,3 +184,13 @@ assert(f()()() === 7);
 
 var f = (((a=1,b=2) => ((x => (((a) => 8))))));
 assert(f()()() === 8);
+
+var f = () => {};
+
+assert(f.hasOwnProperty('caller') === false);
+assert(f.hasOwnProperty('arguments') === false);
+
+must_throw("var f = () => {}; f.caller")
+must_throw("var f = () => {}; f.arguments")
+must_throw("var f = () => {}; f.caller = 1")
+must_throw("var f = () => {}; f.arguments = 2")

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -330,7 +330,6 @@
   <test id="language/computed-property-names/object/accessor/setter-super.js"><reason></reason></test>
   <test id="language/computed-property-names/object/method/super.js"><reason></reason></test>
   <test id="language/default-parameters/function-length.js"><reason></reason></test>
-  <test id="language/expressions/arrow-function/ArrowFunction_restricted-properties.js"><reason></reason></test>
   <test id="language/expressions/arrow-function/lexical-super-call-from-within-constructor.js"><reason></reason></test>
   <test id="language/expressions/assignment/destructuring/array-rest-init.js"><reason></reason></test>
   <test id="language/expressions/assignment/destructuring/obj-prop-elem-target-yield-expr.js"><reason></reason></test>


### PR DESCRIPTION
As stated in [ES11 16.1](http://www.ecma-international.org/ecma-262/11.0/#sec-forbidden-extensions), ArrowFunction should not have caller and arguments properties.

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com