### PR TITLE
Implement realm object and support realms for built-ins and JS functions

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -141,6 +141,8 @@ Possible compile time enabled feature types:
  - JERRY_FEATURE_SET - Set support
  - JERRY_FEATURE_WEAKMAP - WeakMap support
  - JERRY_FEATURE_WEAKSET - WeakSet support
+ - JERRY_FEATURE_BIGINT - BigInt support
+ - JERRY_FEATURE_REALM - realm support
 
 *New in version 2.0*.
 
@@ -5961,6 +5963,38 @@ jerry_create_undefined (void);
   ... // usage of the value
 
   jerry_release_value (undefined_value);
+}
+```
+
+**See also**
+
+- [jerry_release_value](#jerry_release_value)
+
+
+## jerry_create_realm
+
+**Summary**
+
+Creates a `jerry_value_t` representing a new global object.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerry_create_realm (void);
+```
+
+- return value - realm object value
+
+**Example**
+
+```c
+{
+  jerry_value_t realm_value = jerry_create_realm ();
+
+  ... // usage of the value
+
+  jerry_release_value (realm_value);
 }
 ```
 

--- a/jerry-core/api/jerry-snapshot.h
+++ b/jerry-core/api/jerry-snapshot.h
@@ -45,7 +45,8 @@ typedef enum
 {
   /* 8 bits are reserved for dynamic features */
   JERRY_SNAPSHOT_HAS_REGEX_LITERAL = (1u << 0), /**< byte code has regex literal */
-  JERRY_SNAPSHOT_HAS_CLASS_LITERAL = (1u << 1), /**< byte code has class literal */
+  JERRY_SNAPSHOT_HAS_REALM_VALUE = (1u << 1), /**< byte code has realm value */
+  JERRY_SNAPSHOT_HAS_CLASS_LITERAL = (1u << 2), /**< byte code has class literal */
   /* 24 bits are reserved for compile time features */
   JERRY_SNAPSHOT_FOUR_BYTE_CPOINTER = (1u << 8) /**< deprecated, an unused placeholder now */
 } jerry_snapshot_global_flags_t;

--- a/jerry-core/config.h
+++ b/jerry-core/config.h
@@ -79,6 +79,10 @@
 # define JERRY_ESNEXT 1
 #endif /* !defined (JERRY_ESNEXT) */
 
+#ifndef JERRY_BUILTIN_REALMS
+# define JERRY_BUILTIN_REALMS JERRY_ESNEXT
+#endif /* !defined (JERRY_BUILTIN_REALMS) */
+
 #ifndef JERRY_BUILTIN_DATAVIEW
 # define JERRY_BUILTIN_DATAVIEW JERRY_ESNEXT
 #endif /* !defined (JERRY_BUILTIN_DATAVIEW) */
@@ -522,6 +526,10 @@
 #if !defined (JERRY_ESNEXT) \
 || ((JERRY_ESNEXT != 0) && (JERRY_ESNEXT != 1))
 # error "Invalid value for JERRY_ESNEXT macro."
+#endif
+#if !defined (JERRY_BUILTIN_REALMS) \
+|| ((JERRY_BUILTIN_REALMS != 0) && (JERRY_BUILTIN_REALMS != 1))
+# error "Invalid value for JERRY_BUILTIN_REALMS macro."
 #endif
 #if !defined (JERRY_BUILTIN_DATAVIEW) \
 || ((JERRY_BUILTIN_DATAVIEW != 0) && (JERRY_BUILTIN_DATAVIEW != 1))

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -864,13 +864,29 @@ typedef struct
     uint8_t instantiated_bitset[1]; /**< instantiated property bit set for generic built-ins */
     uint8_t routine_flags; /**< flags for built-in routines */
   } u2;
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ecma_value_t realm_value; /**< realm value */
+#else /* !ENABLED (JERRY_BUILTIN_REALMS) */
   uint32_t continue_instantiated_bitset[1]; /**< bit set for instantiated properties */
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 } ecma_built_in_props_t;
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+
+/**
+ * Number of bits available in the instantiated bitset without allocation
+ */
+#define ECMA_BUILTIN_INSTANTIATED_BITSET_MIN_SIZE (8)
+
+#else /* !ENABLED (JERRY_BUILTIN_REALMS) */
 
 /**
  * Number of bits available in the instantiated bitset without allocation
  */
 #define ECMA_BUILTIN_INSTANTIATED_BITSET_MIN_SIZE (8 + 32)
+
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 
 /**
  * Builtin routine function object status flags
@@ -991,6 +1007,12 @@ typedef struct
   ecma_extended_object_t extended_object; /**< extended object part */
   ecma_built_in_props_t built_in; /**< built-in object part */
 } ecma_extended_built_in_object_t;
+
+/**
+ * Checks whether the built-in is an ecma_extended_built_in_object_t
+ */
+#define ECMA_BUILTIN_IS_EXTENDED_BUILT_IN(object_type) \
+  ((object_type) == ECMA_OBJECT_TYPE_CLASS || (object_type) == ECMA_OBJECT_TYPE_ARRAY)
 
 /**
  * Flags for array.length_prop_and_hole_count

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -250,7 +250,7 @@ ecma_get_object_builtin_id (ecma_object_t *object_p) /**< object */
   ecma_built_in_props_t *built_in_props_p;
   ecma_object_type_t object_type = ecma_get_object_type (object_p);
 
-  if (object_type == ECMA_OBJECT_TYPE_CLASS || object_type == ECMA_OBJECT_TYPE_ARRAY)
+  if (ECMA_BUILTIN_IS_EXTENDED_BUILT_IN (object_type))
   {
     built_in_props_p = &((ecma_extended_built_in_object_t *) object_p)->built_in;
   }

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -77,9 +77,9 @@ ecma_finalize (void)
 
   ecma_finalize_global_environment ();
   uint8_t runs = 0;
+
   do
   {
-    ecma_finalize_builtins ();
     ecma_gc_run ();
     if (++runs >= JERRY_GC_LOOP_LIMIT)
     {
@@ -87,6 +87,7 @@ ecma_finalize (void)
     }
   }
   while (JERRY_CONTEXT (ecma_gc_new_objects) != 0);
+
   ecma_finalize_lit_storage ();
 } /* ecma_finalize */
 

--- a/jerry-core/ecma/base/ecma-module.c
+++ b/jerry-core/ecma/base/ecma-module.c
@@ -485,8 +485,15 @@ ecma_module_evaluate (ecma_module_t *module_p) /**< module */
     return ECMA_VALUE_EMPTY;
   }
 
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ecma_object_t *global_object_p;
+  global_object_p = ecma_get_object_from_value (ecma_op_function_get_realm (module_p->compiled_code_p));
+#else /* !ENABLED (JERRY_BUILTIN_REALMS) */
+  ecma_object_t *global_object_p = ecma_builtin_get_global ();
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
   module_p->state = ECMA_MODULE_STATE_EVALUATING;
-  module_p->scope_p = ecma_create_decl_lex_env (ecma_get_global_environment ());
+  module_p->scope_p = ecma_create_decl_lex_env (ecma_get_global_environment (global_object_p));
   module_p->context_p->parent_p = JERRY_CONTEXT (module_top_context_p);
   JERRY_CONTEXT (module_top_context_p) = module_p->context_p;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.h
@@ -88,15 +88,38 @@ typedef enum
  */
 #define ECMA_ACCESSOR_READ_WRITE_GET_GETTER_ID(value) ((uint8_t) ((value) >> 8))
 
+/**
+ * Number ob built-in objects excluding global object
+ */
+#define ECMA_BUILTIN_OBJECTS_COUNT (ECMA_BUILTIN_ID__COUNT - 1)
+
+/**
+ * Description of built-in global ECMA-object.
+ */
+typedef struct
+{
+  ecma_extended_object_t extended_object; /**< extended object part */
+  uint32_t extra_instantiated_bitset[1]; /**< extra bit set for instantiated properties */
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  uint32_t extra_realms_bitset; /**< extra bit set for instantiated properties when realms is enabled */
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+  jmem_cpointer_t global_env_cp; /**< global lexical environment */
+#if ENABLED (JERRY_ESNEXT)
+  jmem_cpointer_t global_scope_cp; /**< global lexical scope */
+#endif /* ENABLED (JERRY_ESNEXT) */
+  jmem_cpointer_t builtin_objects[ECMA_BUILTIN_OBJECTS_COUNT]; /**< pointer to instances of built-in objects */
+} ecma_global_object_t;
+
 /* ecma-builtins.c */
-void ecma_finalize_builtins (void);
+
+ecma_global_object_t *ecma_builtin_create_global_object (void);
 
 ecma_value_t
 ecma_builtin_dispatch_call (ecma_object_t *obj_p, ecma_value_t this_arg_value,
                             const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
 ecma_value_t
-ecma_builtin_dispatch_construct (ecma_object_t *obj_p, ecma_object_t *new_target_p,
-                                 const ecma_value_t *arguments_list_p, uint32_t arguments_list_len);
+ecma_builtin_dispatch_construct (ecma_object_t *obj_p, const ecma_value_t *arguments_list_p,
+                                 uint32_t arguments_list_len);
 ecma_property_t *
 ecma_builtin_routine_try_to_instantiate_property (ecma_object_t *object_p, ecma_string_t *string_p);
 ecma_property_t *
@@ -110,7 +133,9 @@ ecma_builtin_list_lazy_property_names (ecma_object_t *object_p,
                                        ecma_collection_t *prop_names_p,
                                        ecma_property_counter_t *prop_counter_p);
 bool
-ecma_builtin_is (ecma_object_t *obj_p, ecma_builtin_id_t builtin_id);
+ecma_builtin_is (ecma_object_t *object_p, ecma_builtin_id_t builtin_id);
+bool
+ecma_builtin_is_global (ecma_object_t *object_p);
 ecma_object_t *
 ecma_builtin_get (ecma_builtin_id_t builtin_id);
 ecma_object_t *

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -169,6 +169,10 @@ ecma_object_check_constructor (ecma_object_t *obj_p) /**< ecma object */
 #if ENABLED (JERRY_ERROR_MESSAGES)
       switch (CBC_FUNCTION_GET_TYPE (byte_code_p->status_flags))
       {
+        case CBC_FUNCTION_SCRIPT:
+        {
+          return "Script (global) functions cannot be invoked with 'new'.";
+        }
         case CBC_FUNCTION_GENERATOR:
         {
           return "Generator functions cannot be invoked with 'new'.";
@@ -387,7 +391,7 @@ ecma_op_create_function_object (ecma_object_t *scope_p, /**< function's scope */
 #if ENABLED (JERRY_SNAPSHOT_EXEC)
   if (bytecode_data_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION)
   {
-    ext_func_p->u.function.bytecode_cp = ECMA_NULL_POINTER;
+    ext_func_p->u.function.bytecode_cp = JMEM_CP_NULL;
     ((ecma_static_function_t *) func_p)->bytecode_p = bytecode_data_p;
   }
   else
@@ -477,7 +481,13 @@ ecma_op_create_dynamic_function (const ecma_value_t *arguments_list_p, /**< argu
   *func_name_p = ecma_make_magic_string_value (LIT_MAGIC_STRING_ANONYMOUS);
 #endif /* ENABLED (JERRY_ESNEXT) */
 
-  ecma_object_t *global_env_p = ecma_get_global_environment ();
+  ecma_object_t *global_object_p = ecma_builtin_get_global ();
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  JERRY_ASSERT (global_object_p == ecma_get_object_from_value (ecma_op_function_get_realm (bytecode_p)));
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
+  ecma_object_t *global_env_p = ecma_get_global_environment (global_object_p);
   ecma_builtin_id_t fallback_proto = ECMA_BUILTIN_ID_FUNCTION_PROTOTYPE;
 
 #if ENABLED (JERRY_ESNEXT)
@@ -702,6 +712,11 @@ ecma_op_create_native_handler (ecma_native_handler_id_t id, /**< handler id */
   ext_func_obj_p->u.built_in.routine_id = (uint8_t) id;
   ext_func_obj_p->u.built_in.u2.routine_flags = ECMA_NATIVE_HANDLER_FLAGS_NONE;
 
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ECMA_SET_INTERNAL_VALUE_POINTER (ext_func_obj_p->u.built_in.realm_value,
+                                   ecma_builtin_get_global ());
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
   return function_obj_p;
 } /* ecma_op_create_native_handler */
 
@@ -716,20 +731,58 @@ inline const ecma_compiled_code_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p) /**< function pointer */
 {
 #if ENABLED (JERRY_SNAPSHOT_EXEC)
-  if (function_p->u.function.bytecode_cp != ECMA_NULL_POINTER)
+  if (JERRY_LIKELY (function_p->u.function.bytecode_cp != ECMA_NULL_POINTER))
   {
     return ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
                                             function_p->u.function.bytecode_cp);
   }
-  else
-  {
-    return ((ecma_static_function_t *) function_p)->bytecode_p;
-  }
+
+  return ((ecma_static_function_t *) function_p)->bytecode_p;
 #else /* !ENABLED (JERRY_SNAPSHOT_EXEC) */
   return ECMA_GET_INTERNAL_VALUE_POINTER (const ecma_compiled_code_t,
                                           function_p->u.function.bytecode_cp);
 #endif /* ENABLED (JERRY_SNAPSHOT_EXEC) */
 } /* ecma_op_function_get_compiled_code */
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+
+/**
+ * Get realm from a byte code.
+ *
+ * Note:
+ *   Does not increase the reference counter.
+ *
+ * @return realm (global) object
+ */
+inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+ecma_op_function_get_realm (const ecma_compiled_code_t *bytecode_header_p) /**< byte code header */
+{
+  ecma_value_t realm_value;
+
+  if (bytecode_header_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)
+  {
+    cbc_uint16_arguments_t *args_p = (cbc_uint16_arguments_t *) bytecode_header_p;
+    realm_value = args_p->realm_value;
+  }
+  else
+  {
+    cbc_uint8_arguments_t *args_p = (cbc_uint8_arguments_t *) bytecode_header_p;
+    realm_value = args_p->realm_value;
+  }
+
+#if ENABLED (JERRY_SNAPSHOT_EXEC)
+  if (JERRY_LIKELY (realm_value != ECMA_VALUE_UNDEFINED))
+  {
+    return realm_value;
+  }
+
+  return ecma_make_object_value (ecma_builtin_get_global ());
+#else /* !ENABLED (JERRY_SNAPSHOT_EXEC) */
+  return realm_value;
+#endif /* ENABLED (JERRY_SNAPSHOT_EXEC) */
+} /* ecma_op_function_get_realm */
+
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 
 /**
  * 15.3.5.3 implementation of [[HasInstance]] for Function objects
@@ -967,6 +1020,10 @@ ecma_op_function_call_simple (ecma_object_t *func_obj_p, /**< Function object */
 
   shared_args.header.bytecode_header_p = bytecode_data_p;
 
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ecma_value_t realm_value = ecma_op_function_get_realm (bytecode_data_p);
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
   /* 1. */
 #if ENABLED (JERRY_ESNEXT)
   if (JERRY_UNLIKELY (CBC_FUNCTION_IS_ARROW (status_flags)))
@@ -994,7 +1051,11 @@ ecma_op_function_call_simple (ecma_object_t *func_obj_p, /**< Function object */
           || ecma_is_value_null (this_binding))
       {
         /* 2. */
+#if ENABLED (JERRY_BUILTIN_REALMS)
+        this_binding = realm_value;
+#else /* !ENABLED (JERRY_BUILTIN_REALMS) */
         this_binding = ecma_make_object_value (ecma_builtin_get_global ());
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
       }
       else if (!ecma_is_value_object (this_binding))
       {
@@ -1039,7 +1100,16 @@ ecma_op_function_call_simple (ecma_object_t *func_obj_p, /**< Function object */
   }
 #endif /* ENABLED (JERRY_ESNEXT) */
 
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ecma_global_object_t *saved_global_object_p = JERRY_CONTEXT (global_object_p);
+  JERRY_CONTEXT (global_object_p) = (ecma_global_object_t *) ecma_get_object_from_value (realm_value);
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
   ret_value = vm_run (&shared_args.header, this_binding, scope_p);
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  JERRY_CONTEXT (global_object_p) = saved_global_object_p;
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 
 #if ENABLED (JERRY_ESNEXT)
   /* ECMAScript v6, 9.2.2.13 */
@@ -1092,7 +1162,21 @@ ecma_op_function_call_native (ecma_object_t *func_obj_p, /**< Function object */
 
   if (ecma_get_object_is_builtin (func_obj_p))
   {
-    return ecma_builtin_dispatch_call (func_obj_p, this_arg_value, arguments_list_p, arguments_list_len);
+#if ENABLED (JERRY_BUILTIN_REALMS)
+    ecma_global_object_t *saved_global_object_p = JERRY_CONTEXT (global_object_p);
+    ecma_value_t realm_value = ((ecma_extended_object_t *) func_obj_p)->u.built_in.realm_value;
+    JERRY_CONTEXT (global_object_p) = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_global_object_t, realm_value);
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
+    ecma_value_t ret_value = ecma_builtin_dispatch_call (func_obj_p,
+                                                         this_arg_value,
+                                                         arguments_list_p,
+                                                         arguments_list_len);
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+    JERRY_CONTEXT (global_object_p) = saved_global_object_p;
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+    return ret_value;
   }
 
   JERRY_ASSERT (ext_func_obj_p->u.external_handler_cb != NULL);
@@ -1377,7 +1461,27 @@ ecma_op_function_construct (ecma_object_t *func_obj_p, /**< Function object */
   {
     if (JERRY_UNLIKELY (ecma_get_object_is_builtin (func_obj_p)))
     {
-      return ecma_builtin_dispatch_construct (func_obj_p, new_target_p, arguments_list_p, arguments_list_len);
+#if ENABLED (JERRY_BUILTIN_REALMS)
+      ecma_global_object_t *saved_global_object_p = JERRY_CONTEXT (global_object_p);
+      ecma_value_t realm_value = ((ecma_extended_object_t *) func_obj_p)->u.built_in.realm_value;
+      JERRY_CONTEXT (global_object_p) = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_global_object_t, realm_value);
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
+#if ENABLED (JERRY_ESNEXT)
+      ecma_object_t *old_new_target = JERRY_CONTEXT (current_new_target);
+      JERRY_CONTEXT (current_new_target) = new_target_p;
+#endif /* ENABLED (JERRY_ESNEXT) */
+
+      ecma_value_t ret_value = ecma_builtin_dispatch_construct (func_obj_p, arguments_list_p, arguments_list_len);
+
+#if ENABLED (JERRY_ESNEXT)
+      JERRY_CONTEXT (current_new_target) = old_new_target;
+#endif /* ENABLED (JERRY_ESNEXT) */
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+      JERRY_CONTEXT (global_object_p) = saved_global_object_p;
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+      return ret_value;
     }
 
     return ecma_op_function_construct_native (func_obj_p, new_target_p, arguments_list_p, arguments_list_len);

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -56,6 +56,11 @@ ecma_op_create_external_function_object (ecma_native_handler_t handler_cb);
 const ecma_compiled_code_t *
 ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p);
 
+#if ENABLED (JERRY_BUILTIN_REALMS)
+ecma_value_t
+ecma_op_function_get_realm (const ecma_compiled_code_t *bytecode_header_p);
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
 ecma_value_t
 ecma_op_create_dynamic_function (const ecma_value_t *arguments_list_p,
                                  uint32_t arguments_list_len,

--- a/jerry-core/ecma/operations/ecma-get-put-value.c
+++ b/jerry-core/ecma/operations/ecma-get-put-value.c
@@ -304,6 +304,8 @@ ecma_op_put_value_lex_env_base (ecma_object_t *lex_env_p, /**< lexical environme
     lex_env_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, lex_env_p->u2.outer_reference_cp);
   }
 
+  JERRY_ASSERT (ecma_get_lex_env_type (lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND);
+
   if (is_strict)
   {
 #if ENABLED (JERRY_ERROR_MESSAGES)
@@ -315,7 +317,7 @@ ecma_op_put_value_lex_env_base (ecma_object_t *lex_env_p, /**< lexical environme
 #endif /* ENABLED (JERRY_ERROR_MESSAGES) */
   }
 
-  ecma_value_t completion = ecma_op_object_put (ecma_builtin_get_global (),
+  ecma_value_t completion = ecma_op_object_put (ecma_get_lex_env_binding_object (lex_env_p),
                                                 name_p,
                                                 value,
                                                 false);

--- a/jerry-core/ecma/operations/ecma-lex-env.h
+++ b/jerry-core/ecma/operations/ecma-lex-env.h
@@ -32,10 +32,10 @@
 
 void ecma_init_global_environment (void);
 void ecma_finalize_global_environment (void);
-ecma_object_t *ecma_get_global_environment (void);
-ecma_object_t *ecma_get_global_scope (void);
+ecma_object_t *ecma_get_global_environment (ecma_object_t *global_object_p);
+ecma_object_t *ecma_get_global_scope (ecma_object_t *global_object_p);
 #if ENABLED (JERRY_ESNEXT)
-void ecma_create_global_lexical_block (void);
+void ecma_create_global_lexical_block (ecma_object_t *global_object_p);
 #endif /* ENABLED (JERRY_ESNEXT) */
 
 #if ENABLED (JERRY_MODULE_SYSTEM)

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2514,7 +2514,7 @@ inline static bool
 ecma_object_check_class_name_is_object (ecma_object_t *obj_p) /**< object */
 {
 #ifndef JERRY_NDEBUG
-  return (ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_GLOBAL)
+  return (ecma_builtin_is_global (obj_p)
 #if ENABLED (JERRY_BUILTIN_PROMISE)
           || ecma_builtin_is (obj_p, ECMA_BUILTIN_ID_PROMISE_PROTOTYPE)
 #endif /* ENABLED (JERRY_BUILTIN_PROMISE) */

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -79,6 +79,23 @@ ecma_op_resolve_reference_base (ecma_object_t *lex_env_p, /**< starting lexical 
 } /* ecma_op_resolve_reference_base */
 
 #if ENABLED (JERRY_ESNEXT)
+
+/**
+ * Check if the passed lexical environment is a global lexical environment
+ *
+ * @return true  - if the lexical environment is a global lexical environment
+ *         false - otherwise
+ */
+static inline bool JERRY_ATTR_ALWAYS_INLINE
+ecma_op_is_global_environment (ecma_object_t *lex_env_p) /**< lexical environment */
+{
+  JERRY_ASSERT (ecma_get_lex_env_type (lex_env_p) == ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND);
+  JERRY_ASSERT (lex_env_p->u2.outer_reference_cp != JMEM_CP_NULL
+                || ecma_get_lex_env_binding_object (lex_env_p) == ecma_builtin_get_global ());
+
+  return lex_env_p->u2.outer_reference_cp == JMEM_CP_NULL;
+} /* ecma_op_is_global_environment */
+
 /**
  * Perform GetThisEnvironment and GetSuperBase operations
  *
@@ -173,6 +190,7 @@ ecma_op_is_prop_unscopable (ecma_object_t *binding_obj_p, /**< binding object */
 
   return ECMA_VALUE_FALSE;
 } /* ecma_op_is_prop_unscopable */
+
 #endif /* ENABLED (JERRY_ESNEXT) */
 
 /**
@@ -226,7 +244,7 @@ ecma_op_object_bound_environment_resolve_reference_value (ecma_object_t *lex_env
     }
 
 #if ENABLED (JERRY_ESNEXT)
-    if (JERRY_LIKELY (lex_env_p == ecma_get_global_scope ()))
+    if (JERRY_LIKELY (ecma_op_is_global_environment (lex_env_p)))
 #endif /* ENABLED (JERRY_ESNEXT) */
     {
       return found_binding;
@@ -297,7 +315,7 @@ ecma_op_resolve_reference_value (ecma_object_t *lex_env_p, /**< starting lexical
     else if (lex_env_type == ECMA_LEXICAL_ENVIRONMENT_THIS_OBJECT_BOUND)
     {
 #if ENABLED (JERRY_ESNEXT)
-      bool lcache_lookup_allowed = (lex_env_p == ecma_get_global_environment ());
+      bool lcache_lookup_allowed = ecma_op_is_global_environment (lex_env_p);
 #else /* !ENABLED (JERRY_ESNEXT)*/
       bool lcache_lookup_allowed = true;
 #endif /* ENABLED (JERRY_ESNEXT) */

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -105,6 +105,7 @@ typedef enum
   JERRY_FEATURE_WEAKMAP, /**< WeakMap support */
   JERRY_FEATURE_WEAKSET, /**< WeakSet support */
   JERRY_FEATURE_BIGINT, /**< BigInt support */
+  JERRY_FEATURE_REALM, /**< realm support */
   JERRY_FEATURE__COUNT /**< number of features. NOTE: must be at the end of the list */
 } jerry_feature_t;
 
@@ -600,6 +601,7 @@ jerry_value_t jerry_create_external_string_sz (const jerry_char_t *str_p, jerry_
 jerry_value_t jerry_create_symbol (const jerry_value_t value);
 jerry_value_t jerry_create_bigint (const uint64_t *digits_p, uint32_t size, bool sign);
 jerry_value_t jerry_create_undefined (void);
+jerry_value_t jerry_create_realm (void);
 
 /**
  * General API functions of JS objects.

--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -30,7 +30,7 @@ extern "C"
 /**
  * Jerry snapshot format version.
  */
-#define JERRY_SNAPSHOT_VERSION (61u)
+#define JERRY_SNAPSHOT_VERSION (62u)
 
 /**
  * Flags for jerry_generate_snapshot and jerry_generate_function_snapshot.

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -106,7 +106,7 @@ typedef struct jerry_context_data_header
 /**
  * First non-external member of the jerry context
  */
-#define JERRY_CONTEXT_FIRST_MEMBER ecma_builtin_objects
+#define JERRY_CONTEXT_FIRST_MEMBER global_object_p
 
 /**
  * JerryScript context
@@ -125,18 +125,18 @@ struct jerry_context_t
 #endif /* ENABLED (JERRY_EXTERNAL_CONTEXT) */
 
   /* Update JERRY_CONTEXT_FIRST_MEMBER if the first non-external member changes */
-  jmem_cpointer_t ecma_builtin_objects[ECMA_BUILTIN_ID__COUNT]; /**< pointer to instances of built-in objects */
+  ecma_global_object_t *global_object_p; /**< current global object */
+  jmem_heap_free_t *jmem_heap_list_skip_p; /**< improves deallocation performance */
+  jmem_pools_chunk_t *jmem_free_8_byte_chunk_p; /**< list of free eight byte pool chunks */
 #if ENABLED (JERRY_BUILTIN_REGEXP)
   re_compiled_code_t *re_cache[RE_CACHE_SIZE]; /**< regex cache */
 #endif /* ENABLED (JERRY_BUILTIN_REGEXP) */
-  jmem_cpointer_t ecma_gc_objects_cp; /**< List of currently alive objects. */
-  jmem_heap_free_t *jmem_heap_list_skip_p; /**< This is used to speed up deallocation. */
-  jmem_pools_chunk_t *jmem_free_8_byte_chunk_p; /**< list of free eight byte pool chunks */
 #if ENABLED (JERRY_CPOINTER_32_BIT)
   jmem_pools_chunk_t *jmem_free_16_byte_chunk_p; /**< list of free sixteen byte pool chunks */
 #endif /* ENABLED (JERRY_CPOINTER_32_BIT) */
   const lit_utf8_byte_t * const *lit_magic_string_ex_array; /**< array of external magic strings */
   const lit_utf8_size_t *lit_magic_string_ex_sizes; /**< external magic string lengths */
+  jmem_cpointer_t ecma_gc_objects_cp; /**< List of currently alive objects. */
   jmem_cpointer_t string_list_first_cp; /**< first item of the literal string list */
 #if ENABLED (JERRY_ESNEXT)
   jmem_cpointer_t symbol_list_first_cp; /**< first item of the global symbol list */
@@ -145,10 +145,6 @@ struct jerry_context_t
 #if ENABLED (JERRY_BUILTIN_BIGINT)
   jmem_cpointer_t bigint_list_first_cp; /**< first item of the literal bigint list */
 #endif /* ENABLED (JERRY_BUILTIN_BIGINT) */
-  jmem_cpointer_t ecma_global_env_cp; /**< global lexical environment */
-#if ENABLED (JERRY_ESNEXT)
-  jmem_cpointer_t ecma_global_scope_cp; /**< global lexical scope */
-#endif /* ENABLED (JERRY_ESNEXT) */
 
 #if ENABLED (JERRY_MODULE_SYSTEM)
   ecma_module_t *ecma_modules_p; /**< list of referenced modules */

--- a/jerry-core/parser/js/byte-code.h
+++ b/jerry-core/parser/js/byte-code.h
@@ -852,6 +852,9 @@ typedef struct
   uint8_t ident_end;                /**< end position of the identifier group */
   uint8_t const_literal_end;        /**< end position of the const literal group */
   uint8_t literal_end;              /**< end position of the literal group */
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ecma_value_t realm_value;         /**< realm value */
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 } cbc_uint8_arguments_t;
 
 /**
@@ -867,6 +870,9 @@ typedef struct
   uint16_t const_literal_end;       /**< end position of the const literal group */
   uint16_t literal_end;             /**< end position of the literal group */
   uint16_t padding;                 /**< an unused value */
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ecma_value_t realm_value;         /**< realm value */
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 } cbc_uint16_arguments_t;
 
 /**
@@ -901,6 +907,7 @@ typedef enum
   CBC_FUNCTION_CONSTRUCTOR, /**< constructor function */
 
   /* The following functions cannot be constructed (see CBC_FUNCTION_IS_CONSTRUCTABLE) */
+  CBC_FUNCTION_SCRIPT, /**< script (global) function */
   CBC_FUNCTION_GENERATOR, /**< generator function */
   CBC_FUNCTION_ASYNC, /**< async function */
   CBC_FUNCTION_ASYNC_GENERATOR, /**< async generator function */

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -977,6 +977,9 @@ parser_post_processing (parser_context_t *context_p) /**< context */
     args_p->ident_end = ident_end;
     args_p->const_literal_end = const_literal_end;
     args_p->literal_end = context_p->literal_count;
+#if ENABLED (JERRY_BUILTIN_REALMS)
+    args_p->realm_value = ecma_make_object_value ((ecma_object_t *) JERRY_CONTEXT (global_object_p));
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 
     compiled_code_p->status_flags |= CBC_CODE_FLAGS_UINT16_ARGUMENTS;
     byte_code_p += sizeof (cbc_uint16_arguments_t);
@@ -991,6 +994,9 @@ parser_post_processing (parser_context_t *context_p) /**< context */
     args_p->ident_end = (uint8_t) ident_end;
     args_p->const_literal_end = (uint8_t) const_literal_end;
     args_p->literal_end = (uint8_t) context_p->literal_count;
+#if ENABLED (JERRY_BUILTIN_REALMS)
+    args_p->realm_value = ecma_make_object_value ((ecma_object_t *) JERRY_CONTEXT (global_object_p));
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 
     byte_code_p += sizeof (cbc_uint8_arguments_t);
   }
@@ -1032,6 +1038,10 @@ parser_post_processing (parser_context_t *context_p) /**< context */
   {
     function_type = CBC_FUNCTION_TO_TYPE_BITS (CBC_FUNCTION_ACCESSOR);
   }
+  else if (!(context_p->status_flags & PARSER_IS_FUNCTION))
+  {
+    function_type = CBC_FUNCTION_TO_TYPE_BITS (CBC_FUNCTION_SCRIPT);
+  }
 #if ENABLED (JERRY_ESNEXT)
   else if (context_p->status_flags & PARSER_IS_ARROW_FUNCTION)
   {
@@ -1066,10 +1076,6 @@ parser_post_processing (parser_context_t *context_p) /**< context */
   else if (context_p->status_flags & PARSER_IS_METHOD)
   {
     function_type = CBC_FUNCTION_TO_TYPE_BITS (CBC_FUNCTION_METHOD);
-  }
-  else
-  {
-    function_type = CBC_FUNCTION_TO_TYPE_BITS (CBC_FUNCTION_NORMAL);
   }
 
   if (context_p->status_flags & PARSER_LEXICAL_BLOCK_NEEDED)

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -842,7 +842,17 @@ opfunc_resume_executable_object (vm_executable_object_t *executable_object_p, /*
   ecma_object_t *old_new_target = JERRY_CONTEXT (current_new_target);
   JERRY_CONTEXT (current_new_target) = NULL;
 
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  ecma_global_object_t *saved_global_object_p = JERRY_CONTEXT (global_object_p);
+  ecma_value_t realm_value = ecma_op_function_get_realm (bytecode_header_p);
+  JERRY_CONTEXT (global_object_p) = (ecma_global_object_t *) ecma_get_object_from_value (realm_value);
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
+
   ecma_value_t result = vm_execute (&executable_object_p->frame_ctx);
+
+#if ENABLED (JERRY_BUILTIN_REALMS)
+  JERRY_CONTEXT (global_object_p) = saved_global_object_p;
+#endif /* ENABLED (JERRY_BUILTIN_REALMS) */
 
   JERRY_CONTEXT (current_new_target) = old_new_target;
   executable_object_p->extended_object.u.class_prop.extra_info &= (uint16_t) ~ECMA_EXECUTABLE_OBJECT_RUNNING;

--- a/jerry-main/main-utils.c
+++ b/jerry-main/main-utils.c
@@ -44,6 +44,19 @@ main_register_global_function (const char *name_p, /**< name of the function */
   jerry_release_value (result_val);
 } /* main_register_global_function */
 
+static jerry_value_t
+main_create_realm (const jerry_value_t func_obj_val, /**< function object */
+                   const jerry_value_t this_p, /**< this arg */
+                   const jerry_value_t args_p[], /**< function arguments */
+                   const jerry_length_t args_cnt) /**< number of function arguments */
+{
+  (void) func_obj_val; /* unused */
+  (void) this_p; /* unused */
+  (void) args_p; /* unused */
+  (void) args_cnt; /* unused */
+  return jerry_create_realm ();
+} /* main_create_realm */
+
 /**
  * Inits the engine and the debugger
  */
@@ -81,6 +94,7 @@ main_init_engine (main_args_t *arguments_p) /** main arguments */
   main_register_global_function ("gc", jerryx_handler_gc);
   main_register_global_function ("print", jerryx_handler_print);
   main_register_global_function ("resourceName", jerryx_handler_resource_name);
+  main_register_global_function ("createRealm", main_create_realm);
 } /* main_init_engine */
 
 /**

--- a/tests/debugger/do_variables.expected
+++ b/tests/debugger/do_variables.expected
@@ -9,6 +9,7 @@ f            | Function  |
 addX         | Function  |           
 z            | undefined | undefined 
 c            | undefined | undefined 
+createRealm  | Function  |           
 resourceName | Function  |           
 print        | Function  |           
 gc           | Function  |           
@@ -21,6 +22,7 @@ f            | Function  |
 addX         | Function  |           
 z            | undefined | undefined 
 c            | undefined | undefined 
+createRealm  | Function  |           
 resourceName | Function  |           
 print        | Function  |           
 gc           | Function  |           
@@ -48,6 +50,7 @@ f            | Function |
 addX         | Function |       
 z            | Number   | 5     
 c            | Number   | 4     
+createRealm  | Function |       
 resourceName | Function |       
 print        | Function |       
 gc           | Function |       
@@ -68,6 +71,7 @@ f            | Function |
 addX         | Function |       
 z            | Number   | 5     
 c            | Number   | 4     
+createRealm  | Function |       
 resourceName | Function |       
 print        | Function |       
 gc           | Function |       

--- a/tests/jerry/es.next/realms1.js
+++ b/tests/jerry/es.next/realms1.js
@@ -1,0 +1,95 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var realm = createRealm()
+var ev = realm.eval
+
+assert(realm.Math != Math)
+assert(typeof realm.Math === "object")
+assert(realm.Object != Object)
+assert(typeof realm.Object === "function")
+assert(realm.eval != eval)
+assert(typeof realm.eval === "function")
+
+// Share our 'assert' function with the realm
+realm.assert = assert
+
+// Test1: var1 and var2 must be different properties
+
+realm.var1 = 3.5
+assert(realm.var2 === undefined)
+
+var var1 = "X"
+var var2 = "Y"
+
+ev("assert(var1 === 3.5); \
+    try { realm; assert(false) } catch (e) { assert(e instanceof ReferenceError) } \
+    assert(this === globalThis); \
+    var var2 = this")
+assert(realm.var2 === realm)
+
+assert(var1 === "X")
+assert(var2 === "Y")
+
+// Test2: constructing any objects (including errors) must use the realm
+
+assert (realm.RangeError != RangeError)
+assert (realm.RangeError.prototype != RangeError.prototype)
+
+realm.RangeError.prototype.myProperty = "XY"
+assert(RangeError.prototype.myProperty === undefined)
+
+try {
+  var NumberToString = realm.Number.prototype.toString;
+  NumberToString.call(0, 0)
+  assert(false)
+} catch (e) {
+  assert(e instanceof realm.RangeError)
+  assert(!(e instanceof RangeError))
+  assert(e.myProperty === "XY")
+}
+
+assert (realm.SyntaxError != SyntaxError)
+assert (realm.SyntaxError.prototype != SyntaxError.prototype)
+
+realm.SyntaxError.prototype.myProperty = "AB"
+assert(SyntaxError.prototype.myProperty === undefined)
+
+try {
+  ev("5 +")
+  assert(false)
+} catch (e) {
+  assert(e instanceof realm.SyntaxError)
+  assert(!(e instanceof SyntaxError))
+  assert(e.myProperty === "AB")
+}
+
+// Test3: only the realm corresponding to the function matters
+
+realm.Boolean.prototype.valueOf.a = Function.prototype.apply
+Boolean.prototype.valueOf.a = realm.Function.prototype.apply
+
+try {
+  realm.Boolean.prototype.valueOf.a()
+} catch (e) {
+  assert(e instanceof realm.TypeError)
+  assert(!(e instanceof TypeError))
+}
+
+try {
+  Boolean.prototype.valueOf.a()
+} catch (e) {
+  assert(e instanceof TypeError)
+  assert(!(e instanceof realm.TypeError))
+}

--- a/tests/jerry/es.next/realms2.js
+++ b/tests/jerry/es.next/realms2.js
@@ -1,0 +1,48 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test1: realm cannot be gc-ed until it is referenced
+
+function f1() {
+  var ev = createRealm().eval
+
+  gc()
+
+  try {
+    ev("5 +")
+  } catch (e) {
+    assert(e instanceof ev("this").SyntaxError)
+    assert(!(e instanceof SyntaxError))
+  }
+}
+f1()
+
+// Test2: built-ins cannot be gc-ed until the realm exists
+
+function f2() {
+  var realm = createRealm()
+
+  var str = new realm.String("A");
+  // Assign a property to String.prototype
+  Object.getPrototypeOf(str).myProperty = "XY"
+
+  str = null
+  // No reference to String.prototype
+  gc()
+
+  str = new realm.String("A")
+  assert(Object.getPrototypeOf(str).myProperty === "XY")
+  assert(realm.String.prototype.myProperty === "XY")
+}
+f2()

--- a/tests/jerry/es.next/realms3.js
+++ b/tests/jerry/es.next/realms3.js
@@ -1,0 +1,198 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test1: reading global values from other realms
+
+var a = 4.5
+
+function f1()
+{
+  var realm = createRealm()
+  var f = realm.eval("function g() { return a } g")
+
+  realm.a = -6.25
+  assert(f() === -6.25)
+  assert(a === 4.5)
+  assert(realm.g === f)
+
+  realm.eval("var v1 = 6; eval('var v2 = 7.5')")
+  assert(realm.v1 === 6)
+  assert(realm.v2 === 7.5)
+
+  var e = realm.eval
+
+  eval("e('var v3 = -5.25'); var v3 = 1.5; e('v3++')")
+  assert(realm.v3 === -4.25)
+  assert(v3 === 1.5)
+}
+f1()
+
+// Test2: recursive calls
+
+var b = "S"
+
+function f2()
+{
+  function f(fun) {
+    return fun() + b;
+  }
+
+  var realm = createRealm()
+
+  realm.eval("function h() { return b }")
+
+  var g = realm.Function("fun", "return fun(h) + b")
+
+  realm.b = "X"
+  assert(g(f) === "XSX")
+  assert(b === "S")
+}
+f2()
+
+// Test3: built-in functions
+
+function f3()
+{
+  var realm = createRealm()
+
+  realm.f = function () { return eval("/a/") }
+
+  var res = realm.eval("[f(), /a/, f(), /b/]")
+
+  assert(Object.getPrototypeOf(res[0]) === RegExp.prototype)
+  assert(Object.getPrototypeOf(res[1]) === realm.RegExp.prototype)
+  assert(Object.getPrototypeOf(res[2]) === RegExp.prototype)
+  assert(Object.getPrototypeOf(res[3]) === realm.RegExp.prototype)
+
+  realm.g = function () { return non_existent }
+
+  try {
+    realm.eval("g()")
+    assert(false)
+  } catch (e) {
+    assert(e instanceof ReferenceError)
+    assert(!(e instanceof realm.ReferenceError))
+  }
+
+  try {
+    realm.eval("non_existent")
+    assert(false)
+  } catch (e) {
+    assert(e instanceof realm.ReferenceError)
+    assert(!(e instanceof ReferenceError))
+  }
+}
+f3()
+
+// Test4: generator functions
+
+function f4()
+{
+  function f() {
+    return b;
+  }
+
+  var realm = createRealm()
+
+  function check_gen_result(result, value, done)
+  {
+    assert(Object.getPrototypeOf(result) === realm.Object.prototype)
+    assert(result.value === value)
+    assert(result.done === done)
+  }
+
+  realm.eval("var a = 'P', b = 'Q'")
+
+  var gen = realm.eval("function* gen(f) { yield f() + a; yield f() + b; return a + b + f() }")
+
+  var it = realm.gen(f)
+
+  check_gen_result(it.next(), "SP", false)
+  check_gen_result(it.next(), "SQ", false)
+  check_gen_result(it.next(), "PQS", true)
+}
+f4()
+
+// Test5: async functions
+
+var successCount = 0
+
+function f5()
+{
+  function f() {
+    return b;
+  }
+
+  var r, p = new Promise(function(resolve, reject) { r = resolve })
+
+  var realm = createRealm()
+
+  realm.assert = assert
+  realm.eval("async function asy(p, f) { assert(f() === 'S'); assert(await p === 4.5); return f() + b }")
+
+  realm.b = "X"
+
+  realm.asy(p, f).then(function(v) {
+    assert(v === "SX")
+    successCount++
+  }, function() {
+    assert(false)
+  })
+  r(4.5)
+}
+f5()
+
+// Test6: async generator functions
+
+function f6()
+{
+  function f() {
+    return b;
+  }
+
+  var r, p = new Promise(function(resolve, reject) { r = resolve })
+
+  var realm = createRealm()
+
+  function check_fulfilled(p, value, done)
+  {
+    assert(p instanceof realm.Promise)
+
+    p.then(function(v) {
+      assert(v.value === value)
+      assert(v.done === done)
+      successCount++
+    }, function() {
+      assert(false)
+    })
+  }
+
+  realm.assert = assert
+  realm.eval("async function *asygen(p, f) { assert(f() === 'S'); assert(await p === -1.5); yield f() + a; return f() + b }")
+
+  realm.a = "X"
+  realm.b = "Y"
+
+  var gen = realm.asygen(p, f)
+
+  check_fulfilled(gen.next(), "SX", false)
+  check_fulfilled(gen.next(), "SY", true)
+
+  r(-1.5)
+}
+f6()
+
+function __checkAsync() {
+  assert(successCount === 3)
+}

--- a/tests/jerry/regression-test-issue-2105.js
+++ b/tests/jerry/regression-test-issue-2105.js
@@ -51,4 +51,4 @@ try {
 /* Check properties of a */
 assert(Object.keys(a) == "one,two");
 /* Check properties of global object */
-assert(Object.keys(this) == "assert,gc,print,resourceName,a,fail,fail_two");
+assert(Object.keys(this) == "assert,gc,print,resourceName,createRealm,a,fail,fail_two");


### PR DESCRIPTION
- Type for realm objects is introduced (ecma_global_object_t)
- Realm reference is added to built-in objects and ECMAScript functions
- Resolving built-ins, global environments, and scopes require realm object
- Unnecessary global object accesses are removed from the code

Missing: external functions and static snapshot functions have no realm reference