### PR TITLE
Update NuttX to 9.0 on Travis

### DIFF
--- a/targets/nuttx-stm32f4/Makefile.travis
+++ b/targets/nuttx-stm32f4/Makefile.travis
@@ -39,8 +39,8 @@ install-kconfig:
 
 # Fetch nuttx/{apps,nuttx} repositories.
 install-clone-nuttx:
-	git clone https://bitbucket.org/nuttx/apps.git ../apps -b nuttx-7.28
-	git clone https://bitbucket.org/nuttx/nuttx.git ../nuttx -b nuttx-7.28
+	git clone https://bitbucket.org/nuttx/apps.git ../apps -b releases/9.0
+	git clone https://bitbucket.org/nuttx/nuttx.git ../nuttx -b releases/9.0
 
 # Perform all the necessary (JerryScript-independent) installation steps.
 install-noapt: install-kconfig install-clone-nuttx

--- a/targets/nuttx-stm32f4/README.md
+++ b/targets/nuttx-stm32f4/README.md
@@ -7,15 +7,15 @@ This folder contains files to run JerryScript on
 
 #### 1. Setup the build environment for STM32F4-Discovery board
 
-Clone the necessary projects into a `jerry-nuttx` directory. The last tested working version of NuttX is 7.28.
+Clone the necessary projects into a `jerry-nuttx` directory. The last tested working version of NuttX is 9.0.
 
 ```sh
 # Create a base folder for all the projects.
 mkdir jerry-nuttx && cd jerry-nuttx
 
 git clone https://github.com/jerryscript-project/jerryscript.git
-git clone https://bitbucket.org/nuttx/nuttx.git -b nuttx-7.28
-git clone https://bitbucket.org/nuttx/apps.git -b nuttx-7.28
+git clone https://bitbucket.org/nuttx/nuttx.git -b release/9.0
+git clone https://bitbucket.org/nuttx/apps.git -b release/9.0
 git clone https://github.com/texane/stlink.git -b v1.5.1
 ```
 


### PR DESCRIPTION
Update the Travis build system to use NuttX 9.0, which was released on April 26, 2020.

JerryScript-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu