### PR TITLE
Change heap sort to merge sort for Array.prototype

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1178,10 +1178,10 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
   if (copied_num > 1)
   {
     const ecma_builtin_helper_sort_compare_fn_t sort_cb = &ecma_builtin_array_prototype_object_sort_compare_helper;
-    ecma_value_t sort_value = ecma_builtin_helper_array_heap_sort_helper (values_buffer,
-                                                                          (uint32_t) (copied_num - 1),
-                                                                          arg1,
-                                                                          sort_cb);
+    ecma_value_t sort_value = ecma_builtin_helper_array_merge_sort_helper (values_buffer,
+                                                                           (uint32_t) (copied_num),
+                                                                           arg1,
+                                                                           sort_cb);
     if (ECMA_IS_VALUE_ERROR (sort_value))
     {
       goto clean_up;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -238,10 +238,10 @@ typedef ecma_value_t (*ecma_builtin_helper_sort_compare_fn_t) (ecma_value_t lhs,
                                                                ecma_value_t rhs, /**< right value */
                                                                ecma_value_t compare_func); /**< compare function */
 
-ecma_value_t ecma_builtin_helper_array_heap_sort_helper (ecma_value_t *array_p,
-                                                         uint32_t right,
-                                                         ecma_value_t compare_func,
-                                                         const ecma_builtin_helper_sort_compare_fn_t sort_cb);
+ecma_value_t ecma_builtin_helper_array_merge_sort_helper (ecma_value_t *array_p,
+                                                          uint32_t length,
+                                                          ecma_value_t compare_func,
+                                                          const ecma_builtin_helper_sort_compare_fn_t sort_cb);
 
 /**
  * @}

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1527,10 +1527,10 @@ ecma_builtin_typedarray_prototype_sort (ecma_value_t this_arg, /**< this argumen
 
   const ecma_builtin_helper_sort_compare_fn_t sort_cb = &ecma_builtin_typedarray_prototype_sort_compare_helper;
 
-  ecma_value_t sort_value = ecma_builtin_helper_array_heap_sort_helper (values_buffer,
-                                                                        (uint32_t) (info.length - 1),
-                                                                        compare_func,
-                                                                        sort_cb);
+  ecma_value_t sort_value = ecma_builtin_helper_array_merge_sort_helper (values_buffer,
+                                                                         (uint32_t) (info.length),
+                                                                         compare_func,
+                                                                         sort_cb);
 
   if (ECMA_IS_VALUE_ERROR (sort_value))
   {


### PR DESCRIPTION
ES11 requires Array.prototype.sort to be stable. [(22.1.3.27)](https://www.ecma-international.org/ecma-262/11.0/#sec-array.prototype.sort), but heap sort is not.

I choose merge sort because implementation is simple and algorithm is stable. I made some additional performance testing - I used `run-perf-test.sh` and simple tests with randomly generated array of numbers (hardcoded into js file).

Benchmark | Peak alloc.<br>(+ is better) | Perf<br>(+ is better)
---------: | --------- | ---------
sort00100.js | `3336 -> 3336     `<br>`       +0.000%` | `  0.001s ->   0.001s `<br>`        +0.000%  (+-0.000%) : [≈]`
sort00200.js | `5792 -> 5792     `<br>`       +0.000%` | `  0.001s ->   0.001s `<br>`       +20.000% (+-25.951%) : [≈]`
sort00500.js | `13648 -> 13648   `<br>`       +0.000%` | `  0.004s ->   0.003s `<br>`       +19.048% (+-14.721%) : [+]`
sort01000.js | `26672 -> 26672   `<br>`       +0.000%` | `  0.009s ->   0.006s `<br>`       +30.769%  (+-8.816%) : [+]`
sort02000.js | `51560 -> 51560   `<br>`       +0.000%` | `  0.021s ->   0.017s `<br>`       +17.460%  (+-2.102%) : [+]`
sort05000.js | `123128 -> 123128    `<br>`       +0.000%` | `  0.094s ->   0.084s `<br>`       +10.062%  (+-0.580%) : [+]`
sort10000.js | `232768 -> 232768    `<br>`       +0.000%` | `  0.304s ->   0.284s `<br>`        +6.519%  (+-0.808%) : [+]`
Geometric mean: | RSS reduction: `0.000%` | Speed up: `15.362% (+-5.497%) : [+]`

Number in file name indicates number of elements to sort.

I tested also approach with existing heap sort - with additional memory for keeping position in original array but it turned out that merge sort is faster.


JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com