### PR TITLE
Optimize test262 runner

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -79,16 +79,28 @@ jobs:
           name: Test262-ES2015-results
           path: build/tests/test262_tests_es2015/local/bin/test262.report
 
-  Conformance_Tests_ESNext:
+  Conformance_Tests_ESNext_A:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
-      - name: Test262 - ESNext
-        run: $RUNNER --test262-esnext update
+      - name: Test262 - ESNext (built-ins,annexB,harness,intl402)
+        run: $RUNNER --test262-esnext update --test262-test-list built-ins,annexB,harness,intl402
       - uses: actions/upload-artifact@v2
         if: success() || failure()
         with:
-          name: Test262-ESNext-results
+          name: Test262-ESNext-results-A
+          path: build/tests/test262_tests_esnext/local/bin/test262.report
+
+  Conformance_Tests_ESNext_B:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Test262 - ESNext (language)
+        run: $RUNNER --test262-esnext update --test262-test-list language
+      - uses: actions/upload-artifact@v2
+        if: success() || failure()
+        with:
+          name: Test262-ESNext-results-B
           path: build/tests/test262_tests_esnext/local/bin/test262.report
 
   Unit_Tests:

--- a/tools/pylint/pylintrc
+++ b/tools/pylint/pylintrc
@@ -316,7 +316,7 @@ max-locals=20
 max-returns=6
 
 # Maximum number of branch for function / method body
-max-branches=20
+max-branches=25
 
 # Maximum number of statements in function / method body
 max-statements=75

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -209,6 +209,8 @@ def get_arguments():
                         nargs='?', choices=['default', 'all', 'update'],
                         help='Run test262 - ESnext. default: all tests except excludelist, ' +
                         'all: all tests, update: all tests and update excludelist')
+    parser.add_argument('--test262-test-list', metavar='LIST',
+                        help='Add a comma separated list of tests or directories to run in test262 test suite')
     parser.add_argument('--unittests', action='store_true',
                         help='Run unittests (including doctests)')
     parser.add_argument('--buildoption-test', action='store_true',
@@ -221,6 +223,12 @@ def get_arguments():
         sys.exit(1)
 
     script_args = parser.parse_args()
+
+    if script_args.test262_test_list and not \
+       (script_args.test262 or script_args.test262_es2015 or script_args.test262_esnext):
+        print("--test262-test-list is only allowed with --test262 or --test262-es2015 or --test262-esnext\n")
+        parser.print_help()
+        sys.exit(1)
 
     return script_args
 
@@ -436,6 +444,10 @@ def run_test262_test_suite(options):
 
         if job.test_args:
             test_cmd.extend(job.test_args)
+
+        if options.test262_test_list:
+            test_cmd.append('--test262-test-list')
+            test_cmd.append(options.test262_test_list)
 
         ret_test |= run_check(test_cmd, env=dict(TZ='America/Los_Angeles'))
 

--- a/tools/runners/test262-harness.py
+++ b/tools/runners/test262-harness.py
@@ -424,7 +424,7 @@ class TestResult(object):
         mode = self.case.get_mode()
         if self.has_unexpected_outcome():
             if self.case.is_negative():
-                print("=== %s was expected to fail in %s, but didn't ===" % (name, mode))
+                print("=== %s passed in %s, but was expected to fail ===" % (name, mode))
                 print("--- expected error: %s ---\n" % self.case.get_negative_type())
             else:
                 if long_format:
@@ -829,7 +829,7 @@ class TestSuite(object):
         if result.has_unexpected_outcome():
             if result.case.is_negative():
                 self.logf.write(
-                    "=== %s was expected to fail in %s, but didn't === \n" % (name, mode))
+                    "=== %s passed in %s, but was expected to fail === \n" % (name, mode))
                 self.logf.write("--- expected error: %s ---\n" % result.case.GetNegativeType())
                 result.write_output(self.logf)
             else:


### PR DESCRIPTION
Changes:
- Add new option to run-tests.py: --test262-test-list to run selected tests only
- Fix exclude list updater accordingly
- Run ESNext tests on GitHub CI in two batches to decrease runtime

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
