### PR TITLE
Use the Invoke method where the ES10 standard says

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -164,7 +164,6 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg) /**< this argument *
   }
 
   ecma_value_t ret_value = ECMA_VALUE_ERROR;
-
   ecma_object_t *value_obj_p = ecma_get_object_from_value (obj);
 
   /* 4. */
@@ -180,8 +179,7 @@ ecma_builtin_date_prototype_to_json (ecma_value_t this_arg) /**< this argument *
     /* 6. */
     else
     {
-      ecma_object_t *to_iso_obj_p = ecma_get_object_from_value (to_iso);
-      ret_value = ecma_op_function_call (to_iso_obj_p, this_arg, NULL, 0);
+      ret_value = ecma_op_invoke_by_magic_id (obj, LIT_MAGIC_STRING_TO_ISO_STRING_UL, NULL, 0);
     }
 
     ecma_free_value (to_iso);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -210,53 +210,18 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
     return ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
   }
 
-  ecma_value_t index_obj_value = ecma_op_to_object (index_value);
+  ecma_value_t call_value = ecma_op_invoke_by_magic_id (index_value, LIT_MAGIC_STRING_TO_LOCALE_STRING_UL, NULL, 0);
 
-  if (ECMA_IS_VALUE_ERROR (index_obj_value))
-  {
-    ecma_free_value (index_value);
-    return NULL;
-  }
-
-  ecma_string_t *ret_string_p = NULL;
-  ecma_object_t *index_obj_p = ecma_get_object_from_value (index_obj_value);
-  ecma_value_t to_locale_value = ecma_op_object_get_by_magic_id (index_obj_p, LIT_MAGIC_STRING_TO_LOCALE_STRING_UL);
-
-  if (ECMA_IS_VALUE_ERROR (to_locale_value))
-  {
-    goto cleanup;
-  }
-
-  if (!ecma_op_is_callable (to_locale_value))
-  {
-    ecma_free_value (to_locale_value);
-    ecma_raise_type_error (ECMA_ERR_MSG ("'toLocaleString' is missing or not a function."));
-    goto cleanup;
-  }
-
-  ecma_object_t *locale_func_obj_p = ecma_get_object_from_value (to_locale_value);
-#if ENABLED (JERRY_ESNEXT)
-  ecma_value_t index_parameter = index_value;
-#else /* !ENABLED (JERRY_ESNEXT) */
-  ecma_value_t index_parameter = index_obj_value;
-#endif /* ENABLED (JERRY_ESNEXT) */
-  ecma_value_t call_value = ecma_op_function_call (locale_func_obj_p,
-                                                   index_parameter,
-                                                   NULL,
-                                                   0);
-  ecma_deref_object (locale_func_obj_p);
+  ecma_free_value (index_value);
 
   if (ECMA_IS_VALUE_ERROR (call_value))
   {
-    goto cleanup;
+    return NULL;
   }
 
-  ret_string_p = ecma_op_to_string (call_value);
-  ecma_free_value (call_value);
+  ecma_string_t *ret_string_p = ecma_op_to_string (call_value);
 
-cleanup:
-  ecma_deref_object (index_obj_p);
-  ecma_free_value (index_value);
+  ecma_free_value (call_value);
 
   return ret_string_p;
 } /* ecma_builtin_helper_get_to_locale_string_at_index */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -108,33 +108,9 @@ ecma_builtin_object_prototype_object_value_of (ecma_value_t this_arg) /**< this 
  *         Returned value must be freed with ecma_free_value.
  */
 static ecma_value_t
-ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg, /**< this argument */
-                                                       ecma_object_t *obj_p) /**< this argument as an object */
+ecma_builtin_object_prototype_object_to_locale_string (ecma_value_t this_arg) /**< this argument */
 {
-  /* 2. */
-
-  ecma_string_t *string_to_string = ecma_get_magic_string (LIT_MAGIC_STRING_TO_STRING_UL);
-  ecma_value_t to_string_val = ecma_op_object_get_with_receiver (obj_p, string_to_string, this_arg);
-
-  if (ECMA_IS_VALUE_ERROR (to_string_val))
-  {
-    return to_string_val;
-  }
-
-  /* 3. */
-  if (!ecma_op_is_callable (to_string_val))
-  {
-    ecma_free_value (to_string_val);
-    return ecma_raise_type_error (ECMA_ERR_MSG ("'toString is missing or not a function.'"));
-  }
-
-  /* 4. */
-  ecma_object_t *to_string_func_obj_p = ecma_get_object_from_value (to_string_val);
-  ecma_value_t ret_value = ecma_op_function_call (to_string_func_obj_p, this_arg, NULL, 0);
-
-  ecma_deref_object (to_string_func_obj_p);
-
-  return ret_value;
+  return ecma_op_invoke_by_magic_id (this_arg, LIT_MAGIC_STRING_TO_STRING_UL, &this_arg, 1);
 } /* ecma_builtin_object_prototype_object_to_locale_string */
 
 /**
@@ -267,6 +243,11 @@ ecma_builtin_object_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
       }
     }
 
+    if (builtin_routine_id == ECMA_OBJECT_PROTOTYPE_TO_LOCALE_STRING)
+    {
+      return ecma_builtin_object_prototype_object_to_locale_string (this_arg);
+    }
+
     ecma_value_t to_object = ecma_op_to_object (this_arg);
 
     if (ECMA_IS_VALUE_ERROR (to_object))
@@ -278,26 +259,15 @@ ecma_builtin_object_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
 
     ecma_value_t ret_value;
 
-    if (builtin_routine_id == ECMA_OBJECT_PROTOTYPE_IS_PROTOTYPE_OF)
-    {
-      ret_value = ecma_builtin_object_prototype_object_is_prototype_of (obj_p, arguments_list_p[0]);
-    }
-
 #if ENABLED (JERRY_ESNEXT)
-    else if (builtin_routine_id == ECMA_OBJECT_PROTOTYPE_GET_PROTO)
+    if (builtin_routine_id == ECMA_OBJECT_PROTOTYPE_GET_PROTO)
     {
       ret_value = ecma_builtin_object_object_get_prototype_of (obj_p);
     }
-#endif /* ENABLED (JERRY_ESNEXT)*/
-
     else
+#endif /* ENABLED (JERRY_ESNEXT)*/
     {
-#if ENABLED (JERRY_ESNEXT)
-      ecma_value_t this_parameter = this_arg;
-#else /* !ENABLED (JERRY_ESNEXT) */
-      ecma_value_t this_parameter = ecma_make_object_value (obj_p);
-#endif /* ENABLED (JERRY_ESNEXT) */
-      ret_value = ecma_builtin_object_prototype_object_to_locale_string (this_parameter, obj_p);
+      ret_value = ecma_builtin_object_prototype_object_is_prototype_of (obj_p, arguments_list_p[0]);
     }
 
     ecma_deref_object (obj_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise-prototype.c
@@ -65,9 +65,8 @@ static ecma_value_t
 ecma_builtin_promise_prototype_catch (ecma_value_t this_arg, /**< this argument */
                                       ecma_value_t on_rejected) /**< on_rejected function */
 {
-  return ecma_promise_then (this_arg,
-                            ECMA_VALUE_UNDEFINED,
-                            on_rejected);
+  ecma_value_t args[] = {ECMA_VALUE_UNDEFINED, on_rejected};
+  return ecma_op_invoke_by_magic_id (this_arg, LIT_MAGIC_STRING_THEN, args, 2);
 } /* ecma_builtin_promise_prototype_catch */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -655,24 +655,8 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_value, /**< this 
   ecma_deref_object (ecma_get_object_from_value (new_regexp));
 #else /* ENABLED (JERRY_ESNEXT) */
   ecma_object_t *regexp_obj_p = ecma_get_object_from_value (new_regexp);
-  ecma_value_t search_symbol = ecma_op_object_get_by_symbol_id (regexp_obj_p, LIT_GLOBAL_SYMBOL_SEARCH);
-  if (ECMA_IS_VALUE_ERROR (search_symbol))
-  {
-    goto cleanup_regexp;
-  }
-
-  if (!ecma_op_is_callable (search_symbol))
-  {
-    result = ecma_raise_type_error (ECMA_ERR_MSG ("@@search is not callable"));
-    goto cleanup_regexp;
-  }
-
-  ecma_object_t *search_method_p = ecma_get_object_from_value (search_symbol);
-  ecma_value_t arguments[] = { ecma_make_string_value (string_p) };
-  result = ecma_op_function_call (search_method_p, new_regexp, arguments, 1);
-  ecma_deref_object (search_method_p);
-
-cleanup_regexp:
+  ecma_value_t this_str_value = ecma_make_string_value (string_p);
+  result = ecma_op_invoke_by_symbol_id (new_regexp, LIT_GLOBAL_SYMBOL_SEARCH, &this_str_value, 1);
   ecma_deref_object (regexp_obj_p);
 #endif /* !ENABLED (JERRY_ESNEXT) */
 

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -3072,7 +3072,14 @@ ecma_op_invoke (ecma_value_t object, /**< Object value */
   }
 
   ecma_object_t *object_p = ecma_get_object_from_value (object_value);
-  ecma_value_t func = ecma_op_object_get (object_p, property_name_p);
+
+#if ENABLED (JERRY_ESNEXT)
+  ecma_value_t this_arg = object;
+#else /* !ENABLED (JERRY_ESNEXT) */
+  ecma_value_t this_arg = object_value;
+#endif /* ENABLED (JERRY_ESNEXT) */
+
+  ecma_value_t func = ecma_op_object_get_with_receiver (object_p, property_name_p, this_arg);
 
   if (ECMA_IS_VALUE_ERROR (func))
   {
@@ -3089,7 +3096,8 @@ ecma_op_invoke (ecma_value_t object, /**< Object value */
   }
 
   ecma_object_t *func_obj_p = ecma_get_object_from_value (func);
-  ecma_value_t call_result = ecma_op_function_call (func_obj_p, object, args_p, args_len);
+  ecma_value_t call_result = ecma_op_function_call (func_obj_p, this_arg, args_p, args_len);
+
   ecma_deref_object (object_p);
   ecma_deref_object (func_obj_p);
 

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -40,7 +40,6 @@
   <test id="built-ins/Promise/all/invoke-then.js"><reason></reason></test>
   <test id="built-ins/Promise/all/species-get-error.js"><reason></reason></test>
   <test id="built-ins/Promise/exec-args.js"><reason></reason></test>
-  <test id="built-ins/Promise/prototype/catch/invokes-then.js"><reason></reason></test>
   <test id="built-ins/Promise/prototype/then/ctor-custom.js"><reason></reason></test>
   <test id="built-ins/Promise/prototype/then/on-fulfilled-return-thenable.js"><reason></reason></test>
   <test id="built-ins/Promise/race/invoke-then.js"><reason></reason></test>


### PR DESCRIPTION
We can apply this change to methods which use older standards, because
of the backward compatibility the result is the same

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
