### PR TITLE
Add Symbol support to integrity testing routine

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -596,7 +596,7 @@ ecma_builtin_object_test_integrity_level (ecma_object_t *obj_p, /**< routine's a
 
   for (uint32_t i = 0; i < props_p->item_count; i++)
   {
-    ecma_string_t *property_name_p = ecma_get_string_from_value (buffer_p[i]);
+    ecma_string_t *property_name_p = ecma_get_prop_name_from_value (buffer_p[i]);
 
     /* 2.a */
     ecma_property_descriptor_t prop_desc;

--- a/tests/jerry/es.next/object-freeze-with-symbol.js
+++ b/tests/jerry/es.next/object-freeze-with-symbol.js
@@ -26,3 +26,5 @@ obj[s2] = 3
 assert(obj[s1] === 1);
 assert(obj[s2] === undefined);
 assert(delete obj[s1] === false);
+
+assert(Object.isFrozen(obj));


### PR DESCRIPTION
Properties with Symbol caused assertion to fail