### PR TITLE
Revise the API ArrayBuffer related operations

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -9011,7 +9011,9 @@ jerry_get_arraybuffer_pointer (const jerry_value_t value);
 - `value` - Array Buffer object.
 - return value
   - pointer to the Array Buffer's data area.
-  - NULL if the `value` is not an Array Buffer object.
+  - NULL if the `value` is:
+    - not an ArrayBuffer object
+    - an external ArrayBuffer has been detached
 
 *New in version 2.0*.
 
@@ -9095,6 +9097,8 @@ This operation requires the ArrayBuffer to be external that created by
 jerry_value_t
 jerry_detach_arraybuffer (const jerry_value_t value);
 ```
+
+*Note*: If the ArrayBuffer has been created with `jerry_create_arraybuffer_external` the optional free callback is called on a successful detach operation
 
 - `value` - ArrayBuffer to be detached
 - return

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -1384,11 +1384,10 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 
             /* Call external free callback if any. */
             ecma_arraybuffer_external_info *array_p = (ecma_arraybuffer_external_info *) ext_object_p;
-            JERRY_ASSERT (array_p != NULL);
 
             if (array_p->free_cb != NULL)
             {
-              (array_p->free_cb) (array_p->buffer_p);
+              array_p->free_cb (array_p->buffer_p);
             }
           }
           else

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1882,8 +1882,12 @@ typedef enum
 {
   ECMA_ARRAYBUFFER_INTERNAL_MEMORY = 0u,        /* ArrayBuffer memory is handled internally. */
   ECMA_ARRAYBUFFER_EXTERNAL_MEMORY = (1u << 0), /* ArrayBuffer created via jerry_create_arraybuffer_external. */
+  ECMA_ARRAYBUFFER_DETACHED = (1u << 1),        /* ArrayBuffer has been detached */
 } ecma_arraybuffer_extra_flag_t;
 
+/**
+ * Check whether the ArrayBuffer has external underlying buffer
+ */
 #define ECMA_ARRAYBUFFER_HAS_EXTERNAL_MEMORY(object_p) \
     ((((ecma_extended_object_t *) object_p)->u.class_prop.extra_info & ECMA_ARRAYBUFFER_EXTERNAL_MEMORY) != 0)
 

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -45,8 +45,6 @@ uint32_t JERRY_ATTR_PURE
 ecma_arraybuffer_get_length (ecma_object_t *obj_p);
 bool JERRY_ATTR_PURE
 ecma_arraybuffer_is_detached (ecma_object_t *obj_p);
-bool JERRY_ATTR_PURE
-ecma_arraybuffer_is_detachable (ecma_object_t *obj_p);
 bool
 ecma_arraybuffer_detach (ecma_object_t *obj_p);
 bool


### PR DESCRIPTION
 - External ArrayBuffer construction with 0 length should be equivalent to `new ArrayBuffer(0)`
 - Internally allocated ArrayBuffers should be detachable
 - Externally allocated ArrayBuffers free callback should be called when underlying buffer is detached

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu