### PR TITLE
Fix tools/runners/run-test-suite.py with Python 3.6

### DIFF
--- a/tools/runners/run-test-suite.py
+++ b/tools/runners/run-test-suite.py
@@ -83,8 +83,8 @@ def execute_test_command(test_cmd):
     kwargs = {}
     if sys.version_info.major >= 3:
         kwargs['encoding'] = 'unicode_escape'
-        kwargs['text'] = True
-    process = subprocess.Popen(test_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
+    process = subprocess.Popen(test_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                               universal_newlines=True, **kwargs)
     stdout = process.communicate()[0]
     return (process.returncode, stdout)
 


### PR DESCRIPTION
text parameter of Popen introduced in Python 3.7,
we should use the equivalent universal_newlines.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác oszi@inf.u-szeged.hu
