### PR TITLE
Fix scope stack lookup for literal indices

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -2540,7 +2540,8 @@ scanner_save_literal (parser_context_t *context_p, /**< context */
       JERRY_ASSERT (scope_stack_p > context_p->scope_stack_p);
       scope_stack_p--;
     }
-    while (literal_index != (scope_stack_p->map_to & PARSER_SCOPE_STACK_REGISTER_MASK));
+    while (scope_stack_p->map_from == PARSER_SCOPE_STACK_FUNC
+           || literal_index != (scope_stack_p->map_to & PARSER_SCOPE_STACK_REGISTER_MASK));
 
     literal_index = scope_stack_p->map_from;
     PARSER_GET_LITERAL (literal_index)->status_flags |= LEXER_FLAG_USED;
@@ -2574,7 +2575,8 @@ scanner_literal_is_const_reg (parser_context_t *context_p, /**< context */
     JERRY_ASSERT (scope_stack_p > context_p->scope_stack_p);
     scope_stack_p--;
   }
-  while (literal_index != (scope_stack_p->map_to & PARSER_SCOPE_STACK_REGISTER_MASK));
+  while (scope_stack_p->map_from == PARSER_SCOPE_STACK_FUNC
+         || literal_index != (scope_stack_p->map_to & PARSER_SCOPE_STACK_REGISTER_MASK));
 
   return (scope_stack_p->map_to & PARSER_SCOPE_STACK_IS_CONST_REG) != 0;
 } /* scanner_literal_is_const_reg */

--- a/tests/jerry/es.next/regression-test-issue-4051.js
+++ b/tests/jerry/es.next/regression-test-issue-4051.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function foo() {
+  for (var i = 0; i < 3; i++) {
+    const N = class { };
+    function bar(a0) { }
+    assert(N.name === 'N');
+  }
+}
+foo();


### PR DESCRIPTION
This patch fixes #4051.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
