### PR TITLE
Correctly release values in TypedArray's toLocaleString

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1950,15 +1950,15 @@ ecma_builtin_typedarray_prototype_to_locale_string_helper (ecma_object_t *this_o
 
     ecma_string_t *str_p = ecma_op_to_string (call_value);
 
+    ecma_free_value (call_value);
+
     if (JERRY_UNLIKELY (str_p == NULL))
     {
-      ecma_free_value (element_value);
       ecma_deref_object (element_obj_p);
       return ECMA_VALUE_ERROR;
     }
 
     ret_value = ecma_make_string_value (str_p);
-    ecma_deref_ecma_string (str_p);
   }
   else
   {

--- a/tests/jerry/es.next/regression-test-issue-4148.js
+++ b/tests/jerry/es.next/regression-test-issue-4148.js
@@ -1,0 +1,43 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var calls = 0;
+Number.prototype.toLocaleString = function() {
+  return {
+    toString: function() {
+      calls++;
+      if (calls > 1) {
+        throw "ERROR V";
+      }
+    }
+  };
+};
+
+var array = [42.333333, 2.3];
+
+var sampleA = new Float32Array(array);
+try {
+  sampleA.toLocaleString();
+} catch(ex) {
+  assert(ex === "ERROR V");
+}
+assert(calls === 2);
+
+var sampleB = new Uint8Array(array);
+try {
+  sampleB.toLocaleString();
+} catch(ex) {
+  assert(ex === "ERROR V");
+}
+assert(calls === 3);

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -2551,8 +2551,6 @@
   <test id="built-ins/TypedArray/prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tostring.js"><reason></reason></test>
   <test id="built-ins/TypedArray/prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-valueof.js"><reason></reason></test>
   <test id="built-ins/TypedArray/prototype/toLocaleString/BigInt/return-result.js"><reason></reason></test>
-  <test id="built-ins/TypedArray/prototype/toLocaleString/calls-tostring-from-each-value.js"><reason></reason></test>
-  <test id="built-ins/TypedArray/prototype/toLocaleString/calls-valueof-from-each-value.js"><reason></reason></test>
   <test id="built-ins/TypedArray/prototype/toLocaleString/detached-buffer.js"><reason></reason></test>
   <test id="built-ins/TypedArray/prototype/toString/BigInt/detached-buffer.js"><reason></reason></test>
   <test id="built-ins/TypedArray/prototype/toString/detached-buffer.js"><reason></reason></test>


### PR DESCRIPTION
When the `toLocaleString` was called on a TypedArray's value
the resulting object's `toString/valueOf` invocations could
create errors. These error values were not released.

In addition the input element value for the toString operation
was released twice in case of an error.

Fixes: #4148 