### PR TITLE
Run test262 tests on CI on Ubuntu 20.04

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -61,14 +61,14 @@ jobs:
         run: $RUNNER --unittests -q
 
   Conformance_Tests_ES5_1:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Test262 - ES5.1
         run: $RUNNER --test262
 
   Conformance_Tests_ES2015:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Test262 - ES2015
@@ -80,7 +80,7 @@ jobs:
           path: build/tests/test262_tests_es2015/local/bin/test262.report
 
   Conformance_Tests_ESNext_A:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Test262 - ESNext (built-ins,annexB,harness,intl402)
@@ -92,7 +92,7 @@ jobs:
           path: build/tests/test262_tests_esnext/local/bin/test262.report
 
   Conformance_Tests_ESNext_B:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Test262 - ESNext (language)


### PR DESCRIPTION
The timeout utility in Ubuntu 18.04 (GNU CoreUtils 8.28) has a bug which
caused false positive test failures regulary. This bug is already fixed
in CoreUtils, and Ubuntu 20.04 LTS shipped the fixed version of timeout.

https://github.com/coreutils/coreutils/commit/cbf35912da66a17a6113d5a434214dd7651f403a

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
