### PR TITLE
Fix argument list end validation after destructuring argument

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1874,6 +1874,13 @@ parser_parse_function_arguments (parser_context_t *context_p, /**< context */
 
       if (context_p->token.type != LEXER_COMMA)
       {
+        if (context_p->token.type != end_type)
+        {
+          parser_error_t error = ((end_type == LEXER_RIGHT_PAREN) ? PARSER_ERR_RIGHT_PAREN_EXPECTED
+                                                                  : PARSER_ERR_IDENTIFIER_EXPECTED);
+
+          parser_raise_error (context_p, error);
+        }
         break;
       }
 

--- a/tests/jerry/es.next/regression-test-issue-4050.js
+++ b/tests/jerry/es.next/regression-test-issue-4050.js
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`function write([a] of { }
+    (function Test1() {
+        write("");
+    });`);
+  assert(false);
+} catch (e) {
+  assert (e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #4050.
    
JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

