### PR TITLE
Revise tools scripts to be python3 compatible

### DIFF
--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -286,7 +286,7 @@ def create_binary(job, options):
         subprocess.check_output(build_cmd)
         ret = 0
     except subprocess.CalledProcessError as err:
-        print(err.output)
+        print(err.output.decode(errors="ignore"))
         ret = err.returncode
 
     BINARY_CACHE[binary_key] = (ret, build_dir_path)
@@ -495,6 +495,7 @@ def run_buildoption_test(options):
 Check = collections.namedtuple('Check', ['enabled', 'runner', 'arg'])
 
 def main(options):
+    util.setup_stdio()
     checks = [
         Check(options.check_signed_off, run_check, [settings.SIGNED_OFF_SCRIPT]
               + {'tolerant': ['--tolerant'], 'gh-actions': ['--gh-actions']}.get(options.check_signed_off, [])),

--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -24,12 +24,6 @@ import sys
 
 import util
 
-def get_platform_cmd_prefix():
-    if sys.platform == 'win32':
-        return ['cmd', '/S', '/C']
-    return ['python2']  # The official test262.py isn't python3 compatible, but has python shebang.
-
-
 def get_arguments():
     execution_runtime = os.environ.get('RUNTIME', '')
     parser = argparse.ArgumentParser()
@@ -172,6 +166,7 @@ def update_exclude_list(args):
 
 
 def main(args):
+    util.setup_stdio()
     return_code = prepare_test262_test_suite(args)
     if return_code:
         return return_code
@@ -192,7 +187,7 @@ def main(args):
     else:
         test262_harness_path = os.path.join(args.test262_harness_dir, 'test262-harness.py')
 
-    test262_command = get_platform_cmd_prefix() + \
+    test262_command = util.get_python_cmd_prefix() + \
                       [test262_harness_path,
                        '--command', command,
                        '--tests', args.test_dir,

--- a/tools/runners/run-test-suite.py
+++ b/tools/runners/run-test-suite.py
@@ -79,6 +79,7 @@ def execute_test_command(test_cmd):
     kwargs = {}
     if sys.version_info.major >= 3:
         kwargs['encoding'] = 'unicode_escape'
+        kwargs['errors'] = 'ignore'
     process = subprocess.Popen(test_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                universal_newlines=True, **kwargs)
     stdout = process.communicate()[0]
@@ -86,6 +87,7 @@ def execute_test_command(test_cmd):
 
 
 def main(args):
+    util.setup_stdio()
     tests = get_tests(args.test_dir, args.test_list, args.skip_list)
     total = len(tests)
     if total == 0:

--- a/tools/runners/run-unittests.py
+++ b/tools/runners/run-unittests.py
@@ -50,6 +50,7 @@ def get_unittests(path):
 
 
 def main(args):
+    util.setup_stdio()
     unittests = get_unittests(args.path)
     total = len(unittests)
     if total == 0:

--- a/tools/runners/util.py
+++ b/tools/runners/util.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import print_function
+import codecs
 import signal
 import subprocess
 import sys
@@ -43,6 +44,17 @@ def get_timezone():
 def set_sighdl_to_reset_timezone(timezone):
     assert sys.platform == 'win32', "install_signal_handler_to_restore_timezone is Windows only function"
     signal.signal(signal.SIGINT, lambda signal, frame: set_timezone_and_exit(timezone))
+
+
+def setup_stdio():
+    (out_stream, err_stream) = (sys.stdout, sys.stderr)
+    if sys.version_info.major >= 3:
+        (out_stream, err_stream) = (sys.stdout.buffer, sys.stderr.buffer)
+    # For tty using native encoding, otherwise (pipe) use 'utf-8'
+    encoding = sys.stdout.encoding if sys.stdout.isatty() else 'utf-8'
+    # Always override it to anvoid encode error
+    sys.stdout = codecs.getwriter(encoding)(out_stream, 'xmlcharrefreplace')
+    sys.stderr = codecs.getwriter(encoding)(err_stream, 'xmlcharrefreplace')
 
 
 def print_test_summary(summary_string, total, passed, failed):


### PR DESCRIPTION
Revise tools scripts to be python3 compatible
We introduce setup_stdio function to setup stdout/stderr properly.
For python <-> python pipe, we always use 'utf8'/'ignore' encoding for not lost
characters.
For tty <-> python, we using native encoding with xmlcharrefreplace to encode, to
preserve maximal information.
For python <-> native program, we use naive encoding with 'ignore' to not cause error

For reading/writing to file, we use 'utf8' /'ignore' encoding for not lost
characters.

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com