### PR TITLE
Constructor check should return false for arrow and generator functions

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -37,6 +37,16 @@ bool ecma_op_object_is_callable (ecma_object_t *obj_p);
 bool ecma_is_constructor (ecma_value_t value);
 bool ecma_object_is_constructor (ecma_object_t *obj_p);
 
+/**
+ * Special constant indicating that the value is a valid constructor
+ *
+ * Use after the ecma_*_check_constructor calls.
+ */
+#define ECMA_IS_VALID_CONSTRUCTOR ((char *) 0x1)
+
+char *ecma_object_check_constructor (ecma_object_t *obj_p);
+char *ecma_check_constructor (ecma_value_t value);
+
 ecma_object_t *
 ecma_op_create_simple_function_object (ecma_object_t *scope_p, const ecma_compiled_code_t *bytecode_data_p);
 
@@ -72,9 +82,6 @@ void
 ecma_op_native_handler_list_lazy_property_names (ecma_object_t *object_p,
                                                  ecma_collection_t *prop_names_p,
                                                  ecma_property_counter_t *prop_counter_p);
-
-bool
-ecma_op_function_is_generator (ecma_object_t *func_obj_p);
 #endif /* ENABLED (JERRY_ESNEXT) */
 
 ecma_object_t *

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1314,8 +1314,7 @@ opfunc_init_class (vm_frame_ctx_t *frame_ctx_p, /**< frame context */
   else if (!ecma_is_value_null (super_class))
   {
     /* 6.f, 6.g.i */
-    if (!ecma_is_constructor (super_class)
-        || ecma_op_function_is_generator (ecma_get_object_from_value (super_class)))
+    if (!ecma_is_constructor (super_class))
     {
       return ecma_raise_type_error ("Class extends value is not a constructor or null");
     }

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -691,10 +691,10 @@ vm_spread_operation (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
   if (frame_ctx_p->byte_code_p[1] == CBC_EXT_SPREAD_NEW)
   {
-    if (!ecma_is_value_object (func_value)
-        || !ecma_object_is_constructor (ecma_get_object_from_value (func_value)))
+    const char *constructor_message_p = ecma_check_constructor (func_value);
+    if (constructor_message_p != ECMA_IS_VALID_CONSTRUCTOR)
     {
-      completion_value = ecma_raise_type_error (ECMA_ERR_MSG ("Expected a constructor."));
+      completion_value = ecma_raise_type_error (constructor_message_p);
     }
     else
     {
@@ -879,10 +879,10 @@ opfunc_construct (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
   ecma_value_t constructor_value = stack_top_p[-1];
   ecma_value_t completion_value;
 
-  if (!ecma_is_value_object (constructor_value)
-      || !ecma_object_is_constructor (ecma_get_object_from_value (constructor_value)))
+  const char *constructor_message_p = ecma_check_constructor (constructor_value);
+  if (constructor_message_p != ECMA_IS_VALID_CONSTRUCTOR)
   {
-    completion_value = ecma_raise_type_error (ECMA_ERR_MSG ("Expected a constructor."));
+    completion_value = ecma_raise_type_error (constructor_message_p);
   }
   else
   {

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -318,7 +318,6 @@
   <test id="built-ins/TypedArrayConstructors/ctors-bigint/object-arg/custom-proto-access-throws.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors-bigint/object-arg/use-custom-proto-if-object.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors-bigint/typedarray-arg/custom-proto-access-throws.js"><reason></reason></test>
-  <test id="built-ins/TypedArrayConstructors/ctors-bigint/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors/buffer-arg/byteoffset-is-negative-zero.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors/buffer-arg/custom-proto-access-throws.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors/buffer-arg/defined-negative-length.js"><reason></reason></test>
@@ -333,7 +332,6 @@
   <test id="built-ins/TypedArrayConstructors/ctors/object-arg/returns.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors/object-arg/use-custom-proto-if-object.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/custom-proto-access-throws.js"><reason></reason></test>
-  <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/other-ctor-buffer-ctor-species-not-ctor-throws.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors/typedarray-arg/use-custom-proto-if-object.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/from/BigInt/custom-ctor-returns-other-instance.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/from/BigInt/custom-ctor.js"><reason></reason></test>
@@ -368,7 +366,6 @@
   <test id="built-ins/TypedArrayConstructors/of/custom-ctor-returns-other-instance.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/of/custom-ctor.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/of/new-instance-using-custom-ctor.js"><reason></reason></test>
-  <test id="harness/isConstructor.js"><reason></reason></test>
   <test id="language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js"><reason></reason></test>
   <test id="language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js"><reason></reason></test>
   <test id="language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js"><reason></reason></test>
@@ -730,9 +727,7 @@
   <test id="language/statements/class/dstr/meth-static-ary-init-iter-no-close.js"><reason></reason></test>
   <test id="language/statements/class/dstr/meth-static-dflt-ary-init-iter-no-close.js"><reason></reason></test>
   <test id="language/statements/class/subclass/default-constructor-spread-override.js"><reason></reason></test>
-  <test id="language/statements/class/subclass/superclass-arrow-function.js"><reason></reason></test>
   <test id="language/statements/class/subclass/superclass-async-function.js"><reason></reason></test>
-  <test id="language/statements/class/subclass/superclass-generator-function.js"><reason></reason></test>
   <test id="language/statements/class/super/in-constructor-superproperty-evaluation.js"><reason></reason></test>
   <test id="language/statements/const/dstr/ary-init-iter-no-close.js"><reason></reason></test>
   <test id="language/statements/do-while/cptn-abrupt-empty.js"><reason></reason></test>
@@ -9176,7 +9171,6 @@
   <test id="language/statements/class/elements/same-line-async-gen-static-private-methods-with-fields.js"><reason></reason></test>
   <test id="language/statements/class/elements/same-line-async-gen-static-private-methods.js"><reason></reason></test>
   <test id="language/statements/class/elements/syntax/valid/grammar-static-private-async-gen-meth-prototype.js"><reason></reason></test>
-  <test id="language/statements/class/subclass/superclass-async-generator-function.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-from-sync-iterator-continuation-abrupt-completion-get-constructor.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-decl-dstr-array-elem-init-simple-no-strict.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-decl-dstr-array-elem-init-yield-ident-invalid.js"><reason></reason></test>


### PR DESCRIPTION
The previous `ecma_is_constructor` implementation did not checked if the
target function was an arrow or generator function. This resulted in
an incorrect execution for these function types.

Depends on: #4264 