### PR TITLE
Fix heap buffer overflow in Array.prototype.copyWithin

### DIFF
--- a/tests/jerry/es.next/array-prototype-copywithin.js
+++ b/tests/jerry/es.next/array-prototype-copywithin.js
@@ -95,7 +95,6 @@ var value = array.copyWithin(0, {
         array.length = 0;
     }
 })
-
 array_check(value, []);
 
 // Extend the buffer
@@ -105,7 +104,6 @@ var value = array.copyWithin(1, {
         array.length = 6;
     }
 })
-
 array_check(value, [1, 1, 2, undefined, undefined, undefined]);
 
 // Reduce the buffer
@@ -115,5 +113,18 @@ var value = array.copyWithin(4, 2, {
         array.length = 3;
     }
 })
-
 array_check(value, [1, 2, 3]);
+
+// Reduce the buffer and extend the buffer
+var array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+var value = array.copyWithin(7, {
+    valueOf: function() {
+        array.length = 5;
+    }
+})
+array_check(value, [1, 2, 3, 4, 5, , , 1, 2, 3]);
+
+// Copy with overlapping (backward copy)
+var array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+var value = array.copyWithin(0, 2, 8)
+array_check(value, [3, 4, 5, 6, 7, 8, 7, 8, 9, 10]);

--- a/tests/jerry/es.next/regression-test-issue-4146.js
+++ b/tests/jerry/es.next/regression-test-issue-4146.js
@@ -32,7 +32,7 @@ Array.prototype.equals = function (array) {
 
 function longDenseArray(){
         var a = [0];
-        for(var i = 0; i < 200; i++){
+        for(var i = 0; i < 60; i++){
                 a[i] = i;
         }
         return a;
@@ -43,7 +43,8 @@ function shorten(){
         return 1;
 }
 
+var array = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,,,,,,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19];
 var currArray = longDenseArray();
-assert (currArray.copyWithin (200, {valueOf: shorten}).length == 20)
-var array = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19];
-assert (currArray.copyWithin(200, {valueOf: shorten}).equals (array))
+currArray.copyWithin(25, {valueOf: shorten})
+assert (currArray.length == 44)
+assert (currArray.equals (array))

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -142,8 +142,6 @@
   <test id="built-ins/Array/proto-from-ctor-realm-zero.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/concat/create-proto-from-ctor-realm-array.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/concat/create-proto-from-ctor-realm-non-array.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js"><reason></reason></test>
-  <test id="built-ins/Array/prototype/copyWithin/coerced-values-start-change-target.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/filter/create-proto-from-ctor-realm-array.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/filter/create-proto-from-ctor-realm-non-array.js"><reason></reason></test>
   <test id="built-ins/Array/prototype/map/create-proto-from-ctor-realm-array.js"><reason></reason></test>


### PR DESCRIPTION
2nd and 3rd argument evaluation of Array.prototype.copyWithin can change
the length of the array as a side-effect. But ES11 spec says that the
algorithm should use the original length. In this case it could happen
that the underlying buffer should be extended.

Fixes #4204

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
