### PR TITLE
Add missing BigInt type for value type query API

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -27,8 +27,11 @@ Enum that contains JerryScript API value types:
  - JERRY_TYPE_FUNCTION - function type
  - JERRY_TYPE_ERROR - error/abort type
  - JERRY_TYPE_SYMBOL - symbol type
+ - JERRY_TYPE_BIGINT - bigint type
 
 *New in version 2.0*.
+
+*Changed in [[NEXT_RELEASE]]*: Added `JERRY_TYPE_BIGINT` value.
 
 ## jerry_object_type_t
 

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -985,6 +985,12 @@ jerry_value_get_type (const jerry_value_t value) /**< input value to check */
     {
       return JERRY_TYPE_FUNCTION;
     }
+#if ENABLED (JERRY_BUILTIN_BIGINT)
+    case LIT_MAGIC_STRING_BIGINT:
+    {
+      return JERRY_TYPE_BIGINT;
+    }
+#endif /* ENABLED (JERRY_BUILTIN_BIGINT) */
     default:
     {
       JERRY_ASSERT (lit_id == LIT_MAGIC_STRING_OBJECT);

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -411,6 +411,7 @@ typedef enum
   JERRY_TYPE_FUNCTION,  /**< function type */
   JERRY_TYPE_ERROR,     /**< error/abort type */
   JERRY_TYPE_SYMBOL,    /**< symbol type */
+  JERRY_TYPE_BIGINT,    /**< bigint type */
 } jerry_type_t;
 
 /**

--- a/tests/unit-core/test-api-value-type.c
+++ b/tests/unit-core/test-api-value-type.c
@@ -99,6 +99,31 @@ main (void)
     jerry_release_value (symbol_desc_value);
   }
 
+  if (jerry_is_feature_enabled (JERRY_FEATURE_BIGINT))
+  {
+    /* Check simple bigint value type */
+    uint64_t digits_buffer[2] = { 1, 0 };
+    jerry_value_t value_bigint = jerry_create_bigint (digits_buffer, 2, false);
+    jerry_type_t value_type_info = jerry_value_get_type (value_bigint);
+
+    TEST_ASSERT (value_type_info != JERRY_TYPE_NONE);
+    TEST_ASSERT (value_type_info == JERRY_TYPE_BIGINT);
+
+    jerry_release_value (value_bigint);
+
+    /* Check bigint wrapped in object type */
+    jerry_char_t object_bigint_src[] = "Object(5n)";
+    jerry_value_t object_bigint = jerry_eval (object_bigint_src, sizeof (object_bigint_src) - 1, JERRY_PARSE_NO_OPTS);
+    TEST_ASSERT (!jerry_value_is_error (object_bigint));
+
+    jerry_type_t object_type_info = jerry_value_get_type (object_bigint);
+
+    TEST_ASSERT (object_type_info != JERRY_TYPE_NONE);
+    TEST_ASSERT (object_type_info == JERRY_TYPE_OBJECT);
+
+    jerry_release_value (object_bigint);
+  }
+
   jerry_cleanup ();
 
   return 0;


### PR DESCRIPTION
Extended the `jerry_type_t` enum with `JERRY_TYPE_BIGINT` and added it to the `jerry_value_get_type`.
