### PR TITLE
Optimize [[Call]] arguments stack usage

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2793,10 +2793,12 @@ jerry_invoke_function (bool is_invoke_as_constructor, /**< true - invoke functio
   {
     JERRY_ASSERT (jerry_value_is_function (func_obj_val));
 
-    return jerry_return (ecma_op_function_call (ecma_get_object_from_value (func_obj_val),
-                                                this_val,
-                                                args_p,
-                                                args_count));
+    ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (func_obj_val),
+                                                             this_val,
+                                                             args_p,
+                                                             args_count);
+
+    return jerry_return (ecma_op_function_call (&call_args));
   }
 } /* jerry_invoke_function */
 
@@ -3255,10 +3257,11 @@ jerry_resolve_or_reject_promise (jerry_value_t promise, /**< the promise value *
 
   ecma_value_t function = ecma_op_object_get_by_magic_id (ecma_get_object_from_value (promise), prop_name);
 
-  ecma_value_t ret = ecma_op_function_call (ecma_get_object_from_value (function),
-                                            ECMA_VALUE_UNDEFINED,
-                                            &argument,
-                                            1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (function),
+                                                           ECMA_VALUE_UNDEFINED,
+                                                           &argument,
+                                                           1);
+  ecma_value_t ret = ecma_op_function_call (&call_args);
 
   ecma_free_value (function);
 

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -2012,6 +2012,17 @@ typedef struct
 #endif /* ENABLED (JERRY_BUILTIN_PROXY) */
 
 /**
+ * Description of function call arguments.
+ */
+typedef struct
+{
+  ecma_object_t *func_obj_p; /**< function object to call */
+  const ecma_value_t *argv; /**< pointer to the beginning of the arguments */
+  ecma_length_t argc; /**< number of arguments */
+  ecma_value_t this_value; /**< this value to invoke the function */
+} ecma_call_args_t;
+
+/**
  * @}
  * @}
  */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -148,7 +148,8 @@ ecma_builtin_array_prototype_object_to_string (ecma_value_t this_arg, /**< this 
   /* 4. */
   ecma_object_t *join_func_obj_p = ecma_get_object_from_value (join_value);
 
-  ecma_value_t ret_value = ecma_op_function_call (join_func_obj_p, this_arg, NULL, 0);
+  ecma_call_args_t call_args = ecma_op_function_make_args (join_func_obj_p, this_arg, NULL, 0);
+  ecma_value_t ret_value = ecma_op_function_call (&call_args);
 
   ecma_deref_object (join_func_obj_p);
 
@@ -1062,10 +1063,12 @@ ecma_builtin_array_prototype_object_sort_compare_helper (ecma_value_t lhs, /**< 
 
     ecma_value_t compare_args[] = { lhs, rhs };
 
-    ecma_value_t call_value = ecma_op_function_call (comparefn_obj_p,
-                                                     ECMA_VALUE_UNDEFINED,
-                                                     compare_args,
-                                                     2);
+    ecma_call_args_t call_args = ecma_op_function_make_args (comparefn_obj_p,
+                                                             ECMA_VALUE_UNDEFINED,
+                                                             compare_args,
+                                                             2);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
+
     if (ECMA_IS_VALUE_ERROR (call_value))
     {
       return call_value;
@@ -1892,9 +1895,10 @@ ecma_builtin_array_apply (ecma_value_t arg1, /**< callbackfn */
       /* 7.c.i */
       current_index = ecma_make_uint32_value (index);
 
-      ecma_value_t call_args[] = { get_value, current_index, ecma_make_object_value (obj_p) };
+      ecma_value_t args[] = { get_value, current_index, ecma_make_object_value (obj_p) };
       /* 7.c.ii */
-      ecma_value_t call_value = ecma_op_function_call (func_object_p, arg2, call_args, 3);
+      ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, arg2, args, 3);
+      ecma_value_t call_value = ecma_op_function_call (&call_args);
 
       if (ECMA_IS_VALUE_ERROR (call_value))
       {
@@ -1993,9 +1997,10 @@ ecma_builtin_array_prototype_object_map (ecma_value_t arg1, /**< callbackfn */
     {
       /* 8.c.i, 8.c.ii */
       current_index = ecma_make_uint32_value (index);
-      ecma_value_t call_args[] = { current_value, current_index, ecma_make_object_value (obj_p) };
+      ecma_value_t args[] = { current_value, current_index, ecma_make_object_value (obj_p) };
 
-      ecma_value_t mapped_value = ecma_op_function_call (func_object_p, arg2, call_args, 3);
+      ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, arg2, args, 3);
+      ecma_value_t mapped_value = ecma_op_function_call (&call_args);
 
       if (ECMA_IS_VALUE_ERROR (mapped_value))
       {
@@ -2088,9 +2093,10 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t arg1, /**< callbackfn *
       /* 9.c.i */
       current_index = ecma_make_uint32_value (index);
 
-      ecma_value_t call_args[] = { get_value, current_index, ecma_make_object_value (obj_p) };
+      ecma_value_t args[] = { get_value, current_index, ecma_make_object_value (obj_p) };
       /* 9.c.ii */
-      ecma_value_t call_value = ecma_op_function_call (func_object_p, arg2, call_args, 3);
+      ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, arg2, args, 3);
+      ecma_value_t call_value = ecma_op_function_call (&call_args);
 
       if (ECMA_IS_VALUE_ERROR (call_value))
       {
@@ -2231,12 +2237,11 @@ ecma_builtin_array_reduce_from (const ecma_value_t args_p[], /**< routine's argu
     {
       /* 9.c.i, 9.c.ii */
       current_index = ecma_make_uint32_value (corrected_index);
-      ecma_value_t call_args[] = {accumulator, current_value, current_index, ecma_make_object_value (obj_p)};
+      ecma_value_t args[] = {accumulator, current_value, current_index, ecma_make_object_value (obj_p)};
 
-      ecma_value_t call_value = ecma_op_function_call (func_object_p,
-                                                       ECMA_VALUE_UNDEFINED,
-                                                       call_args,
-                                                       4);
+      ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, ECMA_VALUE_UNDEFINED, args, 4);
+      ecma_value_t call_value = ecma_op_function_call (&call_args);
+
       ecma_free_value (current_index);
       ecma_free_value (accumulator);
       ecma_free_value (current_value);
@@ -2389,9 +2394,10 @@ ecma_builtin_array_prototype_object_find (ecma_value_t predicate, /**< callback 
     /* 8.d - 8.e */
     ecma_value_t current_index = ecma_make_uint32_value (index);
 
-    ecma_value_t call_args[] = { get_value, current_index, ecma_make_object_value (obj_p) };
+    ecma_value_t args[] = { get_value, current_index, ecma_make_object_value (obj_p) };
 
-    ecma_value_t call_value = ecma_op_function_call (func_object_p, predicate_this_arg, call_args, 3);
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, predicate_this_arg, args, 3);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
 
     if (ECMA_IS_VALUE_ERROR (call_value))
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
@@ -220,7 +220,9 @@ ecma_builtin_array_object_from (ecma_value_t this_arg, /**< 'this' argument */
         /* 6.g.vii.1 */
         ecma_value_t args_p[2] = { next_value, ecma_make_uint32_value (k) };
         /* 6.g.vii.3 */
-        mapped_value = ecma_op_function_call (mapfn_obj_p, call_this_arg, args_p, 2);
+
+        ecma_call_args_t call_args = ecma_op_function_make_args (mapfn_obj_p, call_this_arg, args_p, 2);
+        mapped_value = ecma_op_function_call (&call_args);
         ecma_free_value (args_p[1]);
         ecma_free_value (next_value);
 
@@ -339,7 +341,8 @@ iterator_cleanup:
     {
       /* 16.d.i */
       ecma_value_t args_p[2] = { k_value, ecma_make_uint32_value (k) };
-      mapped_value = ecma_op_function_call (mapfn_obj_p, call_this_arg, args_p, 2);
+      ecma_call_args_t call_args = ecma_op_function_make_args (mapfn_obj_p, call_this_arg, args_p, 2);
+      mapped_value = ecma_op_function_call (&call_args);
       ecma_free_value (args_p[1]);
       ecma_free_value (k_value);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -102,7 +102,8 @@ ecma_builtin_function_prototype_object_apply (ecma_object_t *func_obj_p, /**< th
   /* 2. */
   if (ecma_is_value_null (arg2) || ecma_is_value_undefined (arg2))
   {
-    return  ecma_op_function_call (func_obj_p, arg1, NULL, 0);
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, arg1, NULL, 0);
+    return ecma_op_function_call (&call_args);
   }
 
   /* 3. */
@@ -149,10 +150,9 @@ ecma_builtin_function_prototype_object_apply (ecma_object_t *func_obj_p, /**< th
   if (ecma_is_value_empty (ret_value))
   {
     JERRY_ASSERT (index == length);
-    ret_value = ecma_op_function_call (func_obj_p,
-                                       arg1,
-                                       arguments_list_p,
-                                       length);
+
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, arg1, arguments_list_p, length);
+    ret_value = ecma_op_function_call (&call_args);
   }
 
   for (uint32_t remove_index = 0; remove_index < index; remove_index++)
@@ -179,19 +179,22 @@ ecma_builtin_function_prototype_object_call (ecma_object_t *func_obj_p , /**< th
                                              const ecma_value_t *arguments_list_p, /**< list of arguments */
                                              ecma_length_t arguments_number) /**< number of arguments */
 {
+  ecma_call_args_t call_args;
+
   if (arguments_number == 0)
   {
     /* Even a 'this' argument is missing. */
-    return ecma_op_function_call (func_obj_p,
-                                  ECMA_VALUE_UNDEFINED,
-                                  NULL,
-                                  0);
+    call_args = ecma_op_function_make_args (func_obj_p, ECMA_VALUE_UNDEFINED, NULL, 0);
+  }
+  else
+  {
+    call_args = ecma_op_function_make_args (func_obj_p,
+                                            arguments_list_p[0],
+                                            arguments_list_p + 1,
+                                            (ecma_length_t) (arguments_number - 1u));
   }
 
-  return ecma_op_function_call (func_obj_p,
-                                arguments_list_p[0],
-                                arguments_list_p + 1,
-                                (ecma_length_t) (arguments_number - 1u));
+  return ecma_op_function_call (&call_args);
 } /* ecma_builtin_function_prototype_object_call */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -677,10 +677,12 @@ ecma_builtin_json_internalize_property (ecma_object_t *reviver_p, /**< reviver f
   arguments_list[1] = value;
 
   /* 4. */
-  ecma_value_t ret_value =  ecma_op_function_call (reviver_p,
-                                                   ecma_make_object_value (holder_p),
-                                                   arguments_list,
-                                                   2);
+  ecma_call_args_t call_args = ecma_op_function_make_args (reviver_p,
+                                                           ecma_make_object_value (holder_p),
+                                                           arguments_list,
+                                                           2);
+  ecma_value_t ret_value = ecma_op_function_call (&call_args);
+
   ecma_free_value (value);
   return ret_value;
 } /* ecma_builtin_json_internalize_property */
@@ -1145,10 +1147,10 @@ ecma_builtin_json_serialize_property (ecma_json_stringify_context_t *context_p, 
     if (ecma_op_is_callable (to_json))
     {
       ecma_value_t key_value = ecma_make_string_value (key_p);
-      ecma_value_t call_args[] = { key_value };
       ecma_object_t *to_json_obj_p = ecma_get_object_from_value (to_json);
 
-      ecma_value_t result = ecma_op_function_call (to_json_obj_p, value, call_args, 1);
+      ecma_call_args_t call_args = ecma_op_function_make_args (to_json_obj_p, value, &key_value, 1);
+      ecma_value_t result = ecma_op_function_call (&call_args);
       ecma_deref_object (value_obj_p);
 
       if (ECMA_IS_VALUE_ERROR (result))
@@ -1167,9 +1169,11 @@ ecma_builtin_json_serialize_property (ecma_json_stringify_context_t *context_p, 
   {
     ecma_value_t holder_value = ecma_make_object_value (holder_p);
     ecma_value_t key_value = ecma_make_string_value (key_p);
-    ecma_value_t call_args[] = { key_value, value };
+    ecma_value_t args[] = { key_value, value };
 
-    ecma_value_t result = ecma_op_function_call (context_p->replacer_function_p, holder_value, call_args, 2);
+    ecma_call_args_t call_args = ecma_op_function_make_args (context_p->replacer_function_p, holder_value, args, 2);
+    ecma_value_t result = ecma_op_function_call (&call_args);
+
     ecma_free_value (value);
 
     if (ECMA_IS_VALUE_ERROR (result))

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -65,10 +65,12 @@ ecma_builtin_promise_reject_abrupt (ecma_value_t value, /**< value */
   ecma_value_t reject = ecma_op_object_get_by_magic_id (ecma_get_object_from_value (capability),
                                                         LIT_INTERNAL_MAGIC_STRING_PROMISE_PROPERTY_REJECT);
 
-  ecma_value_t call_ret = ecma_op_function_call (ecma_get_object_from_value (reject),
-                                                 ECMA_VALUE_UNDEFINED,
-                                                 &reason,
-                                                 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (reject),
+                                                           ECMA_VALUE_UNDEFINED,
+                                                           &reason,
+                                                           1);
+  ecma_value_t call_ret = ecma_op_function_call (&call_args);
+
   ecma_free_value (reject);
   ecma_free_value (reason);
 
@@ -296,10 +298,12 @@ ecma_builtin_promise_all_handler (const ecma_value_t function, /**< the function
   {
     ecma_value_t resolve = ecma_op_object_get_by_magic_id (ecma_get_object_from_value (capability),
                                                            LIT_INTERNAL_MAGIC_STRING_PROMISE_PROPERTY_RESOLVE);
-    ret = ecma_op_function_call (ecma_get_object_from_value (resolve),
-                                 ECMA_VALUE_UNDEFINED,
-                                 &values_array,
-                                 1);
+
+    ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (resolve),
+                                                             ECMA_VALUE_UNDEFINED,
+                                                             &values_array,
+                                                             1);
+    ret = ecma_op_function_call (&call_args);
     ecma_free_value (resolve);
   }
 
@@ -372,10 +376,12 @@ ecma_builtin_promise_perform_all (ecma_value_t iterator, /**< iteratorRecord */
         /* 2. */
         ecma_value_t resolve = ecma_op_object_get_by_magic_id (capability_obj_p,
                                                                LIT_INTERNAL_MAGIC_STRING_PROMISE_PROPERTY_RESOLVE);
-        ecma_value_t resolve_result = ecma_op_function_call (ecma_get_object_from_value (resolve),
-                                                             ECMA_VALUE_UNDEFINED,
-                                                             &values_array,
-                                                             1);
+
+        ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (resolve),
+                                                                 ECMA_VALUE_UNDEFINED,
+                                                                 &values_array,
+                                                                 1);
+        ecma_value_t resolve_result = ecma_op_function_call (&call_args);
         ecma_free_value (resolve);
 
         /* 3. */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -304,7 +304,9 @@ ecma_builtin_string_prototype_object_match (ecma_value_t this_argument, /**< thi
     {
       /* 3.c.i */
       ecma_object_t *matcher_method = ecma_get_object_from_value (matcher);
-      ecma_value_t result = ecma_op_function_call (matcher_method, regexp_arg, &this_argument, 1);
+
+      ecma_call_args_t call_args = ecma_op_function_make_args (matcher_method, regexp_arg, &this_argument, 1);
+      ecma_value_t result = ecma_op_function_call (&call_args);
       ecma_deref_object (matcher_method);
       return result;
     }
@@ -415,7 +417,9 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_value, /**< this
       ecma_object_t *replace_method = ecma_get_object_from_value (replace_symbol);
 
       ecma_value_t arguments[] = { this_value, replace_value };
-      ecma_value_t replace_result = ecma_op_function_call (replace_method, search_value, arguments, 2);
+
+      ecma_call_args_t call_args = ecma_op_function_make_args (replace_method, search_value, arguments, 2);
+      ecma_value_t replace_result = ecma_op_function_call (&call_args);
 
       ecma_deref_object (replace_method);
       return replace_result;
@@ -496,10 +500,8 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_value, /**< this
             ecma_make_string_value (input_str_p)
           };
 
-          result = ecma_op_function_call (function_p,
-                                          ECMA_VALUE_UNDEFINED,
-                                          args,
-                                          3);
+          ecma_call_args_t call_args = ecma_op_function_make_args (function_p, ECMA_VALUE_UNDEFINED, args, 3);
+          result = ecma_op_function_call (&call_args);
 
           if (ECMA_IS_VALUE_ERROR (result))
           {
@@ -602,7 +604,9 @@ ecma_builtin_string_prototype_object_search (ecma_value_t this_value, /**< this 
       }
 
       ecma_object_t *search_method = ecma_get_object_from_value (search_symbol);
-      ecma_value_t search_result = ecma_op_function_call (search_method, regexp_value, &this_value, 1);
+
+      ecma_call_args_t call_args = ecma_op_function_make_args (search_method, regexp_value, &this_value, 1);
+      ecma_value_t search_result = ecma_op_function_call (&call_args);
 
       ecma_deref_object (search_method);
       return search_result;
@@ -753,7 +757,9 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_value, /**< this a
       ecma_object_t *split_method_p = ecma_get_object_from_value (split_symbol);
 
       ecma_value_t arguments[] = { this_value, limit_value };
-      ecma_value_t split_result = ecma_op_function_call (split_method_p, separator_value, arguments, 2);
+
+      ecma_call_args_t call_args = ecma_op_function_make_args (split_method_p, separator_value, arguments, 2);
+      ecma_value_t split_result = ecma_op_function_call (&call_args);
 
       ecma_deref_object (split_method_p);
       return split_result;

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -82,8 +82,7 @@ typedef enum
 void ecma_finalize_builtins (void);
 
 ecma_value_t
-ecma_builtin_dispatch_call (ecma_object_t *obj_p, ecma_value_t this_arg_value,
-                            const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+ecma_builtin_dispatch_call (ecma_call_args_t *call_args_p);
 ecma_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *obj_p, ecma_object_t *new_target_p,
                                  const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -222,9 +222,9 @@ ecma_builtin_typedarray_prototype_exec_routine (ecma_value_t this_arg, /**< this
     ecma_number_t element_num = typedarray_getter_cb (info.buffer_p + byte_pos);
     ecma_value_t get_value = ecma_make_number_value (element_num);
 
-    ecma_value_t call_args[] = { get_value, current_index, this_arg };
-
-    ecma_value_t call_value = ecma_op_function_call (func_object_p, cb_this_arg, call_args, 3);
+    ecma_value_t args[] = { get_value, current_index, this_arg };
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, cb_this_arg, args, 3);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
 
     ecma_fast_free_value (current_index);
     ecma_fast_free_value (get_value);
@@ -466,9 +466,10 @@ ecma_builtin_typedarray_prototype_map (ecma_value_t this_arg, /**< this argument
     ecma_value_t current_index = ecma_make_uint32_value (index);
     ecma_number_t element_num = src_typedarray_getter_cb (src_info.buffer_p + src_byte_pos);
     ecma_value_t get_value = ecma_make_number_value (element_num);
-    ecma_value_t call_args[] = { get_value, current_index, this_arg };
+    ecma_value_t args[] = { get_value, current_index, this_arg };
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, cb_this_arg, args, 3);
+    ecma_value_t mapped_value = ecma_op_function_call (&call_args);
 
-    ecma_value_t mapped_value = ecma_op_function_call (func_object_p, cb_this_arg, call_args, 3);
     if (ECMA_IS_VALUE_ERROR (mapped_value))
     {
       ecma_free_value (current_index);
@@ -593,14 +594,12 @@ ecma_builtin_typedarray_prototype_reduce_with_direction (ecma_value_t this_arg, 
     ecma_number_t get_num = getter_cb (info.buffer_p + byte_pos);
     ecma_value_t get_value = ecma_make_number_value (get_num);
 
-    ecma_value_t call_args[] = { accumulator, get_value, current_index, this_arg };
+    ecma_value_t args[] = { accumulator, get_value, current_index, this_arg };
 
     JERRY_ASSERT (ecma_is_value_number (get_value));
 
-    ecma_value_t call_value = ecma_op_function_call (func_object_p,
-                                                     ECMA_VALUE_UNDEFINED,
-                                                     call_args,
-                                                     4);
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, ECMA_VALUE_UNDEFINED, args, 4);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
 
     ecma_fast_free_value (accumulator);
     ecma_fast_free_value (get_value);
@@ -727,9 +726,9 @@ ecma_builtin_typedarray_prototype_filter (ecma_value_t this_arg, /**< this argum
 
     JERRY_ASSERT (ecma_is_value_number (get_value));
 
-    ecma_value_t call_args[] = { get_value, current_index, this_arg };
-
-    ecma_value_t call_value = ecma_op_function_call (func_object_p, cb_this_arg, call_args, 3);
+    ecma_value_t args[] = { get_value, current_index, this_arg };
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, cb_this_arg, args, 3);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
 
     ecma_fast_free_value (current_index);
     ecma_fast_free_value (get_value);
@@ -1220,7 +1219,8 @@ ecma_builtin_typedarray_prototype_object_to_string (ecma_value_t this_arg) /**< 
     /* 4. */
     ecma_object_t *join_func_obj_p = ecma_get_object_from_value (join_value);
 
-    ret_value = ecma_op_function_call (join_func_obj_p, this_arg, NULL, 0);
+    ecma_call_args_t call_args = ecma_op_function_make_args (join_func_obj_p, this_arg, NULL, 0);
+    ret_value = ecma_op_function_call (&call_args);
   }
 
   ecma_free_value (join_value);
@@ -1440,11 +1440,8 @@ ecma_builtin_typedarray_prototype_sort_compare_helper (ecma_value_t lhs, /**< le
   ecma_object_t *comparefn_obj_p = ecma_get_object_from_value (compare_func);
 
   ecma_value_t compare_args[] = { lhs, rhs };
-
-  ecma_value_t call_value = ecma_op_function_call (comparefn_obj_p,
-                                                   ECMA_VALUE_UNDEFINED,
-                                                   compare_args,
-                                                   2);
+  ecma_call_args_t call_args = ecma_op_function_make_args (comparefn_obj_p, ECMA_VALUE_UNDEFINED, compare_args, 2);
+  ecma_value_t call_value = ecma_op_function_call (&call_args);
 
   if (ECMA_IS_VALUE_ERROR (call_value) || ecma_is_value_number (call_value))
   {
@@ -1617,9 +1614,9 @@ ecma_builtin_typedarray_prototype_find_helper (ecma_value_t this_arg, /**< this 
     ecma_number_t element_num = typedarray_getter_cb (info.buffer_p + byte_index);
     ecma_value_t element_value = ecma_make_number_value (element_num);
 
-    ecma_value_t call_args[] = { element_value, ecma_make_uint32_value (buffer_index), this_arg };
-
-    ecma_value_t call_value = ecma_op_function_call (func_object_p, predicate_this_arg, call_args, 3);
+    ecma_value_t args[] = { element_value, ecma_make_uint32_value (buffer_index), this_arg };
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, predicate_this_arg, args, 3);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
 
     if (ECMA_IS_VALUE_ERROR (call_value))
     {
@@ -2032,10 +2029,8 @@ ecma_builtin_typedarray_prototype_to_locale_string_helper (ecma_object_t *this_o
   if (ecma_op_is_callable (func_value))
   {
     ecma_object_t *func_obj = ecma_get_object_from_value (func_value);
-    ecma_value_t call_value = ecma_op_function_call (func_obj,
-                                                     element_obj,
-                                                     NULL,
-                                                     0);
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_obj, element_obj, NULL, 0);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
 
     ecma_deref_object (func_obj);
 

--- a/jerry-core/ecma/operations/ecma-async-generator-object.c
+++ b/jerry-core/ecma/operations/ecma-async-generator-object.c
@@ -113,15 +113,18 @@ ecma_async_yield_call (ecma_value_t function, /**< function (takes reference) */
   ecma_value_t iterator = async_generator_object_p->frame_ctx.block_result;
   ecma_value_t result;
 
+  ecma_call_args_t call_args;
+
   if (argument == ECMA_VALUE_EMPTY)
   {
-    result = ecma_op_function_call (return_obj_p, iterator, NULL, 0);
+    call_args = ecma_op_function_make_args (return_obj_p, iterator, NULL, 0);
   }
   else
   {
-    result = ecma_op_function_call (return_obj_p, iterator, &argument, 1);
+    call_args = ecma_op_function_make_args (return_obj_p, iterator, &argument, 1);
   }
 
+  result = ecma_op_function_call (&call_args);
   ecma_deref_object (return_obj_p);
 
   if (ECMA_IS_VALUE_ERROR (result))

--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -475,10 +475,8 @@ ecma_op_container_create (const ecma_value_t *arguments_list_p, /**< arguments l
     if (lit_id == LIT_MAGIC_STRING_SET_UL || lit_id == LIT_MAGIC_STRING_WEAKSET_UL)
     {
       const ecma_value_t value = result;
-
-      ecma_value_t arguments[] = { value };
-      result = ecma_op_function_call (adder_func_p, set_value, arguments, 1);
-
+      ecma_call_args_t call_args = ecma_op_function_make_args (adder_func_p, set_value, &value, 1);
+      result = ecma_op_function_call (&call_args);
       ecma_free_value (value);
     }
     else
@@ -517,7 +515,9 @@ ecma_op_container_create (const ecma_value_t *arguments_list_p, /**< arguments l
 
       const ecma_value_t value = result;
       ecma_value_t arguments[] = { key, value };
-      result = ecma_op_function_call (adder_func_p, set_value, arguments, 2);
+
+      ecma_call_args_t call_args = ecma_op_function_make_args (adder_func_p, set_value, arguments, 2);
+      result = ecma_op_function_call (&call_args);
 
       ecma_free_value (key);
       ecma_free_value (value);
@@ -824,8 +824,9 @@ ecma_op_container_foreach (ecma_extended_object_t *map_object_p, /**< map object
     ecma_value_t value_arg = ecma_op_container_get_value (entry_p, lit_id);
 
     ecma_value_t this_arg = ecma_make_object_value ((ecma_object_t *) map_object_p);
-    ecma_value_t call_args[] = { value_arg, key_arg, this_arg };
-    ecma_value_t call_value = ecma_op_function_call (func_object_p, predicate_this_arg, call_args, 3);
+    ecma_value_t args[] = { value_arg, key_arg, this_arg };
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, predicate_this_arg, args, 3);
+    ecma_value_t call_value = ecma_op_function_call (&call_args);
 
     if (ECMA_IS_VALUE_ERROR (call_value))
     {

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -70,9 +70,12 @@ ecma_op_get_prototype_from_constructor (ecma_object_t *ctor_obj_p, ecma_builtin_
 ecma_value_t
 ecma_op_function_has_instance (ecma_object_t *func_obj_p, ecma_value_t value);
 
+ecma_call_args_t
+ecma_op_function_make_args (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
+                               const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+
 ecma_value_t
-ecma_op_function_call (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
-                       const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+ecma_op_function_call (ecma_call_args_t *call_args_p);
 
 ecma_value_t
 ecma_op_function_construct (ecma_object_t *func_obj_p, ecma_object_t *new_target_p,

--- a/jerry-core/ecma/operations/ecma-iterator-object.c
+++ b/jerry-core/ecma/operations/ecma-iterator-object.c
@@ -223,7 +223,8 @@ ecma_op_get_iterator (ecma_value_t value, /**< value to get iterator from */
   }
 
   ecma_object_t *method_obj_p = ecma_get_object_from_value (method);
-  ecma_value_t iterator = ecma_op_function_call (method_obj_p, value, NULL, 0);
+  ecma_call_args_t call_args = ecma_op_function_make_args (method_obj_p, value, NULL, 0);
+  ecma_value_t iterator = ecma_op_function_call (&call_args);
 
   if (use_default_method)
   {
@@ -304,16 +305,18 @@ ecma_op_iterator_next_old (ecma_value_t iterator, /**< iterator value */
   ecma_object_t *next_obj_p = ecma_get_object_from_value (func_next);
 
   bool has_value = !ecma_is_value_empty (value);
+  ecma_call_args_t call_args;
 
-  ecma_value_t result;
   if (has_value)
   {
-    result = ecma_op_function_call (next_obj_p, iterator, &value, 1);
+    call_args = ecma_op_function_make_args (next_obj_p, iterator, &value, 1);
   }
   else
   {
-    result = ecma_op_function_call (next_obj_p, iterator, NULL, 0);
+    call_args = ecma_op_function_make_args (next_obj_p, iterator, NULL, 0);
   }
+
+  ecma_value_t result = ecma_op_function_call (&call_args);
 
   ecma_free_value (func_next);
 
@@ -349,12 +352,18 @@ ecma_op_iterator_next (ecma_value_t iterator, /**< iterator value */
 
   bool has_value = !ecma_is_value_empty (value);
 
+  ecma_call_args_t call_args;
+
   if (has_value)
   {
-    return ecma_op_function_call (next_method_obj_p, iterator, &value, 1);
+    call_args = ecma_op_function_make_args (next_method_obj_p, iterator, &value, 1);
+  }
+  else
+  {
+    call_args = ecma_op_function_make_args (next_method_obj_p, iterator, NULL, 0);
   }
 
-  return ecma_op_function_call (next_method_obj_p, iterator, NULL, 0);
+  return ecma_op_function_call (&call_args);
 } /* ecma_op_iterator_next */
 
 /**
@@ -395,7 +404,8 @@ ecma_op_iterator_return (ecma_value_t iterator, /**< iterator value */
 
   ecma_object_t *return_obj_p = ecma_get_object_from_value (func_return);
 
-  ecma_value_t result = ecma_op_function_call (return_obj_p, iterator, &value, 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (return_obj_p, iterator, &value, 1);
+  ecma_value_t result = ecma_op_function_call (&call_args);
   ecma_free_value (func_return);
 
   return result;
@@ -446,8 +456,8 @@ ecma_op_iterator_throw (ecma_value_t iterator, /**< iterator value */
   }
 
   ecma_object_t *return_obj_p = ecma_get_object_from_value (func_throw);
-
-  ecma_value_t result = ecma_op_function_call (return_obj_p, iterator, &value, 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (return_obj_p, iterator, &value, 1);
+  ecma_value_t result = ecma_op_function_call (&call_args);
   ecma_free_value (func_throw);
 
   return result;
@@ -521,7 +531,8 @@ ecma_op_iterator_close (ecma_value_t iterator) /**< iterator value */
 
   /* 6. */
   ecma_object_t *return_obj_p = ecma_get_object_from_value (return_method);
-  ecma_value_t inner_result = ecma_op_function_call (return_obj_p, iterator, NULL, 0);
+  ecma_call_args_t call_args = ecma_op_function_make_args (return_obj_p, iterator, NULL, 0);
+  ecma_value_t inner_result = ecma_op_function_call (&call_args);
   ecma_deref_object (return_obj_p);
 
   /* 7. */

--- a/jerry-core/ecma/operations/ecma-jobqueue.c
+++ b/jerry-core/ecma/operations/ecma-jobqueue.c
@@ -201,10 +201,11 @@ ecma_process_promise_reaction_job (ecma_job_promise_reaction_t *job_p) /**< the 
   else
   {
     /* 6. */
-    handler_result = ecma_op_function_call (ecma_get_object_from_value (handler),
-                                            ECMA_VALUE_UNDEFINED,
-                                            &(job_p->argument),
-                                            1);
+    ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (handler),
+                                                             ECMA_VALUE_UNDEFINED,
+                                                             &(job_p->argument),
+                                                             1);
+    handler_result = ecma_op_function_call (&call_args);
   }
 
   ecma_value_t status;
@@ -221,10 +222,11 @@ ecma_process_promise_reaction_job (ecma_job_promise_reaction_t *job_p) /**< the 
 
     JERRY_ASSERT (ecma_op_is_callable (reject));
 
-    status = ecma_op_function_call (ecma_get_object_from_value (reject),
-                                    ECMA_VALUE_UNDEFINED,
-                                    &handler_result,
-                                    1);
+    ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (reject),
+                                                             ECMA_VALUE_UNDEFINED,
+                                                             &handler_result,
+                                                             1);
+    status = ecma_op_function_call (&call_args);
     ecma_free_value (reject);
   }
   else
@@ -234,10 +236,11 @@ ecma_process_promise_reaction_job (ecma_job_promise_reaction_t *job_p) /**< the 
 
     JERRY_ASSERT (ecma_op_is_callable (resolve));
 
-    status = ecma_op_function_call (ecma_get_object_from_value (resolve),
-                                    ECMA_VALUE_UNDEFINED,
-                                    &handler_result,
-                                    1);
+    ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (resolve),
+                                                             ECMA_VALUE_UNDEFINED,
+                                                             &handler_result,
+                                                             1);
+    status = ecma_op_function_call (&call_args);
     ecma_free_value (resolve);
   }
 
@@ -388,22 +391,22 @@ ecma_process_promise_resolve_thenable_job (ecma_job_promise_resolve_thenable_t *
 
   ecma_value_t argv[] = { funcs.resolve, funcs.reject };
   ecma_value_t ret;
-  ecma_value_t then_call_result = ecma_op_function_call (ecma_get_object_from_value (job_p->then),
-                                                         job_p->thenable,
-                                                         argv,
-                                                         2);
-
+  ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (job_p->then),
+                                                           job_p->thenable,
+                                                           argv,
+                                                           2);
+  ecma_value_t then_call_result = ecma_op_function_call (&call_args);
   ret = then_call_result;
 
   if (ECMA_IS_VALUE_ERROR (then_call_result))
   {
     then_call_result = jcontext_take_exception ();
 
-    ret = ecma_op_function_call (ecma_get_object_from_value (funcs.reject),
-                                 ECMA_VALUE_UNDEFINED,
-                                 &then_call_result,
-                                 1);
-
+    call_args = ecma_op_function_make_args (ecma_get_object_from_value (funcs.reject),
+                                            ECMA_VALUE_UNDEFINED,
+                                            &then_call_result,
+                                            1);
+    ret = ecma_op_function_call (&call_args);
     ecma_free_value (then_call_result);
   }
 

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -40,12 +40,11 @@
  * See also: ECMA-262 v5, 10.6
  */
 void
-ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function */
+ecma_op_create_arguments_object (const ecma_compiled_code_t *bytecode_data_p, /**< byte code */
                                  ecma_object_t *lex_env_p, /**< lexical environment the Arguments
                                                                 object is created for */
-                                 const ecma_value_t *arguments_list_p, /**< arguments list */
-                                 ecma_length_t arguments_number, /**< length of arguments list */
-                                 const ecma_compiled_code_t *bytecode_data_p) /**< byte code */
+                                 ecma_call_args_t *call_args_p) /**< call arguments */
+
 {
   bool is_strict = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE) != 0;
 
@@ -69,7 +68,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   ecma_object_t *obj_p;
 
   if ((bytecode_data_p->status_flags & CBC_CODE_FLAGS_MAPPED_ARGUMENTS_NEEDED)
-      && arguments_number > 0
+      && call_args_p->argc > 0
       && formal_params_number > 0)
   {
     size_t formal_params_size = formal_params_number * sizeof (ecma_value_t);
@@ -114,9 +113,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   ecma_property_value_t *prop_value_p;
 
   /* 11.a, 11.b */
-  for (ecma_length_t index = 0;
-       index < arguments_number;
-       index++)
+  for (ecma_length_t index = 0; index < call_args_p->argc; index++)
   {
     ecma_string_t *index_string_p = ecma_new_ecma_string_from_uint32 (index);
 
@@ -125,7 +122,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                     ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE,
                                                     NULL);
 
-    prop_value_p->value = ecma_copy_value_if_not_object (arguments_list_p[index]);
+    prop_value_p->value = ecma_copy_value_if_not_object (call_args_p->argv[index]);
 
     ecma_deref_ecma_string (index_string_p);
   }
@@ -136,7 +133,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                   ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                   NULL);
 
-  prop_value_p->value = ecma_make_uint32_value (arguments_number);
+  prop_value_p->value = ecma_make_uint32_value (call_args_p->argc);
 
   ecma_property_descriptor_t prop_desc = ecma_make_empty_property_descriptor ();
 
@@ -164,7 +161,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                                     ECMA_PROPERTY_CONFIGURABLE_WRITABLE,
                                                     NULL);
 
-    prop_value_p->value = ecma_make_object_value (func_obj_p);
+    prop_value_p->value = ecma_make_object_value (call_args_p->func_obj_p);
   }
   else
   {

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -20,9 +20,8 @@
 #include "ecma-helpers.h"
 
 void
-ecma_op_create_arguments_object (ecma_object_t *func_obj_p, ecma_object_t *lex_env_p,
-                                 const ecma_value_t *arguments_list_p, ecma_length_t arguments_number,
-                                 const ecma_compiled_code_t *bytecode_data_p);
+ecma_op_create_arguments_object (const ecma_compiled_code_t *bytecode_data_p, ecma_object_t *lex_env_p,
+                                 ecma_call_args_t *call_args_p);
 
 ecma_value_t
 ecma_op_arguments_object_delete (ecma_object_t *object_p, ecma_string_t *property_name_p, bool is_throw);

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -248,10 +248,8 @@ ecma_op_general_object_default_value (ecma_object_t *obj_p, /**< the object */
     ecma_object_t *call_func_p = ecma_get_object_from_value (exotic_to_prim);
     ecma_value_t argument = ecma_make_magic_string_value (hints[hint]);
 
-    ecma_value_t result = ecma_op_function_call (call_func_p,
-                                                 obj_value,
-                                                 &argument,
-                                                 1);
+    ecma_call_args_t call_args = ecma_op_function_make_args (call_func_p, obj_value, &argument, 1);
+    ecma_value_t result = ecma_op_function_call (&call_args);
 
     ecma_free_value (exotic_to_prim);
 
@@ -321,10 +319,8 @@ ecma_op_general_object_ordinary_value (ecma_object_t *obj_p, /**< the object */
     {
       ecma_object_t *func_obj_p = ecma_get_object_from_value (function_value);
 
-      call_completion = ecma_op_function_call (func_obj_p,
-                                               ecma_make_object_value (obj_p),
-                                               NULL,
-                                               0);
+      ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, ecma_make_object_value (obj_p), NULL, 0);
+      call_completion = ecma_op_function_call (&call_args);
     }
 
     ecma_free_value (function_value);

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -666,8 +666,9 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
   }
 
   ecma_object_t *getter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, get_set_pair_p->getter_cp);
+  ecma_call_args_t call_args = ecma_op_function_make_args (getter_p, base_value, NULL, 0);
 
-  return ecma_op_function_call (getter_p, base_value, NULL, 0);
+  return ecma_op_function_call (&call_args);
 } /* ecma_op_object_find_own */
 
 /**
@@ -1586,10 +1587,9 @@ ecma_op_object_put_with_receiver (ecma_object_t *object_p, /**< the object */
     return ecma_reject (is_throw);
   }
 
-  ecma_value_t ret_value = ecma_op_function_call (ECMA_GET_NON_NULL_POINTER (ecma_object_t, setter_cp),
-                                                  receiver,
-                                                  &value,
-                                                  1);
+  ecma_object_t *setter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, setter_cp);
+  ecma_call_args_t call_args = ecma_op_function_make_args (setter_p, receiver, &value, 1);
+  ecma_value_t ret_value = ecma_op_function_call (&call_args);
 
   if (!ECMA_IS_VALUE_ERROR (ret_value))
   {
@@ -3096,7 +3096,9 @@ ecma_op_invoke (ecma_value_t object, /**< Object value */
   }
 
   ecma_object_t *func_obj_p = ecma_get_object_from_value (func);
-  ecma_value_t call_result = ecma_op_function_call (func_obj_p, this_arg, args_p, args_len);
+
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, this_arg, args_p, args_len);
+  ecma_value_t call_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (object_p);
   ecma_deref_object (func_obj_p);

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -556,10 +556,12 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
     JERRY_ASSERT (ecma_op_is_callable (executor));
 
     ecma_value_t argv[] = { funcs.resolve, funcs.reject };
-    completion = ecma_op_function_call (ecma_get_object_from_value (executor),
-                                        ECMA_VALUE_UNDEFINED,
-                                        argv,
-                                        2);
+
+    ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (executor),
+                                                             ECMA_VALUE_UNDEFINED,
+                                                             argv,
+                                                             2);
+    completion = ecma_op_function_call (&call_args);
   }
   else if (type == ECMA_PROMISE_EXECUTOR_OBJECT)
   {
@@ -581,10 +583,12 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
   {
     /* 10.a. */
     completion = jcontext_take_exception ();
-    status = ecma_op_function_call (ecma_get_object_from_value (funcs.reject),
-                                    ECMA_VALUE_UNDEFINED,
-                                    &completion,
-                                    1);
+
+    ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (funcs.reject),
+                                                             ECMA_VALUE_UNDEFINED,
+                                                             &completion,
+                                                             1);
+    status = ecma_op_function_call (&call_args);
   }
 
   ecma_promise_free_resolving_functions (&funcs);
@@ -808,10 +812,11 @@ ecma_promise_reject_or_resolve (ecma_value_t this_arg, /**< "this" argument */
 
   ecma_value_t func = ecma_op_object_get (ecma_get_object_from_value (capability), property_str_p);
 
-  ecma_value_t call_ret = ecma_op_function_call (ecma_get_object_from_value (func),
-                                                 ECMA_VALUE_UNDEFINED,
-                                                 &value,
-                                                 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (func),
+                                                           ECMA_VALUE_UNDEFINED,
+                                                           &value,
+                                                           1);
+  ecma_value_t call_ret = ecma_op_function_call (&call_args);
 
   ecma_free_value (func);
 

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -320,7 +320,8 @@ ecma_proxy_object_get_prototype_of (ecma_object_t *obj_p) /**< proxy object */
   ecma_object_t *func_obj_p = ecma_get_object_from_value (trap);
 
   /* 8. */
-  ecma_value_t handler_proto = ecma_op_function_call (func_obj_p, handler, &target, 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, &target, 1);
+  ecma_value_t handler_proto = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -433,7 +434,8 @@ ecma_proxy_object_set_prototype_of (ecma_object_t *obj_p, /**< proxy object */
   ecma_value_t args[] = { target, proto };
 
   /* 9. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 2);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, args, 2);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -528,7 +530,8 @@ ecma_proxy_object_is_extensible (ecma_object_t *obj_p) /**< proxy object */
   ecma_object_t *func_obj_p = ecma_get_object_from_value (trap);
 
   /* 8. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, &target, 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, &target, 1);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -621,7 +624,8 @@ ecma_proxy_object_prevent_extensions (ecma_object_t *obj_p) /**< proxy object */
   ecma_object_t *func_obj_p = ecma_get_object_from_value (trap);
 
   /* 8. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, &target, 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, &target, 1);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -702,7 +706,8 @@ ecma_proxy_object_get_own_property_descriptor (ecma_object_t *obj_p, /**< proxy 
   ecma_value_t args[] = { target, prop_value };
 
   /* 9. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 2);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, args, 2);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
   ecma_deref_object (func_obj_p);
 
   /* 10. */
@@ -883,7 +888,8 @@ ecma_proxy_object_define_own_property (ecma_object_t *obj_p, /**< proxy object *
   ecma_value_t args[] = {target, prop_value, desc_obj_value};
 
   /* 10. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 3);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, args, 3);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
   ecma_deref_object (desc_obj);
@@ -1025,7 +1031,8 @@ ecma_proxy_object_has (ecma_object_t *obj_p, /**< proxy object */
   ecma_value_t args[] = {target, prop_value};
 
   /* 9. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 2);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, args, 2);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -1129,7 +1136,8 @@ ecma_proxy_object_get (ecma_object_t *obj_p, /**< proxy object */
   ecma_value_t args[] = { target, prop_value, receiver };
 
   /* 9. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 3);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, args, 3);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -1234,7 +1242,8 @@ ecma_proxy_object_set (ecma_object_t *obj_p, /**< proxy object */
   ecma_value_t args[] = { target, prop_name_value, value, receiver };
 
   /* 9. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 4);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, args, 4);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -1344,7 +1353,8 @@ ecma_proxy_object_delete_property (ecma_object_t *obj_p, /**< proxy object */
   ecma_value_t args[] = { target, prop_name_value };
 
   /* 9. */
-  ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 2);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, args, 2);
+  ecma_value_t trap_result = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -1571,7 +1581,8 @@ ecma_proxy_object_own_property_keys (ecma_object_t *obj_p) /**< proxy object */
   ecma_object_t *func_obj_p = ecma_get_object_from_value (trap);
 
   /* 8. */
-  ecma_value_t trap_result_array = ecma_op_function_call (func_obj_p, handler, &target, 1);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, &target, 1);
+  ecma_value_t trap_result_array = ecma_op_function_call (&call_args);
 
   ecma_deref_object (func_obj_p);
 
@@ -1693,14 +1704,11 @@ free_target_collections:
  *         result of the function call - otherwise
  */
 ecma_value_t
-ecma_proxy_object_call (ecma_object_t *obj_p, /**< proxy object */
-                        ecma_value_t this_argument, /**< this argument to invoke the function */
-                        const ecma_value_t *args_p, /**< argument list */
-                        ecma_length_t argc) /**< number of arguments */
+ecma_proxy_object_call (ecma_call_args_t *call_args_p) /**< call arguments */
 {
-  JERRY_ASSERT (ECMA_OBJECT_IS_PROXY (obj_p));
+  JERRY_ASSERT (ECMA_OBJECT_IS_PROXY (call_args_p->func_obj_p));
 
-  ecma_proxy_object_t *proxy_obj_p = (ecma_proxy_object_t *) obj_p;
+  ecma_proxy_object_t *proxy_obj_p = (ecma_proxy_object_t *) call_args_p->func_obj_p;
 
   /* 1. */
   ecma_value_t handler = proxy_obj_p->handler;
@@ -1719,16 +1727,18 @@ ecma_proxy_object_call (ecma_object_t *obj_p, /**< proxy object */
   /* 7. */
   if (ecma_is_value_undefined (trap))
   {
-    ecma_object_t *target_obj_p = ecma_get_object_from_value (target);
-    return ecma_op_function_call (target_obj_p, this_argument, args_p, argc);
+    ecma_call_args_t call_args = *call_args_p;
+    call_args.func_obj_p = ecma_get_object_from_value (target);
+    return ecma_op_function_call (&call_args);
   }
 
   /* 8. */
-  ecma_value_t args_array = ecma_op_create_array_object (args_p, argc, false);
-  ecma_value_t value_array[] = {target, this_argument, args_array};
+  ecma_value_t args_array = ecma_op_create_array_object (call_args_p->argv, call_args_p->argc, false);
+  ecma_value_t value_array[] = {target, call_args_p->this_value, args_array};
   ecma_object_t *func_obj_p = ecma_get_object_from_value (trap);
   /* 9. */
-  ecma_value_t ret_value = ecma_op_function_call (func_obj_p, handler, value_array, 3);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, value_array, 3);
+  ecma_value_t ret_value = ecma_op_function_call (&call_args);
   ecma_deref_object (func_obj_p);
   ecma_deref_object (ecma_get_object_from_value (args_array));
 
@@ -1787,7 +1797,8 @@ ecma_proxy_object_construct (ecma_object_t *obj_p, /**< proxy object */
   ecma_value_t function_call_args[] = {target, arg_array, new_target_value};
 
   /* 9. */
-  ecma_value_t new_obj = ecma_op_function_call (func_obj_p, handler, function_call_args, 3);
+  ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p, handler, function_call_args, 3);
+  ecma_value_t new_obj = ecma_op_function_call (&call_args);
 
   ecma_free_value (arg_array);
   ecma_deref_object (func_obj_p);

--- a/jerry-core/ecma/operations/ecma-proxy-object.h
+++ b/jerry-core/ecma/operations/ecma-proxy-object.h
@@ -99,10 +99,7 @@ ecma_collection_t *
 ecma_proxy_object_own_property_keys (ecma_object_t *obj_p);
 
 ecma_value_t
-ecma_proxy_object_call (ecma_object_t *obj_p,
-                        ecma_value_t this_argument,
-                        const ecma_value_t *args_p,
-                        ecma_length_t argc);
+ecma_proxy_object_call (ecma_call_args_t *call_args_p);
 
 ecma_value_t
 ecma_proxy_object_construct (ecma_object_t *obj_p,

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -329,7 +329,8 @@ ecma_op_resolve_reference_value (ecma_object_t *lex_env_p, /**< starting lexical
           ecma_object_t *getter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, get_set_pair_p->getter_cp);
 
           ecma_value_t base_value = ecma_make_object_value (binding_obj_p);
-          return ecma_op_function_call (getter_p, base_value, NULL, 0);
+          ecma_call_args_t call_args = ecma_op_function_make_args (getter_p, base_value, NULL, 0);
+          return ecma_op_function_call (&call_args);
         }
 #endif /* ENABLED (JERRY_LCACHE) */
       }

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -2589,12 +2589,11 @@ ecma_regexp_replace_helper_fast (ecma_replace_context_t *ctx_p, /**<replace cont
         ecma_ref_ecma_string (string_p);
         ecma_collection_push_back (arguments_p, ecma_make_string_value (string_p));
         ecma_object_t *function_p = ecma_get_object_from_value (replace_arg);
-
-        result = ecma_op_function_call (function_p,
-                                        ECMA_VALUE_UNDEFINED,
-                                        arguments_p->buffer_p,
-                                        arguments_p->item_count);
-
+        ecma_call_args_t call_args = ecma_op_function_make_args (function_p,
+                                                                 ECMA_VALUE_UNDEFINED,
+                                                                 arguments_p->buffer_p,
+                                                                 arguments_p->item_count);
+        result = ecma_op_function_call (&call_args);
         ecma_collection_free (arguments_p);
 
         if (ECMA_IS_VALUE_ERROR (result))
@@ -2852,7 +2851,8 @@ ecma_regexp_replace_helper (ecma_value_t this_arg, /**< this argument */
       ecma_object_t *const function_p = ecma_get_object_from_value (result);
 
       ecma_value_t arguments[] = { ecma_make_string_value (string_p) };
-      result = ecma_op_function_call (function_p, this_arg, arguments, 1);
+      ecma_call_args_t call_args = ecma_op_function_make_args (function_p, this_arg, arguments, 1);
+      result = ecma_op_function_call (&call_args);
 
       ecma_deref_object (function_p);
 
@@ -3124,11 +3124,11 @@ ecma_regexp_replace_helper (ecma_value_t this_arg, /**< this argument */
       ecma_ref_ecma_string (string_p);
       ecma_collection_push_back (arguments_p, ecma_make_string_value (string_p));
 
-      result = ecma_op_function_call (ecma_get_object_from_value (replace_arg),
-                                      ECMA_VALUE_UNDEFINED,
-                                      arguments_p->buffer_p,
-                                      arguments_p->item_count);
-
+      ecma_call_args_t call_args = ecma_op_function_make_args (ecma_get_object_from_value (replace_arg),
+                                                               ECMA_VALUE_UNDEFINED,
+                                                               arguments_p->buffer_p,
+                                                               arguments_p->item_count);
+      result = ecma_op_function_call (&call_args);
       ecma_collection_free (arguments_p);
 
       if (ECMA_IS_VALUE_ERROR (result))
@@ -3415,7 +3415,8 @@ ecma_op_regexp_exec (ecma_value_t this_arg, /**< this argument */
     ecma_object_t *function_p = ecma_get_object_from_value (exec);
     ecma_value_t arguments[] = { ecma_make_string_value (str_p) };
 
-    ecma_value_t result = ecma_op_function_call (function_p, this_arg, arguments, 1);
+    ecma_call_args_t call_args = ecma_op_function_make_args (function_p, this_arg, arguments, 1);
+    ecma_value_t result = ecma_op_function_call (&call_args);
 
     ecma_deref_object (function_p);
 

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -700,9 +700,9 @@ ecma_op_typedarray_from_helper (ecma_value_t this_val, /**< this_arg for the abo
   {
     /* 17.d 17.f */
     ecma_value_t current_index = ecma_make_uint32_value (index);
-    ecma_value_t call_args[] = { current_value, current_index };
-
-    ecma_value_t cb_value = ecma_op_function_call (func_object_p, this_val, call_args, 2);
+    ecma_value_t args[] = { current_value, current_index };
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_object_p, this_val, args, 2);
+    ecma_value_t cb_value = ecma_op_function_call (&call_args);
 
     ecma_free_value (current_index);
     ecma_free_value (current_value);

--- a/jerry-core/vm/opcodes-ecma-relational-equality.c
+++ b/jerry-core/vm/opcodes-ecma-relational-equality.c
@@ -120,7 +120,8 @@ opfunc_instanceof (ecma_value_t left_value, /**< left value */
   if (JERRY_UNLIKELY (!ecma_is_value_undefined (has_instance_method)))
   {
     ecma_object_t *method_obj_p = ecma_get_object_from_value (has_instance_method);
-    ecma_value_t has_instance_result = ecma_op_function_call (method_obj_p, right_value, &left_value, 1);
+    ecma_call_args_t call_args = ecma_op_function_make_args (method_obj_p, right_value, &left_value, 1);
+    ecma_value_t has_instance_result = ecma_op_function_call (&call_args);
 
     ecma_free_value (has_instance_method);
 

--- a/jerry-core/vm/vm-stack.c
+++ b/jerry-core/vm/vm-stack.c
@@ -336,7 +336,8 @@ vm_stack_find_finally (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
         else
         {
           ecma_object_t *return_obj_p = ecma_get_object_from_value (result);
-          result = ecma_op_function_call (return_obj_p, iterator, NULL, 0);
+          ecma_call_args_t call_args = ecma_op_function_make_args (return_obj_p, iterator, NULL, 0);
+          result = ecma_op_function_call (&call_args);
           ecma_deref_object (return_obj_p);
 
           if (context_type == VM_CONTEXT_FOR_AWAIT_OF && !ECMA_IS_VALUE_ERROR (result))

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -285,11 +285,9 @@ vm_run_module (const ecma_compiled_code_t *bytecode_p, /**< pointer to bytecode 
     return module_init_result;
   }
 
-  return vm_run (bytecode_p,
-                 ECMA_VALUE_UNDEFINED,
-                 lex_env_p,
-                 NULL,
-                 0);
+  ecma_call_args_t call_args = ecma_op_function_make_args (NULL, ECMA_VALUE_UNDEFINED, NULL, 0);
+
+  return vm_run (bytecode_p, lex_env_p, &call_args);
 } /* vm_run_module */
 #endif /* ENABLED (JERRY_MODULE_SYSTEM) */
 
@@ -336,11 +334,9 @@ vm_run_global (const ecma_compiled_code_t *bytecode_p) /**< pointer to bytecode 
   }
 #endif /* ENABLED (JERRY_MODULE_SYSTEM) */
 
-  return vm_run (bytecode_p,
-                 ecma_make_object_value (glob_obj_p),
-                 global_scope_p,
-                 NULL,
-                 0);
+  ecma_call_args_t call_args = ecma_op_function_make_args (glob_obj_p, ecma_make_object_value (glob_obj_p), NULL, 0);
+
+  return vm_run (bytecode_p, global_scope_p, &call_args);
 } /* vm_run_global */
 
 /**
@@ -354,12 +350,14 @@ vm_run_eval (ecma_compiled_code_t *bytecode_data_p, /**< byte-code data */
 {
   ecma_value_t this_binding;
   ecma_object_t *lex_env_p;
+  ecma_value_t *argv = NULL;
 
   /* ECMA-262 v5, 10.4.2 */
   if (parse_opts & ECMA_PARSE_DIRECT_EVAL)
   {
     this_binding = ecma_copy_value (JERRY_CONTEXT (vm_top_context_p)->this_binding);
     lex_env_p = JERRY_CONTEXT (vm_top_context_p)->lex_env_p;
+    argv = VM_DIRECT_EVAL;
 
 #if ENABLED (JERRY_DEBUGGER)
     uint32_t chain_index = parse_opts >> ECMA_PARSE_CHAIN_INDEX_SHIFT;
@@ -409,11 +407,9 @@ vm_run_eval (ecma_compiled_code_t *bytecode_data_p, /**< byte-code data */
     lex_env_p = lex_block_p;
   }
 
-  ecma_value_t completion_value = vm_run (bytecode_data_p,
-                                          this_binding,
-                                          lex_env_p,
-                                          (parse_opts & ECMA_PARSE_DIRECT_EVAL) ? VM_DIRECT_EVAL : NULL,
-                                          0);
+  ecma_call_args_t call_args = ecma_op_function_make_args (NULL, this_binding, argv, 0);
+
+  ecma_value_t completion_value = vm_run (bytecode_data_p, lex_env_p, &call_args);
 
   ecma_deref_object (lex_env_p);
   ecma_free_value (this_binding);
@@ -690,11 +686,11 @@ vm_spread_operation (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
     else
     {
       ecma_object_t *func_obj_p = ecma_get_object_from_value (func_value);
-
-      completion_value = ecma_op_function_call (func_obj_p,
-                                                this_value,
-                                                collection_p->buffer_p,
-                                                collection_p->item_count);
+      ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p,
+                                                               this_value,
+                                                               collection_p->buffer_p,
+                                                               collection_p->item_count);
+      completion_value = ecma_op_function_call (&call_args);
     }
 
     if (is_call_prop)
@@ -774,11 +770,11 @@ opfunc_call (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
   else
   {
     ecma_object_t *func_obj_p = ecma_get_object_from_value (func_value);
-
-    completion_value = ecma_op_function_call (func_obj_p,
-                                              this_value,
-                                              stack_top_p,
-                                              arguments_list_len);
+    ecma_call_args_t call_args = ecma_op_function_make_args (func_obj_p,
+                                                             this_value,
+                                                             stack_top_p,
+                                                             arguments_list_len);
+    completion_value = ecma_op_function_call (&call_args);
   }
 
   JERRY_CONTEXT (status_flags) &= (uint32_t) ~ECMA_STATUS_DIRECT_EVAL;
@@ -4642,6 +4638,7 @@ vm_init_exec (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
   }
 
 #if ENABLED (JERRY_ESNEXT)
+  /* [[TODO]]: Emit bytecode for rest parameter creation */
   if (bytecode_header_p->status_flags & CBC_CODE_FLAGS_REST_PARAMETER)
   {
     JERRY_ASSERT (function_call_argument_count >= arg_list_len);
@@ -4743,10 +4740,8 @@ vm_execute (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
  */
 ecma_value_t
 vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data header */
-        ecma_value_t this_binding_value, /**< value of 'ThisBinding' */
         ecma_object_t *lex_env_p, /**< lexical environment to use */
-        const ecma_value_t *arg_list_p, /**< arguments list */
-        ecma_length_t arg_list_len) /**< length of arguments list */
+        ecma_call_args_t *call_args_p) /**< call arguments */
 {
   vm_frame_ctx_t *frame_ctx_p;
   size_t frame_size;
@@ -4772,9 +4767,10 @@ vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data heade
 
   frame_ctx_p->bytecode_header_p = bytecode_header_p;
   frame_ctx_p->lex_env_p = lex_env_p;
-  frame_ctx_p->this_binding = this_binding_value;
+  /* [[TODO]]: Store call args instead of only the this binding */
+  frame_ctx_p->this_binding = call_args_p->this_value;
 
-  vm_init_exec (frame_ctx_p, arg_list_p, arg_list_len);
+  vm_init_exec (frame_ctx_p, call_args_p->argv, call_args_p->argc);
   return vm_execute (frame_ctx_p);
 } /* vm_run */
 

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -453,8 +453,8 @@ ecma_value_t vm_run_eval (ecma_compiled_code_t *bytecode_data_p, uint32_t parse_
 ecma_value_t vm_run_module (const ecma_compiled_code_t *bytecode_p, ecma_object_t *lex_env_p);
 #endif /* ENABLED (JERRY_MODULE_SYSTEM) */
 
-ecma_value_t vm_run (const ecma_compiled_code_t *bytecode_header_p, ecma_value_t this_binding_value,
-                     ecma_object_t *lex_env_p, const ecma_value_t *arg_list_p, ecma_length_t arg_list_len);
+ecma_value_t vm_run (const ecma_compiled_code_t *bytecode_header_p, ecma_object_t *lex_env_p,
+                     ecma_call_args_t *call_args_p);
 ecma_value_t vm_execute (vm_frame_ctx_t *frame_ctx_p);
 
 bool vm_is_strict_mode (void);


### PR DESCRIPTION
This patch is the first step of incoming changes about function call/construct arguments passing on the C stack.
The patch contains several [[TODO]] comments which are going to be resolved in upcoming PRs.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
