### PR TITLE
Fix compiler warnings

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1708,7 +1708,8 @@ ecma_builtin_typedarray_prototype_dispatch_routine (uint16_t builtin_routine_id,
   }
 
   ecma_object_t *typedarray_p = ecma_get_object_from_value (this_arg);
-  ecma_typedarray_info_t info = { 0 };
+  ecma_typedarray_info_t info;
+  memset (&info, 0, sizeof (info));
 
   if (builtin_routine_id < ECMA_TYPEDARRAY_PROTOTYPE_ROUTINE_BUFFER_GETTER)
   {


### PR DESCRIPTION
In file included from jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c:1711:37

```
      missing field 'buffer_p' initializer [-Werror,-Wmissing-field-initializers]
  ecma_typedarray_info_t info = { 0 };
                                    ^
1 error generated.
```

when using this version of clang:

```
clang version 3.8.0-2ubuntu4 (tags/RELEASE_380/final)
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/lib/llvm-3.8/bin
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5.4.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/6.0.0
Selected GCC installation: /usr/lib/gcc/x86_64-linux-gnu/5.4.0
```

