### PR TITLE
Fix a use-after-free in RegExp.prototype.compile

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -297,6 +297,7 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this */
   }
 
   JERRY_ASSERT (ecma_is_value_true (status));
+  ecma_value_t ret_value;
 
   if (ecma_object_is_regexp_object (pattern_arg))
   {
@@ -310,13 +311,13 @@ ecma_builtin_regexp_prototype_compile (ecma_value_t this_arg, /**< this */
                                                                 pattern_obj_p->u.class_prop.u.value);
 
     ecma_ref_object (this_obj_p);
-    /* ecma_op_create_regexp_from_bytecode will never throw an error while re-initalizing the regexp object, so we
-     * can deref the old bytecode without leaving a dangling pointer. */
+    ret_value = ecma_op_create_regexp_from_bytecode (this_obj_p, bc_p);
+
     ecma_bytecode_deref ((ecma_compiled_code_t *) old_bc_p);
-    return ecma_op_create_regexp_from_bytecode (this_obj_p, bc_p);
+    return ret_value;
   }
 
-  ecma_value_t ret_value = ecma_op_create_regexp_from_pattern (this_obj_p, pattern_arg, flags_arg);
+  ret_value = ecma_op_create_regexp_from_pattern (this_obj_p, pattern_arg, flags_arg);
 
   if (!ECMA_IS_VALUE_ERROR (ret_value))
   {

--- a/tests/jerry/regression-test-issue-4056.js
+++ b/tests/jerry/regression-test-issue-4056.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var r = new RegExp('a');
+
+new RegExp('1');
+new RegExp('2');
+new RegExp('3');
+new RegExp('4');
+new RegExp('5');
+new RegExp('6');
+new RegExp('7');
+new RegExp('8');
+
+r.compile(r);


### PR DESCRIPTION
Fixes #4056.
