### PR TITLE
Add SyntaxError for "await" keyword outside of async functions

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -857,10 +857,16 @@ lexer_parse_identifier (parser_context_t *context_p, /**< context */
 #if ENABLED (JERRY_ESNEXT)
             if (JERRY_UNLIKELY (keyword_p->type == LEXER_KEYW_AWAIT))
             {
-              if (!(context_p->status_flags & PARSER_IS_ASYNC_FUNCTION)
-                  && !(context_p->global_status_flags & ECMA_PARSE_MODULE))
+              if (!(context_p->status_flags & PARSER_IS_ASYNC_FUNCTION))
               {
-                break;
+                if (context_p->global_status_flags & ECMA_PARSE_MODULE)
+                {
+                  parser_raise_error (context_p, PARSER_ERR_INVALID_KEYWORD);
+                }
+                else
+                {
+                  break;
+                }
               }
 
               if (context_p->status_flags & PARSER_DISALLOW_AWAIT_YIELD)

--- a/tests/jerry/regression-test-issue-4189.js
+++ b/tests/jerry/regression-test-issue-4189.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+    eval("1 ; export default await 1")
+    assert(false)
+} catch (e) {
+    assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
Fixes #4189

JerryScript-DCO-1.0-Signed-off-by: Peter Marki marpeter@inf.u-szeged.hu