### PR TITLE
Fix surrogate pair lookahead in String.prototype.toUpper

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-prototype.c
@@ -1002,7 +1002,8 @@ ecma_builtin_string_prototype_object_conversion_helper (ecma_string_t *input_str
     lit_code_point_t cp = lit_cesu8_read_next (&input_curr_p);
 
 #if ENABLED (JERRY_ESNEXT)
-    if (lit_is_code_point_utf16_high_surrogate (cp))
+    if (lit_is_code_point_utf16_high_surrogate (cp)
+        && input_curr_p < input_str_end_p)
     {
       const ecma_char_t next_ch = lit_cesu8_peek_next (input_curr_p);
       if (lit_is_code_point_utf16_low_surrogate (next_ch))

--- a/tests/jerry/es.next/regression-test-issue-4013.js
+++ b/tests/jerry/es.next/regression-test-issue-4013.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert("\ud800".toUpperCase() === "\ud800");


### PR DESCRIPTION
This patch fixes #4013.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu

