### PR TITLE
Add new checks to function lazy list property names methods

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1824,12 +1824,23 @@ ecma_op_function_list_lazy_property_names (ecma_object_t *object_p, /**< functio
 {
 #if ENABLED (JERRY_ESNEXT)
   ecma_extended_object_t *ext_func_p = (ecma_extended_object_t *) object_p;
-  if (!ECMA_GET_FIRST_BIT_FROM_POINTER_TAG (ext_func_p->u.function.scope_cp))
+  ecma_value_t prop_name_val = ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH);
+  if (!ECMA_GET_FIRST_BIT_FROM_POINTER_TAG (ext_func_p->u.function.scope_cp)
+      || ecma_op_ordinary_object_has_own_property (object_p, ecma_op_to_string (prop_name_val)))
   {
     /* Unintialized 'length' property is non-enumerable (ECMA-262 v6, 19.2.4.1) */
-    ecma_collection_push_back (prop_names_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
+    ecma_collection_push_back (prop_names_p, prop_name_val);
     prop_counter_p->string_named_props++;
   }
+
+  prop_name_val = ecma_make_magic_string_value (LIT_MAGIC_STRING_NAME);
+  if (ecma_op_ordinary_object_has_own_property (object_p, ecma_op_to_string (prop_name_val)))
+  {
+    ecma_collection_push_back (prop_names_p, prop_name_val);
+    prop_counter_p->string_named_props++;
+  }
+
+  ecma_free_value (prop_name_val);
 #else /* !ENABLED (JERRY_ESNEXT) */
   /* 'length' property is non-enumerable (ECMA-262 v5, 13.2.5) */
   ecma_collection_push_back (prop_names_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
@@ -1938,11 +1949,22 @@ ecma_op_bound_function_list_lazy_property_names (ecma_object_t *object_p, /**< b
 #if ENABLED (JERRY_ESNEXT)
   /* Unintialized 'length' property is non-enumerable (ECMA-262 v6, 19.2.4.1) */
   ecma_bound_function_t *bound_func_p = (ecma_bound_function_t *) object_p;
-  if (!ECMA_GET_FIRST_BIT_FROM_POINTER_TAG (bound_func_p->header.u.bound_function.target_function))
+  ecma_value_t prop_name_val = ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH);
+  if (!ECMA_GET_FIRST_BIT_FROM_POINTER_TAG (bound_func_p->header.u.bound_function.target_function)
+      || ecma_op_ordinary_object_has_own_property (object_p, ecma_op_to_string (prop_name_val)))
   {
     ecma_collection_push_back (prop_names_p, ecma_make_magic_string_value (LIT_MAGIC_STRING_LENGTH));
     prop_counter_p->string_named_props++;
   }
+
+  prop_name_val = ecma_make_magic_string_value (LIT_MAGIC_STRING_NAME);
+  if (ecma_op_ordinary_object_has_own_property (object_p, ecma_op_to_string (prop_name_val)))
+  {
+    ecma_collection_push_back (prop_names_p, prop_name_val);
+    prop_counter_p->string_named_props++;
+  }
+
+  ecma_free_value (prop_name_val);
 #else /* !ENABLED (JERRY_ESNEXT) */
   JERRY_UNUSED (object_p);
   /* 'length' property is non-enumerable (ECMA-262 v5, 13.2.5) */

--- a/tests/jerry/es.next/regression-test-issue-3267.js
+++ b/tests/jerry/es.next/regression-test-issue-3267.js
@@ -17,6 +17,5 @@ Object.preventExtensions(hasProp);
 assert (Object.isSealed(hasProp) === false);
 
 var keys = Object.getOwnPropertyNames(hasProp);
-assert (keys.length === 1);
+assert (keys.length === 2);
 assert (keys[0] === "length");
-

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -809,8 +809,6 @@
   <test id="built-ins/Number/prototype/toExponential/return-values.js"><reason></reason></test>
   <test id="built-ins/Number/prototype/toFixed/exactness.js"><reason></reason></test>
   <test id="built-ins/Number/prototype/toPrecision/exponential.js"><reason></reason></test>
-  <test id="built-ins/Object/entries/order-after-define-property.js"><reason></reason></test>
-  <test id="built-ins/Object/keys/order-after-define-property.js"><reason></reason></test>
   <test id="built-ins/Object/proto-from-ctor-realm.js"><reason></reason></test>
   <test id="built-ins/Object/prototype/toString/proxy-function.js"><reason></reason></test>
   <test id="built-ins/Object/prototype/toString/symbol-tag-non-str-bigint.js"><reason></reason></test>
@@ -8984,5 +8982,4 @@
   <test id="language/expressions/optional-chaining/short-circuiting.js"><reason></reason></test>
   <test id="language/expressions/optional-chaining/super-property-optional-call.js"><reason></reason></test>
   <!-- END - ES2020: Optional Chaining -->
-
 </excludeList>


### PR DESCRIPTION
BugFix: if one of the lazy initialized property if enumerable then,
it must be added to the collection.

updated jerry/es.next/regression-test-issue-3267.js test-case, since it was outdated

JerryScript-DCO-1.0-Signed-off-by: bence gabor kis kisbg@inf.u-szeged.hu