### PR TITLE
Rework Object's [[OwnPropertyKeys]]

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1431,7 +1431,7 @@ typedef struct
  * Compute the total allocated size of the collection based on it's capacity
  */
 #define ECMA_COLLECTION_ALLOCATED_SIZE(capacity) \
-  (uint32_t) (sizeof (ecma_collection_t) + (capacity * sizeof (ecma_value_t)))
+  (uint32_t) (capacity * sizeof (ecma_value_t))
 
 /**
  * Initial allocated size of an ecma-collection
@@ -2065,6 +2065,17 @@ typedef struct
   ecma_value_t proxy; /**< [[RevocableProxy]] internal slot */
 } ecma_revocable_proxy_object_t;
 #endif /* ENABLED (JERRY_BUILTIN_PROXY) */
+
+/**
+ * Struct for counting the different types properties in objects
+ */
+typedef struct
+{
+  uint32_t array_index_named_props; /**< number of array index named properties */
+  uint32_t string_named_props; /**< number of string named properties */
+  uint32_t symbol_named_props; /**< number of symbol named properties */
+  uint32_t lazy_string_named_props; /**< number of lazy instantiated properties */
+} ecma_property_counter_t;
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-collection.c
@@ -14,6 +14,7 @@
  */
 
 #include "ecma-alloc.h"
+#include "ecma-conversion.h"
 #include "ecma-gc.h"
 #include "ecma-globals.h"
 #include "ecma-helpers.h"
@@ -186,6 +187,61 @@ ecma_collection_append (ecma_collection_t *collection_p, /**< value collection *
   memcpy (collection_p->buffer_p + collection_p->item_count, buffer_p, count * sizeof (ecma_value_t));
   collection_p->item_count += count;
 } /* ecma_collection_append */
+
+/**
+ * Helper function to check if a given collection have duplicated properties or not
+ *
+ * @return true - if there are duplicated properties in the collection
+ *         false - otherwise
+ */
+bool
+ecma_collection_check_duplicated_entries (ecma_collection_t *collection_p) /**< prop name collection */
+{
+  ecma_value_t *buffer_p = collection_p->buffer_p;
+
+  for (uint32_t i = 0; i < collection_p->item_count - 1; i++)
+  {
+    ecma_string_t *current_name_p = ecma_get_prop_name_from_value (buffer_p[i]);
+
+    for (uint32_t j = i + 1; j < collection_p->item_count; j++)
+    {
+      if (ecma_compare_ecma_strings (current_name_p, ecma_get_prop_name_from_value (buffer_p[j])))
+      {
+        return true;
+      }
+    }
+  }
+
+  return false;
+} /* ecma_collection_check_duplicated_entries */
+
+/**
+ * Check the string value existance in the collection.
+ *
+ * Used by:
+ *         - ecma_builtin_json_stringify step 4.b.ii.5
+ *         - ecma_op_object_enumerate
+ *
+ * @return true, if the string is already in the collection.
+ */
+bool
+ecma_collection_has_string_value (ecma_collection_t *collection_p, /**< collection */
+                                  ecma_string_t *string_p) /**< string */
+{
+  ecma_value_t *buffer_p = collection_p->buffer_p;
+
+  for (uint32_t i = 0; i < collection_p->item_count; i++)
+  {
+    ecma_string_t *current_p = ecma_get_string_from_value (buffer_p[i]);
+
+    if (ecma_compare_ecma_strings (current_p, string_p))
+    {
+      return true;
+    }
+  }
+
+  return false;
+} /* ecma_collection_has_string_value */
 
 /**
  * @}

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -439,6 +439,8 @@ void ecma_collection_destroy (ecma_collection_t *collection_p);
 void ecma_collection_free (ecma_collection_t *collection_p);
 void ecma_collection_free_if_not_object (ecma_collection_t *collection_p);
 void ecma_collection_free_objects (ecma_collection_t *collection_p);
+bool ecma_collection_check_duplicated_entries (ecma_collection_t *collection_p);
+bool ecma_collection_has_string_value (ecma_collection_t *collection_p, ecma_string_t *string_p);
 
 /* ecma-helpers.c */
 ecma_object_t *ecma_create_object (ecma_object_t *prototype_object_p, size_t ext_object_size, ecma_object_type_t type);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-json.c
@@ -54,33 +54,6 @@ ecma_json_has_object_in_stack (ecma_json_occurence_stack_item_t *stack_p, /**< s
   return false;
 } /* ecma_json_has_object_in_stack */
 
-/**
- * Check the string value existance in the collection.
- *
- * Used by:
- *         - ecma_builtin_json_stringify step 4.b.ii.5
- *
- * @return true, if the string is already in the collection.
- */
-bool
-ecma_has_string_value_in_collection (ecma_collection_t *collection_p, /**< collection */
-                                     ecma_string_t *string_p) /**< string */
-{
-  ecma_value_t *buffer_p = collection_p->buffer_p;
-
-  for (uint32_t i = 0; i < collection_p->item_count; i++)
-  {
-    ecma_string_t *current_p = ecma_get_string_from_value (buffer_p[i]);
-
-    if (ecma_compare_ecma_strings (current_p, string_p))
-    {
-      return true;
-    }
-  }
-
-  return false;
-} /* ecma_has_string_value_in_collection */
-
 #endif /* ENABLED (JERRY_BUILTIN_JSON) */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -227,42 +227,6 @@ ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, /**< th
 } /* ecma_builtin_helper_get_to_locale_string_at_index */
 
 /**
- * The Object's 'getOwnPropertyNames' routine.
- *
- * See also:
- *          ECMA-262 v5, 15.2.3.4 steps 2-5
- *
- * @return ecma value - Array of property names.
- *         Returned value must be freed with ecma_free_value.
- */
-ecma_value_t
-ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, /**< object */
-                                           uint32_t opts) /**< any combination of ecma_list_properties_options_t */
-{
-  JERRY_ASSERT (obj_p != NULL);
-
-  ecma_collection_t *props_p = ecma_op_object_get_property_names (obj_p, opts);
-
-#if ENABLED (JERRY_BUILTIN_PROXY)
-  if (props_p == NULL)
-  {
-    return ECMA_VALUE_ERROR;
-  }
-#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
-
-  if (props_p->item_count == 0)
-  {
-    ecma_collection_destroy (props_p);
-    return ecma_op_create_array_object (NULL, 0, false);
-  }
-
-  ecma_value_t new_array = ecma_op_create_array_object (props_p->buffer_p, props_p->item_count, false);
-  ecma_collection_free (props_p);
-
-  return new_array;
-} /* ecma_builtin_helper_object_get_properties */
-
-/**
  * Helper function to normalizing an array index
  *
  * See also:

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -46,8 +46,6 @@ ecma_builtin_helper_object_to_string (const ecma_value_t this_arg);
 ecma_string_t *
 ecma_builtin_helper_get_to_locale_string_at_index (ecma_object_t *obj_p, uint32_t index);
 ecma_value_t
-ecma_builtin_helper_object_get_properties (ecma_object_t *obj_p, uint32_t opts);
-ecma_value_t
 ecma_builtin_helper_array_concat_value (ecma_object_t *obj_p, uint32_t *length_p, ecma_value_t value);
 uint32_t
 ecma_builtin_helper_array_index_normalize (ecma_value_t arg, uint32_t length, uint32_t *number_p);
@@ -216,7 +214,6 @@ ecma_value_t ecma_builtin_json_parse_buffer (const lit_utf8_byte_t * str_start_p
                                              lit_utf8_size_t string_size);
 ecma_value_t ecma_builtin_json_stringify_no_opts (const ecma_value_t value);
 bool ecma_json_has_object_in_stack (ecma_json_occurence_stack_item_t *stack_p, ecma_object_t *object_p);
-bool ecma_has_string_value_in_collection (ecma_collection_t *collection_p, ecma_string_t *string_p);
 
 ecma_value_t
 ecma_builtin_helper_json_create_non_formatted_json (lit_utf8_byte_t left_bracket, lit_utf8_byte_t right_bracket,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -694,7 +694,8 @@ ecma_builtin_json_internalize_property (ecma_object_t *reviver_p, /**< reviver f
     /* 3.d */
     else
     {
-      ecma_collection_t *props_p = ecma_op_object_get_property_names (object_p, ECMA_LIST_ENUMERABLE);
+      ecma_collection_t *props_p = ecma_op_object_get_enumerable_property_names (object_p,
+                                                                                 ECMA_ENUMERABLE_PROPERTY_KEYS);
 
       JERRY_ASSERT (props_p != NULL);
 
@@ -983,7 +984,7 @@ ecma_builtin_json_serialize_object (ecma_json_stringify_context_t *context_p, /*
   /* 6. */
   else
   {
-    property_keys_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_ENUMERABLE);
+    property_keys_p = ecma_op_object_get_enumerable_property_names (obj_p, ECMA_ENUMERABLE_PROPERTY_KEYS);
 
 #if ENABLED (JERRY_BUILTIN_PROXY)
     if (property_keys_p == NULL)
@@ -1573,7 +1574,7 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
             JERRY_ASSERT (ecma_is_value_string (item));
             ecma_string_t *string_p = ecma_get_string_from_value (item);
 
-            if (!ecma_has_string_value_in_collection (context.property_list_p, string_p))
+            if (!ecma_collection_has_string_value (context.property_list_p, string_p))
             {
               ecma_collection_push_back (context.property_list_p, item);
             }

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
@@ -165,8 +165,21 @@ ecma_builtin_reflect_dispatch_routine (uint16_t builtin_routine_id, /**< built-i
 
     ecma_object_t *target_p = ecma_get_object_from_value (arguments_list[0]);
 
-    /* 2. 3. */
-    return ecma_builtin_helper_object_get_properties (target_p, ECMA_LIST_SYMBOLS);
+    /* 2. */
+    ecma_collection_t *prop_names = ecma_op_object_own_property_keys (target_p);
+
+#if ENABLED (JERRY_BUILTIN_PROXY)
+    if (prop_names == NULL)
+    {
+      return ECMA_VALUE_ERROR;
+    }
+#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
+
+    /* 3. */
+    ecma_value_t new_array = ecma_op_create_array_object (prop_names->buffer_p, prop_names->item_count, false);
+    ecma_collection_free (prop_names);
+
+    return new_array;
   }
 
   if (builtin_routine_id == ECMA_REFLECT_OBJECT_CONSTRUCT)

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -93,14 +93,12 @@ ecma_property_t *
 ecma_builtin_try_to_instantiate_property (ecma_object_t *object_p, ecma_string_t *string_p);
 void
 ecma_builtin_routine_list_lazy_property_names (ecma_object_t *object_p,
-                                                uint32_t opts,
-                                                ecma_collection_t *main_collection_p,
-                                                ecma_collection_t *non_enum_collection_p);
+                                               ecma_collection_t *prop_names_p,
+                                               ecma_property_counter_t *prop_counter_p);
 void
 ecma_builtin_list_lazy_property_names (ecma_object_t *object_p,
-                                       uint32_t opts,
-                                       ecma_collection_t *main_collection_p,
-                                       ecma_collection_t *non_enum_collection_p);
+                                       ecma_collection_t *prop_names_p,
+                                       ecma_property_counter_t *prop_counter_p);
 bool
 ecma_builtin_is (ecma_object_t *obj_p, ecma_builtin_id_t builtin_id);
 ecma_object_t *

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -511,61 +511,35 @@ ecma_fast_array_set_length (ecma_object_t *object_p, /**< fast access mode array
  * @return collection of strings - property names
  */
 ecma_collection_t *
-ecma_fast_array_get_property_names (ecma_object_t *object_p, /**< fast access mode array object */
-                                    uint32_t opts) /**< any combination of ecma_list_properties_options_t values */
+ecma_fast_array_object_own_property_keys (ecma_object_t *object_p) /**< fast access mode array object */
 {
   JERRY_ASSERT (ecma_op_object_is_fast_array (object_p));
 
   ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) object_p;
   ecma_collection_t *ret_p = ecma_new_collection ();
-
-#if ENABLED (JERRY_ESNEXT)
-  if (opts & ECMA_LIST_SYMBOLS_ONLY)
-  {
-    return ret_p;
-  }
-#endif /* ENABLED (JERRY_ESNEXT) */
-
   uint32_t length = ext_obj_p->u.array.length;
 
-  bool append_length = (!(opts & ECMA_LIST_ENUMERABLE) && !(opts & ECMA_LIST_ARRAY_INDICES));
-
-  if (length == 0)
+  if (length != 0)
   {
-    if (append_length)
+    ecma_value_t *values_p = ECMA_GET_NON_NULL_POINTER (ecma_value_t, object_p->u1.property_list_cp);
+
+    for (uint32_t i = 0; i < length; i++)
     {
-      ecma_collection_push_back (ret_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
+      if (ecma_is_value_array_hole (values_p[i]))
+      {
+        continue;
+      }
+
+      ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (i);
+
+      ecma_collection_push_back (ret_p, ecma_make_string_value (index_str_p));
     }
-
-    return ret_p;
   }
 
-  ecma_value_t *values_p = ECMA_GET_NON_NULL_POINTER (ecma_value_t, object_p->u1.property_list_cp);
-
-  for (uint32_t i = 0; i < length; i++)
-  {
-    if (ecma_is_value_array_hole (values_p[i]))
-    {
-      continue;
-    }
-
-    ecma_string_t *index_str_p = ecma_new_ecma_string_from_uint32 (i);
-
-    ecma_collection_push_back (ret_p, ecma_make_string_value (index_str_p));
-  }
-
-  if (append_length)
-  {
-    ecma_collection_push_back (ret_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
-  }
-
-  if (opts & ECMA_LIST_CONVERT_FAST_ARRAYS)
-  {
-    ecma_fast_array_convert_to_normal (object_p);
-  }
+  ecma_collection_push_back (ret_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
 
   return ret_p;
-} /* ecma_fast_array_get_property_names */
+} /* ecma_fast_array_object_own_property_keys */
 
 /**
  * Array object creation operation.
@@ -1239,30 +1213,6 @@ ecma_array_object_to_string (ecma_value_t this_arg) /**< this argument */
 
   return ret_value;
 } /* ecma_array_object_to_string */
-
-/**
- * List names of a String object's lazy instantiated properties
- *
- * @return string values collection
- */
-void
-ecma_op_array_list_lazy_property_names (ecma_object_t *obj_p, /**< a String object */
-                                        uint32_t opts, /**< listing options using flags
-                                                        *   from ecma_list_properties_options_t */
-                                        ecma_collection_t *main_collection_p, /**< 'main'  collection */
-                                        ecma_collection_t *non_enum_collection_p) /**< skipped
-                                                                                   *   'non-enumerable'
-                                                                                   *   collection */
-{
-  JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_ARRAY);
-
-  ecma_collection_t *for_non_enumerable_p = (opts & ECMA_LIST_ENUMERABLE) ? non_enum_collection_p : main_collection_p;
-
-  if ((opts & ECMA_LIST_ARRAY_INDICES) == 0)
-  {
-    ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
-  }
-} /* ecma_op_array_list_lazy_property_names */
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -90,7 +90,7 @@ uint32_t
 ecma_delete_fast_array_properties (ecma_object_t *object_p, uint32_t new_length);
 
 ecma_collection_t *
-ecma_fast_array_get_property_names (ecma_object_t *object_p, uint32_t opts);
+ecma_fast_array_object_own_property_keys (ecma_object_t *object_p);
 
 void
 ecma_fast_array_convert_to_normal (ecma_object_t *object_p);
@@ -120,12 +120,6 @@ uint32_t ecma_array_get_length (ecma_object_t *array_p);
 
 ecma_value_t
 ecma_array_object_to_string (ecma_value_t this_arg);
-
-void
-ecma_op_array_list_lazy_property_names (ecma_object_t *obj_p,
-                                        uint32_t opts,
-                                        ecma_collection_t *main_collection_p,
-                                        ecma_collection_t *non_enum_collection_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -89,21 +89,18 @@ ecma_op_bound_function_try_to_lazy_instantiate_property (ecma_object_t *object_p
 
 void
 ecma_op_function_list_lazy_property_names (ecma_object_t *object_p,
-                                           uint32_t opts,
-                                           ecma_collection_t *main_collection_p,
-                                           ecma_collection_t *non_enum_collection_p);
+                                           ecma_collection_t *prop_names_p,
+                                           ecma_property_counter_t *prop_counter_p);
 
 void
 ecma_op_external_function_list_lazy_property_names (ecma_object_t *object_p,
-                                                    uint32_t opts,
-                                                    ecma_collection_t *main_collection_p,
-                                                    ecma_collection_t *non_enum_collection_p);
+                                                    ecma_collection_t *prop_names_p,
+                                                    ecma_property_counter_t *prop_counter_p);
 
 void
 ecma_op_bound_function_list_lazy_property_names (ecma_object_t *object_p,
-                                                 uint32_t opts,
-                                                 ecma_collection_t *main_collection_p,
-                                                 ecma_collection_t *non_enum_collection_p);
+                                                 ecma_collection_t *prop_names_p,
+                                                 ecma_property_counter_t *prop_counter_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -67,9 +67,10 @@ ecma_value_t ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p
                                                          ecma_property_descriptor_t *prop_desc_p);
 ecma_value_t ecma_op_object_has_instance (ecma_object_t *obj_p, ecma_value_t value);
 ecma_value_t ecma_op_object_is_prototype_of (ecma_object_t *base_p, ecma_object_t *target_p);
-ecma_collection_t * ecma_op_object_get_property_names (ecma_object_t *obj_p, uint32_t opts);
 ecma_collection_t * ecma_op_object_get_enumerable_property_names (ecma_object_t *obj_p,
                                                                   ecma_enumerable_property_names_options_t option);
+ecma_collection_t *ecma_op_object_own_property_keys (ecma_object_t *obj_p);
+ecma_collection_t *ecma_op_object_enumerate (ecma_object_t *obj_p);
 
 lit_magic_string_id_t ecma_object_get_class_name (ecma_object_t *obj_p);
 bool ecma_object_class_is (ecma_object_t *object_p, uint32_t class_id);

--- a/jerry-core/ecma/operations/ecma-proxy-object.h
+++ b/jerry-core/ecma/operations/ecma-proxy-object.h
@@ -92,9 +92,6 @@ ecma_value_t
 ecma_proxy_object_delete_property (ecma_object_t *obj_p,
                                    ecma_string_t *prop_name_p);
 
-ecma_value_t
-ecma_proxy_object_enumerate (ecma_object_t *obj_p);
-
 ecma_collection_t *
 ecma_proxy_object_own_property_keys (ecma_object_t *obj_p);
 

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -84,18 +84,10 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
  */
 void
 ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String object */
-                                         uint32_t opts, /**< listing options using flags
-                                                         *   from ecma_list_properties_options_t */
-                                         ecma_collection_t *main_collection_p, /**< 'main' collection */
-                                         ecma_collection_t *non_enum_collection_p) /**< skipped
-                                                                                    *   'non-enumerable'
-                                                                                    *   collection */
+                                         ecma_collection_t *prop_names_p, /**< prop name collection */
+                                         ecma_property_counter_t *prop_counter_p)  /**< prop counter */
 {
   JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_CLASS);
-
-  ecma_collection_t *for_enumerable_p = main_collection_p;
-
-  ecma_collection_t *for_non_enumerable_p = (opts & ECMA_LIST_ENUMERABLE) ? non_enum_collection_p : main_collection_p;
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
   JERRY_ASSERT (ext_object_p->u.class_prop.class_id == LIT_MAGIC_STRING_STRING_UL);
@@ -109,13 +101,13 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
     ecma_string_t *name_p = ecma_new_ecma_string_from_uint32 (i);
 
     /* the properties are enumerable (ECMA-262 v5, 15.5.5.2.9) */
-    ecma_collection_push_back (for_enumerable_p, ecma_make_string_value (name_p));
+    ecma_collection_push_back (prop_names_p, ecma_make_string_value (name_p));
   }
 
-  if ((opts & ECMA_LIST_ARRAY_INDICES) == 0)
-  {
-    ecma_collection_push_back (for_non_enumerable_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
-  }
+  prop_counter_p->array_index_named_props += length;
+
+  ecma_collection_push_back (prop_names_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
+  prop_counter_p->string_named_props++;
 } /* ecma_op_string_list_lazy_property_names */
 
 /**

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -30,9 +30,8 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, uint32_t arg
 
 void
 ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p,
-                                         uint32_t opts,
-                                         ecma_collection_t *main_collection_p,
-                                         ecma_collection_t *non_enum_collection_p);
+                                         ecma_collection_t *prop_names_p,
+                                         ecma_property_counter_t *prop_counter_p);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -1300,7 +1300,8 @@ ecma_is_typedarray (ecma_value_t value) /**< the target need to be checked */
  */
 void
 ecma_op_typedarray_list_lazy_property_names (ecma_object_t *obj_p, /**< a TypedArray object */
-                                             ecma_collection_t *main_collection_p) /**< 'main' collection */
+                                             ecma_collection_t *prop_names_p, /**< prop name collection */
+                                             ecma_property_counter_t *prop_counter_p)  /**< prop counter */
 {
   JERRY_ASSERT (ecma_object_is_typedarray (obj_p));
 
@@ -1309,9 +1310,10 @@ ecma_op_typedarray_list_lazy_property_names (ecma_object_t *obj_p, /**< a TypedA
   for (uint32_t i = 0; i < array_length; i++)
   {
     ecma_string_t *name_p = ecma_new_ecma_string_from_uint32 (i);
-
-    ecma_collection_push_back (main_collection_p, ecma_make_string_value (name_p));
+    ecma_collection_push_back (prop_names_p, ecma_make_string_value (name_p));
   }
+
+  prop_counter_p->array_index_named_props += array_length;
 } /* ecma_op_typedarray_list_lazy_property_names */
 
 /**

--- a/jerry-core/ecma/operations/ecma-typedarray-object.h
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.h
@@ -64,7 +64,8 @@ ecma_typedarray_iterators_helper (ecma_value_t this_arg, ecma_iterator_kind_t ki
 bool ecma_object_is_typedarray (ecma_object_t *obj_p);
 bool ecma_is_typedarray (ecma_value_t target);
 void ecma_op_typedarray_list_lazy_property_names (ecma_object_t *obj_p,
-                                                  ecma_collection_t *main_collection_p);
+                                                  ecma_collection_t *prop_names_p,
+                                                  ecma_property_counter_t *prop_counter_p);
 bool ecma_op_typedarray_define_index_prop (ecma_object_t *obj_p,
                                            uint32_t index,
                                            const ecma_property_descriptor_t *property_desc_p);

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -345,10 +345,7 @@ opfunc_for_in (ecma_value_t left_value, /**< left value */
   /* ecma_op_to_object will only raise error on null/undefined values but those are handled above. */
   JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (obj_expr_value));
   ecma_object_t *obj_p = ecma_get_object_from_value (obj_expr_value);
-#if ENABLED (JERRY_BUILTIN_PROXY)
-  JERRY_ASSERT (!ECMA_OBJECT_IS_PROXY (obj_p));
-#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
-  ecma_collection_t *prop_names_p = ecma_op_object_get_property_names (obj_p, ECMA_LIST_ENUMERABLE_PROTOTYPE);
+  ecma_collection_t *prop_names_p = ecma_op_object_enumerate (obj_p);
 
   if (prop_names_p->item_count != 0)
   {

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -1765,7 +1765,8 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           }
 
           ecma_object_t *object_p = ecma_get_object_from_value (result);
-          ecma_collection_t *names_p = ecma_op_object_get_property_names (object_p, ECMA_LIST_ENUMERABLE);
+          ecma_collection_t *names_p = ecma_op_object_get_enumerable_property_names (object_p,
+                                                                                     ECMA_ENUMERABLE_PROPERTY_KEYS);
 
 #if ENABLED (JERRY_BUILTIN_PROXY)
           if (names_p == NULL)
@@ -3704,21 +3705,6 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           JERRY_ASSERT (VM_GET_REGISTERS (frame_ctx_p) + register_end + frame_ctx_p->context_depth == stack_top_p);
 
-#if ENABLED (JERRY_BUILTIN_PROXY)
-          if (ecma_is_value_object (value)
-              && ECMA_OBJECT_IS_PROXY (ecma_get_object_from_value (value)))
-          {
-            /* Note: - For proxy objects we should create a new object which implements the iterable protocol,
-                       and iterates through the enumerated collection below.
-                     - This inkoves that the VM context type should be adjusted and checked in all FOR-IN related
-                       instruction.
-                     - For other objects we should keep the current implementation due to performance reasons.*/
-            result = ecma_raise_type_error (ECMA_ERR_MSG ("UNIMPLEMENTED: Proxy support in for-in."));
-            ecma_free_value (value);
-            goto error;
-          }
-#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
-
           ecma_value_t expr_obj_value = ECMA_VALUE_UNDEFINED;
           ecma_collection_t *prop_names_p = opfunc_for_in (value, &expr_obj_value);
           ecma_free_value (value);
@@ -3776,9 +3762,6 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
           ecma_value_t *buffer_p = collection_p->buffer_p;
           ecma_object_t *object_p = ecma_get_object_from_value (stack_top_p[-4]);
           uint32_t index = stack_top_p[-3];
-#if ENABLED (JERRY_BUILTIN_PROXY)
-          JERRY_ASSERT (!ECMA_OBJECT_IS_PROXY (object_p));
-#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
 
           while (index < collection_p->item_count)
           {

--- a/tests/jerry/es.next/array-prototype-sort.js
+++ b/tests/jerry/es.next/array-prototype-sort.js
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var a = new Proxy({ a : 4, b :4}, {});
-var reached = false;
+var proxy = new Proxy({length: 5}, {
+  getOwnPropertyDescriptor() { throw 42.5; }
+})
 
-for (var $ in a)
-{
-  reached = true;
+try {
+  Array.prototype.sort.call(proxy);
+  assert(false);
+} catch (e) {
+  assert(e === 42.5);
 }
-
-assert (reached === true);

--- a/tests/jerry/es.next/function-properties.js
+++ b/tests/jerry/es.next/function-properties.js
@@ -39,7 +39,7 @@ assert(getProperties(func) == "dummy");
 
 var bound_func = (function() {}).bind(null);
 Object.setPrototypeOf(bound_func, prototype_obj);
-assert(getProperties(bound_func) == "dummy prototype");
+assert(getProperties(bound_func) == "dummy caller arguments prototype");
 
 // 'print' is an external function
 Object.setPrototypeOf(print, prototype_obj);

--- a/tests/jerry/es.next/object-define-properties.js
+++ b/tests/jerry/es.next/object-define-properties.js
@@ -124,7 +124,6 @@ assert (object[symbol] === "a symbol");
 assert (object.bar === 42);
 assert (object[symbol] === undefined);
 
-// This code should throw TypeError
 var object = {};
 var props = {
   [symbol]: {
@@ -142,9 +141,9 @@ var props = {
   },
 };
 
-try {
-  Object.defineProperties(object, props);
-  assert (false);
-} catch (e) {
-  assert (e instanceof TypeError);
-}
+Object.defineProperties(object, props);
+var bar_desc = Object.getOwnPropertyDescriptor(object, 'bar');
+assert(bar_desc.value === 2);
+assert(bar_desc.writable === true);
+assert(object.prop1 === undefined);
+assert(object[symbol] === undefined);

--- a/tests/jerry/es.next/proxy_own_keys.js
+++ b/tests/jerry/es.next/proxy_own_keys.js
@@ -32,14 +32,6 @@ var handler = { ownKeys (target) {
 var proxy = new Proxy(target, handler);
 
 try {
-  // Array.prototype.sort
-  Array.prototype.sort.call(proxy);
-  assert(false);
-} catch (e) {
-  assert(e === 42);
-}
-
-try {
   // 19.1.2.14.4
   Object.keys(proxy);
   assert(false);
@@ -62,6 +54,14 @@ try {
 } catch (e) {
   assert(e === 42);
 }
+
+var handler = { ownKeys (target) {
+  return ["a"];
+}};
+
+var proxy = new Proxy(target, handler);
+var sort_result = Array.prototype.sort.call(proxy);
+assert(Object.keys(sort_result).length === 0);
 
 // test basic functionality
 var symA = Symbol("smA");
@@ -149,16 +149,18 @@ try {
 }
 
 // test with duplicated keys
-var target = { prop1: "prop1", prop2: "prop2"};
-var handler = {
+var p = new Proxy({}, {
 	ownKeys: function(target) {
-      return ["a", "a", "a"];
-    }
-};
+	  return ["foo", "foo"];
+	}
+});
 
-var proxy = new Proxy(target, handler);
-
-assert(JSON.stringify(Object.getOwnPropertyNames(proxy)) === '["a","a","a"]');
+try {
+  Object.keys(p);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
 
 // test with lots of keys
 var keyslist = [];

--- a/tests/jerry/object-define-properties.js
+++ b/tests/jerry/object-define-properties.js
@@ -174,7 +174,6 @@ assert (obj.a === "b");
 assert (obj.bar === 42);
 assert (obj.a === undefined);
 
-// This code should throw TypeError
 var obj = {};
 var props = {
   prop1: {
@@ -196,9 +195,15 @@ var props = {
   }
 };
 
-try {
-  Object.defineProperties(obj, props);
-  assert (false);
-} catch (e) {
-  assert (e instanceof TypeError);
-}
+Object.defineProperties(obj, props);
+var bar_desc = Object.getOwnPropertyDescriptor(obj, 'bar');
+assert(bar_desc.value === 2);
+assert(bar_desc.writable === true);
+assert(obj.prop2 === undefined);
+
+var prop1_desc = Object.getOwnPropertyDescriptor(obj, 'prop1');
+var prop3_desc = Object.getOwnPropertyDescriptor(obj, 'prop3');
+assert(prop1_desc.value === 1);
+assert(prop1_desc.writable === true);
+assert(prop3_desc.value === 4);
+assert(prop3_desc.writable === true);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -69,10 +69,15 @@
   <test id="built-ins/Promise/race/species-get-error.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/call-parameters.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/return-is-abrupt.js"><reason></reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-boolean.js"><reason>For-in supports proxy</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-number.js"><reason>For-in supports proxy</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-string.js"><reason>For-in supports proxy</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-symbol.js"><reason>For-in supports proxy</reason></test>
+  <test id="built-ins/Proxy/enumerate/result-not-an-object-throws-undefined.js"><reason>For-in supports proxy</reason></test>
+  <test id="built-ins/Proxy/enumerate/null-handler.js"><reason>For-in supports proxy</reason></test>
   <test id="built-ins/Proxy/enumerate/return-trap-result.js"><reason></reason></test>
   <test id="built-ins/Proxy/enumerate/return-trap-result-no-value.js"><reason></reason></test>
-  <test id="built-ins/Proxy/enumerate/trap-is-undefined.js"><reason></reason></test>
-  <test id="built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined.js"><reason></reason></test>
+  <test id="built-ins/Proxy/enumerate/trap-is-not-callable.js"><reason>For-in supports proxy</reason></test>
   <test id="built-ins/Reflect/enumerate/does-not-iterate-over-symbol-properties.js"><reason></reason></test>
   <test id="built-ins/Reflect/enumerate/enumerate.js"><reason></reason></test>
   <test id="built-ins/Reflect/enumerate/length.js"><reason></reason></test>


### PR DESCRIPTION
I've removed the ecma_op_object_get_property_names method, and implemented the following ones:
- ecma_op_object_own_property_keys: this is now the internal [[OwnPropertyKeys]] method
- ecma_op_object_enumerate: this is used for the for-in iterator
- ecma_object_sort_property_names: this is used for sorting the property names of an object
- ecma_object_list_lazy_property_names: this is for getting the lazy instantiated properties
- ecma_object_prop_name_is_duplicated: this is for checking if a given property is duplicated in an object

Also the for-in operation with Proxy object works with this patch, #3992 should be closed

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
