### PR TITLE
Fix the value of the caller property of function instances

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1600,8 +1600,10 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
     return ecma_op_lazy_instantiate_prototype_object (object_p);
   }
 
-  if (ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_CALLER)
-      || ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_ARGUMENTS))
+  const bool is_arguments = ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_ARGUMENTS);
+
+  if (is_arguments
+      || ecma_compare_ecma_string_to_magic_id (property_name_p, LIT_MAGIC_STRING_CALLER))
   {
     const ecma_compiled_code_t *bytecode_data_p;
     bytecode_data_p = ecma_op_function_get_compiled_code ((ecma_extended_object_t *) object_p);
@@ -1616,7 +1618,7 @@ ecma_op_function_try_to_lazy_instantiate_property (ecma_object_t *object_p, /**<
                                                                         property_name_p,
                                                                         ECMA_PROPERTY_FIXED,
                                                                         &value_prop_p);
-      value_p->value = ECMA_VALUE_NULL;
+      value_p->value = is_arguments ? ECMA_VALUE_NULL : ECMA_VALUE_UNDEFINED;
       return value_prop_p;
     }
 #else /* !ENABLED (JERRY_ESNEXT) */

--- a/tests/jerry/es.next/function-arguments-caller.js
+++ b/tests/jerry/es.next/function-arguments-caller.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var props = ['arguments', 'caller'];
-
 function f_simple () {
 }
 
@@ -21,27 +19,48 @@ function f_strict () {
   "use strict";
 }
 
-for (let prop of props) {
-  try {
-    Function.prototype[prop];
-    assert(false);
-  } catch (e) {
-    assert(e instanceof TypeError);
-  }
-
-  assert(f_simple[prop] === null);
-
-  try {
-    f_strict[prop];
-    assert(false);
-  } catch (e) {
-    assert(e instanceof TypeError);
-  }
-
-  let desc = Object.getOwnPropertyDescriptor(f_simple, prop);
-  assert(desc.value === null);
-  assert(desc.writable === false);
-  assert(desc.enumerable === false);
-  assert(desc.configurable === false);
-  assert(Object.getOwnPropertyDescriptor(f_strict, prop) === undefined);
+try {
+  Function.prototype["arguments"];
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
 }
+
+assert(f_simple["arguments"] === null);
+
+try {
+  f_strict["arguments"];
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+let desc = Object.getOwnPropertyDescriptor(f_simple, "arguments");
+assert(desc.value === null);
+assert(desc.writable === false);
+assert(desc.enumerable === false);
+assert(desc.configurable === false);
+assert(Object.getOwnPropertyDescriptor(f_strict, "arguments") === undefined);
+
+try {
+  Function.prototype["caller"];
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+assert(f_simple["caller"] === undefined);
+
+try {
+  f_strict["caller"];
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}
+
+desc = Object.getOwnPropertyDescriptor(f_simple, "caller");
+assert(desc.value === undefined);
+assert(desc.writable === false);
+assert(desc.enumerable === false);
+assert(desc.configurable === false);
+assert(Object.getOwnPropertyDescriptor(f_strict, "arguments") === undefined);

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -241,8 +241,6 @@
   <test id="intl402/String/prototype/toLocaleUpperCase/special_casing_Azeri.js"><reason></reason></test>
   <test id="intl402/String/prototype/toLocaleUpperCase/special_casing_Lithuanian.js"><reason></reason></test>
   <test id="intl402/String/prototype/toLocaleUpperCase/special_casing_Turkish.js"><reason></reason></test>
-  <test id="language/arguments-object/10.6-13-a-2.js"><reason></reason></test>
-  <test id="language/arguments-object/10.6-13-a-3.js"><reason></reason></test>
   <test id="language/asi/S7.9_A5.7_T1.js"><reason></reason></test>
   <test id="language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-function-declaration.js"><reason>No longer a SyntaxError in ES11</reason></test>
   <test id="language/default-parameters/function-length.js"><reason></reason></test>

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -2864,8 +2864,6 @@
   <test id="intl402/supportedLocalesOf-test-option-localeMatcher.js"><reason></reason></test>
   <test id="intl402/supportedLocalesOf-throws-if-element-not-string-or-object.js"><reason></reason></test>
   <test id="intl402/supportedLocalesOf-unicode-extensions-ignored.js"><reason></reason></test>
-  <test id="language/arguments-object/10.6-13-a-2.js"><reason></reason></test>
-  <test id="language/arguments-object/10.6-13-a-3.js"><reason></reason></test>
   <test id="language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js"><reason></reason></test>
   <test id="language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js"><reason></reason></test>
   <test id="language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js"><reason></reason></test>


### PR DESCRIPTION
We do not support the caller information for functions, and since a
'null' value represents that there has been no caller, the default value
should be changed to 'undefined' to signal that the information is not
available.