### PR TITLE
Fix assert in BigInt TypedArray filter and reduce methods

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -323,7 +323,7 @@ ecma_builtin_typedarray_prototype_reduce_with_direction (ecma_value_t this_arg, 
 
     ecma_value_t call_args[] = { accumulator, get_value, current_index, this_arg };
 
-    JERRY_ASSERT (ecma_is_value_number (get_value));
+    JERRY_ASSERT (ecma_is_value_number (get_value) || ecma_is_value_bigint (get_value));
 
     ecma_value_t call_value = ecma_op_function_call (func_object_p,
                                                      ECMA_VALUE_UNDEFINED,
@@ -400,7 +400,7 @@ ecma_builtin_typedarray_prototype_filter (ecma_value_t this_arg, /**< this objec
     ecma_value_t current_index = ecma_make_uint32_value (index);
     ecma_value_t get_value = getter_cb (info_p->buffer_p + byte_pos);
 
-    JERRY_ASSERT (ecma_is_value_number (get_value));
+    JERRY_ASSERT (ecma_is_value_number (get_value) || ecma_is_value_bigint (get_value));
 
     ecma_value_t call_args[] = { get_value, current_index, this_arg };
 

--- a/tests/jerry/es.next/bigint-typedarray-prototype-filter.js
+++ b/tests/jerry/es.next/bigint-typedarray-prototype-filter.js
@@ -1,0 +1,34 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function arrayEquals(result, expected) {
+  assert(result.length === expected.length);
+
+  for (var idx = 0; idx < result.length; idx++) {
+    assert(result[idx] === expected[idx]);
+  }
+}
+
+var bigint64_array = new BigInt64Array([1n, 2n, 3n, -4n, 5n]);
+
+function positive(element, index, array) {
+  return element > 0n;
+}
+
+var bigint64_filter = bigint64_array.filter(positive);
+arrayEquals(bigint64_filter, [1n, 2n, 3n, 5n]);
+
+var biguint64_array = new BigUint64Array([1n, 2n, 3n, -4n, 5n]);
+var biguint64_filter = biguint64_array.filter(positive);
+assert(biguint64_filter.length === 5);

--- a/tests/jerry/es.next/bigint-typedarray-prototype-reduce.js
+++ b/tests/jerry/es.next/bigint-typedarray-prototype-reduce.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var bigint64_array = new BigInt64Array([1n, 2n, 3n, -4n, 5n]);
+
+function sum(prev, current) {
+  return prev + current;
+}
+
+var bigint64_reduce_result = bigint64_array.reduce(sum, 7n);
+assert(bigint64_reduce_result === 14n);
+
+var biguint64_array = new BigUint64Array([1n, 2n, 3n, -4n, 5n]);
+var biguint64_reduce_result = biguint64_array.reduce(sum, 7n);
+assert(biguint64_reduce_result === 18446744073709551630n);


### PR DESCRIPTION
The assert in the reduce and filter methods did not checked if the given value is a BigInt. This missing check caused the assert to fail.

Fixes #4219
Fixes #4215
