### PR TITLE
Fix TypedArray construction with incorrect offset

### DIFF
--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -1142,8 +1142,9 @@ ecma_op_create_typedarray (const ecma_value_t *arguments_list_p, /**< the arg li
         return ECMA_VALUE_ERROR;
       }
 
-      if (ecma_number_is_negative (offset))
+      if (ecma_number_is_negative (offset) || fmod (offset, (1 << element_size_shift)) != 0)
       {
+        /* ES2015 22.2.1.5: 9 - 10. */
         ret = ecma_raise_range_error (ECMA_ERR_MSG ("Invalid offset."));
       }
       else if (ecma_arraybuffer_is_detached (arraybuffer_p))

--- a/tests/jerry/es.next/typedarray-offset-modulo.js
+++ b/tests/jerry/es.next/typedarray-offset-modulo.js
@@ -1,0 +1,37 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var types = [
+  Uint16Array,
+  Uint32Array,
+  Float32Array,
+  Float64Array,
+  Int16Array,
+  Int32Array,
+]
+
+var buffer = new ArrayBuffer (100);
+
+for (var idx = 0; idx < types.length; idx++) {
+  try {
+    var target = types[idx];
+
+    /* TypedArray should throw error on incorrect offset (offset % elementSize != 0)! */
+    new target (buffer, target.BYTES_PER_ELEMENT + 1, 1);
+    assert (false);
+  } catch (ex) {
+    assert (ex instanceof RangeError);
+  }
+}


### PR DESCRIPTION
In case of a TypedArray the input `byteOffset` argument must be a
multiple of the `BYTES_PER_ELEMENT` value.
