### PR TITLE
LEXER_ASSIGN_GROUP_EXPR should not be emitted when parsing LHS expression

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -3487,7 +3487,8 @@ parser_process_group_expression (parser_context_t *context_p, /**< context */
   if (JERRY_UNLIKELY (context_p->token.type == LEXER_ASSIGN
                       && PARSER_IS_PUSH_LITERALS_WITH_THIS (context_p->last_cbc_opcode)
                       && context_p->last_cbc.literal_type == LEXER_IDENT_LITERAL
-                      && parser_is_assignment_expr (context_p)))
+                      && parser_is_assignment_expr (context_p)
+                      && *grouping_level_p != PARSE_EXPR_LEFT_HAND_SIDE))
   {
     parser_stack_push_uint8 (context_p, LEXER_ASSIGN_GROUP_EXPR);
   }

--- a/tests/jerry/es.next/regression-test-issue-3935.js
+++ b/tests/jerry/es.next/regression-test-issue-3935.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const obj = {};
+var a = { a : (o) = 1 } = obj;
+
+assert (a === obj);
+assert (o === 1);


### PR DESCRIPTION
This patch fixes #3935.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu