### PR TITLE
Class accessors shouldn't be enumerable.

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1215,6 +1215,7 @@ opfunc_set_class_attributes (ecma_object_t *obj_p, /**< object */
       }
       else if (ECMA_PROPERTY_GET_TYPE (property) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
       {
+        property_pair_p->header.types[index] = (uint8_t) (property & ~ECMA_PROPERTY_FLAG_ENUMERABLE);
         ecma_property_value_t *accessor_objs_p = property_pair_p->values + index;
 
         ecma_getter_setter_pointers_t *get_set_pair_p = ecma_get_named_accessor_property (accessor_objs_p);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -344,11 +344,8 @@
   <test id="language/object-literal/getter.js"><reason></reason></test>
   <test id="language/object-literal/method.js"><reason></reason></test>
   <test id="language/object-literal/setter.js"><reason></reason></test>
-  <test id="language/statements/class/definition/accessors.js"><reason></reason></test>
-  <test id="language/statements/class/definition/getters.js"><reason></reason></test>
   <test id="language/statements/class/definition/methods.js"><reason></reason></test>
   <test id="language/statements/class/definition/numeric-property-names.js"><reason></reason></test>
-  <test id="language/statements/class/definition/setters.js"><reason></reason></test>
   <test id="language/statements/class/definition/this-access-restriction.js"><reason></reason></test>
   <test id="language/statements/class/definition/this-check-ordering.js"><reason></reason></test>
   <test id="language/statements/class/name-binding/in-extends-expression-assigned.js"><reason></reason></test>


### PR DESCRIPTION
Reference:
https://www.ecma-international.org/ecma-262/11.0/index.html#sec-runtime-semantics-classdefinitionevaluation 21.a,b

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
