### PR TITLE
Fix Array.prototype.slice, splice and map builtin methods

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -948,10 +948,15 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t arg1, /**< start */
     {
       /* 10.c.ii */
       ecma_value_t put_comp;
+#if ENABLED (JERRY_ESNEXT)
+      const uint32_t prop_flags = ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE | ECMA_IS_THROW;
+#else /* !ENABLED (JERRY_ESNEXT) */
+      const uint32_t prop_flags = ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE;
+#endif /* ENABLED (JERRY_ESNEXT) */
       put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                         n,
                                                         get_value,
-                                                        ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
+                                                        prop_flags);
       ecma_free_value (get_value);
 
 #if ENABLED (JERRY_ESNEXT)
@@ -1345,10 +1350,15 @@ ecma_builtin_array_prototype_object_splice (const ecma_value_t args[], /**< argu
     {
       /* 9.c.ii */
       ecma_value_t put_comp;
+#if ENABLED (JERRY_ESNEXT)
+      const uint32_t prop_flags = ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE | ECMA_IS_THROW;
+#else /* !ENABLED (JERRY_ESNEXT) */
+      const uint32_t prop_flags = ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE;
+#endif /* ENABLED (JERRY_ESNEXT) */
       put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                         k,
                                                         get_value,
-                                                        ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
+                                                        prop_flags);
       ecma_free_value (get_value);
 #if ENABLED (JERRY_ESNEXT)
       if (ECMA_IS_VALUE_ERROR (put_comp))
@@ -2007,10 +2017,15 @@ ecma_builtin_array_prototype_object_map (ecma_value_t arg1, /**< callbackfn */
 
       /* 8.c.iii */
       ecma_value_t put_comp;
+#if ENABLED (JERRY_ESNEXT)
+      const uint32_t prop_flags = ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE | ECMA_IS_THROW;
+#else /* !ENABLED (JERRY_ESNEXT) */
+      const uint32_t prop_flags = ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE;
+#endif /* ENABLED (JERRY_ESNEXT) */
       put_comp = ecma_builtin_helper_def_prop_by_index (new_array_p,
                                                         index,
                                                         mapped_value,
-                                                        ECMA_PROPERTY_CONFIGURABLE_ENUMERABLE_WRITABLE);
+                                                        prop_flags);
 
       ecma_free_value (mapped_value);
       ecma_free_value (current_value);

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -194,12 +194,8 @@
   <test id="built-ins/Array/prototype/flatMap/thisArg-argument.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/map/create-proto-from-ctor-realm-non-array.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/map/target-array-non-extensible.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/map/target-array-with-non-configurable-property.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/slice/create-proto-from-ctor-realm-array.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/slice/create-proto-from-ctor-realm-non-array.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/slice/target-array-non-extensible.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/slice/target-array-with-non-configurable-property.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/sort/comparefn-nonfunction-call-throws.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/create-non-array-invalid-len.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/create-proto-from-ctor-realm-array.js"><reason></reason></test>
@@ -208,8 +204,6 @@
   <test id="built-ins/Array/prototype/splice/create-species-undef-invalid-len.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/create-species.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/property-traps-order-with-species.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/splice/target-array-non-extensible.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/splice/target-array-with-non-configurable-property.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/splice/throws-if-integer-limit-exceeded.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/unshift/clamps-to-integer-limit.js"><reason></reason></test>
   <test id="built-ins/ArrayBuffer/data-allocation-after-object-creation.js"><reason></reason></test>


### PR DESCRIPTION
CreateDataPropertyOrThrow is introduced in ES2015, and these methods should use it
to throw TypeError exception if the requested property update cannot be performed.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
