### PR TITLE
Improve error detection of nullish coalescing operator

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -3654,7 +3654,7 @@ lexer_compare_literal_to_string (parser_context_t *context_p, /**< context */
 uint8_t
 lexer_convert_binary_lvalue_token_to_binary (uint8_t token) /**< binary lvalue token */
 {
-  JERRY_ASSERT (LEXER_IS_BINARY_LVALUE_TOKEN (token));
+  JERRY_ASSERT (LEXER_IS_BINARY_LVALUE_OP_TOKEN (token));
   JERRY_ASSERT (token != LEXER_ASSIGN);
 
 #if ENABLED (JERRY_ESNEXT)

--- a/jerry-core/parser/js/js-lexer.h
+++ b/jerry-core/parser/js/js-lexer.h
@@ -69,18 +69,37 @@ typedef enum
    * IMPORTANT: update CBC_BINARY_OP_TOKEN_TO_OPCODE,
    *            CBC_BINARY_LVALUE_OP_TOKEN_TO_OPCODE and
    *            parser_binary_precedence_table after changes. */
+/**
+ * Index of first binary operation opcode.
+ */
+#define LEXER_FIRST_BINARY_OP LEXER_ASSIGN
 #if ENABLED (JERRY_ESNEXT)
-#define LEXER_IS_BINARY_OP_TOKEN(token_type) \
-  ((token_type) >= LEXER_ASSIGN && (token_type) <= LEXER_EXPONENTIATION)
+/**
+ * Index of last binary operation opcode.
+ */
+#define LEXER_LAST_BINARY_OP LEXER_EXPONENTIATION
 #else /* !ENABLED (JERRY_ESNEXT) */
-#define LEXER_IS_BINARY_OP_TOKEN(token_type) \
-  ((token_type) >= LEXER_ASSIGN && (token_type) <= LEXER_MODULO)
+/**
+ * Index of last binary operation opcode.
+ */
+#define LEXER_LAST_BINARY_OP LEXER_MODULO
 #endif /* ENABLED (JERRY_ESNEXT) */
 
-#define LEXER_IS_BINARY_LVALUE_TOKEN(token_type) \
+/**
+ * Checks whether the token is a binary operation token.
+ */
+#define LEXER_IS_BINARY_OP_TOKEN(token_type) \
+  ((token_type) >= LEXER_FIRST_BINARY_OP && (token_type) <= LEXER_LAST_BINARY_OP)
+/**
+ * Checks whether the token is an lvalue (assignment) operation token.
+ */
+#define LEXER_IS_BINARY_LVALUE_OP_TOKEN(token_type) \
   ((token_type) >= LEXER_ASSIGN && (token_type) <= LEXER_ASSIGN_BIT_XOR)
-
-#define LEXER_FIRST_BINARY_OP LEXER_ASSIGN
+/**
+ * Checks whether the token is a non-lvalue (assignment) operation token.
+ */
+#define LEXER_IS_BINARY_NON_LVALUE_OP_TOKEN(token_type) \
+  ((token_type) >= LEXER_QUESTION_MARK && (token_type) <= LEXER_LAST_BINARY_OP)
 
   LEXER_ASSIGN,                  /**< "=" (prec: 3) */
   LEXER_ASSIGN_ADD,              /**< "+=" (prec: 3) */


### PR DESCRIPTION
Also rename LEXER_IS_BINARY_LVALUE_TOKEN to LEXER_IS_BINARY_LVALUE_OP_TOKEN because its name is wrong.