### PR TITLE
Remove "arguments" and "caller" from specific functions

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1531,7 +1531,7 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
 
 #if ENABLED (JERRY_ESNEXT)
     if (!(bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE)
-        && !(CBC_FUNCTION_GET_TYPE (bytecode_data_p->status_flags) == CBC_FUNCTION_ARROW))
+        && CBC_FUNCTION_GET_TYPE (bytecode_data_p->status_flags) == CBC_FUNCTION_NORMAL)
     {
       ecma_property_t *value_prop_p;
       /* The property_name_p argument contains the name. */
@@ -1660,6 +1660,7 @@ ecma_op_bound_function_try_to_lazy_instantiate_property (ecma_object_t *object_p
     return len_prop_p;
   }
 
+#if !ENABLED (JERRY_ESNEXT)
   if (ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_CALLER)
       || ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_ARGUMENTS))
   {
@@ -1675,6 +1676,7 @@ ecma_op_bound_function_try_to_lazy_instantiate_property (ecma_object_t *object_p
                                          &caller_prop_p);
     return caller_prop_p;
   }
+#endif /* !ENABLED (JERRY_ESNEXT) */
 
   return NULL;
 } /* ecma_op_bound_function_try_to_lazy_instantiate_property */

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -3379,6 +3379,7 @@ lexer_string_is_directive (parser_context_t *context_p) /**< context */
 {
   return (context_p->token.type == LEXER_SEMICOLON
           || context_p->token.type == LEXER_RIGHT_BRACE
+          || context_p->token.type == LEXER_EOS
           || ((context_p->token.flags & LEXER_WAS_NEWLINE)
               && !LEXER_IS_BINARY_OP_TOKEN (context_p->token.type)
               && context_p->token.type != LEXER_LEFT_PAREN

--- a/tests/jerry/es.next/restricted-properties.js
+++ b/tests/jerry/es.next/restricted-properties.js
@@ -1,0 +1,76 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function must_throw (str) {
+  try {
+    eval ("switch (1) { default: " + str + "}");
+    assert (false);
+  }
+  catch (e) {
+  }
+
+  try {
+    eval (str);
+    assert (false);
+  }
+  catch (e) {
+  }
+}
+
+// strict functions created using the Function constructor
+var strictF = new Function('"use strict"');
+
+assert(strictF.hasOwnProperty('caller') === false);
+assert(strictF.hasOwnProperty('arguments') === false);
+
+must_throw("strictF.caller")
+must_throw("strictF.arguments")
+must_throw("strictF.caller = 1")
+must_throw("strictF.arguments = 2")
+
+// generator functions created using the Generator constructor
+var GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor
+var generatorF = new GeneratorFunction()
+
+assert(generatorF.hasOwnProperty('caller') === false);
+assert(generatorF.hasOwnProperty('arguments') === false);
+
+must_throw("generatorF.caller")
+must_throw("generatorF.arguments")
+must_throw("generatorF.caller = 1")
+must_throw("generatorF.arguments = 2")
+
+// async functions created using the AsyncFunction constructor
+async function asyncF() {}
+
+assert(asyncF.hasOwnProperty('caller') === false);
+assert(asyncF.hasOwnProperty('arguments') === false);
+
+must_throw("asyncF.caller")
+must_throw("asyncF.arguments")
+must_throw("asyncF.caller = 1")
+must_throw("asyncF.arguments = 2")
+
+// functions created using the bind method
+var f = function () {};
+var boundF = f.bind();
+
+assert(boundF.hasOwnProperty('caller') === false);
+assert(boundF.hasOwnProperty('arguments') === false);
+
+must_throw("boundF.caller")
+must_throw("boundF.arguments")
+must_throw("boundF.caller = 1")
+must_throw("boundF.arguments = 2")

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -38,10 +38,6 @@
   <test id="built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid.js"><reason></reason></test>
   <test id="built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js"><reason></reason></test>
   <test id="built-ins/decodeURI/S15.1.3.1_A2.5_T1.js"><reason></reason></test>
-  <test id="built-ins/Function/prototype/bind/15.3.4.5-15-5.js"><reason></reason></test>
-  <test id="built-ins/Function/prototype/bind/BoundFunction_restricted-properties.js"><reason></reason></test>
-  <test id="built-ins/Function/StrictFunction_restricted-properties.js"><reason></reason></test>
-  <test id="built-ins/GeneratorFunction/instance-restricted-properties.js"><reason></reason></test>
   <test id="built-ins/GeneratorPrototype/next/context-constructor-invocation.js"><reason></reason></test>
   <test id="built-ins/GeneratorPrototype/throw/from-state-completed.js"><reason></reason></test>
   <test id="built-ins/Map/prototype/Symbol.iterator.js"><reason></reason></test>
@@ -421,9 +417,7 @@
   <test id="language/statements/for-of/body-dstr-assign.js"><reason></reason></test>
   <test id="language/statements/for/S12.6.3_A9.1.js"><reason></reason></test>
   <test id="language/statements/for/S12.6.3_A9.js"><reason></reason></test>
-  <test id="language/statements/function/13.2-30-s.js"><reason></reason></test>
   <test id="language/statements/generators/has-instance.js"><reason></reason></test>
   <test id="language/statements/generators/prototype-value.js"><reason></reason></test>
-  <test id="language/statements/generators/restricted-properties.js"><reason></reason></test>
   <test id="language/statements/let/syntax/identifier-let-disallowed-as-boundname.js"><reason></reason></test>
 </excludeList>


### PR DESCRIPTION
As stated in [ES 16.1](http://www.ecma-international.org/ecma-262/11.0/#sec-forbidden-extensions), "arguments" and "caller" must not be created in:
- strict functions created using the Function constructor
- generator functions created using the Generator constructor
- async functions created using the AsyncFunction constructor
- functions created using the bind

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com