### PR TITLE
Make Date.UTC to conform to the latest ES11 spec

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -617,7 +617,13 @@ ecma_builtin_date_utc (ecma_value_t this_arg, /**< this argument */
 {
   JERRY_UNUSED (this_arg);
 
-  if (args_number < 2)
+#if ENABLED (JERRY_ESNEXT)
+  const uint32_t required_args_number = 1;
+#else /* !ENABLED (JERRY_ESNEXT) */
+  const uint32_t required_args_number = 2;
+#endif /* ENABLED (JERRY_ESNEXT) */
+
+  if (args_number < required_args_number)
   {
     /* Note:
      *      When the UTC function is called with fewer than two arguments,

--- a/tests/jerry/es5.1/date-utc.js
+++ b/tests/jerry/es5.1/date-utc.js
@@ -12,34 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var d;
-
-d = Date.UTC(undefined);
+var d = Date.UTC(2015);
 assert (isNaN(d));
-
-d = Date.UTC({});
-assert (isNaN(d));
-
-d = Date.UTC(2000 + 15, 0);
-assert (d == 1420070400000);
-
-d = Date.UTC(2015, 0);
-assert (d == 1420070400000);
-
-d = Date.UTC(2015, 0, 1);
-assert (d == 1420070400000);
-
-d = Date.UTC(2015, 0, 1, 0);
-assert (d == 1420070400000);
-
-d = Date.UTC(2015, 0, 1, 0, 0);
-assert (d == 1420070400000);
-
-d = Date.UTC(2015, 0, 1, 0, 0, 0);
-assert (d == 1420070400000);
-
-d = Date.UTC(2015, 0, 1, 0, 0, 0, 0);
-assert (d == 1420070400000);
-
-d = Date.UTC(2015, 6, 3, 14, 35, 43, 123);
-assert (d == 1435934143123);

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -694,7 +694,6 @@
   <test id="built-ins/DataView/toindex-bytelength-sab.js"><reason></reason></test>
   <test id="built-ins/DataView/toindex-byteoffset-sab.js"><reason></reason></test>
   <test id="built-ins/DataView/toindex-byteoffset.js"><reason></reason></test>
-  <test id="built-ins/Date/UTC/return-value.js"><reason></reason></test>
   <test id="built-ins/Date/parse/time-value-maximum-range.js"><reason></reason></test>
   <test id="built-ins/Date/parse/without-utc-offset.js"><reason></reason></test>
   <test id="built-ins/Date/proto-from-ctor-realm-one.js"><reason></reason></test>


### PR DESCRIPTION
Date.UTC should work with only one argument too.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
