### PR TITLE
Handle revoked Proxy during [[Get]] operation

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -919,6 +919,19 @@ ecma_op_get_prototype_from_constructor (ecma_object_t *ctor_obj_p, /**< construc
   if (!ecma_is_value_object (proto))
   {
     ecma_free_value (proto);
+
+#if ENABLED (JERRY_BUILTIN_PROXY)
+    if (ECMA_OBJECT_IS_PROXY (ctor_obj_p))
+    {
+      ecma_proxy_object_t *proxy_obj_p = (ecma_proxy_object_t *) ctor_obj_p;
+      if (ecma_is_value_null (proxy_obj_p->handler))
+      {
+        ecma_raise_type_error (ECMA_ERR_MSG ("Prototype from revoked Proxy is invalid."));
+        return NULL;
+      }
+    }
+#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
+
     proto_obj_p = ecma_builtin_get (default_proto_id);
     ecma_ref_object (proto_obj_p);
   }

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1895,6 +1895,29 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
   return ECMA_VALUE_TRUE;
 } /* ecma_op_object_get_own_property_descriptor */
 
+#if ENABLED (JERRY_BUILTIN_PROXY)
+/**
+ * Get property descriptor from a target value for a specified property.
+ *
+ * For more details see ecma_op_object_get_own_property_descriptor
+ *
+ * @return ECMA_VALUE_ERROR - if the Proxy.[[GetOwnProperty]] operation raises error
+ *         ECMA_VALUE_{TRUE, FALSE} - if property found or not
+ */
+ecma_value_t
+ecma_op_get_own_property_descriptor (ecma_value_t target, /**< target value */
+                                     ecma_string_t *property_name_p, /**< property name */
+                                     ecma_property_descriptor_t *prop_desc_p) /**< property descriptor */
+{
+  if (!ecma_is_value_object (target))
+  {
+    return ECMA_VALUE_FALSE;
+  }
+
+  return ecma_op_object_get_own_property_descriptor (ecma_get_object_from_value (target), property_name_p, prop_desc_p);
+} /* ecma_op_get_own_property_descriptor */
+#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
+
 /**
  * [[HasInstance]] ecma object's operation
  *

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -88,6 +88,12 @@ ecma_value_t ecma_op_ordinary_object_set_prototype_of (ecma_object_t *base_p, ec
 bool JERRY_ATTR_PURE ecma_op_ordinary_object_is_extensible (ecma_object_t *object_p);
 void ecma_op_ordinary_object_prevent_extensions (ecma_object_t *object_p);
 
+#if ENABLED (JERRY_BUILTIN_PROXY)
+ecma_value_t ecma_op_get_own_property_descriptor (ecma_value_t target,
+                                                  ecma_string_t *property_name_p,
+                                                  ecma_property_descriptor_t *prop_desc_p);
+#endif /* ENABLED (JERRY_BUILTIN_PROXY) */
+
 /**
  * @}
  * @}

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -1130,18 +1130,16 @@ ecma_proxy_object_get (ecma_object_t *obj_p, /**< proxy object */
     return trap;
   }
 
-  ecma_value_t target = proxy_obj_p->target;
-  ecma_object_t *target_obj_p = ecma_get_object_from_value (target);
-
   /* 8. */
   if (ecma_is_value_undefined (trap))
   {
+    ecma_object_t *target_obj_p = ecma_get_object_from_value (proxy_obj_p->target);
     return ecma_op_object_get_with_receiver (target_obj_p, prop_name_p, receiver);
   }
 
   ecma_object_t *func_obj_p = ecma_get_object_from_value (trap);
   ecma_value_t prop_value = ecma_make_prop_name_value (prop_name_p);
-  ecma_value_t args[] = { target, prop_value, receiver };
+  ecma_value_t args[] = { proxy_obj_p->target, prop_value, receiver };
 
   /* 9. */
   ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 3);
@@ -1156,8 +1154,7 @@ ecma_proxy_object_get (ecma_object_t *obj_p, /**< proxy object */
 
   /* 11. */
   ecma_property_descriptor_t target_desc;
-
-  ecma_value_t status = ecma_op_object_get_own_property_descriptor (target_obj_p, prop_name_p, &target_desc);
+  ecma_value_t status = ecma_op_get_own_property_descriptor (proxy_obj_p->target, prop_name_p, &target_desc);
 
   /* 12. */
   if (ECMA_IS_VALUE_ERROR (status))

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -40,7 +40,6 @@
   <test id="built-ins/Date/prototype/toTimeString/format.js"><reason></reason></test>
   <test id="built-ins/Date/value-symbol-to-prim-invocation.js"><reason></reason></test>
   <test id="built-ins/Date/value-to-primitive-call.js"><reason></reason></test>
-  <test id="built-ins/Function/internals/Construct/base-ctor-revoked-proxy.js"><reason></reason></test>
   <test id="built-ins/Function/prototype/toString/AsyncFunction.js"><reason></reason></test>
   <test id="built-ins/Function/prototype/toString/Function.js"><reason></reason></test>
   <test id="built-ins/Function/prototype/toString/GeneratorFunction.js"><reason></reason></test>


### PR DESCRIPTION
The handling of Proxy.[[Get]] was not fully correctly in the case when the
Proxy was revoked during the execution of the handler.