### PR TITLE
Remove revoked Proxy checks when creating a Proxy

### DIFF
--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -37,34 +37,11 @@
 
 #if ENABLED (JERRY_BUILTIN_PROXY)
 /**
- * Check whether the argument satifies the requrements of [[ProxyTarget]] or [[ProxyHandler]]
- *
- * See also:
- *          ES2015 9.5.15.1-2
- *          ES2015 9.5.15.3-4
- *
- * @return true - if the arguments can be a valid [[ProxyTarget]] or [[ProxyHandler]]
- *         false - otherwise
- */
-static bool
-ecma_proxy_validate (ecma_value_t argument) /**< argument to validate */
-{
-  if (ecma_is_value_object (argument))
-  {
-    ecma_object_t *obj_p = ecma_get_object_from_value (argument);
-
-    return (!ECMA_OBJECT_IS_PROXY (obj_p)
-            || !ecma_is_value_null (((ecma_proxy_object_t *) obj_p)->handler));
-  }
-
-  return false;
-} /* ecma_proxy_validate */
-
-/**
  * ProxyCreate operation for create a new proxy object
  *
  * See also:
  *         ES2015 9.5.15
+ *         ES11+: 9.5.14 ProxyCreate
  *
  * @return created Proxy object as an ecma-value - if success
  *         raised error - otherwise
@@ -73,26 +50,32 @@ ecma_object_t *
 ecma_proxy_create (ecma_value_t target, /**< proxy target */
                    ecma_value_t handler) /**< proxy handler */
 {
-  /* 1 - 4. */
-  if (!ecma_proxy_validate (target) || !ecma_proxy_validate (handler))
+  /* ES2015: 1, 3. */
+  /* ES11+: 1 - 2. */
+  if (!ecma_is_value_object (target) || !ecma_is_value_object (handler))
   {
     ecma_raise_type_error (ECMA_ERR_MSG ("Cannot create proxy with a non-object target or handler"));
     return NULL;
   }
 
-  /* 5 - 6. */
+  /* ES2015: 5 - 6. */
+  /* ES11+: 3 - 4. */
   ecma_object_t *obj_p = ecma_create_object (ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE),
                                              sizeof (ecma_proxy_object_t),
                                              ECMA_OBJECT_TYPE_PROXY);
 
   ecma_proxy_object_t *proxy_obj_p = (ecma_proxy_object_t *) obj_p;
 
-  /* 8. */
+  /* ES2015: 8. */
+  /* ES11+: 6. */
   proxy_obj_p->target = target;
-  /* 9. */
+
+  /* ES2015: 9. */
+  /* ES11+: 7. */
   proxy_obj_p->handler = handler;
 
-  /* 10. */
+  /* ES2015: 10. */
+  /* ES11+: 8 */
   return obj_p;
 } /* ecma_proxy_create */
 

--- a/tests/jerry/es.next/proxy_create.js
+++ b/tests/jerry/es.next/proxy_create.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Update these tests when the internal routine has been implemented
-
 var target = {}
 var handler = {};
 var proxy = new Proxy(target, handler);
@@ -43,16 +41,6 @@ try {
   assert(e instanceof TypeError);
 }
 
-try {
-  new Proxy({}, rev_proxy);
-  assert(false);
-} catch (e) {
-  assert(e instanceof TypeError);
-}
-
-try {
-  new Proxy(rev_proxy, {});
-  assert(false);
-} catch (e) {
-  assert(e instanceof TypeError);
-}
+/* In ES11+ the standard changed revoked proxy is a valid input for a new Proxy */
+var proxy_rev_handler = new Proxy({}, rev_proxy);
+var proxy_rev_target_Br = new Proxy(rev_proxy, {});

--- a/tests/jerry/es.next/proxy_revocable.js
+++ b/tests/jerry/es.next/proxy_revocable.js
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// TODO: Update these tests when the internal routine has been implemented
-
 var target = function () {};
 var handler = { get (name) {
   return 5;
@@ -48,17 +46,21 @@ try {
   assert(e instanceof TypeError);
 }
 
+var p1 = Proxy.revocable({}, proxy);
+p1.a = 3;
+assert(p1.a == 3);
+
+var p2 = Proxy.revocable(proxy, {});
+p2.b = 43;
+assert(p2.b == 43);
+
+assert(typeof(target.a) === "undefined");
+assert(typeof(target.b) === "undefined");
+
+// Try accessing the "a" property again, it should fail
 try {
-  Proxy.revocable({}, proxy);
+  proxy.a;
   assert(false);
 } catch (e) {
   assert(e instanceof TypeError);
 }
-
-try {
-  Proxy.revocable(proxy, {});
-  assert(false);
-} catch (e) {
-  assert(e instanceof TypeError);
-}
-

--- a/tests/test262-es6-excludelist.xml
+++ b/tests/test262-es6-excludelist.xml
@@ -337,4 +337,6 @@
   <test id="language/arguments-object/10.6-14-b-1-s.js"><reason>ES11: arguments object no longer has caller property</reason></test>
   <test id="language/arguments-object/10.6-14-b-4-s.js"><reason>ES11: arguments object no longer has caller property</reason></test>
   <test id="language/statements/class/strict-mode/arguments-caller.js"><reason>ES11: arguments object no longer has caller property</reason></test>
+  <test id="built-ins/Proxy/create-handler-is-revoked-proxy.js"><reason>ES11+: ProxyCreate does not check Proxy handler and target.</reason></test>
+  <test id="built-ins/Proxy/create-target-is-revoked-proxy.js"><reason>ES11+: ProxyCreate does not check Proxy handler and target.</reason></test>
 </excludeList>

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -932,9 +932,7 @@
   <test id="built-ins/Proxy/construct/trap-is-not-callable-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/construct/trap-is-undefined-proto-from-cross-realm-newtarget.js"><reason></reason></test>
   <test id="built-ins/Proxy/construct/trap-is-undefined-proto-from-newtarget-realm.js"><reason></reason></test>
-  <test id="built-ins/Proxy/create-handler-is-revoked-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/create-target-is-revoked-function-proxy.js"><reason></reason></test>
-  <test id="built-ins/Proxy/create-target-is-revoked-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/defineProperty/desc-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/defineProperty/null-handler-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable-realm.js"><reason></reason></test>
@@ -959,9 +957,7 @@
   <test id="built-ins/Proxy/ownKeys/trap-is-not-callable-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/preventExtensions/trap-is-not-callable-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/preventExtensions/trap-is-undefined-target-is-proxy.js"><reason></reason></test>
-  <test id="built-ins/Proxy/revocable/handler-is-revoked-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/revocable/target-is-revoked-function-proxy.js"><reason></reason></test>
-  <test id="built-ins/Proxy/revocable/target-is-revoked-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/set/trap-is-not-callable-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/setPrototypeOf/toboolean-trap-result-false.js"><reason></reason></test>
   <test id="built-ins/Proxy/setPrototypeOf/trap-is-not-callable-realm.js"><reason></reason></test>


### PR DESCRIPTION
In the newer ecma262 standard (post ES11) the ProxyCreate was
changed and the revoked Proxy handler/target is not checked.

Related standard PR: https://github.com/tc39/ecma262/pull/1814