### PR TITLE
Fix compilation warnings when using 32-bit floats

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-conversion.c
+++ b/jerry-core/ecma/base/ecma-helpers-conversion.c
@@ -347,7 +347,7 @@ ecma_utf8_string_to_number_by_radix (const lit_utf8_byte_t *str_p, /**< utf-8 st
       return ecma_number_make_nan ();
     }
 
-    num = num * radix + (ecma_number_t) digit_value;
+    num = num * (ecma_number_t) radix + (ecma_number_t) digit_value;
   }
 
   return num;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.c
@@ -302,8 +302,8 @@ ecma_builtin_helper_uint32_index_normalize (ecma_value_t arg, /**< index */
     return ECMA_VALUE_ERROR;
   }
 
-  *number_p = ((to_int < 0) ? (uint32_t) JERRY_MAX (length + to_int, 0)
-                            : (uint32_t) JERRY_MIN (to_int, length));
+  *number_p = ((to_int < 0) ? (uint32_t) JERRY_MAX ((ecma_number_t) length + to_int, 0)
+                            : (uint32_t) JERRY_MIN (to_int, (ecma_number_t) length));
 
   return ECMA_VALUE_EMPTY;
 } /* ecma_builtin_helper_uint32_index_normalize */

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -300,7 +300,7 @@ ecma_op_to_numeric (ecma_value_t value, /**< ecma value */
 
   if (ecma_is_value_integer_number (value))
   {
-    *number_p = ecma_get_integer_from_value (value);
+    *number_p = (ecma_number_t) ecma_get_integer_from_value (value);
     return ECMA_VALUE_EMPTY;
   }
 
@@ -893,8 +893,8 @@ ecma_op_is_integer (ecma_number_t num) /**< ecma number */
     return false;
   }
 
-  ecma_number_t floor_fabs = floor (fabs (num));
-  ecma_number_t fabs_value = fabs (num);
+  ecma_number_t floor_fabs = (ecma_number_t) floor (fabs (num));
+  ecma_number_t fabs_value = (ecma_number_t) fabs (num);
 
   return (floor_fabs == fabs_value);
 } /* ecma_op_is_integer*/
@@ -941,7 +941,7 @@ ecma_op_to_integer (ecma_value_t value, /**< ecma value */
     return ECMA_VALUE_EMPTY;
   }
 
-  ecma_number_t floor_fabs = floor (fabs (number));
+  ecma_number_t floor_fabs = (ecma_number_t) floor (fabs (number));
   /* 5 */
   *number_p = ecma_number_is_negative (number) ? -floor_fabs : floor_fabs;
   return ECMA_VALUE_EMPTY;

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1704,7 +1704,7 @@ ecma_op_bound_function_try_to_lazy_instantiate_property (ecma_object_t *object_p
       JERRY_ASSERT (!ECMA_IS_VALUE_ERROR (get_len_value));
       JERRY_ASSERT (ecma_is_value_integer_number (get_len_value));
 
-      length = ecma_get_integer_from_value (get_len_value) - (args_length - 1);
+      length = (ecma_number_t) (ecma_get_integer_from_value (get_len_value) - (args_length - 1));
     }
 #endif /* ENABLED (JERRY_ESNEXT) */
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2678,7 +2678,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
               result = (ecma_value_t) (int_value + int_increase);
               break;
             }
-            result_number = ecma_get_integer_from_value (result);
+            result_number = (ecma_number_t) ecma_get_integer_from_value (result);
           }
           else if (ecma_is_value_float_number (left_value))
           {


### PR DESCRIPTION
This PR allows compiling w/o warning or errors when using 32-bits float. It's just a few casts