### PR TITLE
Speedup AppVeyor CI runtime

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,17 +15,12 @@ platform:
   - x64
   - Win32
 
-environment:
-  matrix:
-    - JERRY_DEBUGGER: ON
-    - JERRY_DEBUGGER: OFF
-
 # Steps of a job.
 init:
   - cmake -version
 before_build:
-  - if "%PLATFORM%"=="Win32" cmake -G"Visual Studio 15 2017" -Bbuild -H. -DJERRY_DEBUGGER=%JERRY_DEBUGGER%
-  - if "%PLATFORM%"=="x64" cmake -G"Visual Studio 15 2017 Win64" -Bbuild -H. -DJERRY_DEBUGGER=%JERRY_DEBUGGER%
+  - if "%PLATFORM%"=="Win32" cmake -G"Visual Studio 15 2017" -Bbuild -H. -DJERRY_DEBUGGER=ON
+  - if "%PLATFORM%"=="x64" cmake -G"Visual Studio 15 2017 Win64" -Bbuild -H. -DJERRY_DEBUGGER=ON
 build:
   project: build\Jerry.sln
   parallel: true


### PR DESCRIPTION
There is no good reason to test JERRY_DEBUGGER=OFF configuration too,
because debugger itself contains Windows specific codepath. If the
build works with debugger, it has to work without debugger too.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
