### PR TITLE
Update Symbol.split functions for String and Regexp to match new standard

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -795,10 +795,13 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_value, /**< this a
   uint32_t limit = UINT32_MAX;
   if (!ecma_is_value_undefined (limit_value))
   {
-    if (ECMA_IS_VALUE_ERROR (ecma_op_to_length (limit_value, &limit)))
+    /* ECMA-262 v11, 21.1.3.20 6 */
+    ecma_number_t num;
+    if (ECMA_IS_VALUE_ERROR (ecma_get_number (limit_value, &num)))
     {
       goto cleanup_string;
     }
+    limit = ecma_number_to_uint32 (num);
   }
 
   /* 12. */

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -2113,10 +2113,13 @@ ecma_regexp_split_helper (ecma_value_t this_arg, /**< this value */
   uint32_t limit = UINT32_MAX;
   if (!ecma_is_value_undefined (limit_arg))
   {
-    if (ECMA_IS_VALUE_ERROR (ecma_op_to_length (limit_arg, &limit)))
+    /* ECMA-262 v11, 21.2.5.13 13 */
+    ecma_number_t num;
+    if (ECMA_IS_VALUE_ERROR (ecma_get_number (limit_arg, &num)))
     {
       goto cleanup_splitter;
     }
+    limit = ecma_number_to_uint32 (num);
   }
 
   /* 15. */
@@ -2213,6 +2216,12 @@ ecma_regexp_split_helper (ecma_value_t this_arg, /**< this value */
       result = ECMA_VALUE_ERROR;
       ecma_deref_object (match_array_p);
       goto cleanup_array;
+    }
+
+    /* ECMA-262 v11, 21.2.5.11 19.d.ii */
+    if (end_index > string_length)
+    {
+      end_index = string_length;
     }
 
     /* 24.f.iii. */

--- a/tests/jerry/es.next/regexp-prototype-split.js
+++ b/tests/jerry/es.next/regexp-prototype-split.js
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var str = "foo//bar/baz//foo";
-res = str.split("a", -1);
-assert (res.length === 3);
-assert (res[0] === "foo//b");
-assert (res[1] === "r/b");
-assert (res[2] === "z//foo");
 
-res = str.split(/\/\//, Infinity);
-assert (res.length === 0);
+result = /./[Symbol.split]('string', -13);
+assert(result.length === 7);
+
+result = /./[Symbol.split]('string', 2);
+assert(result.length === 2);

--- a/tests/jerry/es.next/symbol-split.js
+++ b/tests/jerry/es.next/symbol-split.js
@@ -107,3 +107,14 @@ try {
 } catch (e) {
   assert (e === "abrupt capture");
 }
+
+Object.defineProperty(RegExp.prototype, "exec", { value: function (str) {
+  this.lastIndex = 10;
+  return { };
+}});
+
+var result = split.call ({flags: "g"}, "string");
+
+assert(result.length === 2)
+assert(result[0] === "")
+assert(result[1] === "")

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -86,6 +86,7 @@
   <test id="built-ins/RegExp/prototype/Symbol.replace/y-set-lastindex.js"><reason></reason></test>
   <test id="built-ins/RegExp/prototype/Symbol.search/get-sticky-coerce.js"><reason></reason></test>
   <test id="built-ins/RegExp/prototype/Symbol.search/get-sticky-err.js"><reason></reason></test>
+  <test id="built-ins/RegExp/prototype/Symbol.split/coerce-limit.js"><reason>Test is outdated: ES11, 21.2.5.13 13</reason></test>
   <test id="built-ins/RegExp/prototype/test/get-sticky-err.js"><reason></reason></test>
   <test id="built-ins/String/prototype/normalize/form-is-not-valid-throws.js"><reason></reason></test>
   <test id="built-ins/String/prototype/normalize/length.js"><reason></reason></test>
@@ -96,7 +97,6 @@
   <test id="built-ins/String/prototype/normalize/return-normalized-string-from-coerced-form.js"><reason></reason></test>
   <test id="built-ins/String/prototype/normalize/return-normalized-string.js"><reason></reason></test>
   <test id="built-ins/String/prototype/normalize/return-normalized-string-using-default-parameter.js"><reason></reason></test>
-  <test id="built-ins/String/prototype/split/S15.5.4.14_A2_T37.js"><reason></reason></test>
   <test id="built-ins/String/prototype/toLocaleLowerCase/special_casing_conditional.js"><reason></reason></test>
   <test id="built-ins/String/prototype/toLocaleLowerCase/supplementary_plane.js"><reason></reason></test>
   <test id="built-ins/String/prototype/toLocaleUpperCase/supplementary_plane.js"><reason></reason></test>


### PR DESCRIPTION
In newest ES standard limit parameter is calculated using
ToUint32 function instead of ToLength.

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com

- there was an assert failure in Regexp split function, when lastIndex were forced to value bigger than size (calculation method was changed in ECMA-262 v11, 21.2.5.11 19.d.ii)
- ToLength function for limit argument was changed to ToUint32
- test built-ins/RegExp/prototype/Symbol.split/coerce-limit.js fails, because it is not valid for new version - ToUint32 works different than ToLength for negative numbers. (Test is changed [here](https://github.com/tc39/test262/commit/bd8c91e250690567240e3aa4ade9a740b94b1aee))