### PR TITLE
Update the NuttX-STM32 documentation

### DIFF
--- a/targets/nuttx-stm32f4/Makefile.travis
+++ b/targets/nuttx-stm32f4/Makefile.travis
@@ -33,7 +33,7 @@ install-kconfig:
 	mkdir -p $(LOCAL_INSTALL)
 	# FIXME: 'autoreconf --force --install' is a workaround after
 	#        https://bitbucket.org/nuttx/tools/commits/164450f982b404fdc2b3233db51dc3eaa1f08b7f
-	cd ../tools/kconfig-frontends && autoreconf --force --install && ./configure --disable-mconf --disable-nconf --disable-gconf --disable-qconf --disable-utils --disable-shared --enable-static --prefix=$(LOCAL_INSTALL)
+	cd ../tools/kconfig-frontends && autoreconf --force --install && ./configure --disable-mconf --disable-nconf --disable-gconf --disable-qconf --disable-shared --enable-static --prefix=$(LOCAL_INSTALL)
 	$(MAKE) -C ../tools/kconfig-frontends
 	$(MAKE) -C ../tools/kconfig-frontends install
 

--- a/targets/nuttx-stm32f4/README.md
+++ b/targets/nuttx-stm32f4/README.md
@@ -14,9 +14,9 @@ Clone the necessary projects into a `jerry-nuttx` directory. The last tested wor
 mkdir jerry-nuttx && cd jerry-nuttx
 
 git clone https://github.com/jerryscript-project/jerryscript.git
-git clone https://bitbucket.org/nuttx/nuttx.git -b release/9.0
-git clone https://bitbucket.org/nuttx/apps.git -b release/9.0
-git clone https://github.com/texane/stlink.git -b v1.5.1
+git clone https://bitbucket.org/nuttx/nuttx.git -b releases/9.0
+git clone https://bitbucket.org/nuttx/apps.git -b releases/9.0
+git clone https://github.com/texane/stlink.git -b v1.5.1-patch
 ```
 
 The following directory structure is created after these commands:
@@ -108,7 +108,6 @@ cd nuttx-tools/kconfig-frontends
     --disable-nconf \
     --disable-gconf \
     --disable-qconf \
-    --disable-utils \
     --disable-shared \
     --enable-static \
     --prefix=${PWD}/install


### PR DESCRIPTION
Fixed and updated some of the repository locations and the relevant build commands.

- Updating `stlink` fixes a CMake build error on the 1.5.1 branch
- Updating the `kconfig` build command allows creating `kconfig-tweak`, which fixes a warning during the NuttX configuration

JerryScript-DCO-1.0-Signed-off-by: Mátyás Mustoha mmatyas@inf.u-szeged.hu
