### PR TITLE
Fix test262 excludelist updater

### DIFF
--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -140,6 +140,8 @@ def update_exclude_list(args):
                     exclude_file.write(line)
                 else:
                     new_passing_tests.add(test)
+            else:
+                exclude_file.write(line)
 
         if failing_tests:
             print("New failing tests added to the excludelist")


### PR DESCRIPTION
tools/run-tests.py --test262-es2015 update shouldn't
remove comments and newlines in the excludelist file.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
