### PR TITLE
Rework flags representing arrow functions and complex arguments

### DIFF
--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -65,7 +65,7 @@ typedef enum
   PARSER_IS_ASYNC_FUNCTION = (1u << 15),      /**< an async function is parsed */
   PARSER_DISALLOW_AWAIT_YIELD = (1u << 16),   /**< throw SyntaxError for await / yield keywords */
   PARSER_FUNCTION_IS_PARSING_ARGS = (1u << 17), /**< set when parsing function arguments */
-  PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM = (1u << 18), /**< function has a non simple parameter */
+  PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT = (1u << 18), /**< function has complex (ES2015+) argument definition */
   PARSER_FUNCTION_HAS_REST_PARAM = (1u << 19), /**< function has rest parameter */
   PARSER_CLASS_CONSTRUCTOR = (1u << 20),      /**< a class constructor is parsed
                                                *   Note: PARSER_ALLOW_SUPER must be present */
@@ -193,7 +193,7 @@ typedef enum
  * All flags that affect exotic arguments object creation.
  */
 #define PARSER_ARGUMENTS_RELATED_FLAGS \
-  (PARSER_ARGUMENTS_NEEDED | PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM | PARSER_IS_STRICT)
+  (PARSER_ARGUMENTS_NEEDED | PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT | PARSER_IS_STRICT)
 
 /**
  * Get the corresponding eval flag for a ecma_parse_opts_t flag

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -2773,7 +2773,7 @@ parser_parse_statements (parser_context_t *context_p) /**< context */
 
 #if ENABLED (JERRY_ESNEXT)
     if (strict_mode != PARSER_USE_STRICT_NOT_FOUND
-        && (context_p->status_flags & PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM))
+        && (context_p->status_flags & PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT))
     {
       parser_raise_error (context_p, PARSER_ERR_USE_STRICT_NOT_ALLOWED);
     }

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1793,7 +1793,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
   }
 
 #if ENABLED (JERRY_ESNEXT)
-  bool has_mapped_arguments = (context_p->next_scanner_info_p->u8_arg & SCANNER_FUNCTION_MAPPED_ARGUMENTS) != 0;
+  bool has_complex_argument = (context_p->next_scanner_info_p->u8_arg & SCANNER_FUNCTION_HAS_COMPLEX_ARGUMENT) != 0;
 #endif /* ENABLED (JERRY_ESNEXT) */
 
   scanner_create_variables (context_p, SCANNER_CREATE_VARS_IS_FUNCTION_ARGS);
@@ -1819,7 +1819,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
         parser_raise_error (context_p, PARSER_ERR_DUPLICATED_ARGUMENT_NAMES);
       }
 
-      context_p->status_flags |= PARSER_FUNCTION_HAS_REST_PARAM | PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM;
+      context_p->status_flags |= PARSER_FUNCTION_HAS_REST_PARAM | PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT;
     }
 
     if (context_p->token.type == LEXER_LEFT_SQUARE || context_p->token.type == LEXER_LEFT_BRACE)
@@ -1829,7 +1829,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
         parser_raise_error (context_p, PARSER_ERR_DUPLICATED_ARGUMENT_NAMES);
       }
 
-      context_p->status_flags |= PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM;
+      context_p->status_flags |= PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT;
 
       parser_emit_cbc_literal (context_p,
                                CBC_PUSH_LITERAL,
@@ -1888,7 +1888,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
     if (JERRY_UNLIKELY (context_p->lit_object.literal_p->status_flags & LEXER_FLAG_FUNCTION_ARGUMENT))
     {
 #if ENABLED (JERRY_ESNEXT)
-      if ((context_p->status_flags & PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM)
+      if ((context_p->status_flags & PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT)
           || (context_p->status_flags & PARSER_IS_ARROW_FUNCTION))
       {
         parser_raise_error (context_p, PARSER_ERR_DUPLICATED_ARGUMENT_NAMES);
@@ -1910,7 +1910,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
 
     if (context_p->token.type == LEXER_ASSIGN)
     {
-      JERRY_ASSERT (!has_mapped_arguments);
+      JERRY_ASSERT (has_complex_argument);
 
       if (context_p->status_flags & PARSER_FUNCTION_HAS_REST_PARAM)
       {
@@ -1924,7 +1924,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
         parser_raise_error (context_p, PARSER_ERR_DUPLICATED_ARGUMENT_NAMES);
       }
 
-      context_p->status_flags |= PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM;
+      context_p->status_flags |= PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT;
 
       /* LEXER_ASSIGN does not overwrite lit_object. */
       parser_emit_cbc_literal (context_p,
@@ -1950,7 +1950,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
 
       parser_emit_cbc_literal (context_p, opcode, literal_index);
     }
-    else if (!has_mapped_arguments && literal_index < PARSER_REGISTER_START)
+    else if (has_complex_argument && literal_index < PARSER_REGISTER_START)
     {
       uint16_t opcode = CBC_INIT_ARG_OR_FUNC;
 
@@ -2004,7 +2004,7 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
   scanner_revert_active (context_p);
 
 #if ENABLED (JERRY_ESNEXT)
-  JERRY_ASSERT (!has_mapped_arguments || !(context_p->status_flags & PARSER_FUNCTION_HAS_NON_SIMPLE_PARAM));
+  JERRY_ASSERT (has_complex_argument || !(context_p->status_flags & PARSER_FUNCTION_HAS_COMPLEX_ARGUMENT));
 
   if (context_p->status_flags & PARSER_IS_GENERATOR_FUNCTION)
   {

--- a/jerry-core/parser/js/js-scanner-internal.h
+++ b/jerry-core/parser/js/js-scanner-internal.h
@@ -276,7 +276,7 @@ typedef enum
   SCANNER_LITERAL_POOL_CAN_EVAL = (1 << 3), /**< prepare for executing eval in this block */
   SCANNER_LITERAL_POOL_NO_ARGUMENTS = (1 << 4), /**< arguments object must not be constructed */
 #if ENABLED (JERRY_ESNEXT)
-  SCANNER_LITERAL_POOL_ARGUMENTS_UNMAPPED = (1 << 5), /**< arguments object should be unmapped */
+  SCANNER_LITERAL_POOL_HAS_COMPLEX_ARGUMENT = (1 << 5), /**< function has complex (ES2015+) argument definition */
 #endif /* ENABLED (JERRY_ESNEXT) */
   SCANNER_LITERAL_POOL_IN_WITH = (1 << 6), /**< literal pool is in a with statement */
 #if ENABLED (JERRY_MODULE_SYSTEM)
@@ -284,29 +284,35 @@ typedef enum
 #endif /* ENABLED (JERRY_MODULE_SYSTEM) */
 #if ENABLED (JERRY_ESNEXT)
   SCANNER_LITERAL_POOL_FUNCTION_STATEMENT = (1 << 8), /**< function statement */
-  SCANNER_LITERAL_POOL_GENERATOR = (1 << 9), /**< generator function */
-  SCANNER_LITERAL_POOL_ASYNC = (1 << 10), /**< async function */
-  SCANNER_LITERAL_POOL_ASYNC_ARROW = (1 << 11), /**< can be an async arrow function */
+  SCANNER_LITERAL_POOL_ARROW = (1 << 9), /**< arrow function */
+  SCANNER_LITERAL_POOL_GENERATOR = (1 << 10), /**< generator function */
+  SCANNER_LITERAL_POOL_ASYNC = (1 << 11), /**< async function */
 #endif /* ENABLED (JERRY_ESNEXT) */
 } scanner_literal_pool_flags_t;
 
 /**
  * Define a function where no arguments are allowed.
  */
-#define SCANNER_LITERAL_POOL_FUNCTION_WITHOUT_ARGUMENTS \
-  (SCANNER_LITERAL_POOL_FUNCTION | SCANNER_LITERAL_POOL_NO_ARGUMENTS)
+#define SCANNER_LITERAL_POOL_ARROW_FLAGS \
+  (SCANNER_LITERAL_POOL_FUNCTION | SCANNER_LITERAL_POOL_NO_ARGUMENTS | SCANNER_LITERAL_POOL_ARROW)
+
+/**
+ * This flag represents that the bracketed expression might be an async arrow function.
+ * The SCANNER_LITERAL_POOL_ARROW flag is reused for this purpose.
+ */
+#define SCANNER_LITERAL_POOL_MAY_ASYNC_ARROW SCANNER_LITERAL_POOL_ARROW
 
 /**
  * Getting the generator and async properties of literal pool status flags.
  */
 #define SCANNER_FROM_LITERAL_POOL_TO_COMPUTED(status_flags) \
-  ((uint8_t) ((((status_flags) >> 9) & 0x3) + SCAN_STACK_COMPUTED_PROPERTY))
+  ((uint8_t) ((((status_flags) >> 10) & 0x3) + SCAN_STACK_COMPUTED_PROPERTY))
 
 /**
  * Setting the generator and async properties of literal pool status flags.
  */
 #define SCANNER_FROM_COMPUTED_TO_LITERAL_POOL(mode) \
-  (((mode) - SCAN_STACK_COMPUTED_PROPERTY) << 9)
+  (((mode) - SCAN_STACK_COMPUTED_PROPERTY) << 10)
 
 /**
  * Local literal pool.

--- a/jerry-core/parser/js/js-scanner-ops.c
+++ b/jerry-core/parser/js/js-scanner-ops.c
@@ -110,14 +110,16 @@ scanner_check_arrow (parser_context_t *context_p, /**< context */
   scanner_literal_pool_t *literal_pool_p = scanner_context_p->active_literal_pool_p;
   uint16_t status_flags = literal_pool_p->status_flags;
 
-  status_flags |= SCANNER_LITERAL_POOL_FUNCTION_WITHOUT_ARGUMENTS;
+  bool is_async_arrow = (status_flags & SCANNER_LITERAL_POOL_MAY_ASYNC_ARROW) != 0;
+
+  status_flags |= SCANNER_LITERAL_POOL_ARROW_FLAGS;
   status_flags &= (uint16_t) ~(SCANNER_LITERAL_POOL_IN_WITH
                                | SCANNER_LITERAL_POOL_GENERATOR
                                | SCANNER_LITERAL_POOL_ASYNC);
 
   context_p->status_flags &= (uint32_t) ~(PARSER_IS_GENERATOR_FUNCTION | PARSER_IS_ASYNC_FUNCTION);
 
-  if (status_flags & SCANNER_LITERAL_POOL_ASYNC_ARROW)
+  if (is_async_arrow)
   {
     status_flags |= SCANNER_LITERAL_POOL_ASYNC;
     context_p->status_flags |= PARSER_IS_ASYNC_FUNCTION;
@@ -137,7 +139,7 @@ scanner_scan_simple_arrow (parser_context_t *context_p, /**< context */
                            scanner_context_t *scanner_context_p, /**< scanner context */
                            const uint8_t *source_p) /**< identifier end position */
 {
-  uint16_t status_flags = SCANNER_LITERAL_POOL_FUNCTION_WITHOUT_ARGUMENTS;
+  uint16_t status_flags = SCANNER_LITERAL_POOL_ARROW_FLAGS;
 
   context_p->status_flags &= (uint32_t) ~(PARSER_IS_GENERATOR_FUNCTION | PARSER_IS_ASYNC_FUNCTION);
 
@@ -519,7 +521,7 @@ scanner_scan_bracket (parser_context_t *context_p, /**< context */
 
     if (JERRY_UNLIKELY (scanner_context_p->async_source_p != NULL))
     {
-      status_flags |= SCANNER_LITERAL_POOL_ASYNC_ARROW;
+      status_flags |= SCANNER_LITERAL_POOL_MAY_ASYNC_ARROW;
       arrow_source_p = scanner_context_p->async_source_p;
       scanner_context_p->async_source_p = NULL;
     }

--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -2311,7 +2311,9 @@ scanner_scan_all (parser_context_t *context_p, /**< context */
       context_p->source_p = source_p;
       context_p->source_end_p = source_end_p;
 
-      uint16_t status_flags = SCANNER_LITERAL_POOL_FUNCTION_WITHOUT_ARGUMENTS | SCANNER_LITERAL_POOL_CAN_EVAL;
+      uint16_t status_flags = (SCANNER_LITERAL_POOL_FUNCTION
+                               | SCANNER_LITERAL_POOL_NO_ARGUMENTS
+                               | SCANNER_LITERAL_POOL_CAN_EVAL);
 
       if (context_p->status_flags & PARSER_IS_STRICT)
       {
@@ -2754,7 +2756,7 @@ scanner_scan_all (parser_context_t *context_p, /**< context */
             {
               if (context_p->token.type == LEXER_THREE_DOTS)
               {
-                scanner_context.active_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_ARGUMENTS_UNMAPPED;
+                scanner_context.active_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_HAS_COMPLEX_ARGUMENT;
                 lexer_next_token (context_p);
               }
 
@@ -2784,7 +2786,7 @@ scanner_scan_all (parser_context_t *context_p, /**< context */
 
             if (argument_literal_p == NULL)
             {
-              scanner_context.active_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_ARGUMENTS_UNMAPPED;
+              scanner_context.active_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_HAS_COMPLEX_ARGUMENT;
 
               parser_stack_push_uint8 (context_p, SCAN_STACK_FUNCTION_PARAMETERS);
               scanner_append_hole (context_p, &scanner_context);
@@ -2804,7 +2806,7 @@ scanner_scan_all (parser_context_t *context_p, /**< context */
 
             if (context_p->token.type == LEXER_ASSIGN)
             {
-              scanner_context.active_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_ARGUMENTS_UNMAPPED;
+              scanner_context.active_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_HAS_COMPLEX_ARGUMENT;
 
               parser_stack_push_uint8 (context_p, SCAN_STACK_FUNCTION_PARAMETERS);
               scanner_context.mode = SCAN_MODE_PRIMARY_EXPRESSION;

--- a/jerry-core/parser/js/js-scanner.h
+++ b/jerry-core/parser/js/js-scanner.h
@@ -217,7 +217,7 @@ typedef enum
 typedef enum
 {
   SCANNER_FUNCTION_ARGUMENTS_NEEDED = (1 << 0), /**< arguments object needs to be created */
-  SCANNER_FUNCTION_MAPPED_ARGUMENTS = (1 << 1), /**< arguments object should be mapped */
+  SCANNER_FUNCTION_HAS_COMPLEX_ARGUMENT = (1 << 1), /**< function has complex (ES2015+) argument definition */
 #if ENABLED (JERRY_ESNEXT)
   SCANNER_FUNCTION_LEXICAL_ENV_NEEDED = (1 << 2), /**< lexical environment is needed for the function body */
   SCANNER_FUNCTION_STATEMENT = (1 << 3), /**< function is function statement (not arrow expression)

--- a/tests/jerry/regression-test-issue-3944.js
+++ b/tests/jerry/regression-test-issue-3944.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[function(a, a) { (function() { a }) }()]


### PR DESCRIPTION
This allows detecting cases which was not possible before.

Fixes #3944
