### PR TITLE
Fix argument bounday check order in ecma_builtin_number_prototype_object_to_number_convert

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -493,16 +493,11 @@ ecma_builtin_number_prototype_object_to_number_convert (ecma_number_t this_num, 
     return to_integer;
   }
 
-  /* Argument boundary checks */
-  if (mode != NUMBER_ROUTINE_TO_PRECISION
+  /* Argument boundary check for toFixed method */
+  if (mode == NUMBER_ROUTINE_TO_FIXED
       && (arg_num <= -1 || arg_num >= 101))
   {
     return ecma_raise_range_error (ECMA_ERR_MSG ("Fraction digits must be between 0 and 100."));
-  }
-  else if (mode == NUMBER_ROUTINE_TO_PRECISION
-          && (arg_num < 1 || arg_num > 100))
-  {
-    return ecma_raise_range_error (ECMA_ERR_MSG ("Precision digits must be between 1 and 100."));
   }
 
   /* Handle NaN separately */
@@ -564,6 +559,20 @@ ecma_builtin_number_prototype_object_to_number_convert (ecma_number_t this_num, 
   {
     ecma_stringbuilder_append_magic (&builder, LIT_MAGIC_STRING_INFINITY_UL);
     return ecma_make_string_value (ecma_stringbuilder_finalize (&builder));
+  }
+
+  /* Argument boundary check for toExponential and toPrecision methods */
+  if (mode == NUMBER_ROUTINE_TO_EXPONENTIAL
+      && (arg_num <= -1 || arg_num >= 101))
+  {
+    ecma_stringbuilder_destroy (&builder);
+    return ecma_raise_range_error (ECMA_ERR_MSG ("Fraction digits must be between 0 and 100."));
+  }
+  else if (mode == NUMBER_ROUTINE_TO_PRECISION
+          && (arg_num < 1 || arg_num > 100))
+  {
+    ecma_stringbuilder_destroy (&builder);
+    return ecma_raise_range_error (ECMA_ERR_MSG ("Precision digits must be between 1 and 100."));
   }
 
   num_of_digits = ecma_number_to_decimal (this_num, digits, &exponent);

--- a/tests/jerry/number-prototype-to-precision.js
+++ b/tests/jerry/number-prototype-to-precision.js
@@ -59,3 +59,31 @@ try {
 } catch (e) {
     assert(e instanceof TypeError)
 }
+
+
+assert((+Infinity).toPrecision(1000) === "Infinity");
+var n = new Number(+Infinity);
+assert(n.toPrecision(1000) === "Infinity");
+
+assert((-Infinity).toPrecision(1000) === "-Infinity");
+var n = new Number(-Infinity);
+assert(n.toPrecision(1000) === "-Infinity");
+
+assert(NaN.toPrecision(undefined) === "NaN");
+  
+var calls = 0;
+
+var p = {
+  valueOf: function() {
+    calls++;
+	return Infinity;
+  }
+};
+
+assert(NaN.toPrecision(p) === "NaN");
+assert(calls === 1);
+
+var n = new Number(NaN);
+calls = 0;
+assert(n.toPrecision(p) === "NaN");
+assert(calls === 1);


### PR DESCRIPTION
Also added some tests related to the issues caused by the wrong order

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
