### PR TITLE
Fix async function call parsing.

### DIFF
--- a/jerry-core/parser/js/js-scanner-ops.c
+++ b/jerry-core/parser/js/js-scanner-ops.c
@@ -242,6 +242,12 @@ scanner_check_arrow_arg (parser_context_t *context_p, /**< context */
   scanner_pop_literal_pool (context_p, scanner_context_p);
 
   parser_stack_pop_uint8 (context_p);
+
+  if (context_p->stack_top_uint8 == SCAN_STACK_USE_ASYNC)
+  {
+    scanner_add_async_literal (context_p, scanner_context_p);
+  }
+
   parser_stack_push_uint8 (context_p, SCAN_STACK_PAREN_EXPRESSION);
 
   if (process_arrow)

--- a/tests/jerry/es.next/regresssion-test-issue-3908.js
+++ b/tests/jerry/es.next/regresssion-test-issue-3908.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval("async(a,b+)")
+  assert(false)
+} catch (e) {
+  assert(e instanceof SyntaxError)
+}


### PR DESCRIPTION
The "async" identifier processing is delayed until it is detected that it cannot be part of an arrow expression. The "async" identifier should be processed at this point, but it was not happened in this case.