### PR TITLE
Fix name of install directory of jerry-libm header(s)

### DIFF
--- a/jerry-libm/CMakeLists.txt
+++ b/jerry-libm/CMakeLists.txt
@@ -64,4 +64,4 @@ configure_file(libjerry-libm.pc.in libjerry-libm.pc @ONLY)
 
 install(TARGETS ${JERRY_LIBM_NAME} DESTINATION lib)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libjerry-libm.pc DESTINATION lib/pkgconfig)
-install(DIRECTORY ${INCLUDE_LIBM}/ DESTINATION include/jerry-libm)
+install(DIRECTORY ${INCLUDE_LIBM}/ DESTINATION include/jerryscript-libm)


### PR DESCRIPTION
All installed headers and header directories of the project have
the `jerryscript-` prefix, except the math library, which installed
its `math.h` under `jerry-libm` directory.

This commit changes the name of the include directory to
`jerryscript-libm` to align it with the rest of the project.