### PR TITLE
Fix conversion and signedness warnings

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -113,7 +113,7 @@ ecma_builtin_regexp_prototype_flags_helper (ecma_extended_object_t *re_obj_p, /*
   };
 
   uint16_t offset = (uint16_t) (builtin_routine_id - ECMA_REGEXP_PROTOTYPE_ROUTINE_GET_GLOBAL);
-  return ecma_make_boolean_value (flags & re_flags[offset]);
+  return ecma_make_boolean_value ((flags & re_flags[offset]) != 0);
 } /* ecma_builtin_regexp_prototype_flags_helper */
 
 /**

--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -625,7 +625,7 @@ scanner_pop_literal_pool (parser_context_t *context_p, /**< context */
       {
         compressed_size += 2 + 1;
       }
-      else if (diff >= -UINT8_MAX && diff <= UINT16_MAX)
+      else if (diff >= -UINT8_MAX && diff <= (intptr_t) UINT16_MAX)
       {
         compressed_size += 2 + 2;
       }
@@ -888,7 +888,7 @@ scanner_pop_literal_pool (parser_context_t *context_p, /**< context */
       {
         data_p[-1] = (uint8_t) diff;
       }
-      else if (diff >= -UINT8_MAX && diff <= UINT16_MAX)
+      else if (diff >= -UINT8_MAX && diff <= (intptr_t) UINT16_MAX)
       {
         if (diff < 0)
         {


### PR DESCRIPTION
In case of ARM Nuttx build with IoT.js there are small conversion
and signedness warnings resulting in a build failure.

```
ecma-builtin-regexp-prototype.c: error: conversion from 'int' to '_Bool8' {aka 'unsigned char'}
  may change value [-Werror=conversion]
  116 |   return ecma_make_boolean_value (flags & re_flags[offset]);
      |                                   ~~~~~~^~~~~~~~~~~~~~~~~~

js-scanner-util.c: In function 'scanner_pop_literal_pool':
js-scanner-util.c:628:43: error: comparison of integer expressions of different signedness:
  'intptr_t' {aka 'int'} and 'unsigned int' [-Werror=sign-compare]
  628 |       else if (diff >= -UINT8_MAX && diff <= UINT16_MAX)
      |                                           ^~
js-scanner-util.c:891:43: error: comparison of integer expressions of different signedness:
  'intptr_t' {aka 'int'} and 'unsigned int' [-Werror=sign-compare]
  891 |       else if (diff >= -UINT8_MAX && diff <= UINT16_MAX)
```
