### PR TITLE
Fix Date.parse to handle times without timezone properly

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -293,6 +293,7 @@ ecma_builtin_date_parse_ISO_string_format (const lit_utf8_byte_t *date_str_curr_
       day = ecma_date_parse_date_chars (&date_str_curr_p, date_str_end_p, 2, 1, 31);
     }
 
+    bool is_utc = true;
     /* 4. read time if any */
     if (ecma_date_parse_special_char (&date_str_curr_p, date_str_end_p, 'T'))
     {
@@ -367,13 +368,24 @@ ecma_builtin_date_parse_ISO_string_format (const lit_utf8_byte_t *date_str_curr_
           ecma_number_t timezone_offset = ecma_date_make_time (hours, minutes, ECMA_NUMBER_ZERO, ECMA_NUMBER_ZERO);
           time += is_timezone_sign_negative ? timezone_offset : -timezone_offset;
         }
+        else
+        {
+          is_utc = false;
+        }
       }
     }
 
     if (date_str_curr_p >= date_str_end_p)
     {
       ecma_number_t date = ecma_date_make_day (year, month - 1, day);
-      return ecma_date_make_date (date, time);
+
+      ecma_number_t result_date = ecma_date_make_date (date, time);
+      if (!is_utc)
+      {
+        result_date = ecma_date_utc (result_date);
+      }
+
+      return result_date;
     }
   }
   return ecma_number_make_nan ();

--- a/tests/jerry/date-parse.js
+++ b/tests/jerry/date-parse.js
@@ -98,17 +98,19 @@ assert (d == 1420070400000);
 d = Date.parse("2015-01-01");
 assert (d == 1420070400000);
 
+var timezoneOffsetMS = new Date(0).getTimezoneOffset() * 60000;
+
 d = Date.parse("2015-01T00:00");
-assert (d == 1420070400000);
+assert (d == 1420070400000 + timezoneOffsetMS);
 
 d = Date.parse("2015-01T00:00:00");
-assert (d == 1420070400000);
+assert (d == 1420070400000 + timezoneOffsetMS);
 
 d = Date.parse("2015-01T00:00:00.000");
-assert (d == 1420070400000);
+assert (d == 1420070400000 + timezoneOffsetMS);
 
 d = Date.parse("2015-01T24:00:00.000");
-assert (d == 1420156800000);
+assert (d == 1420156800000 + timezoneOffsetMS);
 
 d = Date.parse("2015-01T00:00:00.000+03:00");
 assert (d == 1420059600000);

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -696,7 +696,6 @@
   <test id="built-ins/DataView/toindex-byteoffset.js"><reason></reason></test>
   <test id="built-ins/Date/UTC/return-value.js"><reason></reason></test>
   <test id="built-ins/Date/parse/time-value-maximum-range.js"><reason></reason></test>
-  <test id="built-ins/Date/parse/without-utc-offset.js"><reason></reason></test>
   <test id="built-ins/Date/proto-from-ctor-realm-one.js"><reason></reason></test>
   <test id="built-ins/Date/proto-from-ctor-realm-two.js"><reason></reason></test>
   <test id="built-ins/Date/proto-from-ctor-realm-zero.js"><reason></reason></test>


### PR DESCRIPTION
https://www.ecma-international.org/ecma-262/11.0/#sec-date.parse
"When the UTC offset representation is absent, date-only forms are
interpreted as a UTC time and date-time forms are interpreted as a local time."

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
