### PR TITLE
Minor fix in ecma_builtin_array_prototype_object_slice

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -948,10 +948,13 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t arg1, /**< start */
     {
       /* 10.c.ii */
       ecma_value_t put_comp;
+
+      uint32_t opts = (ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE | ECMA_PROP_IS_THROW);
       put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                         n,
                                                         get_value,
-                                                        ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
+                                                        opts);
+
       ecma_free_value (get_value);
 
 #if ENABLED (JERRY_ESNEXT)

--- a/tests/jerry/es.next/array-prototype-slice.js
+++ b/tests/jerry/es.next/array-prototype-slice.js
@@ -53,3 +53,36 @@ var c = new ExactArray (5);
 var sliced3 = c.slice();
 assert (sliced3.length == 5);
 assert (JSON.stringify (sliced3) == '["baz","baz","baz","baz","baz"]');
+
+
+var func = function() {
+  Object.defineProperty(this, "0", {
+    set: function(value) {},
+    configurable: false,
+  });
+};
+
+var array = [1, 2, 3];
+array.constructor = {};
+array.constructor[Symbol.species] = func;
+
+try {
+  array.slice(0, 1);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+var func = function() {
+  this.length = 0;
+  Object.preventExtensions(this);
+};
+
+array.constructor[Symbol.species] = func;
+
+try {
+  array.slice(0, 1);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -198,8 +198,6 @@
   <test id="built-ins/Array/prototype/map/target-array-with-non-configurable-property.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/slice/create-proto-from-ctor-realm-non-array.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/slice/target-array-non-extensible.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/slice/target-array-with-non-configurable-property.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/sort/comparefn-nonfunction-call-throws.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/create-non-array-invalid-len.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/create-proto-from-ctor-realm-array.js"><reason></reason></test>


### PR DESCRIPTION
During the property creation the is_throw flag was not used before

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
