### PR TITLE
Fix Object.prototype.toLocaleString() and Array.prototype.toLocaleStr…

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -235,8 +235,13 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
   }
 
   ecma_object_t *locale_func_obj_p = ecma_get_object_from_value (to_locale_value);
+#if ENABLED (JERRY_ESNEXT)
+  ecma_value_t index_parameter = index_value;
+#else /* !ENABLED (JERRY_ESNEXT) */
+  ecma_value_t index_parameter = index_obj_value;
+#endif /* ENABLED (JERRY_ESNEXT) */
   ecma_value_t call_value = ecma_op_function_call (locale_func_obj_p,
-                                                   index_obj_value,
+                                                   index_parameter,
                                                    NULL,
                                                    0);
   ecma_deref_object (locale_func_obj_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -108,10 +108,13 @@ ecma_builtin_object_prototype_object_value_of (ecma_value_t this_arg) /**< this 
  *         Returned value must be freed with ecma_free_value.
  */
 static ecma_value_t
-ecma_builtin_object_prototype_object_to_locale_string (ecma_object_t *obj_p) /**< this argument */
+ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg, /**< this argument */
+                                                       ecma_object_t *obj_p) /**< this argument as an object */
 {
   /* 2. */
-  ecma_value_t to_string_val = ecma_op_object_get_by_magic_id (obj_p, LIT_MAGIC_STRING_TO_STRING_UL);
+
+  ecma_string_t *string_to_string = ecma_get_magic_string (LIT_MAGIC_STRING_TO_STRING_UL);
+  ecma_value_t to_string_val = ecma_op_object_get_with_receiver (obj_p, string_to_string, this_arg);
 
   if (ECMA_IS_VALUE_ERROR (to_string_val))
   {
@@ -127,7 +130,7 @@ ecma_builtin_object_prototype_object_to_locale_string (ecma_object_t *obj_p) /**
 
   /* 4. */
   ecma_object_t *to_string_func_obj_p = ecma_get_object_from_value (to_string_val);
-  ecma_value_t ret_value = ecma_op_function_call (to_string_func_obj_p, ecma_make_object_value (obj_p), NULL, 0);
+  ecma_value_t ret_value = ecma_op_function_call (to_string_func_obj_p, this_arg, NULL, 0);
 
   ecma_deref_object (to_string_func_obj_p);
 
@@ -289,7 +292,12 @@ ecma_builtin_object_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
 
     else
     {
-      ret_value = ecma_builtin_object_prototype_object_to_locale_string (obj_p);
+#if ENABLED (JERRY_ESNEXT)
+      ecma_value_t this_parameter = this_arg;
+#else /* !ENABLED (JERRY_ESNEXT) */
+      ecma_value_t this_parameter = ecma_make_object_value (obj_p);
+#endif /* ENABLED (JERRY_ESNEXT) */
+      ret_value = ecma_builtin_object_prototype_object_to_locale_string (this_parameter, obj_p);
     }
 
     ecma_deref_object (obj_p);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -26,8 +26,6 @@
   <test id="built-ins/Array/prototype/slice/S15.4.4.10_A3_T1.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/slice/S15.4.4.10_A3_T2.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/S15.4.4.12_A3_T1.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/toLocaleString/primitive_this_value_getter.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/toLocaleString/primitive_this_value.js"><reason></reason></test>
   <test id="built-ins/Date/construct_with_date.js"><reason></reason></test>
   <test id="built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid.js"><reason></reason></test>
   <test id="built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js"><reason></reason></test>
@@ -40,8 +38,6 @@
   <test id="built-ins/Object/prototype/propertyIsEnumerable/symbol_property_toPrimitive.js"><reason></reason></test>
   <test id="built-ins/Object/prototype/propertyIsEnumerable/symbol_property_toString.js"><reason></reason></test>
   <test id="built-ins/Object/prototype/propertyIsEnumerable/symbol_property_valueOf.js"><reason></reason></test>
-  <test id="built-ins/Object/prototype/toLocaleString/primitive_this_value_getter.js"><reason></reason></test>
-  <test id="built-ins/Object/prototype/toLocaleString/primitive_this_value.js"><reason></reason></test>
   <test id="built-ins/Promise/all/invoke-then.js"><reason></reason></test>
   <test id="built-ins/Promise/all/species-get-error.js"><reason></reason></test>
   <test id="built-ins/Promise/exec-args.js"><reason></reason></test>


### PR DESCRIPTION
…ing()

Since ES6 Object.prototype.toLocaleString() shouldn't call ToObject() and
Array.prototype.toLocaleString() shouldn't call ToObject() for each element.
References:
- https://www.ecma-international.org/ecma-262/11.0/index.html#sec-array.prototype.tolocalestring
- https://www.ecma-international.org/ecma-262/11.0/index.html#sec-object.prototype.tolocalestring

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
