### PR TITLE
Symbol.prototype[Symbol.toPrimitive].length should be 1

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-symbol-prototype.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-symbol-prototype.inc.h
@@ -33,7 +33,7 @@ ROUTINE (LIT_MAGIC_STRING_VALUE_OF_UL, ecma_builtin_symbol_prototype_object_valu
 ROUTINE_CONFIGURABLE_ONLY (LIT_GLOBAL_SYMBOL_TO_PRIMITIVE,
                            ecma_builtin_symbol_prototype_object_to_primitive,
                            0,
-                           0)
+                           1)
 
 /* ECMA-262 v6, 19.4.3.4 */
 STRING_VALUE (LIT_GLOBAL_SYMBOL_TO_STRING_TAG,

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -103,7 +103,6 @@
   <test id="built-ins/String/prototype/toLowerCase/special_casing_conditional.js"><reason></reason></test>
   <test id="built-ins/String/prototype/toLowerCase/supplementary_plane.js"><reason></reason></test>
   <test id="built-ins/String/prototype/toUpperCase/supplementary_plane.js"><reason></reason></test>
-  <test id="built-ins/Symbol/prototype/Symbol.toPrimitive/length.js"><reason></reason></test>
   <test id="intl402/6.2.2_a.js"><reason></reason></test>
   <test id="intl402/6.2.2_b.js"><reason></reason></test>
   <test id="intl402/6.2.2_c.js"><reason></reason></test>


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
