### PR TITLE
Fix Symbol's description default value

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-symbol-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-symbol-prototype.c
@@ -96,10 +96,15 @@ ecma_builtin_symbol_prototype_dispatch_routine (uint16_t builtin_routine_id, /**
 
   JERRY_ASSERT (builtin_routine_id == ECMA_SYMBOL_PROTOTYPE_DESCRIPTION);
   ecma_string_t *symbol_p = ecma_get_symbol_from_value (sym);
-  ecma_string_t *desc_p = ecma_get_symbol_description (symbol_p);
-  ecma_ref_ecma_string (desc_p);
+  ecma_value_t desc = ecma_get_symbol_description (symbol_p);
+  if (ecma_is_value_undefined (desc))
+  {
+    return desc;
+  }
 
-  return ecma_make_string_value (desc_p);
+  ecma_string_t *desc_p = ecma_get_string_from_value (desc);
+  ecma_ref_ecma_string (desc_p);
+  return desc;
 } /* ecma_builtin_symbol_prototype_dispatch_routine */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-symbol.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-symbol.c
@@ -119,7 +119,15 @@ ecma_builtin_symbol_for_helper (ecma_value_t value_to_find) /**< symbol or ecma-
 
         if (is_for)
         {
-          ecma_string_t *symbol_desc_p = ecma_get_symbol_description (value_p);
+          ecma_value_t symbol_desc = ecma_get_symbol_description (value_p);
+
+          if (ecma_is_value_undefined (symbol_desc))
+          {
+            ecma_ref_ecma_string (value_p);
+            return ecma_make_symbol_value (value_p);
+          }
+
+          ecma_string_t *symbol_desc_p = ecma_get_string_from_value (symbol_desc);
 
           if (ecma_compare_ecma_strings (symbol_desc_p, string_p))
           {
@@ -133,9 +141,16 @@ ecma_builtin_symbol_for_helper (ecma_value_t value_to_find) /**< symbol or ecma-
         {
           if (string_p == value_p)
           {
-            ecma_string_t *symbol_desc_p = ecma_get_symbol_description (string_p);
+            ecma_value_t symbol_desc = ecma_get_symbol_description (string_p);
+
+            if (ecma_is_value_undefined (symbol_desc))
+            {
+              return symbol_desc;
+            }
+
+            ecma_string_t *symbol_desc_p = ecma_get_string_from_value (symbol_desc);
             ecma_ref_ecma_string (symbol_desc_p);
-            return ecma_make_string_value (symbol_desc_p);
+            return symbol_desc;
           }
         }
       }

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -54,16 +54,17 @@ ecma_op_function_form_name (ecma_string_t *prop_name_p, /**< property name */
   if (ecma_prop_name_is_symbol (prop_name_p))
   {
     /* .a */
-    ecma_string_t *string_desc_p = ecma_get_symbol_description (prop_name_p);
+    ecma_value_t string_desc = ecma_get_symbol_description (prop_name_p);
 
     /* .b */
-    if (ecma_string_is_empty (string_desc_p))
+    if (ecma_is_value_undefined (string_desc))
     {
-      prop_name_p = string_desc_p;
+      prop_name_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
     }
     /* .c */
     else
     {
+      ecma_string_t *string_desc_p = ecma_get_string_from_value (string_desc);
       ecma_stringbuilder_t builder = ecma_stringbuilder_create_raw ((lit_utf8_byte_t *) "[", 1);
       ecma_stringbuilder_append (&builder, string_desc_p);
       ecma_stringbuilder_append_byte (&builder, (lit_utf8_byte_t) LIT_CHAR_RIGHT_SQUARE);

--- a/jerry-core/ecma/operations/ecma-symbol-object.c
+++ b/jerry-core/ecma/operations/ecma-symbol-object.c
@@ -52,7 +52,7 @@ ecma_op_create_symbol (const ecma_value_t *arguments_list_p, /**< list of argume
   /* 1-3. */
   if (arguments_list_len == 0)
   {
-    string_desc = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
+    string_desc = ECMA_VALUE_UNDEFINED;
   }
   else
   {
@@ -101,13 +101,13 @@ ecma_op_create_symbol_object (const ecma_value_t value) /**< symbol value */
  *
  * @return pointer to ecma-string descriptor
  */
-ecma_string_t *
+ecma_value_t
 ecma_get_symbol_description (ecma_string_t *symbol_p) /**< ecma-symbol */
 {
   JERRY_ASSERT (symbol_p != NULL);
   JERRY_ASSERT (ecma_prop_name_is_symbol (symbol_p));
 
-  return ecma_get_string_from_value (((ecma_extended_string_t *) symbol_p)->u.symbol_descriptor);
+  return ((ecma_extended_string_t *) symbol_p)->u.symbol_descriptor;
 } /* ecma_get_symbol_description */
 
 /**
@@ -126,13 +126,16 @@ ecma_get_symbol_descriptive_string (ecma_value_t symbol_value) /**< symbol to st
 
   /* 2 - 3. */
   ecma_string_t *symbol_p = ecma_get_symbol_from_value (symbol_value);
-  ecma_string_t *string_desc_p = ecma_get_symbol_description (symbol_p);
-
-  /* 5. */
+  ecma_value_t string_desc = ecma_get_symbol_description (symbol_p);
   ecma_stringbuilder_t builder = ecma_stringbuilder_create_raw ((lit_utf8_byte_t *) ("Symbol("), 7);
-  ecma_stringbuilder_append (&builder, string_desc_p);
-  ecma_stringbuilder_append_byte (&builder, LIT_CHAR_RIGHT_PAREN);
 
+  if (!ecma_is_value_undefined (string_desc))
+  {
+    ecma_string_t *string_desc_p = ecma_get_string_from_value (string_desc);
+    ecma_stringbuilder_append (&builder, string_desc_p);
+  }
+
+  ecma_stringbuilder_append_byte (&builder, LIT_CHAR_RIGHT_PAREN);
   return ecma_make_string_value (ecma_stringbuilder_finalize (&builder));
 } /* ecma_get_symbol_descriptive_string */
 

--- a/jerry-core/ecma/operations/ecma-symbol-object.h
+++ b/jerry-core/ecma/operations/ecma-symbol-object.h
@@ -35,7 +35,7 @@ ecma_op_create_symbol_object (const ecma_value_t value);
 bool
 ecma_prop_name_is_symbol (ecma_string_t *string_p);
 
-ecma_string_t *
+ecma_value_t
 ecma_get_symbol_description (ecma_string_t *symbol_p);
 
 ecma_value_t

--- a/tests/jerry/es.next/symbol-prototype-description.js
+++ b/tests/jerry/es.next/symbol-prototype-description.js
@@ -73,3 +73,6 @@ try {
 } catch (e) {
   assert(e instanceof TypeError);
 }
+
+assert(Symbol("").description !== undefined);
+assert(Symbol().description === undefined);


### PR DESCRIPTION
In the standard if we create a Symbol object without adding a description value
default value is undefined not empty string.

JerryScript-DCO-1.0-Signed-off-by: bence gabor kis kisbg@inf.u-szeged.hu
