### PR TITLE
Add missing value release to TypedArray fill method

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1294,6 +1294,7 @@ ecma_builtin_typedarray_prototype_fill (ecma_value_t this_arg, /**< this argumen
                                                                        info.length,
                                                                        &begin_index_uint32)))
   {
+    ecma_free_value (value_to_set);
     return ECMA_VALUE_ERROR;
   }
 
@@ -1307,6 +1308,7 @@ ecma_builtin_typedarray_prototype_fill (ecma_value_t this_arg, /**< this argumen
                                                                          info.length,
                                                                          &end_index_uint32)))
     {
+      ecma_free_value (value_to_set);
       return ECMA_VALUE_ERROR;
     }
   }

--- a/tests/jerry/es.next/typedArray-fill.js
+++ b/tests/jerry/es.next/typedArray-fill.js
@@ -112,3 +112,24 @@ assert(k.fill(-5n, 3, 5).toString() === '0,0,0,-5,-5');
 var l = new BigUint64Array([1n, 2n, 3n, 4n, 5n]);
 assert(l.fill(-18446744073709551614n, 3, 5).toString() === '1,2,3,2,2');
 assert(l.fill(18446744073709551614n, 4).toString() === '1,2,3,2,18446744073709551614');
+
+var invalid = {
+  valueOf: function() {
+    throw new Error();
+  }
+};
+
+var m = new BigInt64Array();
+try {
+  m.fill(1n, invalid);
+  assert(false)
+} catch (e) {
+  assert(e instanceof Error);
+}
+
+try {
+  m.fill(1n, 0, invalid);
+  assert(false)
+} catch (e) {
+  assert(e instanceof Error);
+}


### PR DESCRIPTION
Value was not freed when error occurs. It caused internal assertion to fail
when BigInt was used.

JerryScript-DCO-1.0-Signed-off-by: Rafal Walczyna r.walczyna@samsung.com