### PR TITLE
Do not check call_arguments twice through parsing function call in statement

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -2630,8 +2630,7 @@ parser_process_unary_expression (parser_context_t *context_p, /**< context */
             continue;
           }
         }
-
-        if (call_arguments == 2)
+        else if (call_arguments == 2)
         {
           if (opcode == CBC_CALL)
           {


### PR DESCRIPTION
Checking call_arguments twice happens in a special case that
only if call_arguments <= 1 and opcode variable has CBC_EXT_SUPER_CALL.

`--unittests` and `--jerry-tests` are done.