### PR TITLE
Make test262-es2015 output more verbose

### DIFF
--- a/tests/test262-es6.patch
+++ b/tests/test262-es6.patch
@@ -1,8 +1,17 @@
 diff --git a/tools/packaging/test262.py b/tools/packaging/test262.py
-index 921360a05e..27a2938e48 100755
+index 921360a05e..a19c8a14e6 100755
 --- a/tools/packaging/test262.py
 +++ b/tools/packaging/test262.py
-@@ -469,8 +469,8 @@ class TestSuite(object):
+@@ -168,6 +168,8 @@ class TestResult(object):
+     if len(err) > 0:
+        target.write("--- errors ---  \n %s" % err)
+ 
++    target.write("\n--- exit code: %d ---\n" % self.exit_code)
++
+   # This is a way to make the output from the "whitespace" tests into valid XML
+   def SafeFormat(self, msg):
+     try:
+@@ -469,8 +471,8 @@ class TestSuite(object):
            if self.ShouldRun(rel_path, tests):
              basename = path.basename(full_path)[:-3]
              name = rel_path.split(path.sep)[:-1] + [basename]

--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -118,7 +118,7 @@ def update_exclude_list(args):
         summary_found = False
         for line in report_file:
             if summary_found:
-                match = re.match(r"  (\S*) ", line)
+                match = re.match(r"  (\S*) in ", line)
                 if match:
                     failing_tests.add(match.group(1) + '.js')
             elif line.startswith('Failed Tests'):
@@ -193,7 +193,7 @@ def main(args):
                             [os.path.join(args.test_dir, 'tools/packaging/test262.py'),
                              '--command', command,
                              '--tests', args.test_dir,
-                             '--summary'],
+                             '--full-summary'],
                             universal_newlines=True,
                             stdout=subprocess.PIPE,
                             **kwargs)


### PR DESCRIPTION
It makes easier to debug unexpected failures on the CI.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
