### PR TITLE
Fix sign-compare compiler warning in js-scanner-util.c

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -758,11 +758,11 @@ scanner_pop_literal_pool (parser_context_t *context_p, /**< context */
 
       intptr_t diff = (intptr_t) (literal_p->char_p - prev_source_p);
 
-      if (diff >= 1 && diff <= UINT8_MAX)
+      if (diff >= 1 && diff <= (intptr_t) UINT8_MAX)
       {
         compressed_size += 2 + 1;
       }
-      else if (diff >= -UINT8_MAX && diff <= (intptr_t) UINT16_MAX)
+      else if (diff >= -(intptr_t) UINT8_MAX && diff <= (intptr_t) UINT16_MAX)
       {
         compressed_size += 2 + 2;
       }
@@ -1066,11 +1066,11 @@ scanner_pop_literal_pool (parser_context_t *context_p, /**< context */
 
       intptr_t diff = (intptr_t) (literal_p->char_p - prev_source_p);
 
-      if (diff >= 1 && diff <= UINT8_MAX)
+      if (diff >= 1 && diff <= (intptr_t) UINT8_MAX)
       {
         data_p[-1] = (uint8_t) diff;
       }
-      else if (diff >= -UINT8_MAX && diff <= (intptr_t) UINT16_MAX)
+      else if (diff >= -(intptr_t) UINT8_MAX && diff <= (intptr_t) UINT16_MAX)
       {
         if (diff < 0)
         {
@@ -2226,7 +2226,7 @@ scanner_check_variables (parser_context_t *context_p) /**< context */
     {
       int32_t diff = ((int32_t) data_p[2]) | ((int32_t) data_p[3]) << 8;
 
-      if (diff <= UINT8_MAX)
+      if (diff <= (intptr_t) UINT8_MAX)
       {
         diff = -diff;
       }
@@ -2463,7 +2463,7 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
     {
       int32_t diff = ((int32_t) data_p[2]) | ((int32_t) data_p[3]) << 8;
 
-      if (diff <= UINT8_MAX)
+      if (diff <= (intptr_t) UINT8_MAX)
       {
         diff = -diff;
       }


### PR DESCRIPTION
Found by mingw32-gcc (MinGW.org GCC Build-2) 9.2.0.

comparison of integer expressions of different signedness:
'intptr_t' {aka 'int'} and 'unsigned int' [-Werror=sign-compare]

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu