### PR TITLE
timeout are not working on windows.

### DIFF
--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -173,12 +173,6 @@ def main(args):
         util.set_timezone('Pacific Standard Time')
 
     command = (args.runtime + ' ' + args.engine).strip()
-    if args.es2015 or args.esnext:
-        try:
-            subprocess.check_output(["timeout", "--version"])
-            command = "timeout 5 " + command
-        except subprocess.CalledProcessError:
-            pass
 
     kwargs = {}
     if sys.version_info.major >= 3:


### PR DESCRIPTION
Fix the test262 timeout on Windows

Use the platform independent python threading.Timer instead of the unix only timeout tool.

The timeout error are like the following things:

```
C:\Users\lygstate>timeout -version
Error: The specified timeout (/T) value is invalid. The valid range is from -1 to 99999 seconds.

C:\Users\lygstate>timeout 0 python
Error: invalid syntax. The default option does not allow more than '1' times.
Type "TIMEOUT /?" to learn how to use it.
```

timeout option are added for future ES5.1 test262 usage
in pull request
https://github.com/jerryscript-project/jerryscript/pull/4391

The timeout setting to 60 to getting maximal tolerance
By doing this also fixes tests for es2015:
built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js
built-ins/decodeURI/S15.1.3.1_A2.5_T1.js

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
