### PR TITLE
Propagate strict mode for Proxy targets during delete

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1612,7 +1612,7 @@ ecma_op_object_delete_by_index (ecma_object_t *obj_p, /**< the object */
 ecma_value_t
 ecma_op_object_delete (ecma_object_t *obj_p, /**< the object */
                        ecma_string_t *property_name_p, /**< property name */
-                       bool is_throw) /**< flag that controls failure handling */
+                       bool is_strict) /**< flag that controls failure handling */
 {
   JERRY_ASSERT (obj_p != NULL
                 && !ecma_is_lexical_environment (obj_p));
@@ -1626,14 +1626,14 @@ ecma_op_object_delete (ecma_object_t *obj_p, /**< the object */
     {
       return ecma_op_arguments_object_delete (obj_p,
                                               property_name_p,
-                                              is_throw);
+                                              is_strict);
     }
   }
 
 #if ENABLED (JERRY_BUILTIN_PROXY)
   if (ECMA_OBJECT_IS_PROXY (obj_p))
   {
-    return ecma_proxy_object_delete_property (obj_p, property_name_p);
+    return ecma_proxy_object_delete_property (obj_p, property_name_p, is_strict);
   }
 #endif /* ENABLED (JERRY_BUILTIN_PROXY) */
 
@@ -1641,7 +1641,7 @@ ecma_op_object_delete (ecma_object_t *obj_p, /**< the object */
 
   return ecma_op_general_object_delete (obj_p,
                                         property_name_p,
-                                        is_throw);
+                                        is_strict);
 } /* ecma_op_object_delete */
 
 /**

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -1314,7 +1314,8 @@ ecma_proxy_object_set (ecma_object_t *obj_p, /**< proxy object */
  */
 ecma_value_t
 ecma_proxy_object_delete_property (ecma_object_t *obj_p, /**< proxy object */
-                                   ecma_string_t *prop_name_p) /**< property name */
+                                   ecma_string_t *prop_name_p, /**< property name */
+                                   bool is_strict) /**< delete in strict mode? */
 {
   JERRY_ASSERT (ECMA_OBJECT_IS_PROXY (obj_p));
 
@@ -1338,7 +1339,7 @@ ecma_proxy_object_delete_property (ecma_object_t *obj_p, /**< proxy object */
   /* 8. */
   if (ecma_is_value_undefined (trap))
   {
-    return ecma_op_object_delete (target_obj_p, prop_name_p, false);
+    return ecma_op_object_delete (target_obj_p, prop_name_p, is_strict);
   }
 
   ecma_object_t *func_obj_p = ecma_get_object_from_value (trap);

--- a/jerry-core/ecma/operations/ecma-proxy-object.h
+++ b/jerry-core/ecma/operations/ecma-proxy-object.h
@@ -91,7 +91,8 @@ ecma_proxy_object_set (ecma_object_t *obj_p,
 
 ecma_value_t
 ecma_proxy_object_delete_property (ecma_object_t *obj_p,
-                                   ecma_string_t *prop_name_p);
+                                   ecma_string_t *prop_name_p,
+                                   bool is_strict);
 
 ecma_collection_t *
 ecma_proxy_object_own_property_keys (ecma_object_t *obj_p);

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -278,6 +278,13 @@ vm_op_delete_prop (ecma_value_t object, /**< base object */
   ecma_deref_object (obj_p);
   ecma_deref_ecma_string (name_string_p);
 
+#if ENABLED (JERRY_ESNEXT)
+  if (is_strict && ecma_is_value_false (delete_op_ret))
+  {
+    return ecma_raise_type_error (ECMA_ERR_MSG ("delete returned false in strict mode."));
+  }
+#endif /* ENABLED (JERRY_ESNEXT) */
+
   return delete_op_ret;
 } /* vm_op_delete_prop */
 

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -937,10 +937,7 @@
   <test id="built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/defineProperty/trap-is-not-callable-realm.js"><reason></reason></test>
-  <test id="built-ins/Proxy/deleteProperty/trap-is-missing-target-is-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/deleteProperty/trap-is-not-callable-realm.js"><reason></reason></test>
-  <test id="built-ins/Proxy/deleteProperty/trap-is-null-target-is-proxy.js"><reason></reason></test>
-  <test id="built-ins/Proxy/deleteProperty/trap-is-undefined-target-is-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/get-fn-realm-recursive.js"><reason></reason></test>
   <test id="built-ins/Proxy/get-fn-realm.js"><reason></reason></test>
   <test id="built-ins/Proxy/get/trap-is-not-callable-realm.js"><reason></reason></test>


### PR DESCRIPTION
After ES5.1 if the delete returns false a TypeError should be thrown
in strict mode.