### PR TITLE
Remove invalid assertion from parser_flush_cbc

### DIFF
--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -153,8 +153,6 @@ parser_flush_cbc (parser_context_t *context_p) /**< context */
     return;
   }
 
-  JERRY_ASSERT (last_opcode != PARSER_TO_EXT_OPCODE (CBC_EXT_PUSH_SUPER));
-
   context_p->status_flags |= PARSER_NO_END_LABEL;
 
   if (PARSER_IS_BASIC_OPCODE (last_opcode))

--- a/tests/jerry/es.next/regression-test-issue-4054.js
+++ b/tests/jerry/es.next/regression-test-issue-4054.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval("var obj = { m() {super.8 = 17;} };");
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #4054.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
