### PR TITLE
Run test262-esnext tests with larger heap

### DIFF
--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -113,14 +113,6 @@
   <test id="built-ins/Proxy/preventExtensions/trap-is-undefined-target-is-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/revocable/target-is-revoked-function-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/setPrototypeOf/toboolean-trap-result-false.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-flags-u.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-digit-class-escape-plus-quantifier-flags-u.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-flags-u.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-whitespace-class-escape-plus-quantifier-flags-u.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-flags-u.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier-flags-u.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape-plus-quantifier.js"><reason></reason></test>
-  <test id="built-ins/RegExp/CharacterClassEscapes/character-class-non-word-class-escape.js"><reason></reason></test>
   <test id="built-ins/RegExp/prototype/Symbol.matchAll/isregexp-called-once.js"><reason></reason></test>
   <test id="built-ins/RegExp/prototype/Symbol.matchAll/isregexp-this-throws.js"><reason></reason></test>
   <test id="built-ins/RegExp/prototype/Symbol.matchAll/length.js"><reason></reason></test>

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -108,7 +108,8 @@ TEST262_ES2015_TEST_SUITE_OPTIONS = [
 
 # Test options for test262-esnext
 TEST262_ESNEXT_TEST_SUITE_OPTIONS = [
-    Options('test262_tests_esnext', OPTIONS_PROFILE_ESNEXT + ['--line-info=on', '--error-messages=on']),
+    Options('test262_tests_esnext', OPTIONS_PROFILE_ESNEXT
+            + ['--line-info=on', '--error-messages=on', '--mem-heap=20480']),
 ]
 
 # Test options for jerry-debugger

--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -176,7 +176,7 @@ def main(args):
     if args.es2015 or args.esnext:
         try:
             subprocess.check_output(["timeout", "--version"])
-            command = "timeout 3 " + command
+            command = "timeout 5 " + command
         except subprocess.CalledProcessError:
             pass
 


### PR DESCRIPTION
built-ins/RegExp/CharacterClassEscapes tests need more memory than 512Kb.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu