### PR TITLE
Convert fast array to normal array when the prototype is changed

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2924,6 +2924,16 @@ ecma_op_ordinary_object_set_prototype_of (ecma_object_t *obj_p, /**< base object
   /* 1. */
   JERRY_ASSERT (ecma_is_value_object (proto) || ecma_is_value_null (proto));
 
+  /**
+   * If the prototype of a fast array changes it is required to fall back to
+   * a "normal" array object. This ensures that all [[Get]]/[[Set]]/etc. calls
+   * works as expected.
+   */
+  if (ecma_op_object_is_fast_array (obj_p))
+  {
+    ecma_fast_array_convert_to_normal (obj_p);
+  }
+
   /* 3. */
   ecma_object_t *current_proto_p = ECMA_GET_POINTER (ecma_object_t, ecma_op_ordinary_object_get_prototype_of (obj_p));
   ecma_object_t *new_proto_p = ecma_is_value_null (proto) ? NULL : ecma_get_object_from_value (proto);

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -988,7 +988,6 @@
   <test id="built-ins/Proxy/revocable/revocation-function-nonconstructor.js"><reason></reason></test>
   <test id="built-ins/Proxy/revocable/target-is-revoked-function-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/revocable/target-is-revoked-proxy.js"><reason></reason></test>
-  <test id="built-ins/Proxy/set/call-parameters-prototype-index.js"><reason></reason></test>
   <test id="built-ins/Proxy/set/trap-is-not-callable-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/setPrototypeOf/toboolean-trap-result-false.js"><reason></reason></test>
   <test id="built-ins/Proxy/setPrototypeOf/trap-is-not-callable-realm.js"><reason></reason></test>


### PR DESCRIPTION
If the prototype of a fast array is changed, for example to a Proxy object,
the array should be converted back to a normal array. This is required to
correctly handle any [[Get]]/[[Set]]/etc... calls which should trigger
these method calls on the before mentioned Proxy object.
