### PR TITLE
Remove Proxy object [[Enumerable]] internal method

### DIFF
--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -1397,25 +1397,6 @@ ecma_proxy_object_delete_property (ecma_object_t *obj_p, /**< proxy object */
 } /* ecma_proxy_object_delete_property */
 
 /**
- * The Proxy object [[Enumerate]] internal routine
- *
- * See also:
- *          ECMAScript v6, 9.5.11
- *
- * Note: Returned value must be freed with ecma_free_value.
- *
- * @return ECMA_VALUE_ERROR - if the operation fails
- *         ecma-object - otherwise
- */
-ecma_value_t
-ecma_proxy_object_enumerate (ecma_object_t *obj_p) /**< proxy object */
-{
-  JERRY_ASSERT (ECMA_OBJECT_IS_PROXY (obj_p));
-  JERRY_UNUSED (obj_p);
-  return ecma_raise_type_error (ECMA_ERR_MSG ("UNIMPLEMENTED: Proxy.[[Enumerate]]"));
-} /* ecma_proxy_object_enumerate */
-
-/**
  * Helper method for the Proxy object [[OwnPropertyKeys]] operation
  *
  * See also:

--- a/jerry-core/ecma/operations/ecma-proxy-object.h
+++ b/jerry-core/ecma/operations/ecma-proxy-object.h
@@ -92,9 +92,6 @@ ecma_value_t
 ecma_proxy_object_delete_property (ecma_object_t *obj_p,
                                    ecma_string_t *prop_name_p);
 
-ecma_value_t
-ecma_proxy_object_enumerate (ecma_object_t *obj_p);
-
 ecma_collection_t *
 ecma_proxy_object_own_property_keys (ecma_object_t *obj_p);
 

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -340,6 +340,14 @@ opfunc_for_in (ecma_value_t left_value, /**< left value */
     return NULL;
   }
 
+#if ENABLED (JERRY_BUILTIN_PROXY)
+  if (ecma_is_value_object (left_value)
+      && ECMA_OBJECT_IS_PROXY (ecma_get_object_from_value (left_value)))
+  {
+    return NULL;
+  }
+#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
+
   /* 4. */
   ecma_value_t obj_expr_value = ecma_op_to_object (left_value);
   /* ecma_op_to_object will only raise error on null/undefined values but those are handled above. */

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -3690,21 +3690,6 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           JERRY_ASSERT (VM_GET_REGISTERS (frame_ctx_p) + register_end + frame_ctx_p->context_depth == stack_top_p);
 
-#if ENABLED (JERRY_BUILTIN_PROXY)
-          if (ecma_is_value_object (value)
-              && ECMA_OBJECT_IS_PROXY (ecma_get_object_from_value (value)))
-          {
-            /* Note: - For proxy objects we should create a new object which implements the iterable protocol,
-                       and iterates through the enumerated collection below.
-                     - This inkoves that the VM context type should be adjusted and checked in all FOR-IN related
-                       instruction.
-                     - For other objects we should keep the current implementation due to performance reasons.*/
-            result = ecma_raise_type_error (ECMA_ERR_MSG ("UNIMPLEMENTED: Proxy support in for-in."));
-            ecma_free_value (value);
-            goto error;
-          }
-#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
-
           ecma_value_t expr_obj_value = ECMA_VALUE_UNDEFINED;
           ecma_collection_t *prop_names_p = opfunc_for_in (value, &expr_obj_value);
           ecma_free_value (value);

--- a/tests/jerry/es.next/regression-test-issue-3868.js
+++ b/tests/jerry/es.next/regression-test-issue-3868.js
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 var a = new Proxy({}, {});
+var reached = false;
 
-try {
-  for (var $ in a);
-  assert(false);
-} catch (e) {
-  assert(e instanceof TypeError);
+for (var $ in a) {
+  reached = true;
 }
+
+assert(reached === false);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -30,7 +30,6 @@
   <test id="language/expressions/assignment/11.13.1-1-2.js"><reason></reason></test>
   <test id="language/expressions/assignment/11.13.1-1-3.js"><reason></reason></test>
   <test id="language/expressions/assignment/11.13.1-1-4.js"><reason></reason></test>
-
   <test id="annexB/B.2.3.10.js"><reason></reason></test>
   <test id="annexB/B.2.3.11.js"><reason></reason></test>
   <test id="annexB/B.2.3.12.js"><reason></reason></test>
@@ -69,9 +68,15 @@
   <test id="built-ins/Promise/race/invoke-then.js"><reason></reason></test>
   <test id="built-ins/Promise/race/species-get-error.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/call-parameters.js"><reason></reason></test>
+  <test id="built-ins/Proxy/enumerate/null-handler.js"><reason>Removed since ES7</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-boolean.js"><reason>Removed since ES7</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-number.js"><reason>Removed since ES7</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-string.js"><reason>Removed since ES7</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-symbol.js"><reason>Removed since ES7</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-undefined.js"><reason>Removed since ES7</reason></test>
   <test id="built-ins/Proxy/enumerate/return-is-abrupt.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/return-trap-result.js"><reason></reason></test>
-  <test id="built-ins/Proxy/enumerate/return-trap-result-no-value.js"><reason></reason></test>
+  <test id="built-ins/Proxy/enumerate/trap-is-not-callable.js"><reason>Removed since ES7</reason></test>
   <test id="built-ins/Proxy/enumerate/trap-is-undefined.js"><reason></reason></test>
   <test id="built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined.js"><reason></reason></test>
   <test id="built-ins/Reflect/enumerate/does-not-iterate-over-symbol-properties.js"><reason></reason></test>


### PR DESCRIPTION
Since the ES7 standard, the Proxy [[Enumerable]] internal method has been removed

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu