### PR TITLE
Correctly release wrapper object in JSON stringify

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1268,6 +1268,7 @@ ecma_builtin_json_serialize_property (ecma_json_stringify_context_t *context_p, 
 
     if (ECMA_IS_VALUE_ERROR (to_json))
     {
+      ecma_free_value (value);
       return to_json;
     }
 

--- a/tests/jerry/es.next/json-stringify.js
+++ b/tests/jerry/es.next/json-stringify.js
@@ -51,3 +51,14 @@ try {
 assert(JSON.stringify("ab𬄕c") === '"ab𬄕\\u001fc"');
 assert(JSON.stringify("ab\uDC01cd") === '"ab\\udc01c\\u001fd"');
 assert(JSON.stringify("ab\uDC01cd\uD8331e") === '"ab\\udc01c\\u001fd\\ud8331e"');
+
+// Test case where the proxy is already revoked
+var handle = Proxy.revocable([], {});
+handle.revoke();
+
+try {
+  JSON.stringify(handle.proxy);
+  assert(false);
+} catch (ex) {
+  assert(ex instanceof TypeError);
+}


### PR DESCRIPTION
When an error occurs accessing a property during JSON stringify call
the wrapper object is not freed at the correct place.
