### PR TITLE
Add Jerryscript to OSS-fuzz

### DIFF
--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -59,7 +59,7 @@ endmacro()
 # Jerry with libfuzzer support
 if(JERRY_LIBFUZZER)
   jerry_create_executable("jerry-libfuzzer" "libfuzzer.c")
-  target_link_libraries("jerry-libfuzzer" jerry-port-default -fsanitize=fuzzer)
+  target_link_libraries("jerry-libfuzzer" jerry-port-default)
 endif()
 
 # Jerry standalones


### PR DESCRIPTION
I have been working on settin up continuous fuzzing of Jerryscript on OSS-fuzz. This will allow Google to run the existing and all future fuzzers continuously with the goal of finding bugs and security vulnerabilities. If and when a bug is found, all maintainers on the mailing list get notified with a detailed bug report.

Fuzzing continuously has many advantages, some of which are:

- It makes sure that the fuzzers are actually run. It happens often that efforts are put into writing the fuzzers, but they are only rarely run if at all.
- Fuzzers can find deeper bugs with more time. There are cases of bugs having been found after several CPU years of continuous fuzzing. 

I have the integration build ready to setup continuous fuzzing of Jerryscript by way of OSS-fuzz. To complete the integration, all I need are the email addresses of maintainers to receive potential bug reports. These will be added to a public list that can be changed at any time. No more changes will need to be made on the Jerryscript repository at this point, but overtime it is recommended to move the build scripts upstream from OSS-fuzz. This usually happens a few months after integration.

Regarding the changes made in this PR: If there is interest from the maintainers to setup continuous fuzzing by way of OSS-fuzz, then the -fsanitize=address flag will need to be removed from the build system. Once integrated, I will be happy to bring this flag back with a seperate flag in the tools/build.py script, but for now I suggest it just gets removed.