### PR TITLE
Fix profile file parsing in CMake

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -264,8 +264,8 @@ endif()
 
 if(EXISTS ${JERRY_PROFILE})
   file(READ "${JERRY_PROFILE}" PROFILE_SETTINGS)
-  string(REGEX REPLACE "^#.*$" "" PROFILE_SETTINGS "${PROFILE_SETTINGS}")
-  string(REGEX REPLACE "[\r|\n]" ";" PROFILE_SETTINGS "${PROFILE_SETTINGS}")
+  string(REGEX REPLACE "[ \t]*#[^\n]*" "" PROFILE_SETTINGS "${PROFILE_SETTINGS}")
+  string(REGEX REPLACE "[\r\n]" ";" PROFILE_SETTINGS "${PROFILE_SETTINGS}")
 
   # Process entries and save them as CMake variables.
   # This is required to correctly generate the jerryscript-config.h file.


### PR DESCRIPTION
Changes:
- Comment can be started anywhere, not only at the beginning of the input.
- The end of the comment isn't the end of the input, but the first newline.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
