### PR TITLE
Fix Object.assign to call [[GetOwnProperty]] Proxy handler only once

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -1053,7 +1053,6 @@ ecma_builtin_object_object_assign (ecma_object_t *target_p, /**< target object *
 
     /* 5.b.iii */
     ecma_collection_t *props_p = ecma_op_object_get_property_names (from_obj_p, ECMA_LIST_CONVERT_FAST_ARRAYS
-                                                                                | ECMA_LIST_ENUMERABLE
                                                                                 | ECMA_LIST_SYMBOLS);
 #if ENABLED (JERRY_BUILTIN_PROXY)
     if (props_p == NULL)

--- a/tests/jerry/es.next/proxy_get_own_property_descriptor.js
+++ b/tests/jerry/es.next/proxy_get_own_property_descriptor.js
@@ -268,3 +268,17 @@ try {
 }
 
 // Step 17: See (Inv-2) above.
+
+var result = [];
+var proxy = new Proxy({foo: 1, bar: 2}, {
+  getOwnPropertyDescriptor: function(o, v) {
+    result.push(v);
+    return Object.getOwnPropertyDescriptor(o, v);
+  }
+});
+
+Object.assign({}, proxy);
+
+assert(result.length === 2);
+assert(result[0] === "foo");
+assert(result[1] === "bar");


### PR DESCRIPTION
Removed the enumerable option when listing properties to prevent an extra [[GetOwnProperty]] function call for Proxy objects. In this case all the property names are collected, but the Object.assign() implementation has already taken care of the enumerable property filtering.
