### PR TITLE
Make test262-harness.py Python 3-compatible

### DIFF
--- a/tools/runners/test262-harness.py
+++ b/tools/runners/test262-harness.py
@@ -129,7 +129,7 @@ def my_maybe_list(value):
 def my_multiline_list(lines, value):
     # assume no explcit indentor (otherwise have to parse value)
     value = []
-    indent = None
+    indent = 0
     while lines:
         line = lines.pop(0)
         leading = my_leading_spaces(line)


### PR DESCRIPTION
indent are using to do arithmetic compare
`leading < indent`, and None can't do that.

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
