### PR TITLE
Update Array.prototype.concat error handling to ES11

### DIFF
--- a/tests/jerry/es.next/regression-test-issue-4044.js
+++ b/tests/jerry/es.next/regression-test-issue-4044.js
@@ -1,0 +1,28 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = Int32Array.prototype;
+a.__proto__ = [];
+
+var b = a.splice(7, -4, 8, 9, 10);
+
+b.__proto__ = a;
+b.length = 5;
+
+try {
+  b = b.concat([]);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #4044.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
