### PR TITLE
Do module cleanup at a later stage

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -242,6 +242,10 @@ jerry_cleanup (void)
     }
   }
 
+#if ENABLED (JERRY_MODULE_SYSTEM)
+  ecma_module_cleanup ();
+#endif /* ENABLED (JERRY_MODULE_SYSTEM) */
+
 #if ENABLED (JERRY_BUILTIN_PROMISE)
   ecma_free_all_enqueued_jobs ();
 #endif /* ENABLED (JERRY_BUILTIN_PROMISE) */

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -323,11 +323,11 @@ vm_run_global (const ecma_compiled_code_t *bytecode_p) /**< pointer to bytecode 
     module_p->scope_p = global_scope_p;
 
     const ecma_value_t module_init_result = ecma_module_initialize_current ();
-    ecma_module_cleanup ();
     JERRY_CONTEXT (module_top_context_p) = NULL;
 
     if (ECMA_IS_VALUE_ERROR (module_init_result))
     {
+      ecma_module_cleanup ();
       return module_init_result;
     }
   }

--- a/tests/jerry/es.next/module-resource-name-export.mjs
+++ b/tests/jerry/es.next/module-resource-name-export.mjs
@@ -1,0 +1,23 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export function getName() {
+  return resourceName();
+}
+
+export function getNamePromise(collector) {
+  return new Promise((resolve) => { collector["start"] = resourceName(); resolve(); })
+    .then(() => { collector["middle"] = resourceName(); });
+}
+

--- a/tests/jerry/es.next/module-resource-name.js
+++ b/tests/jerry/es.next/module-resource-name.js
@@ -1,0 +1,27 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getName, getNamePromise } from "./module-resource-name-export.mjs"
+
+assert(getName().endsWith("/module-resource-name-export.mjs") === true);
+
+var collector = {};
+getNamePromise(collector).then(() => { collector["end"] = resourceName(); });
+
+function __checkAsync() {
+  assert(collector["start"].endsWith("/module-resource-name-export.mjs") === true);
+  assert(collector["middle"].endsWith("/module-resource-name-export.mjs") === true);
+  assert(collector["end"].endsWith("/module-resource-name.js") === true);
+  assert(Object.keys(collector).length === 3);
+}


### PR DESCRIPTION
Module info should be freed at a later stage to correctly have
all module data in every step during the execution.