### PR TITLE
Minor fixes to ecma_builtin_object_prototype_define_getter_setter

### DIFF
--- a/tests/jerry/es.next/object-prototype-define-getter.js
+++ b/tests/jerry/es.next/object-prototype-define-getter.js
@@ -49,3 +49,96 @@ var def = [];
 var p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});
 Object.prototype.__defineGetter__.call(p, "foo", Object);
 assert(def + '' === "foo");
+
+var func = function() {};
+var subject = Object.defineProperty(
+  {}, 'foo', { value: 1, configurable: false }
+);
+
+try {
+  subject.__defineGetter__('foo', func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+var subject = Object.preventExtensions({ existing: null });
+
+subject.__defineGetter__('existing', func);
+
+try {
+  subject.__defineGetter__('brand new', func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+var __defineGetter__ = Object.prototype.__defineGetter__;
+var counter = 0;
+var key = {
+  toString: function() {
+    counter += 1;
+  }
+};
+
+try {
+  __defineGetter__.call(undefined, key, func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  __defineGetter__.call(null, key, func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+assert(counter === 0);
+
+var subject = {};
+var symbol = Symbol('');
+var counter = 0;
+var key = {
+  toString: function() {
+    counter += 1;
+  }
+};
+
+try {
+  subject.__defineGetter__(key, '');
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineGetter__(key, 23);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineGetter__(key, true);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineGetter__(key, symbol);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineGetter__(key, {});
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+assert(counter === 0);

--- a/tests/jerry/es.next/object-prototype-define-setter.js
+++ b/tests/jerry/es.next/object-prototype-define-setter.js
@@ -51,3 +51,96 @@ var def = [];
 var p = new Proxy({}, { defineProperty: function(o, v, desc) { def.push(v); Object.defineProperty(o, v, desc); return true; }});
 Object.prototype.__defineSetter__.call(p, "foo", Object);
 assert(def + '' === "foo");
+
+var func = function() {};
+var subject = Object.defineProperty(
+  {}, 'attr', { value: 1, configurable: false }
+);
+
+try {
+  subject.__defineSetter__('attr', func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+var subject = Object.preventExtensions({ existing: null });
+
+subject.__defineSetter__('existing', func);
+
+try {
+  subject.__defineSetter__('brand new', func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+var __defineSetter__ = Object.prototype.__defineSetter__;
+var counter = 0;
+var key = {
+  toString: function() {
+    counter += 1;
+  }
+};
+
+try {
+  __defineSetter__.call(undefined, key, func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  __defineSetter__.call(null, key, func);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+assert(counter === 0);
+
+var subject = {};
+var symbol = Symbol('');
+var counter = 0;
+var key = {
+  toString: function() {
+    counter += 1;
+  }
+};
+
+try {
+  subject.__defineSetter__(key, '');
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineSetter__(key, 23);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineSetter__(key, true);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineSetter__(key, symbol);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+try {
+  subject.__defineSetter__(key, {});
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+assert(counter === 0);

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -10,14 +10,6 @@
   <test id="annexB/built-ins/Function/createdynfn-html-open-comment-body.js"><reason></reason></test>
   <test id="annexB/built-ins/Function/createdynfn-html-open-comment-params.js"><reason></reason></test>
   <test id="annexB/built-ins/Function/createdynfn-no-line-terminator-html-close-comment-body.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineGetter__/define-non-configurable.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineGetter__/define-non-extensible.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineGetter__/getter-non-callable.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineGetter__/this-non-obj.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineSetter__/define-non-configurable.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineSetter__/define-non-extensible.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineSetter__/setter-non-callable.js"><reason></reason></test>
-  <test id="annexB/built-ins/Object/prototype/__defineSetter__/this-non-obj.js"><reason></reason></test>
   <test id="annexB/built-ins/RegExp/match-indices/indices-groups-object.js"><reason></reason></test>
   <test id="annexB/built-ins/RegExp/named-groups/groups-object.js"><reason></reason></test>
   <test id="annexB/built-ins/RegExp/named-groups/non-unicode-malformed-lookbehind.js"><reason></reason></test>


### PR DESCRIPTION
Fixed tests from the exclude list:
annexB/built-ins/Object/prototype/__defineGetter__/define-non-configurable.js
annexB/built-ins/Object/prototype/__defineGetter__/define-non-extensible.js
annexB/built-ins/Object/prototype/__defineGetter__/getter-non-callable.js
annexB/built-ins/Object/prototype/__defineGetter__/this-non-obj.js
annexB/built-ins/Object/prototype/__defineSetter__/define-non-configurable.js
annexB/built-ins/Object/prototype/__defineSetter__/define-non-extensible.js
annexB/built-ins/Object/prototype/__defineSetter__/setter-non-callable.js
annexB/built-ins/Object/prototype/__defineSetter__/this-non-obj.js

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu

