### PR TITLE
Fix build with disabled ES2015 module system

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -680,10 +680,11 @@ parser_parse_function_statement (parser_context_t *context_p) /**< context */
   {
     parser_raise_error (context_p, PARSER_ERR_VARIABLE_REDECLARED);
   }
+
+  uint16_t function_name_index = context_p->lit_object.index;
 #endif /* ENABLED (JERRY_ESNEXT) */
 
 #if ENABLED (JERRY_MODULE_SYSTEM)
-  uint16_t function_name_index = context_p->lit_object.index;
   parser_module_append_export_name (context_p);
   context_p->status_flags &= (uint32_t) ~(PARSER_MODULE_STORE_IDENT);
 #endif /* ENABLED (JERRY_MODULE_SYSTEM) */

--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -1739,13 +1739,19 @@ scanner_is_context_needed (parser_context_t *context_p, /**< context */
     }
     else if (check_type == PARSER_CHECK_GLOBAL_CONTEXT)
     {
+#if ENABLED (JERRY_MODULE_SYSTEM)
+      const bool is_import = (type == SCANNER_STREAM_TYPE_IMPORT);
+#else
+      const bool is_import = true;
+#endif /* ENABLED (JERRY_MODULE_SYSTEM) */
+
       /* FIXME: a private declarative lexical environment should always be present
        * for modules. Remove SCANNER_STREAM_TYPE_IMPORT after it is implemented. */
       JERRY_ASSERT (type == SCANNER_STREAM_TYPE_VAR
                     || type == SCANNER_STREAM_TYPE_LET
                     || type == SCANNER_STREAM_TYPE_CONST
                     || type == SCANNER_STREAM_TYPE_FUNC
-                    || type == SCANNER_STREAM_TYPE_IMPORT);
+                    || is_import);
 
       /* Only let/const can be stored in registers */
       JERRY_ASSERT ((data & SCANNER_STREAM_NO_REG)
@@ -1792,10 +1798,16 @@ scanner_is_context_needed (parser_context_t *context_p, /**< context */
     }
 
 #if ENABLED (JERRY_ESNEXT)
+#if ENABLED (JERRY_MODULE_SYSTEM)
+    const bool is_import = (type == SCANNER_STREAM_TYPE_IMPORT);
+#else
+    const bool is_import = true;
+#endif /* ENABLED (JERRY_MODULE_SYSTEM) */
+
     if (JERRY_UNLIKELY (check_type == PARSER_CHECK_GLOBAL_CONTEXT)
         && (type == SCANNER_STREAM_TYPE_VAR
             || (type == SCANNER_STREAM_TYPE_FUNC && !(context_p->global_status_flags & ECMA_PARSE_DIRECT_EVAL))
-            || type == SCANNER_STREAM_TYPE_IMPORT))
+            || is_import))
     {
       continue;
     }

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -159,6 +159,8 @@ JERRY_BUILDOPTIONS = [
             ['--cmake-param=-DENABLE_ALL_IN_ONE_SOURCE=ON']),
     Options('buildoption_test-jerry-debugger',
             ['--jerry-debugger=on']),
+    Options('buildoption_test-module-off',
+            ['--compile-flag=-DJERRY_MODULE_SYSTEM=0', '--lto=off']),
 ]
 
 def get_arguments():


### PR DESCRIPTION
With a disabled ES2015 module system the build fails as an enum value
is incorrectly guarded and used.