### PR TITLE
Fix Date.prototype[@@toPrimitive] hint handling

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -202,7 +202,7 @@ ecma_builtin_date_prototype_to_primitive (ecma_value_t this_arg, /**< this argum
   {
     ecma_string_t *hint_str_p = ecma_get_string_from_value (hint_arg);
 
-    ecma_preferred_type_hint_t hint = ECMA_PREFERRED_TYPE_NUMBER;
+    ecma_preferred_type_hint_t hint = ECMA_PREFERRED_TYPE_NO;
 
     if (hint_str_p == ecma_get_magic_string (LIT_MAGIC_STRING_STRING)
         || hint_str_p == ecma_get_magic_string (LIT_MAGIC_STRING_DEFAULT))

--- a/tests/jerry/es.next/date-prototype-toprimitive.js
+++ b/tests/jerry/es.next/date-prototype-toprimitive.js
@@ -42,6 +42,14 @@ try {
   assert(e instanceof TypeError);
 }
 
+// Test with invalid hint value
+try {
+  dateObj[Symbol.toPrimitive]('error');
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
 // Test when unable to call toPrimitive
 try {
   Date.prototype[Symbol.toPrimitive].call(undefined);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -27,7 +27,6 @@
   <test id="built-ins/Array/prototype/slice/S15.4.4.10_A3_T2.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/S15.4.4.12_A3_T1.js"><reason></reason></test>
   <test id="built-ins/Date/construct_with_date.js"><reason></reason></test>
-  <test id="built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid.js"><reason></reason></test>
   <test id="built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js"><reason></reason></test>
   <test id="built-ins/decodeURI/S15.1.3.1_A2.5_T1.js"><reason></reason></test>
   <test id="built-ins/GeneratorPrototype/next/context-constructor-invocation.js"><reason></reason></test>


### PR DESCRIPTION
The Date.prototype[@@toPrimitive] only allows the "string", "default" and "number"
hint values. Any other value should throw a TypeError.