### PR TITLE
Template literal arrays should not be marked.

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -942,13 +942,8 @@ typedef struct
     struct
     {
       uint32_t length; /**< length property value */
-      union
-      {
-        ecma_property_t length_prop; /**< length property */
-        uint32_t hole_count; /**< number of array holes in a fast access mode array
-                              *   multiplied ECMA_FAST_ACCESS_HOLE_ONE */
-      } u;
-
+      uint32_t length_prop_and_hole_count; /**< length property attributes and number of array holes in
+                                            *   a fast access mode array multiplied ECMA_FAST_ACCESS_HOLE_ONE */
     } array;
 
     /**
@@ -996,6 +991,17 @@ typedef struct
   ecma_extended_object_t extended_object; /**< extended object part */
   ecma_built_in_props_t built_in; /**< built-in object part */
 } ecma_extended_built_in_object_t;
+
+/**
+ * Flags for array.length_prop_and_hole_count
+ */
+typedef enum
+{
+  ECMA_FAST_ARRAY_FLAG = 1u << (ECMA_PROPERTY_NAME_TYPE_SHIFT + 0),
+#if ENABLED (JERRY_ESNEXT)
+  ECMA_ARRAY_TEMPLATE_LITERAL = 1u << (ECMA_PROPERTY_NAME_TYPE_SHIFT + 1),
+#endif /* ENABLED (JERRY_ESNEXT) */
+} ecma_array_length_prop_and_hole_count_flags_t;
 
 /**
  * Alignment for the fast access mode array length.

--- a/jerry-core/ecma/base/ecma-helpers-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-collection.c
@@ -79,6 +79,46 @@ ecma_collection_free_objects (ecma_collection_t *collection_p) /**< value collec
   ecma_collection_destroy (collection_p);
 } /* ecma_collection_free_objects */
 
+#if ENABLED (JERRY_ESNEXT)
+
+/**
+ * Free the template literal objects and deallocate the collection
+ */
+void
+ecma_collection_free_template_literal (ecma_collection_t *collection_p) /**< value collection */
+{
+  for (uint32_t i = 0; i < collection_p->item_count; i++)
+  {
+    ecma_object_t *object_p = ecma_get_object_from_value (collection_p->buffer_p[i]);
+
+    JERRY_ASSERT (ecma_get_object_type (object_p) == ECMA_OBJECT_TYPE_ARRAY);
+
+    ecma_extended_object_t *array_object_p = (ecma_extended_object_t *) object_p;
+
+    JERRY_ASSERT (array_object_p->u.array.length_prop_and_hole_count & ECMA_ARRAY_TEMPLATE_LITERAL);
+    array_object_p->u.array.length_prop_and_hole_count &= (uint32_t) ECMA_ARRAY_TEMPLATE_LITERAL;
+
+    ecma_property_value_t *property_value_p;
+
+    property_value_p = ecma_get_named_data_property (object_p, ecma_get_magic_string (LIT_MAGIC_STRING_RAW));
+    ecma_object_t *raw_object_p = ecma_get_object_from_value (property_value_p->value);
+
+    JERRY_ASSERT (ecma_get_object_type (raw_object_p) == ECMA_OBJECT_TYPE_ARRAY);
+
+    array_object_p = (ecma_extended_object_t *) raw_object_p;
+
+    JERRY_ASSERT (array_object_p->u.array.length_prop_and_hole_count & ECMA_ARRAY_TEMPLATE_LITERAL);
+    array_object_p->u.array.length_prop_and_hole_count &= (uint32_t) ECMA_ARRAY_TEMPLATE_LITERAL;
+
+    ecma_deref_object (raw_object_p);
+    ecma_deref_object (object_p);
+  }
+
+  ecma_collection_destroy (collection_p);
+} /* ecma_collection_free_template_literal */
+
+#endif /* ENABLED (JERRY_ESNEXT) */
+
 /**
  * Free the non-object collection elements and deallocate the collection
  */

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1476,8 +1476,8 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
 
       /* Since the objects in the tagged template collection are not strong referenced anymore by the compiled code
          we can treat them as 'new' objects. */
-      JERRY_CONTEXT (ecma_gc_new_objects) += collection_p->item_count;
-      ecma_collection_free (collection_p);
+      JERRY_CONTEXT (ecma_gc_new_objects) += collection_p->item_count * 2;
+      ecma_collection_free_template_literal (collection_p);
     }
 #endif /* ENABLED (JERRY_ESNEXT) */
 

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -439,6 +439,9 @@ void ecma_collection_destroy (ecma_collection_t *collection_p);
 void ecma_collection_free (ecma_collection_t *collection_p);
 void ecma_collection_free_if_not_object (ecma_collection_t *collection_p);
 void ecma_collection_free_objects (ecma_collection_t *collection_p);
+#if ENABLED (JERRY_ESNEXT)
+void ecma_collection_free_template_literal (ecma_collection_t *collection_p);
+#endif /* ENABLED (JERRY_ESNEXT) */
 bool ecma_collection_check_duplicated_entries (ecma_collection_t *collection_p);
 bool ecma_collection_has_string_value (ecma_collection_t *collection_p, ecma_string_t *string_p);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -465,7 +465,7 @@ ecma_builtin_array_prototype_object_push (const ecma_value_t *argument_list_p, /
       buffer_p[index] = ecma_copy_value_if_not_object (argument_list_p[index]);
     }
 
-    ext_obj_p->u.array.u.hole_count -= ECMA_FAST_ARRAY_HOLE_ONE * arguments_number;
+    ext_obj_p->u.array.length_prop_and_hole_count -= ECMA_FAST_ARRAY_HOLE_ONE * arguments_number;
 
     return ecma_make_uint32_value (new_length);
   }
@@ -539,7 +539,7 @@ ecma_builtin_array_prototype_object_reverse (ecma_value_t this_arg, /**< this ar
     uint32_t middle = (uint32_t) len / 2;
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE
         && len != 0
         && ecma_op_ordinary_object_is_extensible (obj_p))
     {
@@ -725,7 +725,7 @@ ecma_builtin_array_prototype_object_shift (ecma_object_t *obj_p, /**< object */
   {
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE
         && len != 0
         && ecma_op_ordinary_object_is_extensible (obj_p))
     {
@@ -873,7 +873,7 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t arg1, /**< start */
   {
     ecma_extended_object_t *ext_from_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_from_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
+    if (ext_from_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
     {
       if (JERRY_UNLIKELY (obj_p->u1.property_list_cp == JMEM_CP_NULL))
       {
@@ -921,7 +921,7 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t arg1, /**< start */
         to_buffer_p[n] = ecma_copy_value_if_not_object (from_buffer_p[k]);
       }
 
-      ext_to_obj_p->u.array.u.hole_count &= ECMA_FAST_ARRAY_HOLE_ONE - 1;
+      ext_to_obj_p->u.array.length_prop_and_hole_count &= ECMA_FAST_ARRAY_HOLE_ONE - 1;
 
       return ecma_make_object_value (new_array_p);
     }
@@ -1513,7 +1513,7 @@ ecma_builtin_array_prototype_object_unshift (const ecma_value_t args[], /**< arg
   {
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE
         && len != 0
         && ecma_op_ordinary_object_is_extensible (obj_p))
     {
@@ -1539,7 +1539,7 @@ ecma_builtin_array_prototype_object_unshift (const ecma_value_t args[], /**< arg
         index++;
       }
 
-      ext_obj_p->u.array.u.hole_count -= args_number * ECMA_FAST_ARRAY_HOLE_ONE;
+      ext_obj_p->u.array.length_prop_and_hole_count -= args_number * ECMA_FAST_ARRAY_HOLE_ONE;
 
       return ecma_make_uint32_value (new_length);
     }
@@ -1670,7 +1670,7 @@ ecma_builtin_array_prototype_object_index_of (const ecma_value_t args[], /**< ar
   {
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
     {
       if (JERRY_UNLIKELY (obj_p->u1.property_list_cp == JMEM_CP_NULL))
       {
@@ -1776,7 +1776,7 @@ ecma_builtin_array_prototype_object_last_index_of (const ecma_value_t args[], /*
   {
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
     {
       if (JERRY_UNLIKELY (obj_p->u1.property_list_cp == JMEM_CP_NULL))
       {
@@ -2302,7 +2302,7 @@ ecma_builtin_array_prototype_fill (ecma_value_t value, /**< value */
   {
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE
         && ecma_op_ordinary_object_is_extensible (obj_p))
     {
       if (JERRY_UNLIKELY (obj_p->u1.property_list_cp == JMEM_CP_NULL))
@@ -2501,7 +2501,7 @@ ecma_builtin_array_prototype_object_copy_within (const ecma_value_t args[], /**<
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
     const uint32_t actual_length = ext_obj_p->u.array.length;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE
         && ((forward && (target + count - 1 < actual_length)) || (!forward && (target < actual_length))))
     {
       if (obj_p->u1.property_list_cp != JMEM_CP_NULL)
@@ -2617,7 +2617,7 @@ ecma_builtin_array_prototype_includes (const ecma_value_t args[], /**< arguments
   {
     ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
 
-    if (ext_obj_p->u.array.u.hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
+    if (ext_obj_p->u.array.length_prop_and_hole_count < ECMA_FAST_ARRAY_HOLE_ONE)
     {
       if (obj_p->u1.property_list_cp != JMEM_CP_NULL)
       {

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -439,7 +439,7 @@ ecma_instantiate_builtin (ecma_builtin_id_t obj_builtin_id) /**< built-in id */
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
       ext_object_p->u.array.length = 0;
-      ext_object_p->u.array.u.length_prop = ECMA_PROPERTY_FLAG_WRITABLE | ECMA_PROPERTY_TYPE_VIRTUAL;
+      ext_object_p->u.array.length_prop_and_hole_count = ECMA_PROPERTY_FLAG_WRITABLE | ECMA_PROPERTY_TYPE_VIRTUAL;
       break;
     }
 #endif /* ENABLED (JERRY_BUILTIN_ARRAY) */
@@ -539,20 +539,6 @@ ecma_finalize_builtins (void)
     {
       ecma_object_t *obj_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, JERRY_CONTEXT (ecma_builtin_objects)[id]);
       ecma_deref_object (obj_p);
-
-#if ENABLED (JERRY_ESNEXT)
-      /* Note: In ES2015 a function object may contain tagged template literal collection. Whenever
-         this function is assigned to a builtin function or function routine during the GC it may cause unresolvable
-         circle since one part of the circle is a weak reference (marked by GC) and the other part is hard reference
-         (reference count). In this case when the function which contains the tagged template literal collection
-         is getting GC marked the arrays in the collection are still holding weak references to properties/prototypes
-         which prevents these objects from getting freed. Releasing the property list and the prototype reference
-         manually eliminates the existence of the unresolvable circle described above. */
-      ecma_gc_free_properties (obj_p);
-      obj_p->u1.property_list_cp = JMEM_CP_NULL;
-      obj_p->u2.prototype_cp = JMEM_CP_NULL;
-#endif /* ENABLED (JERRY_ESNEXT) */
-
       JERRY_CONTEXT (ecma_builtin_objects)[id] = JMEM_CP_NULL;
     }
   }

--- a/jerry-core/parser/js/js-parser-tagged-template-literal.c
+++ b/jerry-core/parser/js/js-parser-tagged-template-literal.c
@@ -114,7 +114,6 @@ parser_new_tagged_template_literal (ecma_object_t **raw_strings_p) /**< [out] ra
                                 ecma_get_magic_string (LIT_MAGIC_STRING_RAW),
                                 ecma_make_object_value (*raw_strings_p),
                                 ECMA_PROPERTY_FIXED);
-  ecma_deref_object (*raw_strings_p);
 
   return template_obj_p;
 } /* parser_new_tagged_template_literal */
@@ -129,8 +128,8 @@ parser_tagged_template_literal_freeze_array (ecma_object_t *obj_p)
 
   ecma_op_ordinary_object_prevent_extensions (obj_p);
   ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
-  uint8_t new_prop_value = (uint8_t) (ext_obj_p->u.array.u.length_prop & ~ECMA_PROPERTY_FLAG_WRITABLE);
-  ext_obj_p->u.array.u.length_prop = new_prop_value;
+  ext_obj_p->u.array.length_prop_and_hole_count &= (uint32_t) ~ECMA_PROPERTY_FLAG_WRITABLE;
+  ext_obj_p->u.array.length_prop_and_hole_count |= ECMA_ARRAY_TEMPLATE_LITERAL;
 } /* parser_tagged_template_literal_freeze_array */
 
 /**

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2732,8 +2732,9 @@ parser_raise_error (parser_context_t *context_p, /**< context */
 #if ENABLED (JERRY_ESNEXT)
     if (saved_context_p->tagged_template_literal_cp != JMEM_CP_NULL)
     {
-      ecma_collection_free (ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
-                                                             saved_context_p->tagged_template_literal_cp));
+      ecma_collection_t *collection = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
+                                                                       saved_context_p->tagged_template_literal_cp);
+      ecma_collection_free_template_literal (collection);
     }
 #endif /* ENABLED (JERRY_ESNEXT)  */
 
@@ -2743,8 +2744,9 @@ parser_raise_error (parser_context_t *context_p, /**< context */
 #if ENABLED (JERRY_ESNEXT)
   if (context_p->tagged_template_literal_cp != JMEM_CP_NULL)
   {
-    ecma_collection_free (ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
-                                                           context_p->tagged_template_literal_cp));
+    ecma_collection_t *collection = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
+                                                                     context_p->tagged_template_literal_cp);
+    ecma_collection_free_template_literal (collection);
   }
 #endif /* ENABLED (JERRY_ESNEXT)  */
 

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -605,7 +605,7 @@ opfunc_append_array (ecma_value_t *stack_top_p, /**< current stack top */
       }
     }
 
-    ext_array_obj_p->u.array.u.hole_count -= filled_holes * ECMA_FAST_ARRAY_HOLE_ONE;
+    ext_array_obj_p->u.array.length_prop_and_hole_count -= filled_holes * ECMA_FAST_ARRAY_HOLE_ONE;
 
     if (JERRY_UNLIKELY ((values_length - filled_holes) > ECMA_FAST_ARRAY_MAX_NEW_HOLES_COUNT))
     {


### PR DESCRIPTION
The idea is that template literal objects are frozen arrays, so their properties and prototype could not be changed. Their properties are strings (no need marking) and their prototype is a built-in (marked elsewhere). Therfore marking these objects is unnecessary. This is compatible with a future improvement called realms, since the realm of the function and its own template literal is the same.

There are two ways to handle unmarking these objects:
- The current choice: prototype refing is moved to the end of `ecma_gc_mark`. Slight binary increase and each array object has an extra check.
- Other option: check these objects when `root` objects are marked (their refcount is always > 0). Slight binary increase and each root object has an extra check.

I am ok with both, let me know your opinion.

Make array object big endian compatible: I noticed that the current code is wrong on big endian system, since the `ecma_property_t` is one byte long, and mapped to the highest byte instead of the lowest in big endian system.
