### PR TITLE
Indentifier should be expected after `static` in class body.

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -571,6 +571,10 @@ parser_parse_class_literal (parser_context_t *context_p, /**< context */
 
     if (context_p->token.type == LEXER_RIGHT_BRACE)
     {
+      if (JERRY_UNLIKELY (is_static))
+      {
+        parser_raise_error (context_p, PARSER_ERR_IDENTIFIER_EXPECTED);
+      }
       break;
     }
 

--- a/tests/jerry/es.next/regression-test-issue-4055.js
+++ b/tests/jerry/es.next/regression-test-issue-4055.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval("class cla { static }");
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #4055.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
