### PR TITLE
Add --buildoption-test to CI

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -60,6 +60,15 @@ jobs:
       - name: Unit Tests
         run: $RUNNER --unittests -q
 
+  Linux_x86-64_Build_Option_Tests:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v1
+      - name: Initializtaion
+        run: sudo apt-get install gcc-multilib
+      - name: Buildoption tests
+        run: $RUNNER --buildoption-test
+
   Conformance_Tests_ES5_1:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
run-tests --buildoption-test was previously tested on Travis CI,
but wasn't added to GitHub CI accidentally.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
