### PR TITLE
Fix date-construct.js test

### DIFF
--- a/tests/jerry/date-construct.js
+++ b/tests/jerry/date-construct.js
@@ -75,4 +75,3 @@ catch (e)
 
 assert (typeof Date (2015) == "string");
 assert (typeof Date() != typeof (new Date ()));
-assert (Date (Number.NaN) == Date ());


### PR DESCRIPTION
Removed an undeterministic subtest.

date-construct.js fails intermittently, because it expects that
two Date() calls return the same date string. But the second one
can be 1 second later. This subtest is undeterministic and already
covered by test262/es2015/test/built-ins/Date/S15.9.2.1_A2.js with
1 second epsilon.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
