### PR TITLE
Implement rest parameter support for destructuring object patterns in for

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1350,14 +1350,25 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
           parser_emit_cbc_ext (context_p, is_for_in ? CBC_EXT_FOR_IN_GET_NEXT
                                                     : CBC_EXT_FOR_OF_GET_NEXT);
 
+          parser_pattern_flags_t flags = (PARSER_PATTERN_BINDING | PARSER_PATTERN_TARGET_ON_STACK);
+
           if (context_p->next_scanner_info_p->source_p == (context_p->source_p + 1))
           {
-            JERRY_ASSERT (context_p->next_scanner_info_p->type == SCANNER_TYPE_INITIALIZER);
+            if (context_p->next_scanner_info_p->type == SCANNER_TYPE_INITIALIZER)
+            {
+              scanner_release_next (context_p, sizeof (scanner_location_info_t));
+            }
+            else
+            {
+              JERRY_ASSERT (context_p->next_scanner_info_p->type == SCANNER_TYPE_LITERAL_FLAGS);
+              if (context_p->next_scanner_info_p->u8_arg & SCANNER_LITERAL_OBJECT_HAS_REST)
+              {
+                flags |= PARSER_PATTERN_HAS_REST_ELEMENT;
+              }
 
-            scanner_release_next (context_p, sizeof (scanner_location_info_t));
+              scanner_release_next (context_p, sizeof (scanner_info_t));
+            }
           }
-
-          parser_pattern_flags_t flags = (PARSER_PATTERN_BINDING | PARSER_PATTERN_TARGET_ON_STACK);
 
           if (token_type == LEXER_KEYW_LET)
           {

--- a/tests/jerry/es.next/object-pattern2.js
+++ b/tests/jerry/es.next/object-pattern2.js
@@ -135,3 +135,25 @@ function f8() {
   rest_compare(b, ["0", "C", "1", "D"])
 }
 f8()
+
+function f9() {
+  var counter = 0;
+
+  for (const { ...rest} in { B: "AA", C: 6.25 }) {
+    switch (counter) {
+      case 0: {
+        /* rest === { '0': 'B' } */
+        assert(rest['0'] === 'B');
+        break;
+        }
+      case 1: {
+        /* rest === { '0': 'C' } */
+        assert(rest['0'] == 'C');
+        break;
+      }
+    }
+    counter++;
+  }
+  assert(counter === 2);
+}
+f9()

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -7499,31 +7499,6 @@
   <test id="language/statements/class/elements/async-gen-private-method/yield-spread-obj.js"><reason></reason></test>
   <test id="language/statements/class/elements/gen-private-method-static/yield-spread-obj.js"><reason></reason></test>
   <test id="language/statements/class/elements/gen-private-method/yield-spread-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/const-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/const-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/const-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/let-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/let-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/let-obj-ptrn-rest-val-obj.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/var-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/var-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-of/dstr/var-obj-ptrn-rest-val-obj.js"><reason></reason></test>
   <!-- END - ES2018: Rest/Spread Properties -->
 
   <!-- ES2020: Dynamic Import
@@ -9252,8 +9227,6 @@
   <test id="language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-ary.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-id.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-not-final-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-get-value-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-unresolvable.js"><reason></reason></test>
@@ -9285,8 +9258,6 @@
   <test id="language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-ary.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-id.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-not-final-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-get-value-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-unresolvable.js"><reason></reason></test>
@@ -9378,9 +9349,6 @@
   <test id="language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-ary.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-id.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-not-final-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-get-value-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-unresolvable.js"><reason></reason></test>
@@ -9389,9 +9357,6 @@
   <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-get-value-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-prop-id-init-unresolvable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-rest-val-obj.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-ary-init-iter-get-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-unresolvable.js"><reason></reason></test>
@@ -9415,9 +9380,6 @@
   <test id="language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-ary.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-id.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-not-final-obj.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-rest-val-obj.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-get-value-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-unresolvable.js"><reason></reason></test>
@@ -9426,9 +9388,6 @@
   <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-get-value-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-prop-id-init-unresolvable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-getter.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-skip-non-enumerable.js"><reason></reason></test>
-  <test id="language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-rest-val-obj.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-var-ary-init-iter-get-err.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-throws.js"><reason></reason></test>
   <test id="language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-unresolvable.js"><reason></reason></test>


### PR DESCRIPTION
In case of `for (const {...rest} ...) ` there was an incorrectly handling of the destructuring pattern.
