### PR TITLE
Add missing isArray checks based on the ES11 standard

### DIFF
--- a/tests/jerry/es.next/regression-test-issue-3945.js
+++ b/tests/jerry/es.next/regression-test-issue-3945.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function a() {
+  this[2] = { b : new Proxy(Function, {}) }
+}
+
+JSON.parse("[1, 2, []]", a);

--- a/tests/jerry/es.next/regression-test-issue-3950.js
+++ b/tests/jerry/es.next/regression-test-issue-3950.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function a() {
+  this[2] = new Proxy(new function() { return new Array }, {})
+  return {}
+}
+
+JSON.parse("[1, 2, []]", a);


### PR DESCRIPTION
Added checks to the following methods:
- ecma_builtin_json_stringify, ECMA-262 v11, 24.5.2
- ecma_builtin_json_internalize_property, ECMA-262 v11, 24.5.1.1

Fixes #3945 
Fixes #3950

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
