### PR TITLE
Add script to extract JerryScript version from headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,11 @@
 cmake_minimum_required (VERSION 2.8.12)
 project (Jerry C)
 
+# Determining version
+execute_process(COMMAND python ${CMAKE_SOURCE_DIR}/tools/version.py
+                OUTPUT_VARIABLE JERRY_VERSION
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 # Determining platform
 set(PLATFORM "${CMAKE_SYSTEM_NAME}")
 string(TOUPPER "${PLATFORM}" PLATFORM)
@@ -124,6 +129,7 @@ message(STATUS "CMAKE_SYSTEM_PROCESSOR         " ${CMAKE_SYSTEM_PROCESSOR})
 message(STATUS "BUILD_SHARED_LIBS              " ${BUILD_SHARED_LIBS})
 message(STATUS "ENABLE_LTO                     " ${ENABLE_LTO} ${ENABLE_LTO_MESSAGE})
 message(STATUS "ENABLE_STRIP                   " ${ENABLE_STRIP} ${ENABLE_STRIP_MESSAGE})
+message(STATUS "JERRY_VERSION                  " ${JERRY_VERSION})
 message(STATUS "JERRY_CMDLINE                  " ${JERRY_CMDLINE} ${JERRY_CMDLINE_MESSAGE})
 message(STATUS "JERRY_CMDLINE_TEST             " ${JERRY_CMDLINE_TEST} ${JERRY_CMDLINE_TEST_MESSAGE})
 message(STATUS "JERRY_CMDLINE_SNAPSHOT         " ${JERRY_CMDLINE_SNAPSHOT} ${JERRY_CMDLINE_SNAPSHOT_MESSAGE})

--- a/jerry-core/libjerry-core.pc.in
+++ b/jerry-core/libjerry-core.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 Name: libjerry-core
 Description: JerryScript: lightweight JavaScript engine (core engine library)
 URL: https://github.com/jerryscript-project/jerryscript
-Version: 1.0
+Version: @JERRY_VERSION@
 Requires.private: @JERRY_CORE_PKGCONFIG_REQUIRES@ # NOTE: libjerry-port-default is not added as a required package
 Libs: -L${libdir} -ljerry-core
 Libs.private: @JERRY_CORE_PKGCONFIG_LIBS@

--- a/jerry-ext/libjerry-ext.pc.in
+++ b/jerry-ext/libjerry-ext.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 Name: libjerry-ext
 Description: JerryScript: lightweight JavaScript engine (extensions library)
 URL: https://github.com/jerryscript-project/jerryscript
-Version: 1.0
+Version: @JERRY_VERSION@
 Requires.private: libjerry-core
 Libs: -L${libdir} -ljerry-ext
 Libs.private: @JERRY_EXT_PKGCONFIG_LIBS@

--- a/jerry-libm/libjerry-libm.pc.in
+++ b/jerry-libm/libjerry-libm.pc.in
@@ -5,6 +5,6 @@ includedir=${prefix}/include/jerry-libm
 Name: libjerry-libm
 Description: JerryScript: lightweight JavaScript engine (minimal math library)
 URL: https://github.com/jerryscript-project/jerryscript
-Version: 1.0
+Version: @JERRY_VERSION@
 Libs: -L${libdir} -ljerry-libm
 Cflags: -I${includedir}

--- a/jerry-port/default/libjerry-port-default.pc.in
+++ b/jerry-port/default/libjerry-port-default.pc.in
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 Name: libjerry-port-default
 Description: JerryScript: lightweight JavaScript engine (default port library)
 URL: https://github.com/jerryscript-project/jerryscript
-Version: 1.0
+Version: @JERRY_VERSION@
 Libs: -L${libdir} -ljerry-port-default
 Cflags: -I${includedir}

--- a/tools/version.py
+++ b/tools/version.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# Copyright JS Foundation and other contributors, http://js.foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import re
+import settings
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Display version of JerryScript',
+        epilog="""
+            Extract version information from sources without relying on
+            compiler or preprocessor features.
+            """
+    )
+    _ = parser.parse_args()
+
+    with open(os.path.join(settings.PROJECT_DIR, 'jerry-core', 'include', 'jerryscript-core.h'), 'r') as header:
+        version = {}
+        version_re = re.compile(r'\s*#define\s+JERRY_API_(?P<key>MAJOR|MINOR|PATCH)_VERSION\s+(?P<value>\S+)')
+        for line in header:
+            match = version_re.match(line)
+            if match:
+                version[match.group('key')] = match.group('value')
+
+    print('%(MAJOR)s.%(MINOR)s.%(PATCH)s' % version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This can be used at configuration time to
- display version in diagnostics, and
- to write proper version number in pkgconfig files.
