### PR TITLE
Variables created by eval in strict mode should ignore the properties of their parent function.

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -2674,7 +2674,8 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
               {
                 opcode = CBC_CREATE_VAR_EVAL;
 
-                if (context_p->global_status_flags & ECMA_PARSE_FUNCTION_CONTEXT)
+                if ((context_p->global_status_flags & ECMA_PARSE_FUNCTION_CONTEXT)
+                    && !(context_p->status_flags & PARSER_IS_STRICT))
                 {
                   opcode = PARSER_TO_EXT_OPCODE (CBC_EXT_CREATE_VAR_EVAL);
                 }

--- a/tests/jerry/es.next/regresssion-test-issue-4018.js
+++ b/tests/jerry/es.next/regresssion-test-issue-4018.js
@@ -1,0 +1,29 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[
+  '"\\ubad',
+].forEach(function(result = JSON.parse (str, function (k, v) {
+  return v;
+})) {
+  r = eval ('"use ' + 's' + 't' + 'r' + 'i' + 'c' + 't"; va' + 'r x = 1;');
+});
+
+// Better test
+function f(result = function () {}) {
+  var x = 1;
+  eval ('"use strict"; var x = 2; assert(x === 2)');
+  assert(x === 1)
+}
+f()


### PR DESCRIPTION
Fixes #4018