### PR TITLE
Fix inline errors with fPIC

### DIFF
--- a/jerry-core/parser/regexp/re-bytecode.c
+++ b/jerry-core/parser/regexp/re-bytecode.c
@@ -254,7 +254,7 @@ re_insert_value (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
  *
  * @return decoded value
  */
-uint32_t JERRY_ATTR_ALWAYS_INLINE
+inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 re_get_value (const uint8_t **bc_p) /** refence to bytecode pointer */
 {
   uint32_t value = *(*bc_p)++;


### PR DESCRIPTION
In case of `-fPIC` and single file build one of the Regexp's method
raises an error during linking:

```
ecma-regexp-object.c: In function ‘ecma_regexp_run’:
re-bytecode.c:258:1: error: inlining failed in call to ‘always_inline’ ‘re_get_value’:
 function body can be overwritten at link time
```

By adding the `inline` keyword for the method the build error can be resolved.
