### PR TITLE
fix string dereference in ecma_op_create_dynamic_function

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-intrinsic.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-intrinsic.c
@@ -258,6 +258,7 @@ ecma_builtin_intrinsic_dispatch_routine (uint16_t builtin_routine_id, /**< built
       ECMA_FINALIZE_UTF8_STRING (start_p, input_start_size);
       ecma_value_t result = ecma_make_string_value (ret_str_p);
       ecma_deref_ecma_string (to_str_p);
+      ecma_deref_ecma_string (ret_str_p);
       return result;
 
     }


### PR DESCRIPTION
In function ecma_op_create_dynamic_function in jerry-core/ecma/builtin-objects/ecma-builtin-instrinsic.c, it returned before dereferencing pointer *to_str_p .