### PR TITLE
Make Test262 results less verbose

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -73,6 +73,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Test262 - ES2015
         run: $RUNNER --test262-es2015 update
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Test262-ES2015-results
+          path: build/tests/test262_tests_es2015/local/bin/test262.report
 
   Conformance_Tests_ESNext:
     runs-on: ubuntu-18.04
@@ -80,6 +84,10 @@ jobs:
       - uses: actions/checkout@v1
       - name: Test262 - ESNext
         run: $RUNNER --test262-esnext update
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Test262-ESNext-results
+          path: build/tests/test262_tests_esnext/local/bin/test262.report
 
   Unit_Tests:
     runs-on: ubuntu-18.04

--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -184,7 +184,7 @@ def main(args):
                       [test262_harness_path,
                        '--command', command,
                        '--tests', args.test_dir,
-                       '--full-summary']
+                       '--summary']
 
     if 'excludelist_path' in args and args.mode == 'default':
         test262_command.extend(['--exclude-list', args.excludelist_path])


### PR DESCRIPTION
Changes:
- Don't dump each test output to stdout
- Upload test outputs as artifact to GitHub

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
