### PR TITLE
Fix error handling in SetIntegrityLevel

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -347,7 +347,8 @@ ecma_builtin_object_set_integrity_level (ecma_object_t *obj_p, /**< object */
 #if ENABLED (JERRY_BUILTIN_PROXY)
       if (ECMA_IS_VALUE_ERROR (status))
       {
-        break;
+        ecma_collection_free (props_p);
+        return ECMA_VALUE_ERROR;
       }
 #endif /* ENABLED (JERRY_BUILTIN_PROXY) */
 
@@ -390,7 +391,8 @@ ecma_builtin_object_set_integrity_level (ecma_object_t *obj_p, /**< object */
 #if ENABLED (JERRY_BUILTIN_PROXY)
       if (ECMA_IS_VALUE_ERROR (status))
       {
-        break;
+        ecma_collection_free (props_p);
+        return ECMA_VALUE_ERROR;
       }
 #endif /* ENABLED (JERRY_BUILTIN_PROXY) */
 

--- a/tests/jerry/es.next/regression-test-issue-4052.js
+++ b/tests/jerry/es.next/regression-test-issue-4052.js
@@ -1,0 +1,36 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var obj = {};
+var proxy = new Proxy(obj, {
+    getOwnPropertyDescriptor: function (target, property) {
+    },
+});
+var proxy2 = new Proxy(proxy, {
+    a: obj.prop2++
+});
+
+try {
+  Object.freeze(proxy);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  Object.seal(proxy);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #4052.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu