### PR TITLE
Remove the usage of ecma_length_t

### DIFF
--- a/docs/08.CODING-STANDARDS.md
+++ b/docs/08.CODING-STANDARDS.md
@@ -739,6 +739,12 @@ typedef
 char wrong_newlines_again_t;
 ```
 
+### Type usage conventions
+
+ - Passing the number of arguments for a function call is always `uint32_t`
+ - String size/length/position related operation should use `lit_utf8_size_t`
+ - Extended objects internal fields must be `uint32_t`
+
 ## Function declarations
 
 Function declarations in JerryScript are verbose but this format

--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -189,7 +189,7 @@ snapshot_add_compiled_code (ecma_compiled_code_t *compiled_code_p, /**< compiled
     ecma_value_t pattern = ((re_compiled_code_t *) compiled_code_p)->source;
     ecma_string_t *pattern_string_p = ecma_get_string_from_value (pattern);
 
-    ecma_length_t pattern_size = 0;
+    lit_utf8_size_t pattern_size = 0;
 
     ECMA_STRING_TO_UTF8_STRING (pattern_string_p, buffer_p, buffer_size);
 
@@ -219,7 +219,7 @@ snapshot_add_compiled_code (ecma_compiled_code_t *compiled_code_p, /**< compiled
     /* Regexp character size is stored in refs. */
     copied_code_p->refs = (uint16_t) pattern_size;
 
-    pattern_size += (ecma_length_t) sizeof (ecma_compiled_code_t);
+    pattern_size += (lit_utf8_size_t) sizeof (ecma_compiled_code_t);
     copied_code_p->size = (uint16_t) ((pattern_size + JMEM_ALIGNMENT - 1) >> JMEM_ALIGNMENT_LOG);
 
     copied_code_p->status_flags = compiled_code_p->status_flags;

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -1200,7 +1200,7 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 #if ENABLED (JERRY_BUILTIN_TYPEDARRAY)
         case LIT_MAGIC_STRING_ARRAY_BUFFER_UL:
         {
-          ecma_length_t arraybuffer_length = ext_object_p->u.class_prop.u.length;
+          uint32_t arraybuffer_length = ext_object_p->u.class_prop.u.length;
 
           if (ECMA_ARRAYBUFFER_HAS_EXTERNAL_MEMORY (ext_object_p))
           {
@@ -1340,14 +1340,14 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
         {
           JERRY_ASSERT (ext_object_p->u.pseudo_array.type == ECMA_PSEUDO_ARRAY_ARGUMENTS);
 
-          ecma_length_t formal_params_number = ext_object_p->u.pseudo_array.u1.length;
-          ecma_value_t *arg_Literal_p = (ecma_value_t *) (ext_object_p + 1);
+          uint32_t formal_params_number = ext_object_p->u.pseudo_array.u1.length;
+          ecma_value_t *arg_literal_p = (ecma_value_t *) (ext_object_p + 1);
 
-          for (ecma_length_t i = 0; i < formal_params_number; i++)
+          for (uint32_t i = 0; i < formal_params_number; i++)
           {
-            if (arg_Literal_p[i] != ECMA_VALUE_EMPTY)
+            if (arg_literal_p[i] != ECMA_VALUE_EMPTY)
             {
-              ecma_string_t *name_p = ecma_get_string_from_value (arg_Literal_p[i]);
+              ecma_string_t *name_p = ecma_get_string_from_value (arg_literal_p[i]);
               ecma_deref_ecma_string (name_p);
             }
           }

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -288,7 +288,7 @@ typedef ecma_value_t (*ecma_vm_exec_stop_callback_t) (void *user_p);
 typedef ecma_value_t (*ecma_external_handler_t) (const ecma_value_t function_obj,
                                                  const ecma_value_t this_val,
                                                  const ecma_value_t args_p[],
-                                                 const ecma_length_t args_count);
+                                                 const uint32_t args_count);
 
 /**
  * Native free callback of an object.
@@ -1851,8 +1851,8 @@ typedef struct
 typedef struct
 {
   ecma_extended_object_t extended_object; /**< extended object part */
-  ecma_length_t byte_offset; /**< the byteoffset of the above arraybuffer */
-  ecma_length_t array_length; /**< the array length */
+  uint32_t byte_offset; /**< the byteoffset of the above arraybuffer */
+  uint32_t array_length; /**< the array length */
 } ecma_extended_typedarray_object_t;
 
 /**
@@ -1867,7 +1867,7 @@ typedef struct
                               *    - This address must be used during indexed read/write operation. */
   ecma_typedarray_type_t id; /**< [[TypedArrayName]] internal slot */
   uint32_t length; /**< [[ByteLength]] internal slot */
-  ecma_length_t offset; /**< [[ByteOffset]] internal slot. */
+  uint32_t offset; /**< [[ByteOffset]] internal slot. */
   uint8_t shift; /**< the element size shift in the typedArray */
   uint8_t element_size; /**< element size based on [[TypedArrayName]] in Table 49 */
 } ecma_typedarray_info_t;

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -372,7 +372,7 @@ ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *string
 {
   JERRY_ASSERT (string_p != NULL || string_size == 0);
 
-  ecma_length_t converted_string_length = 0;
+  lit_utf8_size_t converted_string_length = 0;
   lit_utf8_size_t converted_string_size = 0;
   lit_utf8_size_t pos = 0;
 
@@ -1057,8 +1057,8 @@ ecma_string_copy_to_utf8_buffer (const ecma_string_t *string_p, /**< ecma-string
  */
 lit_utf8_size_t
 ecma_substring_copy_to_cesu8_buffer (const ecma_string_t *string_desc_p, /**< ecma-string descriptor */
-                                     ecma_length_t start_pos, /**< position of the first character */
-                                     ecma_length_t end_pos, /**< position of the last character */
+                                     lit_utf8_size_t start_pos, /**< position of the first character */
+                                     lit_utf8_size_t end_pos, /**< position of the last character */
                                      lit_utf8_byte_t *buffer_p, /**< destination buffer pointer
                                                                  * (can be NULL if buffer_size == 0) */
                                      lit_utf8_size_t buffer_size) /**< size of buffer */
@@ -1066,7 +1066,7 @@ ecma_substring_copy_to_cesu8_buffer (const ecma_string_t *string_desc_p, /**< ec
   JERRY_ASSERT (string_desc_p != NULL);
   JERRY_ASSERT (buffer_p != NULL || buffer_size == 0);
 
-  ecma_length_t string_length = ecma_string_get_length (string_desc_p);
+  lit_utf8_size_t string_length = ecma_string_get_length (string_desc_p);
   lit_utf8_size_t size = 0;
 
   if (start_pos >= string_length || start_pos >= end_pos)
@@ -1136,8 +1136,8 @@ ecma_substring_copy_to_cesu8_buffer (const ecma_string_t *string_desc_p, /**< ec
  */
 lit_utf8_size_t
 ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, /**< ecma-string descriptor */
-                                    ecma_length_t start_pos, /**< position of the first character */
-                                    ecma_length_t end_pos, /**< position of the last character */
+                                    lit_utf8_size_t start_pos, /**< position of the first character */
+                                    lit_utf8_size_t end_pos, /**< position of the last character */
                                     lit_utf8_byte_t *buffer_p, /**< destination buffer pointer
                                                                 * (can be NULL if buffer_size == 0) */
                                     lit_utf8_size_t buffer_size) /**< size of buffer */
@@ -1148,7 +1148,7 @@ ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, /**< ecm
 
   lit_utf8_size_t size = 0;
 
-  ecma_length_t utf8_str_length = ecma_string_get_utf8_length (string_desc_p);
+  lit_utf8_size_t utf8_str_length = ecma_string_get_utf8_length (string_desc_p);
 
   if (start_pos >= utf8_str_length || start_pos >= end_pos)
   {
@@ -1161,7 +1161,7 @@ ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, /**< ecm
   }
 
   ECMA_STRING_TO_UTF8_STRING (string_desc_p, cesu8_str_p, cesu8_str_size);
-  ecma_length_t cesu8_str_length = ecma_string_get_length (string_desc_p);
+  lit_utf8_size_t cesu8_str_length = ecma_string_get_length (string_desc_p);
 
   if (cesu8_str_length == cesu8_str_size)
   {
@@ -1280,12 +1280,12 @@ ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, /**< ecma-string 
  *
  * @return size in bytes
  */
-static inline ecma_length_t JERRY_ATTR_ALWAYS_INLINE
+static inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_get_uint32_size (const uint32_t uint32_number) /**< number in the string-descriptor */
 {
   uint32_t prev_number = 1;
   uint32_t next_number = 100;
-  ecma_length_t size = 1;
+  lit_utf8_size_t size = 1;
 
   const uint32_t max_size = 9;
 
@@ -1330,7 +1330,7 @@ ecma_string_get_chars (const ecma_string_t *string_p, /**< ecma-string */
                                                         *    uint32 string descriptor */
                        uint8_t *flags_p) /**< [in,out] any combination of ecma_string_flag_t bits */
 {
-  ecma_length_t length;
+  lit_utf8_size_t length;
   lit_utf8_size_t size;
   const lit_utf8_byte_t *result_p;
 
@@ -1896,7 +1896,7 @@ ecma_compare_ecma_strings_relational (const ecma_string_t *string1_p, /**< ecma-
  *
  * @return number of characters in the string
  */
-static ecma_length_t
+static lit_utf8_size_t
 ecma_string_get_ascii_size (const ecma_string_t *string_p) /**< ecma-string */
 {
   if (ECMA_IS_DIRECT_STRING (string_p))
@@ -1945,10 +1945,10 @@ ecma_string_get_ascii_size (const ecma_string_t *string_p) /**< ecma-string */
  *
  * @return number of characters in the string
  */
-ecma_length_t
+lit_utf8_size_t
 ecma_string_get_length (const ecma_string_t *string_p) /**< ecma-string */
 {
-  ecma_length_t length = ecma_string_get_ascii_size (string_p);
+  lit_utf8_size_t length = ecma_string_get_ascii_size (string_p);
 
   if (length != ECMA_STRING_NO_ASCII_SIZE)
   {
@@ -1967,12 +1967,12 @@ ecma_string_get_length (const ecma_string_t *string_p) /**< ecma-string */
 
   if (ECMA_STRING_GET_CONTAINER (string_p) == ECMA_STRING_CONTAINER_HEAP_UTF8_STRING)
   {
-    return (ecma_length_t) (((ecma_utf8_string_t *) string_p)->length);
+    return (lit_utf8_size_t) (((ecma_utf8_string_t *) string_p)->length);
   }
 
   if (ECMA_STRING_GET_CONTAINER (string_p) == ECMA_STRING_CONTAINER_HEAP_LONG_UTF8_STRING)
   {
-    return (ecma_length_t) (((ecma_long_utf8_string_t *) string_p)->length);
+    return (lit_utf8_size_t) (((ecma_long_utf8_string_t *) string_p)->length);
   }
 
   JERRY_ASSERT (ECMA_STRING_GET_CONTAINER (string_p) == ECMA_STRING_CONTAINER_MAGIC_STRING_EX);
@@ -1987,10 +1987,10 @@ ecma_string_get_length (const ecma_string_t *string_p) /**< ecma-string */
  *
  * @return number of characters in the UTF-8 encoded string
  */
-ecma_length_t
+lit_utf8_size_t
 ecma_string_get_utf8_length (const ecma_string_t *string_p) /**< ecma-string */
 {
-  ecma_length_t length = ecma_string_get_ascii_size (string_p);
+  lit_utf8_size_t length = ecma_string_get_ascii_size (string_p);
 
   if (length != ECMA_STRING_NO_ASCII_SIZE)
   {
@@ -2013,7 +2013,7 @@ ecma_string_get_utf8_length (const ecma_string_t *string_p) /**< ecma-string */
 
     if (utf8_string_p->size == utf8_string_p->length)
     {
-      return (ecma_length_t) (utf8_string_p->length);
+      return (lit_utf8_size_t) (utf8_string_p->length);
     }
 
     return lit_get_utf8_length_of_cesu8_string (ECMA_UTF8_STRING_GET_BUFFER (string_p), utf8_string_p->size);
@@ -2025,7 +2025,7 @@ ecma_string_get_utf8_length (const ecma_string_t *string_p) /**< ecma-string */
 
     if (long_utf8_string_p->size == long_utf8_string_p->length)
     {
-      return (ecma_length_t) (long_utf8_string_p->length);
+      return (lit_utf8_size_t) (long_utf8_string_p->length);
     }
 
     return lit_get_utf8_length_of_cesu8_string (ECMA_LONG_UTF8_STRING_GET_BUFFER (string_p),
@@ -2048,7 +2048,7 @@ ecma_string_get_utf8_length (const ecma_string_t *string_p) /**< ecma-string */
 lit_utf8_size_t
 ecma_string_get_size (const ecma_string_t *string_p) /**< ecma-string */
 {
-  ecma_length_t length = ecma_string_get_ascii_size (string_p);
+  lit_utf8_size_t length = ecma_string_get_ascii_size (string_p);
 
   if (length != ECMA_STRING_NO_ASCII_SIZE)
   {
@@ -2086,7 +2086,7 @@ ecma_string_get_size (const ecma_string_t *string_p) /**< ecma-string */
 lit_utf8_size_t
 ecma_string_get_utf8_size (const ecma_string_t *string_p) /**< ecma-string */
 {
-  ecma_length_t length = ecma_string_get_ascii_size (string_p);
+  lit_utf8_size_t length = ecma_string_get_ascii_size (string_p);
 
   if (length != ECMA_STRING_NO_ASCII_SIZE)
   {
@@ -2142,7 +2142,7 @@ ecma_string_get_utf8_size (const ecma_string_t *string_p) /**< ecma-string */
  */
 static ecma_char_t JERRY_ATTR_NOINLINE
 ecma_external_string_get_char_at_pos (lit_utf8_size_t id, /**< id of the external magic string */
-                                      ecma_length_t index) /**< index of character */
+                                      lit_utf8_size_t index) /**< index of character */
 {
   id -= LIT_MAGIC_STRING__COUNT;
   const lit_utf8_byte_t *data_p = lit_get_magic_string_ex_utf8 (id);
@@ -2164,7 +2164,7 @@ ecma_external_string_get_char_at_pos (lit_utf8_size_t id, /**< id of the externa
  */
 ecma_char_t
 ecma_string_get_char_at_pos (const ecma_string_t *string_p, /**< ecma-string */
-                             ecma_length_t index) /**< index of character */
+                             lit_utf8_size_t index) /**< index of character */
 {
   JERRY_ASSERT (index < ecma_string_get_length (string_p));
 
@@ -2297,10 +2297,10 @@ ecma_string_hash (const ecma_string_t *string_p) /**< ecma-string to calculate h
  */
 ecma_string_t *
 ecma_string_substr (const ecma_string_t *string_p, /**< pointer to an ecma string */
-                    ecma_length_t start_pos, /**< start position, should be less or equal than string length */
-                    ecma_length_t end_pos) /**< end position, should be less or equal than string length */
+                    lit_utf8_size_t start_pos, /**< start position, should be less or equal than string length */
+                    lit_utf8_size_t end_pos) /**< end position, should be less or equal than string length */
 {
-  const ecma_length_t string_length = ecma_string_get_length (string_p);
+  const lit_utf8_size_t string_length = ecma_string_get_length (string_p);
   JERRY_ASSERT (start_pos <= string_length);
   JERRY_ASSERT (end_pos <= string_length);
 
@@ -2767,7 +2767,7 @@ ecma_op_advance_string_index (ecma_string_t *str_p, /**< input string */
     return next_index;
   }
 
-  ecma_length_t str_len = ecma_string_get_length (str_p);
+  lit_utf8_size_t str_len = ecma_string_get_length (str_p);
 
   if (next_index >= str_len)
   {

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1489,7 +1489,7 @@ ecma_compiled_code_get_tagged_template_collection (const ecma_compiled_code_t *b
  *
  * @return number of formal parameters
  */
-ecma_length_t
+uint32_t
 ecma_compiled_code_get_formal_params (const ecma_compiled_code_t *bytecode_header_p) /**< compiled code */
 {
   if (!(bytecode_header_p->status_flags & CBC_CODE_FLAGS_MAPPED_ARGUMENTS_NEEDED))

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -336,14 +336,14 @@ ecma_string_copy_to_utf8_buffer (const ecma_string_t *string_desc_p,
                                  lit_utf8_size_t buffer_size);
 lit_utf8_size_t
 ecma_substring_copy_to_cesu8_buffer (const ecma_string_t *string_desc_p,
-                                     ecma_length_t start_pos,
-                                     ecma_length_t end_pos,
+                                     lit_utf8_size_t start_pos,
+                                     lit_utf8_size_t end_pos,
                                      lit_utf8_byte_t *buffer_p,
                                      lit_utf8_size_t buffer_size);
 lit_utf8_size_t
 ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p,
-                                    ecma_length_t start_pos,
-                                    ecma_length_t end_pos,
+                                    lit_utf8_size_t start_pos,
+                                    lit_utf8_size_t end_pos,
                                     lit_utf8_byte_t *buffer_p,
                                     lit_utf8_size_t buffer_size);
 void ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, lit_utf8_byte_t *buffer_p,
@@ -367,16 +367,16 @@ bool ecma_string_compare_to_property_name (ecma_property_t property, jmem_cpoint
 bool ecma_compare_ecma_strings (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
 bool ecma_compare_ecma_non_direct_strings (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
 bool ecma_compare_ecma_strings_relational (const ecma_string_t *string1_p, const ecma_string_t *string2_p);
-ecma_length_t ecma_string_get_length (const ecma_string_t *string_p);
-ecma_length_t ecma_string_get_utf8_length (const ecma_string_t *string_p);
+lit_utf8_size_t ecma_string_get_length (const ecma_string_t *string_p);
+lit_utf8_size_t ecma_string_get_utf8_length (const ecma_string_t *string_p);
 lit_utf8_size_t ecma_string_get_size (const ecma_string_t *string_p);
 lit_utf8_size_t ecma_string_get_utf8_size (const ecma_string_t *string_p);
-ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *string_p, ecma_length_t index);
+ecma_char_t ecma_string_get_char_at_pos (const ecma_string_t *string_p, lit_utf8_size_t index);
 
 lit_magic_string_id_t ecma_get_string_magic (const ecma_string_t *string_p);
 
 lit_string_hash_t ecma_string_hash (const ecma_string_t *string_p);
-ecma_string_t *ecma_string_substr (const ecma_string_t *string_p, ecma_length_t start_pos, ecma_length_t end_pos);
+ecma_string_t *ecma_string_substr (const ecma_string_t *string_p, lit_utf8_size_t start_pos, lit_utf8_size_t end_pos);
 void ecma_string_trim_helper (const lit_utf8_byte_t **utf8_str_p,
                               lit_utf8_size_t *utf8_str_size);
 ecma_string_t *ecma_string_trim (const ecma_string_t *string_p);
@@ -502,7 +502,7 @@ void ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p);
 ecma_collection_t *ecma_compiled_code_get_tagged_template_collection (const ecma_compiled_code_t *bytecode_header_p);
 #endif /* ENABLED (JERRY_ESNEXT) */
 #if ENABLED (JERRY_ESNEXT)
-ecma_length_t ecma_compiled_code_get_formal_params (const ecma_compiled_code_t *bytecode_p);
+uint32_t ecma_compiled_code_get_formal_params (const ecma_compiled_code_t *bytecode_p);
 ecma_value_t *ecma_compiled_code_resolve_arguments_start (const ecma_compiled_code_t *bytecode_header_p);
 ecma_value_t *ecma_compiled_code_resolve_function_name (const ecma_compiled_code_t *bytecode_header_p);
 #endif /* ENABLED (JERRY_ESNEXT) */

--- a/jerry-core/ecma/base/ecma-literal-storage.c
+++ b/jerry-core/ecma/base/ecma-literal-storage.c
@@ -453,7 +453,7 @@ ecma_save_literals_for_snapshot (ecma_collection_t *lit_pool_p, /**< list of kno
   }
 
   lit_mem_to_snapshot_id_map_entry_t *map_p;
-  ecma_length_t total_count = lit_pool_p->item_count;
+  uint32_t total_count = lit_pool_p->item_count;
 
   map_p = jmem_heap_alloc_block (total_count * sizeof (lit_mem_to_snapshot_id_map_entry_t));
 
@@ -475,7 +475,7 @@ ecma_save_literals_for_snapshot (ecma_collection_t *lit_pool_p, /**< list of kno
     map_p->literal_id = lit_buffer_p[i];
     map_p->literal_offset = (literal_offset << JERRY_SNAPSHOT_LITERAL_SHIFT) | ECMA_TYPE_SNAPSHOT_OFFSET;
 
-    ecma_length_t length;
+    lit_utf8_size_t length;
 
     if (ecma_is_value_float_number (lit_buffer_p[i]))
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -218,7 +218,7 @@ ecma_builtin_array_prototype_object_to_locale_string (ecma_object_t *obj_p, /**<
  */
 static ecma_value_t
 ecma_builtin_array_prototype_object_concat (const ecma_value_t args[], /**< arguments list */
-                                            ecma_length_t args_number, /**< number of arguments */
+                                            uint32_t args_number, /**< number of arguments */
                                             ecma_object_t *obj_p) /**< array object */
 {
   /* 2. */
@@ -472,7 +472,7 @@ ecma_builtin_array_prototype_object_pop (ecma_object_t *obj_p, /**< array object
  */
 static ecma_value_t
 ecma_builtin_array_prototype_object_push (const ecma_value_t *argument_list_p, /**< arguments list */
-                                          ecma_length_t arguments_number, /**< number of arguments */
+                                          uint32_t arguments_number, /**< number of arguments */
                                           ecma_object_t *obj_p, /**< array object */
                                           uint32_t length) /**< array object's length */
 {
@@ -1259,7 +1259,7 @@ clean_up:
  */
 static ecma_value_t
 ecma_builtin_array_prototype_object_splice (const ecma_value_t args[], /**< arguments list */
-                                            ecma_length_t args_number, /**< number of arguments */
+                                            uint32_t args_number, /**< number of arguments */
                                             ecma_object_t *obj_p, /**< array object */
                                             uint32_t len) /**< array object's length */
 {
@@ -1380,11 +1380,11 @@ ecma_builtin_array_prototype_object_splice (const ecma_value_t args[], /**< argu
 #endif /* ENABLED (JERRY_ESNEXT) */
 
   /* 11. */
-  ecma_length_t item_count;
+  uint32_t item_count;
 
   if (args_number > 2)
   {
-    item_count = (ecma_length_t) (args_number - 2);
+    item_count = (uint32_t) (args_number - 2);
   }
   else
   {
@@ -1489,8 +1489,8 @@ ecma_builtin_array_prototype_object_splice (const ecma_value_t args[], /**< argu
   }
 
   /* 15. */
-  ecma_length_t idx = 0;
-  for (ecma_length_t arg_index = 2; arg_index < args_number; arg_index++, idx++)
+  uint32_t idx = 0;
+  for (uint32_t arg_index = 2; arg_index < args_number; arg_index++, idx++)
   {
     ecma_value_t put_value = ecma_op_object_put_by_uint32_index (obj_p,
                                                                  (uint32_t) (start + idx),
@@ -1527,7 +1527,7 @@ ecma_builtin_array_prototype_object_splice (const ecma_value_t args[], /**< argu
  */
 static ecma_value_t
 ecma_builtin_array_prototype_object_unshift (const ecma_value_t args[], /**< arguments list */
-                                             ecma_length_t args_number, /**< number of arguments */
+                                             uint32_t args_number, /**< number of arguments */
                                              ecma_object_t *obj_p, /**< array object */
                                              uint32_t len) /**< array object's length */
 {
@@ -1635,7 +1635,7 @@ ecma_builtin_array_prototype_object_unshift (const ecma_value_t args[], /**< arg
  */
 static ecma_value_t
 ecma_builtin_array_prototype_object_index_of (const ecma_value_t args[], /**< arguments list */
-                                              ecma_length_t args_number, /**< number of arguments */
+                                              uint32_t args_number, /**< number of arguments */
                                               ecma_object_t *obj_p, /**< array object */
                                               uint32_t len) /**< array object's length */
 {
@@ -1740,7 +1740,7 @@ ecma_builtin_array_prototype_object_index_of (const ecma_value_t args[], /**< ar
  */
 static ecma_value_t
 ecma_builtin_array_prototype_object_last_index_of (const ecma_value_t args[], /**< arguments list */
-                                                   ecma_length_t args_number, /**< number of arguments */
+                                                   uint32_t args_number, /**< number of arguments */
                                                    ecma_object_t *obj_p, /**< array object */
                                                    uint32_t len) /**< array object's length */
 {
@@ -2142,7 +2142,7 @@ ecma_builtin_array_prototype_object_filter (ecma_value_t arg1, /**< callbackfn *
  */
 static ecma_value_t
 ecma_builtin_array_reduce_from (const ecma_value_t args_p[], /**< routine's arguments */
-                                ecma_length_t args_number, /**< arguments list length */
+                                uint32_t args_number, /**< arguments list length */
                                 bool start_from_left, /**< whether the reduce starts from left or right */
                                 ecma_object_t *obj_p, /**< array object */
                                 uint32_t len) /**< array object's length */
@@ -2436,7 +2436,7 @@ ecma_builtin_array_prototype_object_find (ecma_value_t predicate, /**< callback 
  */
 static ecma_value_t
 ecma_builtin_array_prototype_object_copy_within (const ecma_value_t args[], /**< arguments list */
-                                                 ecma_length_t args_number, /**< number of arguments */
+                                                 uint32_t args_number, /**< number of arguments */
                                                  ecma_object_t *obj_p, /**< array object */
                                                  uint32_t len) /**< array object's length */
 {
@@ -2592,7 +2592,7 @@ ecma_builtin_array_prototype_object_copy_within (const ecma_value_t args[], /**<
  */
 static ecma_value_t
 ecma_builtin_array_prototype_includes (const ecma_value_t args[], /**< arguments list */
-                                       ecma_length_t args_number, /**< number of arguments */
+                                       uint32_t args_number, /**< number of arguments */
                                        ecma_object_t *obj_p, /**< array object */
                                        uint32_t len) /**< array object's length */
 {
@@ -2678,7 +2678,7 @@ ecma_builtin_array_prototype_dispatch_routine (uint16_t builtin_routine_id, /**<
                                               ecma_value_t this_arg, /**< 'this' argument value */
                                               const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                     *   passed to routine */
-                                              ecma_length_t arguments_number) /**< length of arguments' list */
+                                              uint32_t arguments_number) /**< length of arguments' list */
 {
   ecma_value_t obj_this = ecma_op_to_object (this_arg);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
@@ -78,7 +78,7 @@ ecma_builtin_array_object_is_array (ecma_value_t this_arg, /**< 'this' argument 
 static ecma_value_t
 ecma_builtin_array_object_from (ecma_value_t this_arg, /**< 'this' argument */
                                 const ecma_value_t *arguments_list_p, /**< arguments list */
-                                ecma_length_t arguments_list_len) /**< number of arguments */
+                                uint32_t arguments_list_len) /**< number of arguments */
 {
   /* 1. */
   ecma_value_t constructor = this_arg;
@@ -408,7 +408,7 @@ cleanup:
 static ecma_value_t
 ecma_builtin_array_object_of (ecma_value_t this_arg, /**< 'this' argument */
                               const ecma_value_t *arguments_list_p, /**< arguments list */
-                              ecma_length_t arguments_list_len) /**< number of arguments */
+                              uint32_t arguments_list_len) /**< number of arguments */
 {
   if (!ecma_is_constructor (this_arg))
   {
@@ -485,7 +485,7 @@ ecma_builtin_array_species_get (ecma_value_t this_value) /**< This Value */
  */
 ecma_value_t
 ecma_builtin_array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                  ecma_length_t arguments_list_len) /**< number of arguments */
+                                  uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -499,7 +499,7 @@ ecma_builtin_array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arg
  */
 ecma_value_t
 ecma_builtin_array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer-prototype.c
@@ -65,7 +65,7 @@ ecma_builtin_arraybuffer_prototype_bytelength_getter (ecma_value_t this_arg) /**
       {
         return ecma_raise_type_error (ECMA_ERR_MSG ("ArrayBuffer has been detached."));
       }
-      ecma_length_t len = ecma_arraybuffer_get_length (object_p);
+      uint32_t len = ecma_arraybuffer_get_length (object_p);
 
       return ecma_make_uint32_value (len);
     }
@@ -105,9 +105,9 @@ ecma_builtin_arraybuffer_prototype_object_slice (ecma_value_t this_arg, /**< thi
     return ecma_raise_type_error (ECMA_ERR_MSG ("ArrayBuffer has been detached."));
   }
 
-  ecma_length_t len = ecma_arraybuffer_get_length (object_p);
+  uint32_t len = ecma_arraybuffer_get_length (object_p);
 
-  ecma_length_t start = 0, end = len;
+  uint32_t start = 0, end = len;
 
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
 
@@ -134,7 +134,7 @@ ecma_builtin_arraybuffer_prototype_object_slice (ecma_value_t this_arg, /**< thi
   }
 
   JERRY_ASSERT (start <= len && end <= len);
-  ecma_length_t new_len = (end >= start) ? (end - start) : 0;
+  uint32_t new_len = (end >= start) ? (end - start) : 0;
   ecma_object_t *new_arraybuffer_p = ecma_arraybuffer_new_object (new_len);
   lit_utf8_byte_t *old_buf = ecma_arraybuffer_get_buffer (object_p);
   lit_utf8_byte_t *new_buf = ecma_arraybuffer_get_buffer (new_arraybuffer_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-arraybuffer.c
@@ -72,7 +72,7 @@ ecma_builtin_arraybuffer_object_is_view (ecma_value_t this_arg, /**< 'this' argu
  */
 ecma_value_t
 ecma_builtin_arraybuffer_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -86,7 +86,7 @@ ecma_builtin_arraybuffer_dispatch_call (const ecma_value_t *arguments_list_p, /*
  */
 ecma_value_t
 ecma_builtin_arraybuffer_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                             ecma_length_t arguments_list_len) /**< number of arguments */
+                                             uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-async-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-async-function.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_async_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                           ecma_length_t arguments_list_len) /**< number of arguments */
+                                           uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -60,7 +60,7 @@ ecma_builtin_async_function_dispatch_call (const ecma_value_t *arguments_list_p,
  */
 ecma_value_t
 ecma_builtin_async_function_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                ecma_length_t arguments_list_len) /**< number of arguments */
+                                                uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_async_function_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_async_function_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-async-generator-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-async-generator-function.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_async_generator_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                     ecma_length_t arguments_list_len) /**< number of arguments */
+                                                     uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -60,7 +60,7 @@ ecma_builtin_async_generator_function_dispatch_call (const ecma_value_t *argumen
  */
 ecma_value_t
 ecma_builtin_async_generator_function_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                          ecma_length_t arguments_list_len) /**< number of arguments */
+                                                          uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_async_generator_function_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_async_generator_function_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-async-generator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-async-generator-prototype.c
@@ -91,8 +91,8 @@ ecma_builtin_async_generator_prototype_dispatch_routine (uint16_t builtin_routin
                                                          const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                                  *   passed to
                                                                                                  *   routine */
-                                                         ecma_length_t arguments_number) /**< length of arguments'
-                                                                                          *   list */
+                                                         uint32_t arguments_number) /**< length of arguments'
+                                                                                     *   list */
 {
   JERRY_UNUSED (arguments_number);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_boolean_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                    ecma_length_t arguments_list_len) /**< number of arguments */
+                                    uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -76,7 +76,7 @@ ecma_builtin_boolean_dispatch_call (const ecma_value_t *arguments_list_p, /**< a
  */
 ecma_value_t
 ecma_builtin_boolean_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-dataview-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-dataview-prototype.c
@@ -142,7 +142,7 @@ ecma_builtin_dataview_prototype_dispatch_routine (uint16_t builtin_routine_id, /
                                                   ecma_value_t this_arg, /**< 'this' argument value */
                                                   const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                           *   passed to routine */
-                                                  ecma_length_t arguments_number) /**< length of arguments' list */
+                                                  uint32_t arguments_number) /**< length of arguments' list */
 {
   ecma_value_t byte_offset = arguments_number > 0 ? arguments_list_p[0] : ECMA_VALUE_UNDEFINED;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-dataview.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-dataview.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_dataview_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                     ecma_length_t arguments_list_len) /**< number of arguments */
+                                     uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -57,7 +57,7 @@ ecma_builtin_dataview_dispatch_call (const ecma_value_t *arguments_list_p, /**< 
  */
 ecma_value_t
 ecma_builtin_dataview_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                          ecma_length_t arguments_list_len) /**< number of arguments */
+                                          uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_op_dataview_create (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_dataview_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -340,10 +340,10 @@ ecma_builtin_date_prototype_dispatch_set (uint16_t builtin_routine_id, /**< buil
                                           ecma_number_t date_num, /**< date converted to number */
                                           const ecma_value_t arguments_list[], /**< list of arguments
                                                                                 *   passed to routine */
-                                          ecma_length_t arguments_number) /**< length of arguments' list */
+                                          uint32_t arguments_number) /**< length of arguments' list */
 {
   ecma_number_t converted_number[4];
-  ecma_length_t conversions = 0;
+  uint32_t conversions = 0;
 
   /* If the first argument is not specified, it is always converted to NaN. */
   converted_number[0] = ecma_number_make_nan ();
@@ -392,7 +392,7 @@ ecma_builtin_date_prototype_dispatch_set (uint16_t builtin_routine_id, /**< buil
     conversions = arguments_number;
   }
 
-  for (ecma_length_t i = 0; i < conversions; i++)
+  for (uint32_t i = 0; i < conversions; i++)
   {
     ecma_value_t value = ecma_op_to_number (arguments_list[i]);
 
@@ -591,7 +591,7 @@ ecma_builtin_date_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< 
                                               ecma_value_t this_arg, /**< 'this' argument value */
                                               const ecma_value_t arguments_list[], /**< list of arguments
                                                                                     *   passed to routine */
-                                              ecma_length_t arguments_number) /**< length of arguments' list */
+                                              uint32_t arguments_number) /**< length of arguments' list */
 {
   if (JERRY_UNLIKELY (builtin_routine_id == ECMA_DATE_PROTOTYPE_TO_JSON))
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -195,7 +195,7 @@ ecma_date_parse_month_name (const lit_utf8_byte_t **str_p, /**< pointer to the c
   */
 static ecma_value_t
 ecma_date_construct_helper (const ecma_value_t *args, /**< arguments passed to the Date constructor */
-                            ecma_length_t args_len) /**< number of arguments */
+                            uint32_t args_len) /**< number of arguments */
 {
   ecma_number_t date_nums[7] =
   {
@@ -301,8 +301,8 @@ ecma_builtin_date_parse_ISO_string_format (const lit_utf8_byte_t *date_str_curr_
       ecma_number_t seconds = ECMA_NUMBER_ZERO;
       ecma_number_t milliseconds = ECMA_NUMBER_ZERO;
 
-      ecma_length_t remaining_length = lit_utf8_string_length (date_str_curr_p,
-                                                               (lit_utf8_size_t) (date_str_end_p - date_str_curr_p));
+      lit_utf8_size_t remaining_length = lit_utf8_string_length (date_str_curr_p,
+                                                                 (lit_utf8_size_t) (date_str_end_p - date_str_curr_p));
 
       if (remaining_length >= 5)
       {
@@ -613,7 +613,7 @@ ecma_builtin_date_parse (ecma_value_t this_arg, /**< this argument */
 static ecma_value_t
 ecma_builtin_date_utc (ecma_value_t this_arg, /**< this argument */
                        const ecma_value_t args[], /**< arguments list */
-                       ecma_length_t args_number) /**< number of arguments */
+                       uint32_t args_number) /**< number of arguments */
 {
   JERRY_UNUSED (this_arg);
 
@@ -677,7 +677,7 @@ ecma_builtin_date_now (ecma_value_t this_arg) /**< this argument */
  */
 ecma_value_t
 ecma_builtin_date_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                 ecma_length_t arguments_list_len) /**< number of arguments */
+                                 uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_UNUSED (arguments_list_p);
   JERRY_UNUSED (arguments_list_len);
@@ -698,7 +698,7 @@ ecma_builtin_date_dispatch_call (const ecma_value_t *arguments_list_p, /**< argu
  */
 ecma_value_t
 ecma_builtin_date_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                      ecma_length_t arguments_list_len) /**< number of arguments */
+                                      uint32_t arguments_list_len) /**< number of arguments */
 {
 #if ENABLED (JERRY_ESNEXT)
   JERRY_ASSERT (JERRY_CONTEXT (current_new_target));

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                  ecma_length_t arguments_list_len) /**< number of arguments */
+                                  uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_helper_error_dispatch_call (ECMA_ERROR_COMMON, arguments_list_p, arguments_list_len);
 } /* ecma_builtin_error_dispatch_call */
@@ -61,7 +61,7 @@ ecma_builtin_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arg
  */
 ecma_value_t
 ecma_builtin_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_error_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_error_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-evalerror.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_eval_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_helper_error_dispatch_call (ECMA_ERROR_EVAL, arguments_list_p, arguments_list_len);
 } /* ecma_builtin_eval_error_dispatch_call */
@@ -63,7 +63,7 @@ ecma_builtin_eval_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
  */
 ecma_value_t
 ecma_builtin_eval_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                            ecma_length_t arguments_list_len) /**< number of arguments */
+                                            uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_eval_error_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_eval_error_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -177,7 +177,7 @@ ecma_builtin_function_prototype_object_apply (ecma_object_t *func_obj_p, /**< th
 static ecma_value_t
 ecma_builtin_function_prototype_object_call (ecma_object_t *func_obj_p , /**< this argument object */
                                              const ecma_value_t *arguments_list_p, /**< list of arguments */
-                                             ecma_length_t arguments_number) /**< number of arguments */
+                                             uint32_t arguments_number) /**< number of arguments */
 {
   if (arguments_number == 0)
   {
@@ -191,7 +191,7 @@ ecma_builtin_function_prototype_object_call (ecma_object_t *func_obj_p , /**< th
   return ecma_op_function_call (func_obj_p,
                                 arguments_list_p[0],
                                 arguments_list_p + 1,
-                                (ecma_length_t) (arguments_number - 1u));
+                                (uint32_t) (arguments_number - 1u));
 } /* ecma_builtin_function_prototype_object_call */
 
 /**
@@ -206,7 +206,7 @@ ecma_builtin_function_prototype_object_call (ecma_object_t *func_obj_p , /**< th
 static ecma_value_t
 ecma_builtin_function_prototype_object_bind (ecma_object_t *this_arg_obj_p , /**< this argument object */
                                              const ecma_value_t *arguments_list_p, /**< list of arguments */
-                                             ecma_length_t arguments_number) /**< number of arguments */
+                                             uint32_t arguments_number) /**< number of arguments */
 {
   /* 4. 11. 18. */
   ecma_object_t *prototype_obj_p;
@@ -287,7 +287,7 @@ ecma_builtin_function_prototype_object_bind (ecma_object_t *this_arg_obj_p , /**
     bound_func_p->header.u.bound_function.args_len_or_this = ECMA_VALUE_UNDEFINED;
     ecma_value_t *args_p = (ecma_value_t *) (bound_func_p + 1);
 
-    for (ecma_length_t i = 0; i < arguments_number; i++)
+    for (uint32_t i = 0; i < arguments_number; i++)
     {
       *args_p++ = ecma_copy_value_if_not_object (arguments_list_p[i]);
     }
@@ -390,7 +390,7 @@ ecma_builtin_function_prototype_object_bind (ecma_object_t *this_arg_obj_p , /**
  */
 ecma_value_t
 ecma_builtin_function_prototype_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                               ecma_length_t arguments_list_len) /**< number of arguments */
+                                               uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -404,7 +404,7 @@ ecma_builtin_function_prototype_dispatch_call (const ecma_value_t *arguments_lis
  */
 ecma_value_t
 ecma_builtin_function_prototype_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                    ecma_length_t arguments_list_len) /**< number of arguments */
+                                                    uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -423,7 +423,7 @@ ecma_builtin_function_prototype_dispatch_routine (uint16_t builtin_routine_id, /
                                                   ecma_value_t this_arg, /**< 'this' argument value */
                                                   const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                         *   passed to routine */
-                                                  ecma_length_t arguments_number) /**< length of arguments' list */
+                                                  uint32_t arguments_number) /**< length of arguments' list */
 {
   if (!ecma_op_is_callable (this_arg))
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function.c
@@ -48,7 +48,7 @@
  */
 ecma_value_t
 ecma_builtin_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                     ecma_length_t arguments_list_len) /**< number of arguments */
+                                     uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -65,7 +65,7 @@ ecma_builtin_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< 
  */
 ecma_value_t
 ecma_builtin_function_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                          ecma_length_t arguments_list_len) /**< number of arguments */
+                                          uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_op_create_dynamic_function (arguments_list_p, arguments_list_len, ECMA_PARSE_NO_OPTS);
 } /* ecma_builtin_function_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-generator-function.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-generator-function.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_generator_function_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                               ecma_length_t arguments_list_len) /**< number of arguments */
+                                               uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -58,7 +58,7 @@ ecma_builtin_generator_function_dispatch_call (const ecma_value_t *arguments_lis
  */
 ecma_value_t
 ecma_builtin_generator_function_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                    ecma_length_t arguments_list_len) /**< number of arguments */
+                                                    uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_generator_function_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_generator_function_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-generator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-generator-prototype.c
@@ -205,7 +205,7 @@ ecma_builtin_generator_prototype_dispatch_routine (uint16_t builtin_routine_id, 
                                                    ecma_value_t this_arg, /**< 'this' argument value */
                                                    const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                            *   passed to routine */
-                                                   ecma_length_t arguments_number) /**< length of arguments' list */
+                                                   uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (arguments_number);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -595,7 +595,7 @@ ecma_builtin_global_dispatch_routine (uint16_t builtin_routine_id, /**< built-in
                                       ecma_value_t this_arg, /**< 'this' argument value */
                                       const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                               *   passed to routine */
-                                      ecma_length_t arguments_number) /**< length of arguments' list */
+                                      uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (this_arg);
   JERRY_UNUSED (arguments_list_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-error.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-error.c
@@ -40,7 +40,7 @@
 ecma_value_t
 ecma_builtin_helper_error_dispatch_call (ecma_standard_error_t error_type, /**< native error type */
                                          const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -414,11 +414,11 @@ ecma_builtin_helper_array_concat_value (ecma_object_t *array_obj_p, /**< array *
  *         - The String.prototype.substring routine.
  *         - The ecma_builtin_helper_string_prototype_object_index_of helper routine.
  *
- * @return uint32_t - the normalized value of the index
+ * @return lit_utf8_size_t - the normalized value of the index
  */
-uint32_t
+lit_utf8_size_t
 ecma_builtin_helper_string_index_normalize (ecma_number_t index, /**< index */
-                                            uint32_t length, /**< string's length */
+                                            lit_utf8_size_t length, /**< string's length */
                                             bool nan_to_zero) /**< whether NaN is mapped to zero (t) or length (f) */
 {
   uint32_t norm_index = 0;
@@ -477,7 +477,7 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_string_t *original_st
                                                       ecma_string_index_of_mode_t mode) /**< routine's mode */
 {
   /* 5 (indexOf) -- 6 (lastIndexOf) */
-  const ecma_length_t original_len = ecma_string_get_length (original_str_p);
+  const lit_utf8_size_t original_len = ecma_string_get_length (original_str_p);
 
 #if ENABLED (JERRY_ESNEXT)
   /* 4, 6 (startsWith, includes, endsWith) */
@@ -532,11 +532,11 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_string_t *original_st
   bool use_first_index = mode != ECMA_STRING_LAST_INDEX_OF;
 
   /* 4b, 6 (indexOf) - 4b, 5, 7 (lastIndexOf) */
-  ecma_length_t start = ecma_builtin_helper_string_index_normalize (pos_num, original_len, use_first_index);
+  lit_utf8_size_t start = ecma_builtin_helper_string_index_normalize (pos_num, original_len, use_first_index);
 
   ecma_number_t ret_num = ECMA_NUMBER_MINUS_ONE;
 
-  ecma_length_t index_of = 0;
+  lit_utf8_size_t index_of = 0;
 
   ret_value = ECMA_VALUE_FALSE;
 
@@ -545,7 +545,7 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_string_t *original_st
 #if ENABLED (JERRY_ESNEXT)
     case ECMA_STRING_STARTS_WITH:
     {
-      const ecma_length_t search_len = ecma_string_get_length (search_str_p);
+      const lit_utf8_size_t search_len = ecma_string_get_length (search_str_p);
 
       if (search_len + start > original_len)
       {
@@ -574,7 +574,7 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_string_t *original_st
         start = original_len;
       }
 
-      ecma_length_t search_str_len = ecma_string_get_length (search_str_p);
+      lit_utf8_size_t search_str_len = ecma_string_get_length (search_str_p);
 
       if (search_str_len == 0)
       {
@@ -589,9 +589,9 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_string_t *original_st
         break;
       }
       if (ecma_builtin_helper_string_find_index (original_str_p, search_str_p, true,
-                                                 (ecma_length_t) start_ends_with, &index_of))
+                                                 (lit_utf8_size_t) start_ends_with, &index_of))
       {
-        ret_value = ecma_make_boolean_value (index_of == (ecma_length_t) start_ends_with);
+        ret_value = ecma_make_boolean_value (index_of == (lit_utf8_size_t) start_ends_with);
       }
       break;
     }
@@ -637,12 +637,12 @@ bool
 ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index */
                                        ecma_string_t *search_str_p, /**< string's length */
                                        bool first_index, /**< whether search for first (t) or last (f) index */
-                                       ecma_length_t start_pos, /**< start position */
-                                       ecma_length_t *ret_index_p) /**< [out] position found in original string */
+                                       lit_utf8_size_t start_pos, /**< start position */
+                                       lit_utf8_size_t *ret_index_p) /**< [out] position found in original string */
 {
   bool match_found = false;
-  const ecma_length_t original_len = ecma_string_get_length (original_str_p);
-  const ecma_length_t search_len = ecma_string_get_length (search_str_p);
+  const lit_utf8_size_t original_len = ecma_string_get_length (original_str_p);
+  const lit_utf8_size_t search_len = ecma_string_get_length (search_str_p);
 
   if (search_len <= original_len)
   {
@@ -656,10 +656,10 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
       /* create utf8 string from original string and advance to position */
       ECMA_STRING_TO_UTF8_STRING (original_str_p, original_str_utf8_p, original_str_size);
 
-      ecma_length_t index = start_pos;
+      lit_utf8_size_t index = start_pos;
 
       const lit_utf8_byte_t *original_str_curr_p = original_str_utf8_p;
-      for (ecma_length_t idx = 0; idx < index; idx++)
+      for (lit_utf8_size_t idx = 0; idx < index; idx++)
       {
         lit_utf8_incr (&original_str_curr_p);
       }
@@ -675,7 +675,7 @@ ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, /**< index
       while (searching)
       {
         /* match as long as possible */
-        ecma_length_t match_len = 0;
+        lit_utf8_size_t match_len = 0;
         const lit_utf8_byte_t *stored_original_str_curr_p = original_str_curr_p;
 
         if (match_len < search_len &&

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -58,7 +58,7 @@ ecma_builtin_helper_string_prototype_object_index_of (ecma_string_t *original_st
                                                       ecma_value_t arg2, ecma_string_index_of_mode_t mode);
 bool
 ecma_builtin_helper_string_find_index (ecma_string_t *original_str_p, ecma_string_t *search_str_p, bool first_index,
-                                       ecma_length_t start_pos, ecma_length_t *ret_index_p);
+                                       lit_utf8_size_t start_pos, lit_utf8_size_t *ret_index_p);
 ecma_value_t
 ecma_builtin_helper_def_prop (ecma_object_t *obj_p, ecma_string_t *name_p, ecma_value_t value, uint32_t opts);
 
@@ -227,7 +227,7 @@ ecma_builtin_helper_json_create_non_formatted_json (lit_utf8_byte_t left_bracket
 
 ecma_value_t
 ecma_builtin_helper_error_dispatch_call (ecma_standard_error_t error_type, const ecma_value_t *arguments_list_p,
-                                         ecma_length_t arguments_list_len);
+                                         uint32_t arguments_list_len);
 
 /* ecma-builtin-helpers-sort.c */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-internal-routines-template.inc.h
@@ -40,7 +40,7 @@
 #define ROUTINE_ARG_LIST_2 ROUTINE_ARG_LIST_1 ROUTINE_ARG(2)
 #define ROUTINE_ARG_LIST_3 ROUTINE_ARG_LIST_2 ROUTINE_ARG(3)
 #define ROUTINE_ARG_LIST_NON_FIXED ROUTINE_ARG_LIST_0, \
-  const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len
+  const ecma_value_t *arguments_list_p, uint32_t arguments_list_len
 #define ROUTINE(name, c_function_name, args_number, length_prop_value) \
   static ecma_value_t c_function_name (ROUTINE_ARG_LIST_ ## args_number);
 #define ROUTINE_CONFIGURABLE_ONLY(name, c_function_name, args_number, length_prop_value) \
@@ -236,8 +236,8 @@ DISPATCH_ROUTINE_ROUTINE_NAME (uint16_t builtin_routine_id, /**< built-in wide r
                                                                  value */
                                const ecma_value_t arguments_list[], /**< list of arguments
                                                                          passed to routine */
-                               ecma_length_t arguments_number) /**< length of
-                                                                    arguments' list */
+                               uint32_t arguments_number) /**< length of
+                                                           *   arguments' list */
 {
   /* the arguments may be unused for some built-ins */
   JERRY_UNUSED (this_arg_value);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-intrinsic.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-intrinsic.c
@@ -120,7 +120,7 @@ ecma_builtin_intrinsic_dispatch_routine (uint16_t builtin_routine_id, /**< built
                                          ecma_value_t this_arg, /**< 'this' argument value */
                                          const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                  *   passed to routine */
-                                         ecma_length_t arguments_number) /**< length of arguments' list */
+                                         uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (arguments_number);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1668,7 +1668,7 @@ ecma_builtin_json_stringify (ecma_value_t this_arg, /**< 'this' argument */
   else if (ecma_is_value_string (space))
   {
     ecma_string_t *space_str_p = ecma_get_string_from_value (space);
-    ecma_length_t num_of_chars = ecma_string_get_length (space_str_p);
+    lit_utf8_size_t num_of_chars = ecma_string_get_length (space_str_p);
 
     if (num_of_chars < 10)
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-map-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-map-prototype.c
@@ -50,7 +50,7 @@ ecma_builtin_map_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< b
                                              ecma_value_t this_arg, /**< 'this' argument value */
                                              const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                      *   passed to routine */
-                                             ecma_length_t arguments_number) /**< length of arguments' list */
+                                             uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (arguments_number);
   return ecma_builtin_container_dispatch_routine (builtin_routine_id,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-map.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-map.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_map_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                ecma_length_t arguments_list_len) /**< number of arguments */
+                                uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -57,7 +57,7 @@ ecma_builtin_map_dispatch_call (const ecma_value_t *arguments_list_p, /**< argum
  */
 ecma_value_t
 ecma_builtin_map_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                     ecma_length_t arguments_list_len) /**< number of arguments */
+                                     uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_op_container_create (arguments_list_p,
                                    arguments_list_len,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-math.c
@@ -120,7 +120,7 @@ enum
 static ecma_value_t
 ecma_builtin_math_object_max_min (bool is_max, /**< 'max' or 'min' operation */
                                   const ecma_value_t *arg, /**< arguments list */
-                                  ecma_length_t args_number) /**< number of arguments */
+                                  uint32_t args_number) /**< number of arguments */
 {
   ecma_number_t result_num = ecma_number_make_infinity (is_max);
   bool nan_found = false;
@@ -195,7 +195,7 @@ ecma_builtin_math_object_max_min (bool is_max, /**< 'max' or 'min' operation */
  */
 static ecma_value_t
 ecma_builtin_math_object_hypot (const ecma_value_t *arg, /**< arguments list */
-                                ecma_length_t args_number) /**< number of arguments */
+                                uint32_t args_number) /**< number of arguments */
 {
   if (args_number == 0)
   {
@@ -340,7 +340,7 @@ ecma_builtin_math_dispatch_routine (uint16_t builtin_routine_id, /**< built-in w
                                     ecma_value_t this_arg, /**< 'this' argument value */
                                     const ecma_value_t arguments_list[], /**< list of arguments
                                                                           *   passed to routine */
-                                    ecma_length_t arguments_number) /**< length of arguments' list */
+                                    uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (this_arg);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -247,7 +247,7 @@ ecma_builtin_number_prototype_helper_round (lit_utf8_byte_t *digits_p, /**< [in,
 static ecma_value_t
 ecma_builtin_number_prototype_object_to_string (ecma_number_t this_arg_number, /**< this argument number */
                                                 const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                ecma_length_t arguments_list_len) /**< number of arguments */
+                                                uint32_t arguments_list_len) /**< number of arguments */
 {
   static const lit_utf8_byte_t digit_chars[36] =
   {
@@ -977,7 +977,7 @@ ecma_builtin_number_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
                                                 ecma_value_t this_arg, /**< 'this' argument value */
                                                 const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                       *   passed to routine */
-                                                ecma_length_t arguments_number) /**< length of arguments' list */
+                                                uint32_t arguments_number) /**< length of arguments' list */
 {
   ecma_value_t this_value = ecma_builtin_number_prototype_object_value_of (this_arg);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
@@ -53,7 +53,7 @@
  */
 ecma_value_t
 ecma_builtin_number_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                   ecma_length_t arguments_list_len) /**< number of arguments */
+                                   uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -78,7 +78,7 @@ ecma_builtin_number_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
  */
 ecma_value_t
 ecma_builtin_number_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -215,7 +215,7 @@ ecma_builtin_object_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
                                                 ecma_value_t this_arg, /**< 'this' argument value */
                                                 const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                       *   passed to routine */
-                                                ecma_length_t arguments_number) /**< length of arguments' list */
+                                                uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (arguments_number);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -94,7 +94,7 @@ enum
  */
 ecma_value_t
 ecma_builtin_object_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                   ecma_length_t arguments_list_len) /**< number of arguments */
+                                   uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -115,7 +115,7 @@ ecma_builtin_object_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
  */
 ecma_value_t
 ecma_builtin_object_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -1048,7 +1048,7 @@ ecma_builtin_object_object_define_property (ecma_object_t *obj_p, /**< routine's
 static ecma_value_t
 ecma_builtin_object_object_assign (ecma_object_t *target_p, /**< target object */
                                    const ecma_value_t arguments_list_p[], /**< arguments list */
-                                   ecma_length_t arguments_list_len) /**< number of arguments */
+                                   uint32_t arguments_list_len) /**< number of arguments */
 {
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
 
@@ -1178,7 +1178,7 @@ ecma_builtin_object_dispatch_routine (uint16_t builtin_routine_id, /**< built-in
                                       ecma_value_t this_arg, /**< 'this' argument value */
                                       const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                               *   passed to routine */
-                                      ecma_length_t arguments_number) /**< length of arguments' list */
+                                      uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (this_arg);
   JERRY_UNUSED (arguments_list_p);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -453,7 +453,7 @@ ecma_builtin_promise_all (ecma_value_t this_arg, /**< 'this' argument */
  */
 ecma_value_t
 ecma_builtin_promise_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                    ecma_length_t arguments_list_len) /**< number of arguments */
+                                    uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -467,7 +467,7 @@ ecma_builtin_promise_dispatch_call (const ecma_value_t *arguments_list_p, /**< a
  */
 ecma_value_t
 ecma_builtin_promise_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-proxy.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-proxy.c
@@ -76,7 +76,7 @@ ecma_builtin_proxy_object_revocable (ecma_value_t this_arg, /**< 'this' argument
  */
 ecma_value_t
 ecma_builtin_proxy_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                  ecma_length_t arguments_list_len) /**< number of arguments */
+                                  uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -95,7 +95,7 @@ ecma_builtin_proxy_dispatch_call (const ecma_value_t *arguments_list_p, /**< arg
  */
 ecma_value_t
 ecma_builtin_proxy_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-rangeerror.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_range_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_helper_error_dispatch_call (ECMA_ERROR_RANGE, arguments_list_p, arguments_list_len);
 } /* ecma_builtin_range_error_dispatch_call */
@@ -63,7 +63,7 @@ ecma_builtin_range_error_dispatch_call (const ecma_value_t *arguments_list_p, /*
  */
 ecma_value_t
 ecma_builtin_range_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                             ecma_length_t arguments_list_len) /**< number of arguments */
+                                             uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_range_error_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_range_error_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-referenceerror.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_reference_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                            ecma_length_t arguments_list_len) /**< number of arguments */
+                                            uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_helper_error_dispatch_call (ECMA_ERROR_REFERENCE, arguments_list_p, arguments_list_len);
 } /* ecma_builtin_reference_error_dispatch_call */
@@ -63,7 +63,7 @@ ecma_builtin_reference_error_dispatch_call (const ecma_value_t *arguments_list_p
  */
 ecma_value_t
 ecma_builtin_reference_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                 ecma_length_t arguments_list_len) /**< number of arguments */
+                                                 uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_reference_error_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_reference_error_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
@@ -82,7 +82,7 @@ ecma_builtin_reflect_dispatch_routine (uint16_t builtin_routine_id, /**< built-i
                                        ecma_value_t this_arg, /**< 'this' argument value */
                                        const ecma_value_t arguments_list[], /**< list of arguments
                                                                              *   passed to routine */
-                                       ecma_length_t arguments_number) /**< length of arguments' list */
+                                       uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (this_arg);
   JERRY_UNUSED (arguments_number);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp.c
@@ -45,7 +45,7 @@
 
 static ecma_value_t
 ecma_builtin_regexp_dispatch_helper (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                     ecma_length_t arguments_list_len) /**< number of arguments */
+                                     uint32_t arguments_list_len) /**< number of arguments */
 {
   ecma_value_t pattern_value = ECMA_VALUE_UNDEFINED;
   ecma_value_t flags_value = ECMA_VALUE_UNDEFINED;
@@ -199,7 +199,7 @@ ecma_builtin_regexp_dispatch_helper (const ecma_value_t *arguments_list_p, /**< 
  */
 ecma_value_t
 ecma_builtin_regexp_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                   ecma_length_t arguments_list_len) /**< number of arguments */
+                                   uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_regexp_dispatch_helper (arguments_list_p,
                                               arguments_list_len);
@@ -213,7 +213,7 @@ ecma_builtin_regexp_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
  */
 ecma_value_t
 ecma_builtin_regexp_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_regexp_dispatch_helper (arguments_list_p,
                                               arguments_list_len);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-set-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-set-prototype.c
@@ -49,7 +49,7 @@ ecma_builtin_set_prototype_dispatch_routine (uint16_t builtin_routine_id, /**< b
                                              ecma_value_t this_arg, /**< 'this' argument value */
                                              const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                      *   passed to routine */
-                                             ecma_length_t arguments_number) /**< length of arguments' list */
+                                             uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (arguments_number);
   return ecma_builtin_container_dispatch_routine (builtin_routine_id,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-set.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-set.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_set_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                ecma_length_t arguments_list_len) /**< number of arguments */
+                                uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -57,7 +57,7 @@ ecma_builtin_set_dispatch_call (const ecma_value_t *arguments_list_p, /**< argum
  */
 ecma_value_t
 ecma_builtin_set_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                     ecma_length_t arguments_list_len) /**< number of arguments */
+                                     uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_op_container_create (arguments_list_p,
                                    arguments_list_len,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-iterator-prototype.c
@@ -80,7 +80,7 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   ecma_string_t *string_p = ecma_get_string_from_value (iterated_value);
 
   /* 6. */
-  ecma_length_t position = ext_obj_p->u.pseudo_array.u1.iterator_index;
+  lit_utf8_size_t position = ext_obj_p->u.pseudo_array.u1.iterator_index;
 
   if (JERRY_UNLIKELY (position == ECMA_ITERATOR_INDEX_LIMIT))
   {
@@ -88,7 +88,7 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   }
 
   /* 7. */
-  ecma_length_t len = ecma_string_get_length (string_p);
+  lit_utf8_size_t len = ecma_string_get_length (string_p);
 
   /* 8. */
   if (position >= len)
@@ -102,7 +102,7 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   ecma_char_t first = ecma_string_get_char_at_pos (string_p, position);
 
   ecma_string_t *result_str_p;
-  ecma_length_t result_size = 1;
+  lit_utf8_size_t result_size = 1;
 
   /* 10. */
   if (first < LIT_UTF16_HIGH_SURROGATE_MIN || first > LIT_UTF16_HIGH_SURROGATE_MAX || (position + 1 == len))
@@ -113,7 +113,7 @@ ecma_builtin_string_iterator_prototype_object_next (ecma_value_t this_val) /**< 
   else
   {
     /* 11.a */
-    ecma_char_t second = ecma_string_get_char_at_pos (string_p, (ecma_length_t) (position + 1));
+    ecma_char_t second = ecma_string_get_char_at_pos (string_p, position + 1);
 
     /* 11.b */
     if (second < LIT_UTF16_LOW_SURROGATE_MIN || second > LIT_UTF16_LOW_SURROGATE_MAX)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -167,7 +167,7 @@ ecma_builtin_string_prototype_char_at_helper (ecma_value_t this_arg, /**< this a
   }
 
   /* 4 */
-  const ecma_length_t len = ecma_string_get_length (original_string_p);
+  const lit_utf8_size_t len = ecma_string_get_length (original_string_p);
 
   /* 5 */
   // When index_num is NaN, then the first two comparisons are false
@@ -206,7 +206,7 @@ ecma_builtin_string_prototype_char_at_helper (ecma_value_t this_arg, /**< this a
 static ecma_value_t
 ecma_builtin_string_prototype_object_concat (ecma_string_t *this_string_p, /**< this argument */
                                              const ecma_value_t *argument_list_p, /**< arguments list */
-                                             ecma_length_t arguments_number) /**< number of arguments */
+                                             uint32_t arguments_number) /**< number of arguments */
 {
   ecma_stringbuilder_t builder = ecma_stringbuilder_create_from (this_string_p);
 
@@ -475,7 +475,7 @@ ecma_builtin_string_prototype_object_replace (ecma_value_t this_value, /**< this
     const lit_utf8_byte_t *const input_end_p = replace_ctx.string_p + replace_ctx.string_size;
     const lit_utf8_byte_t *const loop_end_p = input_end_p - search_size;
 
-    uint32_t pos = 0;
+    lit_utf8_size_t pos = 0;
     for (const lit_utf8_byte_t *curr_p = replace_ctx.string_p;
          curr_p <= loop_end_p;
          lit_utf8_incr (&curr_p), pos++)
@@ -681,10 +681,10 @@ ecma_builtin_string_prototype_object_slice (ecma_string_t *get_string_val, /**< 
                                             ecma_value_t arg1, /**< routine's first argument */
                                             ecma_value_t arg2) /**< routine's second argument */
 {
-  const ecma_length_t len = ecma_string_get_length (get_string_val);
+  const lit_utf8_size_t len = ecma_string_get_length (get_string_val);
 
   /* 4. 6. */
-  ecma_length_t start = 0, end = len;
+  lit_utf8_size_t start = 0, end = len;
 
   if (ECMA_IS_VALUE_ERROR (ecma_builtin_helper_array_index_normalize (arg1,
                                                                       len,
@@ -805,7 +805,7 @@ ecma_builtin_string_prototype_object_split (ecma_value_t this_value, /**< this a
   }
 
   ecma_object_t *array_p = ecma_get_object_from_value (result);
-  ecma_length_t array_length = 0;
+  lit_utf8_size_t array_length = 0;
 
   /* 15. */
   if (ecma_is_value_undefined (separator_value))
@@ -923,8 +923,8 @@ ecma_builtin_string_prototype_object_substring (ecma_string_t *original_string_p
                                                 ecma_value_t arg2) /**< routine's second argument */
 {
   /* 3 */
-  const ecma_length_t len = ecma_string_get_length (original_string_p);
-  ecma_length_t start = 0, end = len;
+  const lit_utf8_size_t len = ecma_string_get_length (original_string_p);
+  lit_utf8_size_t start = 0, end = len;
 
   /* 4 */
   ecma_number_t start_num;
@@ -1130,9 +1130,9 @@ ecma_builtin_string_prototype_object_code_point_at (ecma_string_t *this_string_p
     return error;
   }
 
-  ecma_length_t size = ecma_string_get_length (this_string_p);
+  lit_utf8_size_t length = ecma_string_get_length (this_string_p);
 
-  if (pos_num < 0 || pos_num >= size)
+  if (pos_num < 0 || pos_num >= length)
   {
     return ECMA_VALUE_UNDEFINED;
   }
@@ -1143,7 +1143,7 @@ ecma_builtin_string_prototype_object_code_point_at (ecma_string_t *this_string_p
 
   if (first < LIT_UTF16_HIGH_SURROGATE_MIN
       || first > LIT_UTF16_HIGH_SURROGATE_MAX
-      || index + 1 == size)
+      || index + 1 == length)
   {
     return ecma_make_uint32_value (first);
   }
@@ -1201,7 +1201,7 @@ ecma_builtin_string_prototype_object_substr (ecma_string_t *this_string_p, /**< 
   }
 
   /* 4. */
-  ecma_length_t this_len = ecma_string_get_length (this_string_p);
+  lit_utf8_size_t this_len = ecma_string_get_length (this_string_p);
 
   /* 5. */
   uint32_t from = (uint32_t) ((start_num < 0) ? JERRY_MAX (this_len + start_num, 0) : start_num);
@@ -1258,7 +1258,7 @@ ecma_builtin_string_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
                                                 ecma_value_t this_arg, /**< 'this' argument value */
                                                 const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                       *   passed to routine */
-                                                ecma_length_t arguments_number) /**< length of arguments' list */
+                                                uint32_t arguments_number) /**< length of arguments' list */
 {
   if (builtin_routine_id <= ECMA_STRING_PROTOTYPE_VALUE_OF)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string.c
@@ -60,7 +60,7 @@
 static ecma_value_t
 ecma_builtin_string_object_from_char_code (ecma_value_t this_arg, /**< 'this' argument */
                                            const ecma_value_t args[], /**< arguments list */
-                                           ecma_length_t args_number) /**< number of arguments */
+                                           uint32_t args_number) /**< number of arguments */
 {
   JERRY_UNUSED (this_arg);
 
@@ -79,7 +79,7 @@ ecma_builtin_string_object_from_char_code (ecma_value_t this_arg, /**< 'this' ar
 
   lit_utf8_size_t utf8_buf_used = 0;
 
-  for (ecma_length_t arg_index = 0;
+  for (uint32_t arg_index = 0;
        arg_index < args_number && ecma_is_value_empty (ret_value);
        arg_index++)
   {
@@ -124,13 +124,13 @@ ecma_builtin_string_object_from_char_code (ecma_value_t this_arg, /**< 'this' ar
 static ecma_value_t
 ecma_builtin_string_object_raw (ecma_value_t this_arg, /**< 'this' argument */
                                 const ecma_value_t args[], /**< arguments list */
-                                ecma_length_t args_number) /**< number of arguments */
+                                uint32_t args_number) /**< number of arguments */
 {
   JERRY_UNUSED (this_arg);
 
   /* 1 - 2. */
   const ecma_value_t *substitutions;
-  ecma_length_t number_of_substitutions;
+  uint32_t number_of_substitutions;
 
   if (args_number > 1)
   {
@@ -278,7 +278,7 @@ cleanup:
 static ecma_value_t
 ecma_builtin_string_object_from_code_point (ecma_value_t this_arg, /**< 'this' argument */
                                             const ecma_value_t args[], /**< arguments list */
-                                            ecma_length_t args_number) /**< number of arguments */
+                                            uint32_t args_number) /**< number of arguments */
 {
   JERRY_UNUSED (this_arg);
 
@@ -289,7 +289,7 @@ ecma_builtin_string_object_from_code_point (ecma_value_t this_arg, /**< 'this' a
 
   ecma_stringbuilder_t builder = ecma_stringbuilder_create ();
 
-  for (ecma_length_t index = 0; index < args_number; index++)
+  for (uint32_t index = 0; index < args_number; index++)
   {
     ecma_value_t to_number_value = ecma_op_to_number (args[index]);
 
@@ -317,7 +317,7 @@ ecma_builtin_string_object_from_code_point (ecma_value_t this_arg, /**< 'this' a
       return ecma_raise_range_error (ECMA_ERR_MSG ("Error: Invalid code point"));
     }
 
-    lit_code_point_t code_point = (uint32_t) to_int_num;
+    lit_code_point_t code_point = (lit_code_point_t) to_int_num;
 
     ecma_char_t converted_cp[2];
     uint8_t encoded_size = lit_utf16_encode_code_point (code_point, converted_cp);
@@ -345,7 +345,7 @@ ecma_builtin_string_object_from_code_point (ecma_value_t this_arg, /**< 'this' a
  */
 ecma_value_t
 ecma_builtin_string_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                   ecma_length_t arguments_list_len) /**< number of arguments */
+                                   uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -385,7 +385,7 @@ ecma_builtin_string_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
  */
 ecma_value_t
 ecma_builtin_string_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-symbol-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-symbol-prototype.c
@@ -73,7 +73,7 @@ ecma_builtin_symbol_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
                                                 ecma_value_t this_arg, /**< 'this' argument value */
                                                 const ecma_value_t arguments_list[], /**< list of arguments
                                                                              *   passed to routine */
-                                                ecma_length_t arguments_number) /**< length of arguments' list */
+                                                uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED_2 (arguments_list, arguments_number);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-symbol.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-symbol.c
@@ -53,7 +53,7 @@
  */
 ecma_value_t
 ecma_builtin_symbol_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                   ecma_length_t arguments_list_len) /**< number of arguments */
+                                   uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -72,7 +72,7 @@ ecma_builtin_symbol_dispatch_call (const ecma_value_t *arguments_list_p, /**< ar
  */
 ecma_value_t
 ecma_builtin_symbol_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-syntaxerror.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_syntax_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_helper_error_dispatch_call (ECMA_ERROR_SYNTAX, arguments_list_p, arguments_list_len);
 } /* ecma_builtin_syntax_error_dispatch_call */
@@ -63,7 +63,7 @@ ecma_builtin_syntax_error_dispatch_call (const ecma_value_t *arguments_list_p, /
  */
 ecma_value_t
 ecma_builtin_syntax_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                              ecma_length_t arguments_list_len) /**< number of arguments */
+                                              uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_syntax_error_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_syntax_error_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-type-error-thrower.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_type_error_thrower_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                               ecma_length_t arguments_list_len) /**< number of arguments */
+                                               uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -69,7 +69,7 @@ ecma_builtin_type_error_thrower_dispatch_call (const ecma_value_t *arguments_lis
  */
 ecma_value_t
 ecma_builtin_type_error_thrower_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                    ecma_length_t arguments_list_len) /**< number of arguments */
+                                                    uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-typeerror.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_type_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_helper_error_dispatch_call (ECMA_ERROR_TYPE, arguments_list_p, arguments_list_len);
 } /* ecma_builtin_type_error_dispatch_call */
@@ -63,7 +63,7 @@ ecma_builtin_type_error_dispatch_call (const ecma_value_t *arguments_list_p, /**
  */
 ecma_value_t
 ecma_builtin_type_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                            ecma_length_t arguments_list_len) /**< number of arguments */
+                                            uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_type_error_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_type_error_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-urierror.c
@@ -51,7 +51,7 @@
  */
 ecma_value_t
 ecma_builtin_uri_error_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                      ecma_length_t arguments_list_len) /**< number of arguments */
+                                      uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_helper_error_dispatch_call (ECMA_ERROR_URI, arguments_list_p, arguments_list_len);
 } /* ecma_builtin_uri_error_dispatch_call */
@@ -63,7 +63,7 @@ ecma_builtin_uri_error_dispatch_call (const ecma_value_t *arguments_list_p, /**<
  */
 ecma_value_t
 ecma_builtin_uri_error_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                           ecma_length_t arguments_list_len) /**< number of arguments */
+                                           uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_builtin_uri_error_dispatch_call (arguments_list_p, arguments_list_len);
 } /* ecma_builtin_uri_error_dispatch_construct */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-weakmap-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-weakmap-prototype.c
@@ -49,7 +49,7 @@ ecma_builtin_weakmap_prototype_dispatch_routine (uint16_t builtin_routine_id, /*
                                                  ecma_value_t this_arg, /**< 'this' argument value */
                                                  const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                          *   passed to routine */
-                                                 ecma_length_t arguments_number) /**< length of arguments' list */
+                                                 uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (arguments_number);
   return ecma_builtin_container_dispatch_routine (builtin_routine_id,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-weakmap.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-weakmap.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_weakmap_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                    ecma_length_t arguments_list_len) /**< number of arguments */
+                                    uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -57,7 +57,7 @@ ecma_builtin_weakmap_dispatch_call (const ecma_value_t *arguments_list_p, /**< a
  */
 ecma_value_t
 ecma_builtin_weakmap_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_op_container_create (arguments_list_p,
                                    arguments_list_len,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-weakset-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-weakset-prototype.c
@@ -50,7 +50,7 @@ ecma_builtin_weakset_prototype_dispatch_routine (uint16_t builtin_routine_id, /*
                                                  ecma_value_t this_arg, /**< 'this' argument value */
                                                  const ecma_value_t arguments_list_p[], /**< list of arguments
                                                                                          *   passed to routine */
-                                                 ecma_length_t arguments_number) /**< length of arguments' list */
+                                                 uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (arguments_number);
   return ecma_builtin_container_dispatch_routine (builtin_routine_id,

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-weakset.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-weakset.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_builtin_weakset_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                    ecma_length_t arguments_list_len) /**< number of arguments */
+                                    uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -57,7 +57,7 @@ ecma_builtin_weakset_dispatch_call (const ecma_value_t *arguments_list_p, /**< a
  */
 ecma_value_t
 ecma_builtin_weakset_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_op_container_create (arguments_list_p,
                                    arguments_list_len,

--- a/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins-internal.h
@@ -89,15 +89,15 @@ extern const ecma_builtin_property_descriptor_t \
 ecma_builtin_ ## lowercase_name ## _property_descriptor_list[]; \
 ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_call (const ecma_value_t *, \
-                                                   ecma_length_t); \
+                                                   uint32_t); \
 ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_construct (const ecma_value_t *, \
-                                                        ecma_length_t); \
+                                                        uint32_t); \
 ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_routine (uint16_t builtin_routine_id, \
                                                       ecma_value_t this_arg_value, \
                                                       const ecma_value_t [], \
-                                                      ecma_length_t);
+                                                      uint32_t);
 #define BUILTIN(builtin_id, \
                 object_type, \
                 object_prototype_builtin_id, \
@@ -109,7 +109,7 @@ ecma_value_t \
 ecma_builtin_ ## lowercase_name ## _dispatch_routine (uint16_t builtin_routine_id, \
                                                       ecma_value_t this_arg_value, \
                                                       const ecma_value_t [], \
-                                                      ecma_length_t);
+                                                      uint32_t);
 #include "ecma-builtins.inc.h"
 
 #undef BUILTIN_ROUTINE

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -47,12 +47,12 @@ typedef const ecma_builtin_property_descriptor_t *ecma_builtin_property_list_ref
 typedef ecma_value_t (*ecma_builtin_dispatch_routine_t) (uint16_t builtin_routine_id,
                                                          ecma_value_t this_arg,
                                                          const ecma_value_t arguments_list[],
-                                                         ecma_length_t arguments_number);
+                                                         uint32_t arguments_number);
 /**
  * Definition of built-in dispatch call function pointer.
  */
 typedef ecma_value_t (*ecma_builtin_dispatch_call_t) (const ecma_value_t arguments_list[],
-                                                      ecma_length_t arguments_number);
+                                                      uint32_t arguments_number);
 /**
  * Definition of a builtin descriptor which contains the builtin object's:
  * - prototype objects's id (13-bits)
@@ -1118,7 +1118,7 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p, /**< a built-in 
 
   const ecma_builtin_property_descriptor_t *curr_property_p = ecma_builtin_property_list_references[builtin_id];
 
-  ecma_length_t index = 0;
+  uint32_t index = 0;
   uint32_t *bitset_p = built_in_props_p->u.instantiated_bitset;
 
   ecma_collection_t *for_non_enumerable_p = (separate_enumerable ? non_enum_collection_p
@@ -1182,7 +1182,7 @@ static ecma_value_t
 ecma_builtin_dispatch_routine (ecma_extended_object_t *func_obj_p, /**< builtin object */
                                ecma_value_t this_arg_value, /**< 'this' argument value */
                                const ecma_value_t *arguments_list_p, /**< list of arguments passed to routine */
-                               ecma_length_t arguments_list_len) /**< length of arguments' list */
+                               uint32_t arguments_list_len) /**< length of arguments' list */
 {
   JERRY_ASSERT (ecma_builtin_function_is_routine ((ecma_object_t *) func_obj_p));
 
@@ -1226,7 +1226,7 @@ ecma_value_t
 ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
                             ecma_value_t this_arg_value, /**< 'this' argument value */
                             const ecma_value_t *arguments_list_p, /**< arguments list */
-                            ecma_length_t arguments_list_len) /**< arguments list length */
+                            uint32_t arguments_list_len) /**< arguments list length */
 {
   JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_FUNCTION);
   JERRY_ASSERT (ecma_get_object_is_builtin (obj_p));
@@ -1255,7 +1255,7 @@ ecma_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *obj_p, /**< built-in object */
                                  ecma_object_t *new_target_p, /**< new target */
                                  const ecma_value_t *arguments_list_p, /**< arguments list */
-                                 ecma_length_t arguments_list_len) /**< arguments list length */
+                                 uint32_t arguments_list_len) /**< arguments list length */
 {
   JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_FUNCTION);
   JERRY_ASSERT (ecma_get_object_is_builtin (obj_p));

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -83,10 +83,10 @@ void ecma_finalize_builtins (void);
 
 ecma_value_t
 ecma_builtin_dispatch_call (ecma_object_t *obj_p, ecma_value_t this_arg_value,
-                            const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+                            const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 ecma_value_t
 ecma_builtin_dispatch_construct (ecma_object_t *obj_p, ecma_object_t *new_target_p,
-                                 const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+                                 const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 ecma_property_t *
 ecma_builtin_routine_try_to_instantiate_property (ecma_object_t *object_p, ecma_string_t *string_p);
 ecma_property_t *

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float32array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float32array.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_float32array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_float32array_dispatch_call (const ecma_value_t *arguments_list_p, /
  */
 ecma_value_t
 ecma_builtin_float32array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                              ecma_length_t arguments_list_len) /**< number of arguments */
+                                              uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_typedarray_helper_dispatch_construct (arguments_list_p, arguments_list_len,
                                                     ECMA_FLOAT32_ARRAY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float64array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-float64array.c
@@ -50,7 +50,7 @@
  */
 ecma_value_t
 ecma_builtin_float64array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                         ecma_length_t arguments_list_len) /**< number of arguments */
+                                         uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -64,7 +64,7 @@ ecma_builtin_float64array_dispatch_call (const ecma_value_t *arguments_list_p, /
  */
 ecma_value_t
 ecma_builtin_float64array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                              ecma_length_t arguments_list_len) /**< number of arguments */
+                                              uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_typedarray_helper_dispatch_construct (arguments_list_p, arguments_list_len,
                                                     ECMA_FLOAT64_ARRAY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int16array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int16array.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_int16array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_int16array_dispatch_call (const ecma_value_t *arguments_list_p, /**
  */
 ecma_value_t
 ecma_builtin_int16array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                            ecma_length_t arguments_list_len) /**< number of arguments */
+                                            uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_typedarray_helper_dispatch_construct (arguments_list_p, arguments_list_len,
                                                     ECMA_INT16_ARRAY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int32array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int32array.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_int32array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_int32array_dispatch_call (const ecma_value_t *arguments_list_p, /**
  */
 ecma_value_t
 ecma_builtin_int32array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                            ecma_length_t arguments_list_len) /**< number of arguments */
+                                            uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_typedarray_helper_dispatch_construct (arguments_list_p, arguments_list_len,
                                                     ECMA_INT32_ARRAY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int8array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-int8array.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_int8array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                      ecma_length_t arguments_list_len) /**< number of arguments */
+                                      uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_int8array_dispatch_call (const ecma_value_t *arguments_list_p, /**<
  */
 ecma_value_t
 ecma_builtin_int8array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                           ecma_length_t arguments_list_len) /**< number of arguments */
+                                           uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_typedarray_helper_dispatch_construct (arguments_list_p, arguments_list_len,
                                                     ECMA_INT8_ARRAY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.c
@@ -33,7 +33,7 @@
  */
 ecma_value_t
 ecma_typedarray_helper_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                           ecma_length_t arguments_list_len, /**< number of arguments */
+                                           uint32_t arguments_list_len, /**< number of arguments */
                                            ecma_typedarray_type_t typedarray_id) /**< id of the typedarray */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.h
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-helpers.h
@@ -28,7 +28,7 @@
 
 ecma_value_t
 ecma_typedarray_helper_dispatch_construct (const ecma_value_t *arguments_list_p,
-                                           ecma_length_t arguments_list_len,
+                                           uint32_t arguments_list_len,
                                            ecma_typedarray_type_t typedarray_id);
 
 /**

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -213,7 +213,7 @@ ecma_builtin_typedarray_prototype_exec_routine (ecma_value_t this_arg, /**< this
   ecma_typedarray_getter_fn_t typedarray_getter_cb = ecma_get_typedarray_getter_fn (info.id);
 
   ecma_object_t *func_object_p = ecma_get_object_from_value (cb_func_val);
-  ecma_length_t byte_pos = 0;
+  uint32_t byte_pos = 0;
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
 
   for (uint32_t index = 0; index < info.length && ecma_is_value_empty (ret_value); index++)
@@ -459,7 +459,7 @@ ecma_builtin_typedarray_prototype_map (ecma_value_t this_arg, /**< this argument
   ecma_typedarray_getter_fn_t src_typedarray_getter_cb = ecma_get_typedarray_getter_fn (src_info.id);
   ecma_typedarray_setter_fn_t target_typedarray_setter_cb = ecma_get_typedarray_setter_fn (target_info.id);
 
-  ecma_length_t src_byte_pos = 0;
+  uint32_t src_byte_pos = 0;
 
   for (uint32_t index = 0; index < src_info.length; index++)
   {
@@ -488,7 +488,7 @@ ecma_builtin_typedarray_prototype_map (ecma_value_t this_arg, /**< this argument
     }
     else
     {
-      ecma_length_t target_byte_pos = index << target_info.shift;
+      uint32_t target_byte_pos = index << target_info.shift;
       target_typedarray_setter_cb (target_info.buffer_p + target_byte_pos, mapped_num);
     }
 
@@ -535,7 +535,7 @@ ecma_builtin_typedarray_prototype_reduce_with_direction (ecma_value_t this_arg, 
   ecma_typedarray_info_t info = ecma_typedarray_get_info (obj_p);
 
   ecma_typedarray_getter_fn_t getter_cb = ecma_get_typedarray_getter_fn (info.id);
-  ecma_length_t byte_pos;
+  uint32_t byte_pos;
 
   if (info.length == 0)
   {
@@ -717,7 +717,7 @@ ecma_builtin_typedarray_prototype_filter (ecma_value_t this_arg, /**< this argum
   JMEM_DEFINE_LOCAL_ARRAY (pass_value_list_p, info.length * info.element_size, lit_utf8_byte_t);
 
   lit_utf8_byte_t *pass_value_p = pass_value_list_p;
-  ecma_length_t byte_pos = 0;
+  uint32_t byte_pos = 0;
 
   for (uint32_t index = 0; index < info.length; index++)
   {
@@ -1286,7 +1286,7 @@ ecma_builtin_typedarray_prototype_subarray (ecma_value_t this_arg, /**< this arg
   }
 
   /* 13. newLength */
-  ecma_length_t subarray_length = 0;
+  uint32_t subarray_length = 0;
 
   if (end_index_uint32 > begin_index_uint32)
   {
@@ -1294,7 +1294,7 @@ ecma_builtin_typedarray_prototype_subarray (ecma_value_t this_arg, /**< this arg
   }
 
   /* 17. beginByteOffset */
-  ecma_length_t begin_byte_offset = info.offset + begin_index_uint32 * info.element_size;
+  uint32_t begin_byte_offset = info.offset + begin_index_uint32 * info.element_size;
 
   ecma_value_t arguments_p[3] =
   {
@@ -1364,7 +1364,7 @@ ecma_builtin_typedarray_prototype_fill (ecma_value_t this_arg, /**< this argumen
     }
   }
 
-  ecma_length_t subarray_length = 0;
+  uint32_t subarray_length = 0;
 
   if (end_index_uint32 > begin_index_uint32)
   {
@@ -1695,7 +1695,7 @@ ecma_builtin_typedarray_prototype_find_index (ecma_value_t this_arg, /**< this a
 static ecma_value_t
 ecma_builtin_typedarray_prototype_index_of (ecma_value_t this_arg, /**< this argument */
                                             const ecma_value_t args[], /**< arguments list */
-                                            ecma_length_t args_number) /**< number of arguments */
+                                            uint32_t args_number) /**< number of arguments */
 {
   if (!ecma_is_typedarray (this_arg))
   {
@@ -1775,7 +1775,7 @@ ecma_builtin_typedarray_prototype_index_of (ecma_value_t this_arg, /**< this arg
 static ecma_value_t
 ecma_builtin_typedarray_prototype_last_index_of (ecma_value_t this_arg, /**< this argument */
                                                 const ecma_value_t args[], /**< arguments list */
-                                                ecma_length_t args_number) /**< number of arguments */
+                                                uint32_t args_number) /**< number of arguments */
 {
   if (!ecma_is_typedarray (this_arg))
   {
@@ -1856,7 +1856,7 @@ ecma_builtin_typedarray_prototype_last_index_of (ecma_value_t this_arg, /**< thi
 static ecma_value_t
 ecma_builtin_typedarray_prototype_copy_within (ecma_value_t this_arg, /**< this argument */
                                                const ecma_value_t args[], /**< arguments list */
-                                               ecma_length_t args_number) /**< number of arguments */
+                                               uint32_t args_number) /**< number of arguments */
 {
   if (!ecma_is_typedarray (this_arg))
   {
@@ -1929,7 +1929,7 @@ ecma_builtin_typedarray_prototype_copy_within (ecma_value_t this_arg, /**< this 
 static ecma_value_t
 ecma_builtin_typedarray_prototype_slice (ecma_value_t this_arg, /**< this argument */
                                          const ecma_value_t args[], /**< arguments list */
-                                         ecma_length_t args_number) /**< number of arguments */
+                                         uint32_t args_number) /**< number of arguments */
 {
   if (!ecma_is_typedarray (this_arg))
   {

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
@@ -57,7 +57,7 @@
 static ecma_value_t
 ecma_builtin_typedarray_from (ecma_value_t this_arg, /**< 'this' argument */
                               const ecma_value_t *arguments_list_p, /**< arguments list */
-                              ecma_length_t arguments_list_len) /**< number of arguments */
+                              uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -126,7 +126,7 @@ ecma_builtin_typedarray_from (ecma_value_t this_arg, /**< 'this' argument */
 static ecma_value_t
 ecma_builtin_typedarray_of (ecma_value_t this_arg, /**< 'this' argument */
                             const ecma_value_t *arguments_list_p, /**< arguments list */
-                            ecma_length_t arguments_list_len) /**< number of arguments */
+                            uint32_t arguments_list_len) /**< number of arguments */
 {
   if (!ecma_is_constructor (this_arg))
   {
@@ -192,7 +192,7 @@ ecma_builtin_typedarray_of (ecma_value_t this_arg, /**< 'this' argument */
  */
 ecma_value_t
 ecma_builtin_typedarray_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -209,7 +209,7 @@ ecma_builtin_typedarray_dispatch_call (const ecma_value_t *arguments_list_p, /**
  */
 ecma_value_t
 ecma_builtin_typedarray_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                            ecma_length_t arguments_list_len) /**< number of arguments */
+                                            uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint16array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint16array.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_uint16array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_uint16array_dispatch_call (const ecma_value_t *arguments_list_p, /*
  */
 ecma_value_t
 ecma_builtin_uint16array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                             ecma_length_t arguments_list_len) /**< number of arguments */
+                                             uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_typedarray_helper_dispatch_construct (arguments_list_p, arguments_list_len,
                                                     ECMA_UINT16_ARRAY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint32array.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_uint32array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                        ecma_length_t arguments_list_len) /**< number of arguments */
+                                        uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_uint32array_dispatch_call (const ecma_value_t *arguments_list_p, /*
  */
 ecma_value_t
 ecma_builtin_uint32array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                             ecma_length_t arguments_list_len) /**< number of arguments */
+                                             uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8array.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8array.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_uint8array_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                       ecma_length_t arguments_list_len) /**< number of arguments */
+                                       uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_uint8array_dispatch_call (const ecma_value_t *arguments_list_p, /**
  */
 ecma_value_t
 ecma_builtin_uint8array_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                            ecma_length_t arguments_list_len) /**< number of arguments */
+                                            uint32_t arguments_list_len) /**< number of arguments */
 {
   return ecma_typedarray_helper_dispatch_construct (arguments_list_p, arguments_list_len,
                                                     ECMA_UINT8_ARRAY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-uint8clampedarray.c
@@ -49,7 +49,7 @@
  */
 ecma_value_t
 ecma_builtin_uint8clampedarray_dispatch_call (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                              ecma_length_t arguments_list_len) /**< number of arguments */
+                                              uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -63,7 +63,7 @@ ecma_builtin_uint8clampedarray_dispatch_call (const ecma_value_t *arguments_list
  */
 ecma_value_t
 ecma_builtin_uint8clampedarray_dispatch_construct (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                   ecma_length_t arguments_list_len) /**< number of arguments */
+                                                   uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -67,7 +67,7 @@
  * @return pointer to the constructed array object
  */
 ecma_object_t *
-ecma_op_new_array_object (ecma_length_t length) /**< length of the new array */
+ecma_op_new_array_object (uint32_t length) /**< length of the new array */
 {
 #if ENABLED (JERRY_BUILTIN_ARRAY)
   ecma_object_t *array_prototype_object_p = ecma_builtin_get (ECMA_BUILTIN_ID_ARRAY_PROTOTYPE);
@@ -127,7 +127,7 @@ ecma_op_array_is_fast_array (ecma_extended_object_t *array_p) /**< ecma-array-ob
  *         pointer to the constructed fast access mode array object otherwise
  */
 ecma_object_t *
-ecma_op_new_fast_array_object (ecma_length_t length) /**< length of the new fast access mode array */
+ecma_op_new_fast_array_object (uint32_t length) /**< length of the new fast access mode array */
 {
   const uint32_t aligned_length = ECMA_FAST_ARRAY_ALIGN_LENGTH (length);
   ecma_value_t *values_p = NULL;
@@ -579,7 +579,7 @@ ecma_fast_array_get_property_names (ecma_object_t *object_p, /**< fast access mo
 ecma_value_t
 ecma_op_create_array_object (const ecma_value_t *arguments_list_p, /**< list of arguments that
                                                                     *   are passed to Array constructor */
-                             ecma_length_t arguments_list_len, /**< length of the arguments' list */
+                             uint32_t arguments_list_len, /**< length of the arguments' list */
                              bool is_treat_single_arg_as_length) /**< if the value is true,
                                                                   *   arguments_list_len is 1
                                                                   *   and single argument is Number,
@@ -592,7 +592,7 @@ ecma_op_create_array_object (const ecma_value_t *arguments_list_p, /**< list of 
 
   uint32_t length;
   const ecma_value_t *array_items_p;
-  ecma_length_t array_items_count;
+  uint32_t array_items_count;
 
   if (is_treat_single_arg_as_length
       && arguments_list_len == 1
@@ -678,7 +678,7 @@ ecma_op_create_array_object (const ecma_value_t *arguments_list_p, /**< list of 
 ecma_value_t
 ecma_op_array_species_create (ecma_object_t *original_array_p, /**< The object from whom the new array object
                                                                 *   is being created */
-                              ecma_length_t length) /**< length of the array */
+                              uint32_t length) /**< length of the array */
 {
   ecma_value_t constructor = ECMA_VALUE_UNDEFINED;
   ecma_value_t original_array = ecma_make_object_value (original_array_p);

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -62,10 +62,10 @@ typedef enum
 } ecma_array_object_set_length_flags_t;
 
 ecma_object_t *
-ecma_op_new_array_object (ecma_length_t length);
+ecma_op_new_array_object (uint32_t length);
 
 ecma_object_t *
-ecma_op_new_fast_array_object (ecma_length_t length);
+ecma_op_new_fast_array_object (uint32_t length);
 
 bool
 ecma_op_object_is_fast_array (ecma_object_t *object_p);
@@ -96,13 +96,13 @@ void
 ecma_fast_array_convert_to_normal (ecma_object_t *object_p);
 
 ecma_value_t
-ecma_op_create_array_object (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len,
+ecma_op_create_array_object (const ecma_value_t *arguments_list_p, uint32_t arguments_list_len,
                              bool is_treat_single_arg_as_length);
 
 #if ENABLED (JERRY_ESNEXT)
 ecma_value_t
 ecma_op_array_species_create (ecma_object_t *original_array_p,
-                              ecma_length_t length);
+                              uint32_t length);
 
 ecma_value_t
 ecma_op_create_array_iterator (ecma_object_t *obj_p,

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -44,7 +44,7 @@
  * @return ecma_object_t *
  */
 ecma_object_t *
-ecma_arraybuffer_new_object (ecma_length_t length) /**< length of the arraybuffer */
+ecma_arraybuffer_new_object (uint32_t length) /**< length of the arraybuffer */
 {
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_ARRAYBUFFER_PROTOTYPE);
   ecma_object_t *object_p = ecma_create_object (prototype_obj_p,
@@ -73,7 +73,7 @@ ecma_arraybuffer_new_object (ecma_length_t length) /**< length of the arraybuffe
  * @return ecma_object_t *, pointer to the created ArrayBuffer object
  */
 ecma_object_t *
-ecma_arraybuffer_new_object_external (ecma_length_t length, /**< length of the buffer_p to use */
+ecma_arraybuffer_new_object_external (uint32_t length, /**< length of the buffer_p to use */
                                       void *buffer_p, /**< pointer for ArrayBuffer's buffer backing */
                                       ecma_object_native_free_callback_t free_cb) /**< buffer free callback */
 {
@@ -104,7 +104,7 @@ ecma_arraybuffer_new_object_external (ecma_length_t length, /**< length of the b
 ecma_value_t
 ecma_op_create_arraybuffer_object (const ecma_value_t *arguments_list_p, /**< list of arguments that
                                                                           *   are passed to String constructor */
-                                   ecma_length_t arguments_list_len) /**< length of the arguments' list */
+                                   uint32_t arguments_list_len) /**< length of the arguments' list */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -169,9 +169,9 @@ ecma_is_arraybuffer (ecma_value_t target) /**< the target value */
 /**
  * Helper function: return the length of the buffer inside the arraybuffer object
  *
- * @return ecma_length_t, the length of the arraybuffer
+ * @return uint32_t, the length of the arraybuffer
  */
-ecma_length_t JERRY_ATTR_PURE
+uint32_t JERRY_ATTR_PURE
 ecma_arraybuffer_get_length (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -28,20 +28,20 @@
  */
 
 ecma_value_t
-ecma_op_create_arraybuffer_object (const ecma_value_t *, ecma_length_t);
+ecma_op_create_arraybuffer_object (const ecma_value_t *, uint32_t);
 
 /**
  * Helper functions for arraybuffer.
  */
 ecma_object_t *
-ecma_arraybuffer_new_object (ecma_length_t lengh);
+ecma_arraybuffer_new_object (uint32_t lengh);
 ecma_object_t *
-ecma_arraybuffer_new_object_external (ecma_length_t length,
+ecma_arraybuffer_new_object_external (uint32_t length,
                                       void *buffer_p,
                                       ecma_object_native_free_callback_t free_cb);
 lit_utf8_byte_t * JERRY_ATTR_PURE
 ecma_arraybuffer_get_buffer (ecma_object_t *obj_p);
-ecma_length_t JERRY_ATTR_PURE
+uint32_t JERRY_ATTR_PURE
 ecma_arraybuffer_get_length (ecma_object_t *obj_p);
 bool JERRY_ATTR_PURE
 ecma_arraybuffer_is_detached (ecma_object_t *obj_p);

--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -364,7 +364,7 @@ ecma_op_container_free_entries (ecma_object_t *object_p) /**< collection object 
  */
 ecma_value_t
 ecma_op_container_create (const ecma_value_t *arguments_list_p, /**< arguments list */
-                          ecma_length_t arguments_list_len, /**< number of arguments */
+                          uint32_t arguments_list_len, /**< number of arguments */
                           lit_magic_string_id_t lit_id, /**< internal class id */
                           ecma_builtin_id_t proto_id) /**< prototype builtin id */
 {

--- a/jerry-core/ecma/operations/ecma-container-object.h
+++ b/jerry-core/ecma/operations/ecma-container-object.h
@@ -51,7 +51,7 @@ enum
 
 uint8_t ecma_op_container_entry_size (lit_magic_string_id_t lit_id);
 ecma_extended_object_t *ecma_op_container_get_object (ecma_value_t this_arg, lit_magic_string_id_t lit_id);
-ecma_value_t ecma_op_container_create (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len,
+ecma_value_t ecma_op_container_create (const ecma_value_t *arguments_list_p, uint32_t arguments_list_len,
                                        lit_magic_string_id_t lit_id, ecma_builtin_id_t proto_id);
 ecma_value_t ecma_op_container_size (ecma_extended_object_t *map_object_p);
 ecma_value_t ecma_op_container_get (ecma_extended_object_t *map_object_p, ecma_value_t key_arg,

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -1026,7 +1026,7 @@ ecma_op_create_list_from_array_like (ecma_value_t arr,  /**< array value */
   ecma_object_t *obj_p = ecma_get_object_from_value (arr);
 
   /* 4. 5. */
-  ecma_length_t len;
+  uint32_t len;
   if (ECMA_IS_VALUE_ERROR (ecma_op_object_get_length (obj_p, &len)))
   {
     return NULL;

--- a/jerry-core/ecma/operations/ecma-dataview-object.c
+++ b/jerry-core/ecma/operations/ecma-dataview-object.c
@@ -44,7 +44,7 @@
  */
 ecma_value_t
 ecma_op_dataview_create (const ecma_value_t *arguments_list_p, /**< arguments list */
-                         ecma_length_t arguments_list_len) /**< number of arguments */
+                         uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
   JERRY_ASSERT (JERRY_CONTEXT (current_new_target));
@@ -96,10 +96,10 @@ ecma_op_dataview_create (const ecma_value_t *arguments_list_p, /**< arguments li
   }
 
   /* 9. */
-  ecma_length_t buffer_byte_length = ecma_arraybuffer_get_length (buffer_p);
+  uint32_t buffer_byte_length = ecma_arraybuffer_get_length (buffer_p);
 
   /* 10. */
-  if ((ecma_length_t) offset > buffer_byte_length)
+  if (offset > buffer_byte_length)
   {
     return ecma_raise_range_error (ECMA_ERR_MSG ("Start offset is outside the bounds of the buffer."));
   }
@@ -126,7 +126,7 @@ ecma_op_dataview_create (const ecma_value_t *arguments_list_p, /**< arguments li
   else
   {
     /* 11.a */
-    viewByteLength = (uint32_t) (buffer_byte_length - (ecma_length_t) offset);
+    viewByteLength = (uint32_t) (buffer_byte_length - offset);
   }
 
   /* 13. */

--- a/jerry-core/ecma/operations/ecma-dataview-object.h
+++ b/jerry-core/ecma/operations/ecma-dataview-object.h
@@ -27,7 +27,7 @@
  * @{
  */
 
-ecma_value_t ecma_op_dataview_create (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+ecma_value_t ecma_op_dataview_create (const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 ecma_dataview_object_t *ecma_op_dataview_get_object (ecma_value_t this_arg);
 ecma_value_t ecma_op_dataview_get_set_view_value (ecma_value_t view, ecma_value_t request_index,
                                                   ecma_value_t little_endian, ecma_value_t value_to_set,

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -190,7 +190,7 @@ ecma_is_constructor (ecma_value_t value) /**< ecma value */
  */
 static ecma_string_t *
 ecma_op_create_dynamic_function_arguments_helper (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                                  ecma_length_t arguments_list_len) /**< number of arguments */
+                                                  uint32_t arguments_list_len) /**< number of arguments */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 
@@ -214,7 +214,7 @@ ecma_op_create_dynamic_function_arguments_helper (const ecma_value_t *arguments_
   ecma_stringbuilder_t builder = ecma_stringbuilder_create_from (str_p);
   ecma_deref_ecma_string (str_p);
 
-  for (ecma_length_t idx = 1; idx < arguments_list_len - 1; idx++)
+  for (uint32_t idx = 1; idx < arguments_list_len - 1; idx++)
   {
     str_p = ecma_op_to_string (arguments_list_p[idx]);
 
@@ -318,7 +318,7 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
  */
 ecma_value_t
 ecma_op_create_dynamic_function (const ecma_value_t *arguments_list_p, /**< arguments list */
-                                 ecma_length_t arguments_list_len, /**< number of arguments */
+                                 uint32_t arguments_list_len, /**< number of arguments */
                                  ecma_parse_opts_t parse_opts) /**< parse options */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
@@ -835,7 +835,7 @@ static ecma_value_t
 ecma_op_function_call_simple (ecma_object_t *func_obj_p, /**< Function object */
                               ecma_value_t this_arg_value, /**< 'this' argument's value */
                               const ecma_value_t *arguments_list_p, /**< arguments list */
-                              ecma_length_t arguments_list_len) /**< length of arguments list */
+                              uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_FUNCTION);
 
@@ -989,7 +989,7 @@ static ecma_value_t JERRY_ATTR_NOINLINE
 ecma_op_function_call_external (ecma_object_t *func_obj_p, /**< Function object */
                                 ecma_value_t this_arg_value, /**< 'this' argument's value */
                                 const ecma_value_t *arguments_list_p, /**< arguments list */
-                                ecma_length_t arguments_list_len) /**< length of arguments list */
+                                uint32_t arguments_list_len) /**< length of arguments list */
 
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION);
@@ -1034,11 +1034,11 @@ ecma_op_bound_function_get_argument_list (ecma_object_t *func_obj_p, /**< bound 
 
   ecma_value_t args_len_or_this = bound_func_p->header.u.bound_function.args_len_or_this;
 
-  ecma_length_t args_length = 1;
+  uint32_t args_length = 1;
 
   if (ecma_is_value_integer_number (args_len_or_this))
   {
-    args_length = (ecma_length_t) ecma_get_integer_from_value (args_len_or_this);
+    args_length = (uint32_t) ecma_get_integer_from_value (args_len_or_this);
   }
 
   /* 5. */
@@ -1070,7 +1070,7 @@ ecma_op_bound_function_get_argument_list (ecma_object_t *func_obj_p, /**< bound 
 static ecma_value_t JERRY_ATTR_NOINLINE
 ecma_op_function_call_bound (ecma_object_t *func_obj_p, /**< Function object */
                              const ecma_value_t *arguments_list_p, /**< arguments list */
-                             ecma_length_t arguments_list_len) /**< length of arguments list */
+                             uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
 
@@ -1088,7 +1088,7 @@ ecma_op_function_call_bound (ecma_object_t *func_obj_p, /**< Function object */
   ecma_value_t ret_value = ecma_op_function_call (target_obj_p,
                                                   bound_arg_list_p->buffer_p[0],
                                                   bound_arg_list_p->buffer_p + 1,
-                                                  (ecma_length_t) (bound_arg_list_p->item_count - 1));
+                                                  (uint32_t) (bound_arg_list_p->item_count - 1));
 
   ecma_collection_destroy (bound_arg_list_p);
 
@@ -1109,7 +1109,7 @@ ecma_value_t
 ecma_op_function_call (ecma_object_t *func_obj_p, /**< Function object */
                        ecma_value_t this_arg_value, /**< 'this' argument's value */
                        const ecma_value_t *arguments_list_p, /**< arguments list */
-                       ecma_length_t arguments_list_len) /**< length of arguments list */
+                       uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (func_obj_p != NULL
                 && !ecma_is_lexical_environment (func_obj_p));
@@ -1166,7 +1166,7 @@ static ecma_value_t JERRY_ATTR_NOINLINE
 ecma_op_function_construct_bound (ecma_object_t *func_obj_p, /**< Function object */
                                   ecma_object_t *new_target_p, /**< new target */
                                   const ecma_value_t *arguments_list_p, /**< arguments list */
-                                  ecma_length_t arguments_list_len) /**< length of arguments list */
+                                  uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BOUND_FUNCTION);
 
@@ -1185,7 +1185,7 @@ ecma_op_function_construct_bound (ecma_object_t *func_obj_p, /**< Function objec
   ecma_value_t ret_value = ecma_op_function_construct (target_obj_p,
                                                        new_target_p,
                                                        bound_arg_list_p->buffer_p + 1,
-                                                       (ecma_length_t) (bound_arg_list_p->item_count - 1));
+                                                       (uint32_t) (bound_arg_list_p->item_count - 1));
 
   ecma_collection_destroy (bound_arg_list_p);
 
@@ -1202,7 +1202,7 @@ static ecma_value_t JERRY_ATTR_NOINLINE
 ecma_op_function_construct_external (ecma_object_t *func_obj_p, /**< Function object */
                                      ecma_object_t *new_target_p, /**< new target */
                                      const ecma_value_t *arguments_list_p, /**< arguments list */
-                                     ecma_length_t arguments_list_len) /**< length of arguments list */
+                                     uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_EXTERNAL_FUNCTION);
 
@@ -1251,7 +1251,7 @@ ecma_value_t
 ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
                             ecma_object_t *new_target_p, /**< new target */
                             const ecma_value_t *arguments_list_p, /**< arguments list */
-                            ecma_length_t arguments_list_len) /**< length of arguments list */
+                            uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (func_obj_p != NULL
                 && !ecma_is_lexical_environment (func_obj_p));

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -47,7 +47,7 @@ ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p);
 
 ecma_value_t
 ecma_op_create_dynamic_function (const ecma_value_t *arguments_list_p,
-                                 ecma_length_t arguments_list_len,
+                                 uint32_t arguments_list_len,
                                  ecma_parse_opts_t opts);
 
 #if ENABLED (JERRY_ESNEXT)
@@ -72,11 +72,11 @@ ecma_op_function_has_instance (ecma_object_t *func_obj_p, ecma_value_t value);
 
 ecma_value_t
 ecma_op_function_call (ecma_object_t *func_obj_p, ecma_value_t this_arg_value,
-                       const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+                       const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 
 ecma_value_t
 ecma_op_function_construct (ecma_object_t *func_obj_p, ecma_object_t *new_target_p,
-                            const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+                            const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 
 ecma_property_t *
 ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, ecma_string_t *property_name_p);

--- a/jerry-core/ecma/operations/ecma-objects-arguments.c
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.c
@@ -44,12 +44,12 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
                                  ecma_object_t *lex_env_p, /**< lexical environment the Arguments
                                                                 object is created for */
                                  const ecma_value_t *arguments_list_p, /**< arguments list */
-                                 ecma_length_t arguments_number, /**< length of arguments list */
+                                 uint32_t arguments_number, /**< length of arguments list */
                                  const ecma_compiled_code_t *bytecode_data_p) /**< byte code */
 {
   bool is_strict = (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STRICT_MODE) != 0;
 
-  ecma_length_t formal_params_number;
+  uint32_t formal_params_number;
 
   if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)
   {
@@ -86,19 +86,19 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
 
     ext_object_p->u.pseudo_array.u1.length = (uint16_t) formal_params_number;
 
-    ecma_value_t *arg_Literal_p = (ecma_value_t *) (ext_object_p + 1);
+    ecma_value_t *arg_literal_p = (ecma_value_t *) (ext_object_p + 1);
 
     uint8_t *byte_p = (uint8_t *) bytecode_data_p;
     byte_p += ((size_t) bytecode_data_p->size) << JMEM_ALIGNMENT_LOG;
     byte_p -= formal_params_size;
 
-    memcpy (arg_Literal_p, byte_p, formal_params_size);
+    memcpy (arg_literal_p, byte_p, formal_params_size);
 
-    for (ecma_length_t i = 0; i < formal_params_number; i++)
+    for (uint32_t i = 0; i < formal_params_number; i++)
     {
-      if (arg_Literal_p[i] != ECMA_VALUE_EMPTY)
+      if (arg_literal_p[i] != ECMA_VALUE_EMPTY)
       {
-        ecma_string_t *name_p = ecma_get_string_from_value (arg_Literal_p[i]);
+        ecma_string_t *name_p = ecma_get_string_from_value (arg_literal_p[i]);
         ecma_ref_ecma_string (name_p);
       }
     }
@@ -114,7 +114,7 @@ ecma_op_create_arguments_object (ecma_object_t *func_obj_p, /**< callee function
   ecma_property_value_t *prop_value_p;
 
   /* 11.a, 11.b */
-  for (ecma_length_t index = 0;
+  for (uint32_t index = 0;
        index < arguments_number;
        index++)
   {
@@ -259,19 +259,19 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *object_p, /**< the 
     return ret_value;
   }
 
-  ecma_value_t *arg_Literal_p = (ecma_value_t *) (ext_object_p + 1);
+  ecma_value_t *arg_literal_p = (ecma_value_t *) (ext_object_p + 1);
 
-  if (arg_Literal_p[index] == ECMA_VALUE_EMPTY)
+  if (arg_literal_p[index] == ECMA_VALUE_EMPTY)
   {
     return ret_value;
   }
 
-  ecma_string_t *name_p = ecma_get_string_from_value (arg_Literal_p[index]);
+  ecma_string_t *name_p = ecma_get_string_from_value (arg_literal_p[index]);
 
   if (property_desc_p->flags & (ECMA_PROP_IS_GET_DEFINED | ECMA_PROP_IS_SET_DEFINED))
   {
     ecma_deref_ecma_string (name_p);
-    arg_Literal_p[index] = ECMA_VALUE_EMPTY;
+    arg_literal_p[index] = ECMA_VALUE_EMPTY;
   }
   else
   {
@@ -293,7 +293,7 @@ ecma_op_arguments_object_define_own_property (ecma_object_t *object_p, /**< the 
         && !(property_desc_p->flags & ECMA_PROP_IS_WRITABLE))
     {
       ecma_deref_ecma_string (name_p);
-      arg_Literal_p[index] = ECMA_VALUE_EMPTY;
+      arg_literal_p[index] = ECMA_VALUE_EMPTY;
     }
   }
 
@@ -335,13 +335,13 @@ ecma_op_arguments_object_delete (ecma_object_t *object_p, /**< the object */
 
       if (index < ext_object_p->u.pseudo_array.u1.length)
       {
-        ecma_value_t *arg_Literal_p = (ecma_value_t *) (ext_object_p + 1);
+        ecma_value_t *arg_literal_p = (ecma_value_t *) (ext_object_p + 1);
 
-        if (arg_Literal_p[index] != ECMA_VALUE_EMPTY)
+        if (arg_literal_p[index] != ECMA_VALUE_EMPTY)
         {
-          ecma_string_t *name_p = ecma_get_string_from_value (arg_Literal_p[index]);
+          ecma_string_t *name_p = ecma_get_string_from_value (arg_literal_p[index]);
           ecma_deref_ecma_string (name_p);
-          arg_Literal_p[index] = ECMA_VALUE_EMPTY;
+          arg_literal_p[index] = ECMA_VALUE_EMPTY;
         }
       }
     }

--- a/jerry-core/ecma/operations/ecma-objects-arguments.h
+++ b/jerry-core/ecma/operations/ecma-objects-arguments.h
@@ -21,7 +21,7 @@
 
 void
 ecma_op_create_arguments_object (ecma_object_t *func_obj_p, ecma_object_t *lex_env_p,
-                                 const ecma_value_t *arguments_list_p, ecma_length_t arguments_number,
+                                 const ecma_value_t *arguments_list_p, uint32_t arguments_number,
                                  const ecma_compiled_code_t *bytecode_data_p);
 
 ecma_value_t

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -101,7 +101,7 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
             ecma_value_t prim_value_p = ext_object_p->u.class_prop.u.value;
             ecma_string_t *prim_value_str_p = ecma_get_string_from_value (prim_value_p);
 
-            ecma_length_t length = ecma_string_get_length (prim_value_str_p);
+            lit_utf8_size_t length = ecma_string_get_length (prim_value_str_p);
             property_ref_p->virtual_value = ecma_make_uint32_value (length);
           }
 
@@ -193,7 +193,7 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
 
           if (array_index < info.length)
           {
-            ecma_length_t byte_pos = array_index << info.shift;
+            uint32_t byte_pos = array_index << info.shift;
             ecma_number_t num = ecma_get_typedarray_element (info.buffer_p + byte_pos, info.id);
             value = ecma_make_number_value (num);
           }
@@ -464,7 +464,7 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
           ecma_value_t prim_value_p = ext_object_p->u.class_prop.u.value;
 
           ecma_string_t *prim_value_str_p = ecma_get_string_from_value (prim_value_p);
-          ecma_length_t length = ecma_string_get_length (prim_value_str_p);
+          lit_utf8_size_t length = ecma_string_get_length (prim_value_str_p);
 
           return ecma_make_uint32_value (length);
         }
@@ -564,7 +564,7 @@ ecma_op_object_find_own (ecma_value_t base_value, /**< base value */
             return ECMA_VALUE_UNDEFINED;
           }
 
-          ecma_length_t byte_pos = array_index << info.shift;
+          uint32_t byte_pos = array_index << info.shift;
           ecma_number_t num = ecma_get_typedarray_element (info.buffer_p + byte_pos, info.id);
           return ecma_make_number_value (num);
         }
@@ -1330,7 +1330,7 @@ ecma_op_object_put_with_receiver (ecma_object_t *object_p, /**< the object */
             return ecma_reject (is_throw);
           }
 
-          ecma_length_t byte_pos = array_index << info.shift;
+          uint32_t byte_pos = array_index << info.shift;
           ecma_set_typedarray_element (info.buffer_p + byte_pos, num_var, info.id);
 
           return ECMA_VALUE_TRUE;
@@ -2209,10 +2209,10 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
   {
     const ecma_object_type_t type = ecma_get_object_type (obj_p);
     const bool obj_is_builtin = ecma_get_object_is_builtin (obj_p);
-    ecma_length_t string_named_properties_count = 0;
-    ecma_length_t array_index_named_properties_count = 0;
+    uint32_t string_named_properties_count = 0;
+    uint32_t array_index_named_properties_count = 0;
 #if ENABLED (JERRY_ESNEXT)
-    ecma_length_t symbol_named_properties_count = 0;
+    uint32_t symbol_named_properties_count = 0;
 #endif /* ENABLED (JERRY_ESNEXT) */
     ecma_collection_t *prop_names_p = ecma_new_collection ();
 
@@ -2537,7 +2537,7 @@ ecma_op_object_get_property_names (ecma_object_t *obj_p, /**< object */
       }
     }
 
-    ecma_length_t all_properties_count = array_index_named_properties_count + string_named_properties_count;
+    uint32_t all_properties_count = array_index_named_properties_count + string_named_properties_count;
 
 #if ENABLED (JERRY_ESNEXT)
     all_properties_count += symbol_named_properties_count;
@@ -3106,7 +3106,7 @@ inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_invoke_by_symbol_id (ecma_value_t object, /**< Object value */
                              lit_magic_string_id_t symbol_id, /**< Symbol ID */
                              ecma_value_t *args_p, /**< Argument list */
-                             ecma_length_t args_len) /**< Argument list length */
+                             uint32_t args_len) /**< Argument list length */
 {
   ecma_string_t *symbol_p = ecma_op_get_global_symbol (symbol_id);
   ecma_value_t ret_value = ecma_op_invoke (object, symbol_p, args_p, args_len);
@@ -3126,7 +3126,7 @@ inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_invoke_by_magic_id (ecma_value_t object, /**< Object value */
                             lit_magic_string_id_t magic_string_id, /**< Magic string ID */
                             ecma_value_t *args_p, /**< Argument list */
-                            ecma_length_t args_len) /**< Argument list length */
+                            uint32_t args_len) /**< Argument list length */
 {
   return ecma_op_invoke (object, ecma_get_magic_string (magic_string_id), args_p, args_len);
 } /* ecma_op_invoke_by_magic_id */
@@ -3141,7 +3141,7 @@ ecma_value_t
 ecma_op_invoke (ecma_value_t object, /**< Object value */
                 ecma_string_t *property_name_p, /**< Property name */
                 ecma_value_t *args_p, /**< Argument list */
-                ecma_length_t args_len) /**< Argument list length */
+                uint32_t args_len) /**< Argument list length */
 {
   /* 3. */
   ecma_value_t object_value = ecma_op_to_object (object);

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -79,12 +79,12 @@ ecma_value_t ecma_op_is_concat_spreadable (ecma_value_t arg);
 ecma_value_t ecma_op_is_regexp (ecma_value_t arg);
 ecma_value_t ecma_op_species_constructor (ecma_object_t *this_value, ecma_builtin_id_t default_constructor_id);
 ecma_value_t ecma_op_invoke_by_symbol_id (ecma_value_t object, lit_magic_string_id_t magic_string_id,
-                                          ecma_value_t *args_p, ecma_length_t args_len);
+                                          ecma_value_t *args_p, uint32_t args_len);
 #endif /* ENABLED (JERRY_ESNEXT) */
 ecma_value_t ecma_op_invoke (ecma_value_t object, ecma_string_t *property_name_p, ecma_value_t *args_p,
-                             ecma_length_t args_len);
+                             uint32_t args_len);
 ecma_value_t ecma_op_invoke_by_magic_id (ecma_value_t object, lit_magic_string_id_t magic_string_id,
-                                         ecma_value_t *args_p, ecma_length_t args_len);
+                                         ecma_value_t *args_p, uint32_t args_len);
 
 jmem_cpointer_t ecma_op_ordinary_object_get_prototype_of (ecma_object_t *obj_p);
 ecma_value_t ecma_op_ordinary_object_set_prototype_of (ecma_object_t *base_p, ecma_value_t proto);

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -301,7 +301,7 @@ static ecma_value_t
 ecma_promise_reject_handler (const ecma_value_t function, /**< the function itself */
                              const ecma_value_t this, /**< this_arg of the function */
                              const ecma_value_t argv[], /**< argument list */
-                             const ecma_length_t argc) /**< argument number */
+                             const uint32_t argc) /**< argument number */
 {
   JERRY_UNUSED (this);
 
@@ -338,7 +338,7 @@ static ecma_value_t
 ecma_promise_resolve_handler (const ecma_value_t function, /**< the function itself */
                               const ecma_value_t this, /**< this_arg of the function */
                               const ecma_value_t argv[], /**< argument list */
-                              const ecma_length_t argc) /**< argument number */
+                              const uint32_t argc) /**< argument number */
 {
   JERRY_UNUSED (this);
 
@@ -545,7 +545,7 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
  *
  * @return the current remaining count after increase or decrease.
  */
-ecma_length_t
+uint32_t
 ecma_promise_remaining_inc_or_dec (ecma_value_t remaining, /**< the remaining count */
                                    bool is_inc) /**< whether to increase the count */
 {
@@ -558,7 +558,7 @@ ecma_promise_remaining_inc_or_dec (ecma_value_t remaining, /**< the remaining co
 
   JERRY_ASSERT (ecma_is_value_integer_number (ext_object_p->u.class_prop.u.value));
 
-  ecma_length_t current = (ecma_length_t) ecma_get_integer_from_value (ext_object_p->u.class_prop.u.value);
+  uint32_t current = (uint32_t) ecma_get_integer_from_value (ext_object_p->u.class_prop.u.value);
 
   if (is_inc)
   {
@@ -585,7 +585,7 @@ ecma_value_t
 ecma_promise_all_handler_cb (const ecma_value_t function_obj, /**< the function itself */
                              const ecma_value_t this_val, /**< this_arg of the function */
                              const ecma_value_t args_p[], /**< argument list */
-                             const ecma_length_t args_count) /**< argument number */
+                             const uint32_t args_count) /**< argument number */
 {
   JERRY_UNUSED (this_val);
   JERRY_UNUSED (args_count);
@@ -634,7 +634,7 @@ ecma_value_t
 ecma_op_get_capabilities_executor_cb (const ecma_value_t function_obj, /**< the function itself */
                                       const ecma_value_t this_val, /**< this_arg of the function */
                                       const ecma_value_t args_p[], /**< argument list */
-                                      const ecma_length_t args_count) /**< argument number */
+                                      const uint32_t args_count) /**< argument number */
 {
   JERRY_UNUSED (this_val);
 

--- a/jerry-core/ecma/operations/ecma-promise-object.h
+++ b/jerry-core/ecma/operations/ecma-promise-object.h
@@ -96,12 +96,12 @@ void ecma_promise_create_resolving_functions (ecma_object_t *object_p, ecma_prom
                                               bool create_already_resolved);
 void ecma_promise_free_resolving_functions (ecma_promise_resolving_functions_t *funcs);
 
-ecma_length_t ecma_promise_remaining_inc_or_dec (ecma_value_t remaining, bool is_inc);
+uint32_t ecma_promise_remaining_inc_or_dec (ecma_value_t remaining, bool is_inc);
 ecma_value_t ecma_promise_all_handler_cb (const ecma_value_t function_obj, const ecma_value_t this_val,
-                                          const ecma_value_t args_p[], const ecma_length_t args_count);
+                                          const ecma_value_t args_p[], const uint32_t args_count);
 
 ecma_value_t ecma_op_get_capabilities_executor_cb (const ecma_value_t function_obj, const ecma_value_t this_val,
-                                                   const ecma_value_t args_p[], const ecma_length_t args_count);
+                                                   const ecma_value_t args_p[], const uint32_t args_count);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -107,7 +107,7 @@ ecma_value_t
 ecma_proxy_revoke_cb (const ecma_value_t function_obj, /**< the function itself */
                       const ecma_value_t this_val, /**< this_arg of the function */
                       const ecma_value_t args_p[], /**< argument list */
-                      const ecma_length_t args_count) /**< argument number */
+                      const uint32_t args_count) /**< argument number */
 {
   JERRY_UNUSED_3 (this_val, args_p, args_count);
 
@@ -1696,7 +1696,7 @@ ecma_value_t
 ecma_proxy_object_call (ecma_object_t *obj_p, /**< proxy object */
                         ecma_value_t this_argument, /**< this argument to invoke the function */
                         const ecma_value_t *args_p, /**< argument list */
-                        ecma_length_t argc) /**< number of arguments */
+                        uint32_t argc) /**< number of arguments */
 {
   JERRY_ASSERT (ECMA_OBJECT_IS_PROXY (obj_p));
 
@@ -1750,7 +1750,7 @@ ecma_value_t
 ecma_proxy_object_construct (ecma_object_t *obj_p, /**< proxy object */
                              ecma_object_t *new_target_p, /**< new target */
                              const ecma_value_t *args_p, /**< argument list */
-                             ecma_length_t argc) /**< number of arguments */
+                             uint32_t argc) /**< number of arguments */
 {
   JERRY_ASSERT (ECMA_OBJECT_IS_PROXY (obj_p));
 

--- a/jerry-core/ecma/operations/ecma-proxy-object.h
+++ b/jerry-core/ecma/operations/ecma-proxy-object.h
@@ -39,7 +39,7 @@ ecma_value_t
 ecma_proxy_revoke_cb (const ecma_value_t function_obj,
                       const ecma_value_t this_val,
                       const ecma_value_t args_p[],
-                      const ecma_length_t args_count);
+                      const uint32_t args_count);
 
 jmem_cpointer_t
 ecma_proxy_object_prototype_to_cp (ecma_value_t proto);
@@ -102,13 +102,13 @@ ecma_value_t
 ecma_proxy_object_call (ecma_object_t *obj_p,
                         ecma_value_t this_argument,
                         const ecma_value_t *args_p,
-                        ecma_length_t argc);
+                        uint32_t argc);
 
 ecma_value_t
 ecma_proxy_object_construct (ecma_object_t *obj_p,
                              ecma_object_t *new_target_p,
                              const ecma_value_t *args_p,
-                             ecma_length_t argc);
+                             uint32_t argc);
 
 #endif /* ENABLED (JERRY_BUILTIN_PROXY) */
 

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -2163,7 +2163,7 @@ ecma_regexp_split_helper (ecma_value_t this_arg, /**< this value */
   const lit_utf8_size_t string_length = ecma_string_get_length (string_p);
 
   ecma_object_t *const array_p = ecma_get_object_from_value (array);
-  ecma_length_t array_length = 0;
+  uint32_t array_length = 0;
 
   /* 22. */
   if (string_length == 0)
@@ -2379,7 +2379,7 @@ cleanup_string:
   }
 
   ecma_object_t *const array_p = ecma_get_object_from_value (array);
-  ecma_length_t array_length = 0;
+  uint32_t array_length = 0;
 
   ecma_object_t *const regexp_p = ecma_get_object_from_value (this_arg);
   ecma_extended_object_t *const ext_object_p = (ecma_extended_object_t *) regexp_p;
@@ -2561,7 +2561,7 @@ ecma_regexp_replace_helper_fast (ecma_replace_context_t *ctx_p, /**<replace cont
   const lit_utf8_byte_t *matched_p = NULL;
   const lit_utf8_byte_t *current_p = ctx_p->string_p;
   const lit_utf8_byte_t *last_append_p = current_p;
-  ecma_length_t index;
+  lit_utf8_size_t index;
 
   ecma_regexp_ctx_t re_ctx;
   ecma_regexp_initialize_context (&re_ctx,
@@ -2607,7 +2607,7 @@ ecma_regexp_replace_helper_fast (ecma_replace_context_t *ctx_p, /**<replace cont
     }
     else
     {
-      ecma_length_t counter = index;
+      lit_utf8_size_t counter = index;
       while (counter--)
       {
         lit_utf8_incr (&current_p);
@@ -3039,7 +3039,7 @@ ecma_regexp_replace_helper (ecma_value_t this_arg, /**< this argument */
   replace_ctx.builder = ecma_stringbuilder_create ();
   replace_ctx.matched_p = NULL;
   replace_ctx.capture_count = 0;
-  ecma_length_t index = 0;
+  lit_utf8_size_t index = 0;
 
   /* 15. */
   const lit_utf8_byte_t *source_position_p = replace_ctx.string_p;
@@ -3101,7 +3101,7 @@ ecma_regexp_replace_helper (ecma_value_t this_arg, /**< this argument */
     }
 
     /* 16.i */
-    ecma_length_t position = JERRY_MIN ((ecma_length_t) JERRY_MAX (position_num, 0.0f), string_length);
+    lit_utf8_size_t position = JERRY_MIN ((lit_utf8_size_t) JERRY_MAX (position_num, 0.0f), string_length);
 
     /* 16.k */
     ecma_collection_t *arguments_p = ecma_new_collection ();

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -41,7 +41,7 @@
 ecma_value_t
 ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of arguments that
                                                                          are passed to String constructor */
-                              ecma_length_t arguments_list_len) /**< length of the arguments' list */
+                              uint32_t arguments_list_len) /**< length of the arguments' list */
 {
   JERRY_ASSERT (arguments_list_len == 0
                 || arguments_list_p != NULL);
@@ -102,9 +102,9 @@ ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p, /**< a String obj
 
   ecma_string_t *prim_value_str_p = ecma_get_string_from_value (ext_object_p->u.class_prop.u.value);
 
-  ecma_length_t length = ecma_string_get_length (prim_value_str_p);
+  lit_utf8_size_t length = ecma_string_get_length (prim_value_str_p);
 
-  for (ecma_length_t i = 0; i < length; i++)
+  for (lit_utf8_size_t i = 0; i < length; i++)
   {
     ecma_string_t *name_p = ecma_new_ecma_string_from_uint32 (i);
 

--- a/jerry-core/ecma/operations/ecma-string-object.h
+++ b/jerry-core/ecma/operations/ecma-string-object.h
@@ -26,7 +26,7 @@
  */
 
 ecma_value_t
-ecma_op_create_string_object (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+ecma_op_create_string_object (const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 
 void
 ecma_op_string_list_lazy_property_names (ecma_object_t *obj_p,

--- a/jerry-core/ecma/operations/ecma-symbol-object.c
+++ b/jerry-core/ecma/operations/ecma-symbol-object.c
@@ -43,7 +43,7 @@
  */
 ecma_value_t
 ecma_op_create_symbol (const ecma_value_t *arguments_list_p, /**< list of arguments */
-                       ecma_length_t arguments_list_len) /**< length of the arguments' list */
+                       uint32_t arguments_list_len) /**< length of the arguments' list */
 {
   JERRY_ASSERT (arguments_list_len == 0 || arguments_list_p != NULL);
 

--- a/jerry-core/ecma/operations/ecma-symbol-object.h
+++ b/jerry-core/ecma/operations/ecma-symbol-object.h
@@ -27,7 +27,7 @@
  */
 
 ecma_value_t
-ecma_op_create_symbol (const ecma_value_t *arguments_list_p, ecma_length_t arguments_list_len);
+ecma_op_create_symbol (const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 
 ecma_value_t
 ecma_op_create_symbol_object (const ecma_value_t value);

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -501,7 +501,7 @@ ecma_typedarray_helper_builtin_to_typedarray_id (ecma_builtin_id_t builtin_id)
  *         Returned value must be freed with ecma_free_value
  */
 ecma_value_t
-ecma_typedarray_create_object_with_length (ecma_length_t array_length, /**< length of the typedarray */
+ecma_typedarray_create_object_with_length (uint32_t array_length, /**< length of the typedarray */
                                            ecma_object_t *src_buffer_p, /**< source buffer */
                                            ecma_object_t *proto_p, /**< prototype object */
                                            uint8_t element_size_shift, /**< the size shift of the element length */
@@ -512,7 +512,7 @@ ecma_typedarray_create_object_with_length (ecma_length_t array_length, /**< leng
     return ecma_raise_range_error (ECMA_ERR_MSG ("Maximum typedarray size is reached."));
   }
 
-  ecma_length_t byte_length = array_length << element_size_shift;
+  uint32_t byte_length = array_length << element_size_shift;
 
   if (byte_length > UINT32_MAX - sizeof (ecma_extended_object_t) - JMEM_ALIGNMENT + 1)
   {
@@ -576,8 +576,8 @@ ecma_typedarray_create_object_with_length (ecma_length_t array_length, /**< leng
  */
 static ecma_value_t
 ecma_typedarray_create_object_with_buffer (ecma_object_t *arraybuffer_p, /**< the arraybuffer inside */
-                                           ecma_length_t byte_offset, /**< the byte offset of the arraybuffer */
-                                           ecma_length_t array_length, /**< length of the typedarray */
+                                           uint32_t byte_offset, /**< the byte offset of the arraybuffer */
+                                           uint32_t array_length, /**< length of the typedarray */
                                            ecma_object_t *proto_p, /**< prototype object */
                                            uint8_t element_size_shift, /**< the size shift of the element length */
                                            ecma_typedarray_type_t typedarray_id) /**< id of the typedarray */
@@ -586,7 +586,7 @@ ecma_typedarray_create_object_with_buffer (ecma_object_t *arraybuffer_p, /**< th
   {
     return ecma_raise_type_error (ECMA_ERR_MSG ("ArrayBuffer has been detached."));
   }
-  ecma_length_t expected_length = (ecma_arraybuffer_get_length (arraybuffer_p) >> element_size_shift);
+  uint32_t expected_length = (ecma_arraybuffer_get_length (arraybuffer_p) >> element_size_shift);
 
   bool needs_ext_typedarray_obj = (byte_offset != 0 || array_length != expected_length);
 
@@ -627,7 +627,7 @@ ecma_typedarray_create_object_with_typedarray (ecma_object_t *typedarray_p, /**<
                                                uint8_t element_size_shift, /**< the size shift of the element length */
                                                ecma_typedarray_type_t typedarray_id) /**< id of the typedarray */
 {
-  ecma_length_t array_length = ecma_typedarray_get_length (typedarray_p);
+  uint32_t array_length = ecma_typedarray_get_length (typedarray_p);
   ecma_object_t *src_arraybuffer_p = ecma_typedarray_get_arraybuffer (typedarray_p);
   if (ecma_arraybuffer_is_detached (src_arraybuffer_p))
   {
@@ -992,7 +992,7 @@ ecma_typedarray_get_element_size_shift (ecma_object_t *typedarray_p) /**< the po
  *
  * @return the array length
  */
-ecma_length_t
+uint32_t
 ecma_typedarray_get_length (ecma_object_t *typedarray_p) /**< the pointer to the typedarray object */
 {
   JERRY_ASSERT (ecma_object_is_typedarray (typedarray_p));
@@ -1002,7 +1002,7 @@ ecma_typedarray_get_length (ecma_object_t *typedarray_p) /**< the pointer to the
   if (ext_object_p->u.pseudo_array.type == ECMA_PSEUDO_ARRAY_TYPEDARRAY)
   {
     ecma_object_t *arraybuffer_p = ecma_get_object_from_value (ext_object_p->u.pseudo_array.u2.arraybuffer);
-    ecma_length_t buffer_length = ecma_arraybuffer_get_length (arraybuffer_p);
+    uint32_t buffer_length = ecma_arraybuffer_get_length (arraybuffer_p);
     uint8_t shift = ecma_typedarray_get_element_size_shift (typedarray_p);
 
     return buffer_length >> shift;
@@ -1024,7 +1024,7 @@ ecma_typedarray_get_length (ecma_object_t *typedarray_p) /**< the pointer to the
  *
  * @return the offset
  */
-ecma_length_t
+uint32_t
 ecma_typedarray_get_offset (ecma_object_t *typedarray_p) /**< the pointer to the typedarray object */
 {
   JERRY_ASSERT (ecma_object_is_typedarray (typedarray_p));
@@ -1073,7 +1073,7 @@ ecma_typedarray_get_buffer (ecma_object_t *typedarray_p) /**< the pointer to the
  */
 ecma_value_t
 ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg list passed to typedarray construct */
-                           ecma_length_t arguments_list_len, /**< the length of the arguments_list_p */
+                           uint32_t arguments_list_len, /**< the length of the arguments_list_p */
                            ecma_object_t *proto_p, /**< prototype object */
                            uint8_t element_size_shift, /**< the size shift of the element length */
                            ecma_typedarray_type_t typedarray_id) /**< id of the typedarray */
@@ -1152,8 +1152,8 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
       }
       else
       {
-        ecma_length_t buf_byte_length = ecma_arraybuffer_get_length (arraybuffer_p);
-        ecma_length_t new_byte_length = 0;
+        uint32_t buf_byte_length = ecma_arraybuffer_get_length (arraybuffer_p);
+        uint32_t new_byte_length = 0;
 
         if (ecma_is_value_undefined (arg3))
         {
@@ -1167,7 +1167,7 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
           }
           else
           {
-            new_byte_length = (ecma_length_t) (buf_byte_length - offset);
+            new_byte_length = (uint32_t) (buf_byte_length - offset);
           }
         }
         else
@@ -1184,7 +1184,7 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
           }
           else
           {
-            new_byte_length = (ecma_length_t) new_length << element_size_shift;
+            new_byte_length = (uint32_t) new_length << element_size_shift;
 
             if (((ecma_number_t) new_byte_length + offset) > buf_byte_length)
             {
@@ -1195,9 +1195,9 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
 
         if (ecma_is_value_empty (ret))
         {
-          ecma_length_t array_length = new_byte_length >> element_size_shift;
+          uint32_t array_length = new_byte_length >> element_size_shift;
           ret = ecma_typedarray_create_object_with_buffer (arraybuffer_p,
-                                                           (ecma_length_t) offset,
+                                                           (uint32_t) offset,
                                                            array_length,
                                                            proto_p,
                                                            element_size_shift,
@@ -1271,9 +1271,9 @@ ecma_op_typedarray_list_lazy_property_names (ecma_object_t *obj_p, /**< a TypedA
 {
   JERRY_ASSERT (ecma_object_is_typedarray (obj_p));
 
-  ecma_length_t array_length = ecma_typedarray_get_length (obj_p);
+  uint32_t array_length = ecma_typedarray_get_length (obj_p);
 
-  for (ecma_length_t i = 0; i < array_length; i++)
+  for (uint32_t i = 0; i < array_length; i++)
   {
     ecma_string_t *name_p = ecma_new_ecma_string_from_uint32 (i);
 
@@ -1296,7 +1296,7 @@ ecma_op_typedarray_define_index_prop (ecma_object_t *obj_p, /**< a TypedArray ob
 {
   JERRY_ASSERT (ecma_object_is_typedarray (obj_p));
 
-  ecma_length_t array_length = ecma_typedarray_get_length (obj_p);
+  uint32_t array_length = ecma_typedarray_get_length (obj_p);
 
   if ((index >= array_length)
       || (property_desc_p->flags & (ECMA_PROP_IS_GET_DEFINED | ECMA_PROP_IS_SET_DEFINED))
@@ -1342,7 +1342,7 @@ ecma_op_typedarray_define_index_prop (ecma_object_t *obj_p, /**< a TypedArray ob
  */
 ecma_value_t
 ecma_op_create_typedarray_with_type_and_length (ecma_typedarray_type_t typedarray_id, /** TypedArray id  */
-                                                ecma_length_t array_length) /**< length of the typedarray */
+                                                uint32_t array_length) /**< length of the typedarray */
 {
   // TODO: assert validate typedarray_id
   ecma_object_t *proto_p = ecma_builtin_get (ecma_typedarray_helper_get_prototype_id (typedarray_id));

--- a/jerry-core/ecma/operations/ecma-typedarray-object.h
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.h
@@ -48,13 +48,13 @@ ecma_value_t ecma_op_typedarray_from (ecma_value_t items_val,
                                       ecma_object_t *proto_p,
                                       uint8_t element_size_shift,
                                       ecma_typedarray_type_t typedarray_id);
-ecma_length_t ecma_typedarray_get_length (ecma_object_t *typedarray_p);
-ecma_length_t ecma_typedarray_get_offset (ecma_object_t *typedarray_p);
+uint32_t ecma_typedarray_get_length (ecma_object_t *typedarray_p);
+uint32_t ecma_typedarray_get_offset (ecma_object_t *typedarray_p);
 lit_utf8_byte_t *ecma_typedarray_get_buffer (ecma_object_t *typedarray_p);
 uint8_t ecma_typedarray_get_element_size_shift (ecma_object_t *typedarray_p);
 ecma_object_t *ecma_typedarray_get_arraybuffer (ecma_object_t *typedarray_p);
 ecma_value_t ecma_op_create_typedarray (const ecma_value_t *arguments_list_p,
-                                        ecma_length_t arguments_list_len,
+                                        uint32_t arguments_list_len,
                                         ecma_object_t *proto_p,
                                         uint8_t element_size_shift,
                                         ecma_typedarray_type_t typedarray_id);
@@ -66,9 +66,9 @@ bool ecma_op_typedarray_define_index_prop (ecma_object_t *obj_p,
                                            uint32_t index,
                                            const ecma_property_descriptor_t *property_desc_p);
 ecma_value_t ecma_op_create_typedarray_with_type_and_length (ecma_typedarray_type_t typedarray_id,
-                                                             ecma_length_t array_length);
+                                                             uint32_t array_length);
 ecma_typedarray_info_t ecma_typedarray_get_info (ecma_object_t *typedarray_p);
-ecma_value_t ecma_typedarray_create_object_with_length (ecma_length_t array_length,
+ecma_value_t ecma_typedarray_create_object_with_length (uint32_t array_length,
                                                         ecma_object_t *src_arraybuffer_p,
                                                         ecma_object_t *proto_p,
                                                         uint8_t element_size_shift,

--- a/jerry-core/lit/lit-globals.h
+++ b/jerry-core/lit/lit-globals.h
@@ -74,11 +74,6 @@
 typedef uint16_t ecma_char_t;
 
 /**
- * Description of a collection's/string's length
- */
-typedef uint32_t ecma_length_t;
-
-/**
  * Max bytes needed to represent a code unit (utf-16 char) via utf-8 encoding
  */
 #define LIT_UTF8_MAX_BYTES_IN_CODE_UNIT (3)

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -287,11 +287,11 @@ lit_zt_utf8_string_size (const lit_utf8_byte_t *utf8_str_p) /**< zero-terminated
  *
  * @return UTF-16 code units count
  */
-ecma_length_t
+lit_utf8_size_t
 lit_utf8_string_length (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 string */
                         lit_utf8_size_t utf8_buf_size) /**< string size */
 {
-  ecma_length_t length = 0;
+  lit_utf8_size_t length = 0;
   lit_utf8_size_t size = 0;
 
   while (size < utf8_buf_size)
@@ -341,12 +341,12 @@ lit_get_utf8_size_of_cesu8_string (const lit_utf8_byte_t *cesu8_buf_p, /**< cesu
  *
  * @return length of an utf-8 encoded string
  */
-ecma_length_t
+lit_utf8_size_t
 lit_get_utf8_length_of_cesu8_string (const lit_utf8_byte_t *cesu8_buf_p, /**< cesu-8 string */
                                      lit_utf8_size_t cesu8_buf_size) /**< string size */
 {
   lit_utf8_size_t offset = 0;
-  ecma_length_t utf8_length = 0;
+  lit_utf8_size_t utf8_length = 0;
   ecma_char_t prev_ch = 0;
 
   while (offset < cesu8_buf_size)
@@ -387,7 +387,7 @@ lit_read_code_point_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with ch
   }
 
   lit_code_point_t ret = LIT_UNICODE_CODE_POINT_NULL;
-  ecma_length_t bytes_count = 0;
+  lit_utf8_size_t bytes_count = 0;
   if ((c & LIT_UTF8_2_BYTE_MASK) == LIT_UTF8_2_BYTE_MARKER)
   {
     bytes_count = 2;
@@ -436,7 +436,7 @@ lit_read_code_unit_from_utf8 (const lit_utf8_byte_t *buf_p, /**< buffer with cha
   }
 
   lit_code_point_t ret = LIT_UNICODE_CODE_POINT_NULL;
-  ecma_length_t bytes_count;
+  lit_utf8_size_t bytes_count;
   if ((c & LIT_UTF8_2_BYTE_MASK) == LIT_UTF8_2_BYTE_MARKER)
   {
     bytes_count = 2;
@@ -623,7 +623,7 @@ lit_utf8_string_calc_hash (const lit_utf8_byte_t *utf8_buf_p, /**< characters bu
 ecma_char_t
 lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 string */
                               lit_utf8_size_t utf8_buf_size, /**< string size in bytes */
-                              ecma_length_t code_unit_offset) /**< ofset of a code_unit */
+                              lit_utf8_size_t code_unit_offset) /**< ofset of a code_unit */
 {
   lit_utf8_byte_t *current_p = (lit_utf8_byte_t *) utf8_buf_p;
   ecma_char_t code_unit;

--- a/jerry-core/lit/lit-strings.h
+++ b/jerry-core/lit/lit-strings.h
@@ -96,8 +96,9 @@ lit_utf8_size_t lit_zt_utf8_string_size (const lit_utf8_byte_t *utf8_str_p);
 lit_utf8_size_t lit_get_utf8_size_of_cesu8_string (const lit_utf8_byte_t *cesu8_buf_p, lit_utf8_size_t cesu8_buf_size);
 
 /* length */
-ecma_length_t lit_utf8_string_length (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t utf8_buf_size);
-ecma_length_t lit_get_utf8_length_of_cesu8_string (const lit_utf8_byte_t *cesu8_buf_p, lit_utf8_size_t cesu8_buf_size);
+lit_utf8_size_t lit_utf8_string_length (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t utf8_buf_size);
+lit_utf8_size_t lit_get_utf8_length_of_cesu8_string (const lit_utf8_byte_t *cesu8_buf_p,
+                                                     lit_utf8_size_t cesu8_buf_size);
 
 /* hash */
 lit_string_hash_t lit_utf8_string_calc_hash (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t utf8_buf_size);
@@ -106,7 +107,7 @@ lit_string_hash_t lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, co
 
 /* code unit access */
 ecma_char_t lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, lit_utf8_size_t utf8_buf_size,
-                                          ecma_length_t code_unit_offset);
+                                          lit_utf8_size_t code_unit_offset);
 lit_utf8_size_t lit_get_unicode_char_size_by_utf8_first_byte (const lit_utf8_byte_t first_byte);
 
 /* conversion */

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -958,7 +958,7 @@ static ecma_value_t
 ecma_op_implicit_constructor_handler_cb (const ecma_value_t function_obj, /**< the function itself */
                                          const ecma_value_t this_val, /**< this_arg of the function */
                                          const ecma_value_t args_p[], /**< argument list */
-                                         const ecma_length_t args_count) /**< argument number */
+                                         const uint32_t args_count) /**< argument number */
 {
   JERRY_UNUSED_4 (function_obj, this_val, args_p, args_count);
 
@@ -982,7 +982,7 @@ static ecma_value_t
 ecma_op_implicit_constructor_handler_heritage_cb (const ecma_value_t function_obj, /**< the function itself */
                                                   const ecma_value_t this_val, /**< this_arg of the function */
                                                   const ecma_value_t args_p[], /**< argument list */
-                                                  const ecma_length_t args_count) /**< argument number */
+                                                  const uint32_t args_count) /**< argument number */
 {
   JERRY_UNUSED_4 (function_obj, this_val, args_p, args_count);
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -4586,7 +4586,7 @@ finish:
 static void JERRY_ATTR_NOINLINE
 vm_init_exec (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
               const ecma_value_t *arg_p, /**< arguments list */
-              ecma_length_t arg_list_len) /**< length of arguments list */
+              uint32_t arg_list_len) /**< length of arguments list */
 {
   frame_ctx_p->prev_context_p = JERRY_CONTEXT (vm_top_context_p);
   frame_ctx_p->block_result = ECMA_VALUE_UNDEFINED;
@@ -4760,7 +4760,7 @@ vm_run (const ecma_compiled_code_t *bytecode_header_p, /**< byte-code data heade
         ecma_value_t this_binding_value, /**< value of 'ThisBinding' */
         ecma_object_t *lex_env_p, /**< lexical environment to use */
         const ecma_value_t *arg_list_p, /**< arguments list */
-        ecma_length_t arg_list_len) /**< length of arguments list */
+        uint32_t arg_list_len) /**< length of arguments list */
 {
   vm_frame_ctx_t *frame_ctx_p;
   size_t frame_size;

--- a/jerry-core/vm/vm.h
+++ b/jerry-core/vm/vm.h
@@ -458,7 +458,7 @@ ecma_value_t vm_run_module (const ecma_compiled_code_t *bytecode_p, ecma_object_
 #endif /* ENABLED (JERRY_MODULE_SYSTEM) */
 
 ecma_value_t vm_run (const ecma_compiled_code_t *bytecode_header_p, ecma_value_t this_binding_value,
-                     ecma_object_t *lex_env_p, const ecma_value_t *arg_list_p, ecma_length_t arg_list_len);
+                     ecma_object_t *lex_env_p, const ecma_value_t *arg_list_p, uint32_t arg_list_len);
 ecma_value_t vm_execute (vm_frame_ctx_t *frame_ctx_p);
 
 bool vm_is_strict_mode (void);

--- a/tests/unit-core/test-strings.c
+++ b/tests/unit-core/test-strings.c
@@ -72,11 +72,11 @@ generate_cesu8_char (utf8_char_size char_size,
   return lit_code_unit_to_utf8 ((ecma_char_t) code_point, buf);
 } /* generate_cesu8_char */
 
-static ecma_length_t
+static lit_utf8_size_t
 generate_cesu8_string (lit_utf8_byte_t *buf_p,
                        lit_utf8_size_t buf_size)
 {
-  ecma_length_t length = 0;
+  lit_utf8_size_t length = 0;
 
   lit_utf8_size_t size = 0;
   while (size  < buf_size)
@@ -114,10 +114,10 @@ main (void)
   for (int i = 0; i < test_iters; i++)
   {
     lit_utf8_size_t cesu8_string_size = (i == 0) ? 0 : (lit_utf8_size_t) (rand () % max_bytes_in_string);
-    ecma_length_t length = generate_cesu8_string (cesu8_string, cesu8_string_size);
+    lit_utf8_size_t length = generate_cesu8_string (cesu8_string, cesu8_string_size);
 
     ecma_string_t *char_collection_string_p = ecma_new_ecma_string_from_utf8 (cesu8_string, cesu8_string_size);
-    ecma_length_t char_collection_len = ecma_string_get_length (char_collection_string_p);
+    lit_utf8_size_t char_collection_len = ecma_string_get_length (char_collection_string_p);
     TEST_ASSERT (char_collection_len == length);
     ecma_deref_ecma_string (char_collection_string_p);
 
@@ -126,8 +126,8 @@ main (void)
     const lit_utf8_byte_t *curr_p = cesu8_string;
     const lit_utf8_byte_t *end_p = cesu8_string + cesu8_string_size;
 
-    ecma_length_t calculated_length = 0;
-    ecma_length_t code_units_count = 0;
+    lit_utf8_size_t calculated_length = 0;
+    lit_utf8_size_t code_units_count = 0;
 
     while (curr_p < end_p)
     {
@@ -145,7 +145,7 @@ main (void)
     {
       for (int j = 0; j < test_subiters; j++)
       {
-        ecma_length_t index = (ecma_length_t) rand () % code_units_count;
+        lit_utf8_size_t index = (lit_utf8_size_t) rand () % code_units_count;
         curr_p = saved_positions[index];
         TEST_ASSERT (lit_cesu8_peek_next (curr_p) == code_units[index]);
       }


### PR DESCRIPTION
Now the following conventions are applied:
 - passing the number of arguments for a function call is always `uint32_t`
 - string size/length/position related operation should use `lit_utf8_size_t`
 - extended objects internal fields must be `uint32_t`

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
