### PR TITLE
Fixes ENABLE_AMALGAM need FORCE set to ON when building with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,10 +105,8 @@ if(USING_TI)
 endif()
 
 if(USING_MSVC)
-  set(ENABLE_AMALGAM     ON) # FIXME: This should not be needed but right now it is. To be tracked down and followed up.
   set(ENABLE_STRIP       OFF)
 
-  set(ENABLE_AMALGAM_MESSAGE     " (FORCED BY COMPILER)")
   set(ENABLE_STRIP_MESSAGE       " (FORCED BY COMPILER)")
 endif()
 

--- a/jerry-core/ecma/base/ecma-alloc.c
+++ b/jerry-core/ecma/base/ecma-alloc.c
@@ -71,7 +71,7 @@ ecma_dealloc_number (ecma_number_t *number_p) /**< number to be freed */
  *
  * @return pointer to allocated memory
  */
-inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_object (void)
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -84,7 +84,7 @@ ecma_alloc_object (void)
 /**
  * Dealloc memory from an ecma-object
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_object (ecma_object_t *object_p) /**< object to be freed */
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -99,7 +99,7 @@ ecma_dealloc_object (ecma_object_t *object_p) /**< object to be freed */
  *
  * @return pointer to allocated memory
  */
-inline ecma_extended_object_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_extended_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_extended_object (size_t size) /**< size of object */
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -112,7 +112,7 @@ ecma_alloc_extended_object (size_t size) /**< size of object */
 /**
  * Dealloc memory of an extended object
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_extended_object (ecma_object_t *object_p, /**< extended object */
                               size_t size) /**< size of object */
 {
@@ -128,7 +128,7 @@ ecma_dealloc_extended_object (ecma_object_t *object_p, /**< extended object */
  *
  * @return pointer to allocated memory
  */
-inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_string (void)
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -141,7 +141,7 @@ ecma_alloc_string (void)
 /**
  * Dealloc memory from ecma-string descriptor
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_string (ecma_string_t *string_p) /**< string to be freed */
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -156,7 +156,7 @@ ecma_dealloc_string (ecma_string_t *string_p) /**< string to be freed */
  *
  * @return pointer to allocated memory
  */
-inline ecma_extended_string_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_extended_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_extended_string (void)
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -169,7 +169,7 @@ ecma_alloc_extended_string (void)
 /**
  * Dealloc memory from extended ecma-string descriptor
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_extended_string (ecma_extended_string_t *ext_string_p) /**< extended string to be freed */
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -184,7 +184,7 @@ ecma_dealloc_extended_string (ecma_extended_string_t *ext_string_p) /**< extende
  *
  * @return pointer to allocated memory
  */
-inline ecma_external_string_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_external_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_external_string (void)
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -197,7 +197,7 @@ ecma_alloc_external_string (void)
 /**
  * Dealloc memory from external ecma-string descriptor
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_external_string (ecma_external_string_t *ext_string_p) /**< external string to be freed */
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -212,7 +212,7 @@ ecma_dealloc_external_string (ecma_external_string_t *ext_string_p) /**< externa
  *
  * @return pointer to allocated memory
  */
-inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_string_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_string_buffer (size_t size) /**< size of string */
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -225,7 +225,7 @@ ecma_alloc_string_buffer (size_t size) /**< size of string */
 /**
  * Dealloc memory of a string with character data
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_string_buffer (ecma_string_t *string_p, /**< string with data */
                             size_t size) /**< size of string */
 {
@@ -241,7 +241,7 @@ ecma_dealloc_string_buffer (ecma_string_t *string_p, /**< string with data */
  *
  * @return pointer to allocated memory
  */
-inline ecma_property_pair_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_property_pair_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_alloc_property_pair (void)
 {
 #if ENABLED (JERRY_MEM_STATS)
@@ -254,7 +254,7 @@ ecma_alloc_property_pair (void)
 /**
  * Dealloc memory of an ecma-property
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_dealloc_property_pair (ecma_property_pair_t *property_pair_p) /**< property pair to be freed */
 {
 #if ENABLED (JERRY_MEM_STATS)

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -111,7 +111,7 @@ ecma_gc_set_object_visited (ecma_object_t *object_p) /**< object */
 /**
  * Initialize GC information for the object
  */
-inline void
+extern inline void
 ecma_init_gc_info (ecma_object_t *object_p) /**< object */
 {
   JERRY_CONTEXT (ecma_gc_objects_number)++;
@@ -143,7 +143,7 @@ ecma_ref_object (ecma_object_t *object_p) /**< object */
 /**
  * Decrease reference counter of an object
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_deref_object (ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p->type_flags_refs >= ECMA_OBJECT_REF_ONE);

--- a/jerry-core/ecma/base/ecma-helpers-collection.c
+++ b/jerry-core/ecma/base/ecma-helpers-collection.c
@@ -49,7 +49,7 @@ ecma_new_collection (void)
 /**
  * Deallocate a collection of ecma values without freeing it's values
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_collection_destroy (ecma_collection_t *collection_p) /**< value collection */
 {
   JERRY_ASSERT (collection_p != NULL);

--- a/jerry-core/ecma/base/ecma-helpers-errol.c
+++ b/jerry-core/ecma/base/ecma-helpers-errol.c
@@ -133,7 +133,7 @@ ecma_divide_high_prec_by_10 (ecma_high_prec_t *hp_data_p) /**< [in, out] high-pr
  *
  * @return number of generated digits
  */
-inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 ecma_errol0_dtoa (double val, /**< ecma number */
                   lit_utf8_byte_t *buffer_p, /**< buffer to generate digits into */
                   int32_t *exp_p) /**< [out] exponent */

--- a/jerry-core/ecma/base/ecma-helpers-number.c
+++ b/jerry-core/ecma/base/ecma-helpers-number.c
@@ -282,7 +282,7 @@ ecma_number_make_infinity (bool sign) /**< true - for negative Infinity,
  * @return true - if sign bit of ecma-number is set
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_number_is_negative (ecma_number_t num) /**< ecma-number */
 {
   JERRY_ASSERT (!ecma_number_is_nan (num));
@@ -688,7 +688,7 @@ ecma_number_pow (ecma_number_t x, /**< left operand */
  *
  * @return number - result of multiplication.
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_integer_multiply (ecma_integer_value_t left_integer, /**< left operand */
                        ecma_integer_value_t right_integer) /**< right operand */
 {

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -1012,7 +1012,7 @@ ecma_string_to_number (const ecma_string_t *string_p) /**< ecma-string */
  * @return ECMA_STRING_NOT_ARRAY_INDEX if string is not array index
  *         the array index otherwise
  */
-inline uint32_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_get_array_index (const ecma_string_t *str_p) /**< ecma-string */
 {
   if (ECMA_IS_DIRECT_STRING (str_p))
@@ -1369,7 +1369,7 @@ ecma_substring_copy_to_utf8_buffer (const ecma_string_t *string_desc_p, /**< ecm
  * It is the caller's responsibility to make sure that the string fits in the buffer.
  * Check if the size of the string is equal with the size of the buffer.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_string_to_utf8_bytes (const ecma_string_t *string_desc_p, /**< ecma-string descriptor */
                            lit_utf8_byte_t *buffer_p, /**< destination buffer pointer
                                                        * (can be NULL if buffer_size == 0) */
@@ -1589,7 +1589,7 @@ ecma_string_get_chars (const ecma_string_t *string_p, /**< ecma-string */
  * @return true - if the string equals to the magic string id
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_compare_ecma_string_to_magic_id (const ecma_string_t *string_p, /**< property name */
                                       lit_magic_string_id_t id) /**< magic string id */
 {
@@ -1602,7 +1602,7 @@ ecma_compare_ecma_string_to_magic_id (const ecma_string_t *string_p, /**< proper
  * @return true - if the string is an empty string
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_string_is_empty (const ecma_string_t *string_p) /**< ecma-string */
 {
   return ecma_compare_ecma_string_to_magic_id (string_p, LIT_MAGIC_STRING__EMPTY);
@@ -1614,7 +1614,7 @@ ecma_string_is_empty (const ecma_string_t *string_p) /**< ecma-string */
  * @return true - if the string equals to "length"
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_string_is_length (const ecma_string_t *string_p) /**< property name */
 {
   return ecma_compare_ecma_string_to_magic_id (string_p, LIT_MAGIC_STRING_LENGTH);
@@ -1639,7 +1639,7 @@ ecma_property_to_string (ecma_property_t property, /**< property name type */
  *
  * @return the compressed pointer part of the name
  */
-inline jmem_cpointer_t JERRY_ATTR_ALWAYS_INLINE
+extern inline jmem_cpointer_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_to_property_name (ecma_string_t *prop_name_p, /**< property name */
                               ecma_property_t *name_type_p) /**< [out] property name type */
 {
@@ -1683,7 +1683,7 @@ ecma_string_from_property_name (ecma_property_t property, /**< property name typ
  *
  * @return hash code of property name
  */
-inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_get_property_name_hash (ecma_property_t property, /**< property name type */
                                     jmem_cpointer_t prop_name_cp) /**< property name compressed pointer */
 {
@@ -1730,7 +1730,7 @@ ecma_string_get_property_index (ecma_property_t property, /**< property name typ
  * @return true if they are equals
  *         false otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_string_compare_to_property_name (ecma_property_t property, /**< property name type */
                                       jmem_cpointer_t prop_name_cp, /**< property name compressed pointer */
                                       const ecma_string_t *string_p) /**< other string */
@@ -1864,7 +1864,7 @@ ecma_compare_ecma_strings (const ecma_string_t *string1_p, /**< ecma-string */
  * @return true - if strings are equal;
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_compare_ecma_non_direct_strings (const ecma_string_t *string1_p, /**< ecma-string */
                                       const ecma_string_t *string2_p) /**< ecma-string */
 {
@@ -2379,7 +2379,7 @@ ecma_get_string_magic (const ecma_string_t *string_p) /**< ecma-string */
  *
  * @return calculated hash
  */
-inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 ecma_string_hash (const ecma_string_t *string_p) /**< ecma-string to calculate hash for */
 {
   if (ECMA_IS_DIRECT_STRING (string_p))
@@ -2507,7 +2507,7 @@ ecma_string_trim_back (const lit_utf8_byte_t *start_p, /**< current string's sta
  *        - ecma_string_trim
  *        - ecma_utf8_string_to_number
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_string_trim_helper (const lit_utf8_byte_t **utf8_str_p, /**< [in, out] current string position */
                          lit_utf8_size_t *utf8_str_size)  /**< [in, out] size of the given string */
 {

--- a/jerry-core/ecma/base/ecma-helpers-value.c
+++ b/jerry-core/ecma/base/ecma-helpers-value.c
@@ -128,7 +128,7 @@ ecma_get_pointer_from_ecma_value (ecma_value_t value) /**< value */
  * @return true - if the value is a direct value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_direct (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT);
@@ -140,7 +140,7 @@ ecma_is_value_direct (ecma_value_t value) /**< ecma value */
  * @return true - if the value is a simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_simple (ecma_value_t value) /**< ecma value */
 {
   return (value & ECMA_DIRECT_TYPE_MASK) == ECMA_DIRECT_TYPE_SIMPLE_VALUE;
@@ -165,7 +165,7 @@ ecma_is_value_equal_to_simple_value (ecma_value_t value, /**< ecma value */
  * @return true - if the value contains implementation-defined empty simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_empty (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_EMPTY);
@@ -177,7 +177,7 @@ ecma_is_value_empty (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-undefined simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_UNDEFINED);
@@ -189,7 +189,7 @@ ecma_is_value_undefined (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-null simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_null (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_NULL);
@@ -201,7 +201,7 @@ ecma_is_value_null (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true or ecma-false simple values,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_true (value | (1 << ECMA_DIRECT_SHIFT));
@@ -213,7 +213,7 @@ ecma_is_value_boolean (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-true simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_true (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_TRUE);
@@ -225,7 +225,7 @@ ecma_is_value_true (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-false simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_false (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_FALSE);
@@ -237,7 +237,7 @@ ecma_is_value_false (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-not-found simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_found (ecma_value_t value) /**< ecma value */
 {
   return value != ECMA_VALUE_NOT_FOUND;
@@ -249,7 +249,7 @@ ecma_is_value_found (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains ecma-array-hole simple value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
 {
   return ecma_is_value_equal_to_simple_value (value, ECMA_VALUE_ARRAY_HOLE);
@@ -261,7 +261,7 @@ ecma_is_value_array_hole (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains an integer ecma-number value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_integer_number (ecma_value_t value) /**< ecma value */
 {
   return (value & ECMA_DIRECT_TYPE_MASK) == ECMA_DIRECT_TYPE_INTEGER_VALUE;
@@ -273,7 +273,7 @@ ecma_is_value_integer_number (ecma_value_t value) /**< ecma value */
  * @return true - if both values contain integer ecma-number values,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_are_values_integer_numbers (ecma_value_t first_value, /**< first ecma value */
                                  ecma_value_t second_value) /**< second ecma value */
 {
@@ -289,7 +289,7 @@ ecma_are_values_integer_numbers (ecma_value_t first_value, /**< first ecma value
  * @return true - if the value contains a floating-point ecma-number value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_float_number (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_FLOAT);
@@ -329,7 +329,7 @@ ecma_is_value_string (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains symbol value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_symbol (ecma_value_t value) /**< ecma value */
 {
 #if ENABLED (JERRY_ESNEXT)
@@ -346,7 +346,7 @@ ecma_is_value_symbol (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains bigint value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_bigint (ecma_value_t value) /**< ecma value */
 {
   #if ENABLED (JERRY_BUILTIN_BIGINT)
@@ -363,7 +363,7 @@ ecma_is_value_bigint (ecma_value_t value) /**< ecma value */
  * @return true - if the value can be property name value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_prop_name (ecma_value_t value) /**< ecma value */
 {
 #if ENABLED (JERRY_ESNEXT)
@@ -379,7 +379,7 @@ ecma_is_value_prop_name (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains direct ecma-string value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_direct_string (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT_STRING);
@@ -391,7 +391,7 @@ ecma_is_value_direct_string (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains non-direct ecma-string value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_non_direct_string (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_STRING);
@@ -403,7 +403,7 @@ ecma_is_value_non_direct_string (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains object value,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_object (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_OBJECT);
@@ -415,7 +415,7 @@ ecma_is_value_object (ecma_value_t value) /**< ecma value */
  * @return true - if the value contains an error reference,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_is_value_error_reference (ecma_value_t value) /**< ecma value */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_ERROR);
@@ -482,7 +482,7 @@ ecma_is_value_array (ecma_value_t arg) /**< argument */
  *
  * @return boolean ecma_value
  */
-inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_make_boolean_value (bool boolean_value) /**< raw bool value from which the ecma value will be created */
 {
   return boolean_value ? ECMA_VALUE_TRUE : ECMA_VALUE_FALSE;
@@ -496,7 +496,7 @@ ecma_make_boolean_value (bool boolean_value) /**< raw bool value from which the 
  *
  * @return ecma-value
  */
-inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_make_integer_value (ecma_integer_value_t integer_value) /**< integer number to be encoded */
 {
   JERRY_ASSERT (ECMA_IS_INTEGER_NUMBER (integer_value));
@@ -631,7 +631,7 @@ ecma_make_uint32_value (uint32_t uint32_number) /**< uint32 number to be encoded
  *
  * @return ecma-value representation of the string argument
  */
-inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to reference in value */
 {
   JERRY_ASSERT (ecma_string_p != NULL);
@@ -653,7 +653,7 @@ ecma_make_string_value (const ecma_string_t *ecma_string_p) /**< string to refer
  *
  * @return ecma-value representation of the string argument
  */
-inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_symbol_value (const ecma_string_t *ecma_symbol_p) /**< symbol to reference in value */
 {
   JERRY_ASSERT (ecma_symbol_p != NULL);
@@ -668,7 +668,7 @@ ecma_make_symbol_value (const ecma_string_t *ecma_symbol_p) /**< symbol to refer
  *
  * @return ecma-value representation of a property name argument
  */
-inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_prop_name_value (const ecma_string_t *ecma_prop_name_p) /**< property name to reference in value */
 {
   JERRY_ASSERT (ecma_prop_name_p != NULL);
@@ -688,7 +688,7 @@ ecma_make_prop_name_value (const ecma_string_t *ecma_prop_name_p) /**< property 
  *
  * @return ecma-value representation of the string argument
  */
-inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_magic_string_value (lit_magic_string_id_t id) /**< magic string id */
 {
   return (ecma_value_t) ECMA_CREATE_DIRECT_STRING (ECMA_DIRECT_STRING_MAGIC, (uintptr_t) id);
@@ -699,7 +699,7 @@ ecma_make_magic_string_value (lit_magic_string_id_t id) /**< magic string id */
  *
  * @return ecma-value representation of the object argument
  */
-inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference in value */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -712,7 +712,7 @@ ecma_make_object_value (const ecma_object_t *object_p) /**< object to reference 
  *
  * @return ecma-value representation of the Error reference
  */
-inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_make_extended_primitive_value (const ecma_extended_primitive_t *primitve_p, /**< extended primitve value */
                                     uint32_t type) /**< ecma type of extended primitve value */
 {
@@ -730,7 +730,7 @@ ecma_make_extended_primitive_value (const ecma_extended_primitive_t *primitve_p,
  *
  * @return integer value
  */
-inline ecma_integer_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_integer_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_get_integer_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_integer_number (value));
@@ -743,7 +743,7 @@ ecma_get_integer_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return floating point value
  */
-inline ecma_number_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_number_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_float_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_FLOAT);
@@ -756,7 +756,7 @@ ecma_get_float_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return floating point value
  */
-inline ecma_number_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_number_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_pointer_from_float_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_get_value_type_field (value) == ECMA_TYPE_FLOAT);
@@ -785,7 +785,7 @@ ecma_get_number_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the string pointer
  */
-inline ecma_string_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_string_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_string_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_string (value));
@@ -804,7 +804,7 @@ ecma_get_string_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the string pointer
  */
-inline ecma_string_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_string_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_symbol_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_symbol (value));
@@ -818,7 +818,7 @@ ecma_get_symbol_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the string pointer
  */
-inline ecma_string_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_string_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_prop_name_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_prop_name (value));
@@ -836,7 +836,7 @@ ecma_get_prop_name_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the pointer
  */
-inline ecma_object_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_object_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_object_from_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_object (value));
@@ -849,7 +849,7 @@ ecma_get_object_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return the pointer
  */
-inline ecma_extended_primitive_t *JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_extended_primitive_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_get_extended_primitive_from_value (ecma_value_t value) /**< ecma value */
 {
 #if ENABLED (JERRY_BUILTIN_BIGINT)
@@ -866,7 +866,7 @@ ecma_get_extended_primitive_from_value (ecma_value_t value) /**< ecma value */
  *
  * @return ecma value
  */
-inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_CONST JERRY_ATTR_ALWAYS_INLINE
 ecma_invert_boolean_value (ecma_value_t value) /**< ecma value */
 {
   JERRY_ASSERT (ecma_is_value_boolean (value));
@@ -938,7 +938,7 @@ ecma_copy_value (ecma_value_t value)  /**< value description */
  *
  * @return copy of the given value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_fast_copy_value (ecma_value_t value)  /**< value description */
 {
   return (ecma_get_value_type_field (value) == ECMA_TYPE_DIRECT) ? value : ecma_copy_value (value);
@@ -949,7 +949,7 @@ ecma_fast_copy_value (ecma_value_t value)  /**< value description */
  *
  * @return copy of the given value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_copy_value_if_not_object (ecma_value_t value) /**< value description */
 {
   if (!ecma_is_value_object (value))
@@ -963,7 +963,7 @@ ecma_copy_value_if_not_object (ecma_value_t value) /**< value description */
 /**
  * Increase reference counter of a value if it is an object.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_ref_if_object (ecma_value_t value) /**< value description */
 {
   if (ecma_is_value_object (value))
@@ -975,7 +975,7 @@ ecma_ref_if_object (ecma_value_t value) /**< value description */
 /**
  * Decrease reference counter of a value if it is an object.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_deref_if_object (ecma_value_t value) /**< value description */
 {
   if (ecma_is_value_object (value))
@@ -1170,7 +1170,7 @@ ecma_free_value (ecma_value_t value) /**< value description */
  *   It also increases the binary size so it is recommended for
  *   critical code paths only.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_fast_free_value (ecma_value_t value) /**< value description */
 {
   if (ecma_get_value_type_field (value) != ECMA_TYPE_DIRECT)
@@ -1194,7 +1194,7 @@ ecma_free_value_if_not_object (ecma_value_t value) /**< value description */
 /**
  * Free an ecma-value object
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_free_object (ecma_value_t value) /**< value description */
 {
   ecma_deref_object (ecma_get_object_from_value (value));
@@ -1203,7 +1203,7 @@ ecma_free_object (ecma_value_t value) /**< value description */
 /**
  * Free an ecma-value number
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_free_number (ecma_value_t value) /**< value description */
 {
   JERRY_ASSERT (ecma_is_value_number (value));

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -166,7 +166,7 @@ ecma_create_object_lex_env (ecma_object_t *outer_lexical_environment_p, /**< out
  * @return true  - if object is a lexical environment
  *         false - otherwise
  */
-inline bool JERRY_ATTR_PURE
+extern inline bool JERRY_ATTR_PURE
 ecma_is_lexical_environment (const ecma_object_t *object_p) /**< object or lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -179,7 +179,7 @@ ecma_is_lexical_environment (const ecma_object_t *object_p) /**< object or lexic
 /**
  * Set value of [[Extensible]] object's internal property.
  */
-inline void
+extern inline void
 ecma_op_ordinary_object_set_extensible (ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -193,7 +193,7 @@ ecma_op_ordinary_object_set_extensible (ecma_object_t *object_p) /**< object */
  *
  * @return type of the object (ecma_object_type_t)
  */
-inline ecma_object_type_t JERRY_ATTR_PURE
+extern inline ecma_object_type_t JERRY_ATTR_PURE
 ecma_get_object_type (const ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -208,7 +208,7 @@ ecma_get_object_type (const ecma_object_t *object_p) /**< object */
  * @return true  - if object is a built-in object
  *         false - otherwise
  */
-inline bool JERRY_ATTR_PURE
+extern inline bool JERRY_ATTR_PURE
 ecma_get_object_is_builtin (const ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -220,7 +220,7 @@ ecma_get_object_is_builtin (const ecma_object_t *object_p) /**< object */
 /**
  * Set flag indicating whether the object is a built-in object
  */
-inline void
+extern inline void
 ecma_set_object_is_builtin (ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -236,7 +236,7 @@ ecma_set_object_is_builtin (ecma_object_t *object_p) /**< object */
  *
  * @return the ID of the built-in
  */
-inline uint8_t
+extern inline uint8_t
 ecma_get_object_builtin_id (ecma_object_t *object_p) /**< object */
 {
   if (!ecma_get_object_is_builtin (object_p))
@@ -264,7 +264,7 @@ ecma_get_object_builtin_id (ecma_object_t *object_p) /**< object */
  *
  * @return type of the lexical environment (ecma_lexical_environment_type_t)
  */
-inline ecma_lexical_environment_type_t JERRY_ATTR_PURE
+extern inline ecma_lexical_environment_type_t JERRY_ATTR_PURE
 ecma_get_lex_env_type (const ecma_object_t *object_p) /**< lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -278,7 +278,7 @@ ecma_get_lex_env_type (const ecma_object_t *object_p) /**< lexical environment *
  *
  * @return pointer to ecma object
  */
-inline ecma_object_t *JERRY_ATTR_PURE
+extern inline ecma_object_t *JERRY_ATTR_PURE
 ecma_get_lex_env_binding_object (const ecma_object_t *object_p) /**< object-bound lexical environment */
 {
   JERRY_ASSERT (object_p != NULL);
@@ -942,7 +942,7 @@ ecma_assert_object_contains_the_property (const ecma_object_t *object_p, /**< ec
  * Note:
  *      value previously stored in the property is freed
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_named_data_property_assign_value (ecma_object_t *obj_p, /**< object */
                                        ecma_property_value_t *prop_value_p, /**< property value reference */
                                        ecma_value_t value) /**< value to assign */
@@ -1013,7 +1013,7 @@ ecma_set_named_accessor_property_setter (ecma_object_t *object_p, /**< the prope
  * @return true - property is writable,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_writable (ecma_property_t property) /**< property */
 {
   JERRY_ASSERT (property & ECMA_PROPERTY_FLAG_DATA);
@@ -1046,7 +1046,7 @@ ecma_set_property_writable_attr (ecma_property_t *property_p, /**< [in,out] prop
  * @return true - property is enumerable,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_enumerable (ecma_property_t property) /**< property */
 {
   JERRY_ASSERT (ECMA_PROPERTY_IS_NAMED_PROPERTY (property));
@@ -1079,7 +1079,7 @@ ecma_set_property_enumerable_attr (ecma_property_t *property_p, /**< [in,out] pr
  * @return true - property is configurable,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_configurable (ecma_property_t property) /**< property */
 {
   JERRY_ASSERT (ECMA_PROPERTY_IS_NAMED_PROPERTY (property));
@@ -1113,7 +1113,7 @@ ecma_set_property_configurable_attr (ecma_property_t *property_p, /**< [in,out] 
  *
  * @return true / false
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_property_lcached (ecma_property_t *property_p) /**< property */
 {
   JERRY_ASSERT (ECMA_PROPERTY_IS_NAMED_PROPERTY (*property_p));
@@ -1124,7 +1124,7 @@ ecma_is_property_lcached (ecma_property_t *property_p) /**< property */
 /**
  * Set value of flag indicating whether the property is registered in LCache
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 ecma_set_property_lcached (ecma_property_t *property_p, /**< property */
                            bool is_lcached) /**< new value for lcached flag */
 {
@@ -1300,7 +1300,7 @@ ecma_create_error_reference_from_context (void)
  *
  * @return error reference value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_create_error_object_reference (ecma_object_t *object_p) /**< referenced object */
 {
   return ecma_create_error_reference (ecma_make_object_value (object_p), true);
@@ -1505,7 +1505,7 @@ ecma_compiled_code_resolve_arguments_start (const ecma_compiled_code_t *bytecode
  *
  * @return position of the function name of the compiled code
  */
-inline ecma_value_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_compiled_code_resolve_function_name (const ecma_compiled_code_t *bytecode_header_p) /**< compiled code */
 {
   JERRY_ASSERT (bytecode_header_p != NULL);

--- a/jerry-core/ecma/base/ecma-lcache.c
+++ b/jerry-core/ecma/base/ecma-lcache.c
@@ -136,7 +136,7 @@ insert:
  * @return a pointer to an ecma_property_t if the lookup is successful
  *         NULL otherwise
  */
-inline ecma_property_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_property_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_lcache_lookup (const ecma_object_t *object_p, /**< object */
                     const ecma_string_t *prop_name_p) /**< property's name */
 {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -325,7 +325,7 @@ ecma_date_week_day (ecma_number_t time) /**< time value */
  *
  * @return local time zone adjustment
  */
-inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_local_time_zone_adjustment (ecma_number_t time) /**< time value */
 {
   return jerry_port_get_local_time_zone_adjustment (time, true);
@@ -574,7 +574,7 @@ ecma_date_time_clip (ecma_number_t time) /**< time value */
  *
  * @return timezone offset
  */
-inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_number_t JERRY_ATTR_ALWAYS_INLINE
 ecma_date_timezone_offset (ecma_number_t time) /**< time value */
 {
   JERRY_ASSERT (!ecma_number_is_nan (time));

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -506,7 +506,7 @@ ecma_builtin_regexp_prototype_to_string (ecma_object_t *object_p) /**< this obje
  * @return true, if function is the builtin exec method
  *         false, otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_is_regexp_exec (ecma_extended_object_t *obj_p)
 {
   return (ecma_get_object_is_builtin ((ecma_object_t *) obj_p)

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -319,7 +319,7 @@ ecma_builtin_is_global (ecma_object_t *object_p) /**< pointer to an object */
  *
  * @return pointer to the global object
  */
-inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_get_global (void)
 {
   JERRY_ASSERT (JERRY_CONTEXT (global_object_p) != NULL);
@@ -333,7 +333,7 @@ ecma_builtin_get_global (void)
  * @return true - if the function object is a built-in routine
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_builtin_function_is_routine (ecma_object_t *func_obj_p) /**< function object */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_NATIVE_FUNCTION);

--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -94,7 +94,7 @@ ecma_op_alloc_array_object (uint32_t length) /**< length of the new array */
  * @return true - if the object is fast-access mode array
  *         false, otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_is_fast_array (ecma_object_t *object_p) /**< ecma-object */
 {
   return (ecma_get_object_type (object_p) == ECMA_OBJECT_TYPE_ARRAY &&
@@ -107,7 +107,7 @@ ecma_op_object_is_fast_array (ecma_object_t *object_p) /**< ecma-object */
  * @return true - if the array object is fast-access mode array
  *         false, otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_op_array_is_fast_array (ecma_extended_object_t *array_p) /**< ecma-array-object */
 {
   JERRY_ASSERT (ecma_get_object_type ((ecma_object_t *) array_p) == ECMA_OBJECT_TYPE_ARRAY);
@@ -442,7 +442,7 @@ ecma_fast_array_set_property (ecma_object_t *object_p, /**< fast access mode arr
  *
  * @return number of array holes in a fast access array object
  */
-inline uint32_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 ecma_fast_array_get_hole_count (ecma_object_t *obj_p) /**< fast access mode array object */
 {
   JERRY_ASSERT (ecma_op_object_is_fast_array (obj_p));

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -194,7 +194,7 @@ ecma_arraybuffer_get_length (ecma_object_t *object_p) /**< pointer to the ArrayB
  *
  * @return pointer to the data buffer
  */
-inline lit_utf8_byte_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_utf8_byte_t * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_arraybuffer_get_buffer (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));
@@ -221,7 +221,7 @@ ecma_arraybuffer_get_buffer (ecma_object_t *object_p) /**< pointer to the ArrayB
  * @return true - if value is an detached ArrayBuffer object
  *         false - otherwise
  */
-inline bool JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 ecma_arraybuffer_is_detached (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));
@@ -237,7 +237,7 @@ ecma_arraybuffer_is_detached (ecma_object_t *object_p) /**< pointer to the Array
  * @return true - if detach op succeeded
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_arraybuffer_detach (ecma_object_t *object_p) /**< pointer to the ArrayBuffer object */
 {
   JERRY_ASSERT (ecma_object_class_is (object_p, LIT_MAGIC_STRING_ARRAY_BUFFER_UL));

--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -972,7 +972,7 @@ ecma_op_container_remove_weak_entry (ecma_object_t *object_p, /**< internal cont
  * @return Map/Set iterator object, if success
  *         error - otherwise
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_container_create_iterator (ecma_value_t this_arg, /**< this argument */
                                    ecma_builtin_id_t proto_id, /**< prototype builtin id */
                                    ecma_pseudo_array_type_t iterator_type, /**< iterator type */

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -274,7 +274,7 @@ ecma_op_to_boolean (ecma_value_t value) /**< ecma value */
  * @return ecma value
  *         Returned value must be freed with ecma_free_value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_to_number (ecma_value_t value, /**< ecma value */
                    ecma_number_t *number_p) /**< [out] ecma number */
 {

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -96,7 +96,7 @@ ecma_op_function_form_name (ecma_string_t *prop_name_p, /**< property name */
  * @return true - if the given object is callable;
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_is_callable (ecma_object_t *obj_p) /**< ecma object */
 {
   JERRY_ASSERT (!ecma_is_lexical_environment (obj_p));
@@ -247,7 +247,7 @@ ecma_object_check_constructor (ecma_object_t *obj_p) /**< ecma object */
  * @return ECMA_IS_VALID_CONSTRUCTOR - if the input value is a constructor.
  *         any other value - if the input value is not a valid constructor, the pointer contains the error message.
  */
-inline char *JERRY_ATTR_ALWAYS_INLINE
+extern inline char *JERRY_ATTR_ALWAYS_INLINE
 ecma_check_constructor (ecma_value_t value) /**< ecma object */
 {
   if (!ecma_is_value_object (value))
@@ -264,7 +264,7 @@ ecma_check_constructor (ecma_value_t value) /**< ecma object */
  * @return true - if the given object is constructor;
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_object_is_constructor (ecma_object_t *obj_p) /**< ecma object */
 {
   return ecma_object_check_constructor (obj_p) == ECMA_IS_VALID_CONSTRUCTOR;
@@ -730,7 +730,7 @@ ecma_op_create_native_handler (ecma_native_handler_id_t id, /**< handler id */
  *
  * @return compiled code
  */
-inline const ecma_compiled_code_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline const ecma_compiled_code_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p) /**< function pointer */
 {
 #if ENABLED (JERRY_SNAPSHOT_EXEC)
@@ -757,7 +757,7 @@ ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p) /**< fun
  *
  * @return pointer to realm (global) object
  */
-inline ecma_global_object_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_global_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_op_function_get_realm (const ecma_compiled_code_t *bytecode_header_p) /**< byte code header */
 {
   ecma_value_t realm_value;

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -387,7 +387,7 @@ ecma_op_object_get_own_property (ecma_object_t *object_p, /**< the object */
  * @return ECMA_VALUE_ERROR - if the operation fails
  *         ECMA_VALUE_{TRUE_FALSE} - whether the property is found
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_has_property (ecma_object_t *object_p, /**< the object */
                              ecma_string_t *property_name_p) /**< property name */
 {
@@ -756,7 +756,7 @@ ecma_op_object_find (ecma_object_t *object_p, /**< the object */
  * @return ecma value
  *         Returned value must be freed with ecma_free_value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_get (ecma_object_t *object_p, /**< the object */
                     ecma_string_t *property_name_p) /**< property name */
 {
@@ -874,7 +874,7 @@ ecma_op_object_get_length (ecma_object_t *object_p, /**< the object */
  * @return ecma value
  *         Returned value must be freed with ecma_free_value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_get_by_magic_id (ecma_object_t *object_p, /**< the object */
                                 lit_magic_string_id_t property_id) /**< property magic string id */
 {
@@ -1096,7 +1096,7 @@ ecma_op_object_put_by_index (ecma_object_t *object_p, /**< the object */
  *         Note: even if is_throw is false, the setter can throw an
  *         error, and this function returns with that error.
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_object_put (ecma_object_t *object_p, /**< the object */
                     ecma_string_t *property_name_p, /**< property name */
                     ecma_value_t value, /**< ecma value */
@@ -2868,7 +2868,7 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
  * @return value of the object if the class matches
  *         ECMA_VALUE_NOT_FOUND otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_object_class_is (ecma_object_t *object_p, /**< object */
                       uint32_t class_id) /**< class id */
 {
@@ -2891,7 +2891,7 @@ ecma_object_class_is (ecma_object_t *object_p, /**< object */
  * @return true - if the given argument is a regexp
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_object_is_regexp_object (ecma_value_t arg) /**< argument */
 {
   return (ecma_is_value_object (arg)
@@ -3033,7 +3033,7 @@ ecma_op_species_constructor (ecma_object_t *this_value, /**< This Value */
  * @return ecma_value result of the invoked function or raised error
  *         note: returned value must be freed with ecma_free_value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_invoke_by_symbol_id (ecma_value_t object, /**< Object value */
                              lit_magic_string_id_t symbol_id, /**< Symbol ID */
                              ecma_value_t *args_p, /**< Argument list */
@@ -3053,7 +3053,7 @@ ecma_op_invoke_by_symbol_id (ecma_value_t object, /**< Object value */
  * @return ecma_value result of the invoked function or raised error
  *         note: returned value must be freed with ecma_free_value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_invoke_by_magic_id (ecma_value_t object, /**< Object value */
                             lit_magic_string_id_t magic_string_id, /**< Magic string ID */
                             ecma_value_t *args_p, /**< Argument list */
@@ -3122,7 +3122,7 @@ ecma_op_invoke (ecma_value_t object, /**< Object value */
  *
  * @return the value of the [[Prototype]] internal slot of the given object.
  */
-inline jmem_cpointer_t JERRY_ATTR_ALWAYS_INLINE
+extern inline jmem_cpointer_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_ordinary_object_get_prototype_of (ecma_object_t *obj_p) /**< object */
 {
   JERRY_ASSERT (!ecma_is_lexical_environment (obj_p));
@@ -3140,7 +3140,7 @@ ecma_op_ordinary_object_get_prototype_of (ecma_object_t *obj_p) /**< object */
  * @return ECMA_VALUE_FALSE - if the operation fails
  *         ECMA_VALUE_TRUE - otherwise
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_op_ordinary_object_set_prototype_of (ecma_object_t *obj_p, /**< base object */
                                           ecma_value_t proto) /**< prototype object */
 {
@@ -3222,7 +3222,7 @@ ecma_op_ordinary_object_set_prototype_of (ecma_object_t *obj_p, /**< base object
  * @return true  - if object is extensible
  *         false - otherwise
  */
-inline bool JERRY_ATTR_PURE
+extern inline bool JERRY_ATTR_PURE
 ecma_op_ordinary_object_is_extensible (ecma_object_t *object_p) /**< object */
 {
   JERRY_ASSERT (!ECMA_OBJECT_IS_PROXY (object_p));
@@ -3246,7 +3246,7 @@ ecma_op_ordinary_object_prevent_extensions (ecma_object_t *object_p) /**< object
  * @return true - if property is found
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_op_ordinary_object_has_own_property (ecma_object_t *object_p, /**< the object */
                                           ecma_string_t *property_name_p) /**< property name */
 {

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -44,7 +44,7 @@
  * @return true - if the object is a promise.
  *         false - otherwise.
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 ecma_is_promise (ecma_object_t *obj_p) /**< points to object */
 {
   return ecma_object_class_is (obj_p, LIT_MAGIC_STRING_PROMISE_UL);

--- a/jerry-core/ecma/operations/ecma-typedarray-object.c
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.c
@@ -608,7 +608,7 @@ static const uint16_t ecma_typedarray_magic_string_list[] =
  *
  * @return ecma_typedarray_getter_fn_t: the getter function for the given builtin TypedArray id
  */
-inline ecma_typedarray_getter_fn_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_typedarray_getter_fn_t JERRY_ATTR_ALWAYS_INLINE
 ecma_get_typedarray_getter_fn (ecma_typedarray_type_t typedarray_id)
 {
   return ecma_typedarray_getters[typedarray_id];
@@ -619,7 +619,7 @@ ecma_get_typedarray_getter_fn (ecma_typedarray_type_t typedarray_id)
  *
  * @return ecma_number_t: the value of the element
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_get_typedarray_element (lit_utf8_byte_t *src_p,
                              ecma_typedarray_type_t typedarray_id)
 {
@@ -631,7 +631,7 @@ ecma_get_typedarray_element (lit_utf8_byte_t *src_p,
  *
  * @return ecma_typedarray_setter_fn_t: the setter function for the given builtin TypedArray id
  */
-inline ecma_typedarray_setter_fn_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_typedarray_setter_fn_t JERRY_ATTR_ALWAYS_INLINE
 ecma_get_typedarray_setter_fn (ecma_typedarray_type_t typedarray_id)
 {
   return ecma_typedarray_setters[typedarray_id];
@@ -640,7 +640,7 @@ ecma_get_typedarray_setter_fn (ecma_typedarray_type_t typedarray_id)
 /**
  * set typedarray's element value
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 ecma_set_typedarray_element (lit_utf8_byte_t *dst_p,
                              ecma_value_t value,
                              ecma_typedarray_type_t typedarray_id)
@@ -653,7 +653,7 @@ ecma_set_typedarray_element (lit_utf8_byte_t *dst_p,
  *
  * @return uint8_t
  */
-inline uint8_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint8_t JERRY_ATTR_ALWAYS_INLINE
 ecma_typedarray_helper_get_shift_size (ecma_typedarray_type_t typedarray_id)
 {
   return ecma_typedarray_element_shift_sizes[typedarray_id];
@@ -1215,7 +1215,7 @@ ecma_op_typedarray_from (ecma_value_t items_val, /**< the source array-like obje
  *
  * @return the pointer to the internal arraybuffer
  */
-inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_typedarray_get_arraybuffer (ecma_object_t *typedarray_p) /**< the pointer to the typedarray object */
 {
   JERRY_ASSERT (ecma_object_is_typedarray (typedarray_p));

--- a/jerry-core/jmem/jmem-allocator.c
+++ b/jerry-core/jmem/jmem-allocator.c
@@ -175,7 +175,7 @@ jmem_finalize (void)
  *
  * @return packed pointer
  */
-inline jmem_cpointer_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline jmem_cpointer_t JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 jmem_compress_pointer (const void *pointer_p) /**< pointer to compress */
 {
   JERRY_ASSERT (pointer_p != NULL);
@@ -209,7 +209,7 @@ jmem_compress_pointer (const void *pointer_p) /**< pointer to compress */
  *
  * @return unpacked pointer
  */
-inline void * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
+extern inline void * JERRY_ATTR_PURE JERRY_ATTR_ALWAYS_INLINE
 jmem_decompress_pointer (uintptr_t compressed_pointer) /**< pointer to decompress */
 {
   JERRY_ASSERT (compressed_pointer != JMEM_CP_NULL);

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -304,7 +304,7 @@ jmem_heap_gc_and_alloc_block (const size_t size, /**< required memory size */
 /**
  * Internal method for allocating a memory block.
  */
-inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
+extern inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_heap_alloc_block_internal (const size_t size) /**< required memory size */
 {
   return jmem_heap_gc_and_alloc_block (size, JMEM_PRESSURE_FULL);
@@ -337,7 +337,7 @@ jmem_heap_alloc_block (const size_t size) /**< required memory size */
  *         also NULL, if the allocation has failed
  *         pointer to the allocated memory block, otherwise
  */
-inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
+extern inline void * JERRY_ATTR_HOT JERRY_ATTR_ALWAYS_INLINE
 jmem_heap_alloc_block_null_on_error (const size_t size) /**< required memory size */
 {
   void *block_p = jmem_heap_gc_and_alloc_block (size, JMEM_PRESSURE_HIGH);

--- a/jerry-core/lit/lit-magic-strings.c
+++ b/jerry-core/lit/lit-magic-strings.c
@@ -28,7 +28,7 @@
  * @return number of the strings, if there were registered,
  *         zero - otherwise.
  */
-inline uint32_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 lit_get_magic_string_ex_count (void)
 {
   return JERRY_CONTEXT (lit_magic_string_ex_count);

--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -543,7 +543,7 @@ lit_cesu8_peek_prev (const lit_utf8_byte_t *buf_p) /**< [in,out] buffer with cha
 /**
  * Increase cesu-8 encoded string pointer by one code unit.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 lit_utf8_incr (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characters */
 {
   JERRY_ASSERT (*buf_p);
@@ -579,7 +579,7 @@ lit_utf8_decr (const lit_utf8_byte_t **buf_p) /**< [in,out] buffer with characte
  *
  * @return ecma-string's hash
  */
-inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, /**< hash to be combined with */
                               const lit_utf8_byte_t *utf8_buf_p, /**< characters buffer */
                               lit_utf8_size_t utf8_buf_size) /**< number of characters in the buffer */
@@ -602,7 +602,7 @@ lit_utf8_string_hash_combine (lit_string_hash_t hash_basis, /**< hash to be comb
  *
  * @return ecma-string's hash
  */
-inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_string_hash_t JERRY_ATTR_ALWAYS_INLINE
 lit_utf8_string_calc_hash (const lit_utf8_byte_t *utf8_buf_p, /**< characters buffer */
                            lit_utf8_size_t utf8_buf_size) /**< number of characters in the buffer */
 {
@@ -643,7 +643,7 @@ lit_utf8_string_code_unit_at (const lit_utf8_byte_t *utf8_buf_p, /**< utf-8 stri
  *
  * @return number of bytes occupied in CESU-8
  */
-inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_utf8_size_t JERRY_ATTR_ALWAYS_INLINE
 lit_get_unicode_char_size_by_utf8_first_byte (const lit_utf8_byte_t first_byte) /**< buffer with characters */
 {
   if ((first_byte & LIT_UTF8_1_BYTE_MASK) == LIT_UTF8_1_BYTE_MARKER)

--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1976,7 +1976,7 @@ lexer_check_next_characters (parser_context_t *context_p, /**< context */
  *
  * @return consumed character
  */
-inline uint8_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint8_t JERRY_ATTR_ALWAYS_INLINE
 lexer_consume_next_character (parser_context_t *context_p) /**< context */
 {
   JERRY_ASSERT (context_p->source_p < context_p->source_end_p);
@@ -3662,7 +3662,7 @@ lexer_current_is_literal (parser_context_t *context_p, /**< context */
  *
  * @return true if "use strict" is found, false otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 lexer_string_is_use_strict (parser_context_t *context_p) /**< context */
 {
   JERRY_ASSERT (context_p->token.type == LEXER_LITERAL
@@ -3678,7 +3678,7 @@ lexer_string_is_use_strict (parser_context_t *context_p) /**< context */
  *
  * @return true if the string is a directive, false otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 lexer_string_is_directive (parser_context_t *context_p) /**< context */
 {
   return (context_p->token.type == LEXER_SEMICOLON
@@ -3701,7 +3701,7 @@ lexer_string_is_directive (parser_context_t *context_p) /**< context */
  *
  * @return true if they are the same, false otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 lexer_token_is_identifier (parser_context_t *context_p, /**< context */
                            const char *identifier_p, /**< identifier */
                            size_t identifier_length) /**< identifier length */
@@ -3721,7 +3721,7 @@ lexer_token_is_identifier (parser_context_t *context_p, /**< context */
  *
  * @return true if "let" is found, false otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 lexer_token_is_let (parser_context_t *context_p) /**< context */
 {
   JERRY_ASSERT (context_p->token.type == LEXER_LITERAL);
@@ -3738,7 +3738,7 @@ lexer_token_is_let (parser_context_t *context_p) /**< context */
  *
  * @return true if "async" is found, false otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 lexer_token_is_async (parser_context_t *context_p) /**< context */
 {
   JERRY_ASSERT (context_p->token.type == LEXER_LITERAL
@@ -3758,7 +3758,7 @@ lexer_token_is_async (parser_context_t *context_p) /**< context */
  *
  * @return true if they are the same, false otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 lexer_compare_literal_to_string (parser_context_t *context_p, /**< context */
                                  const char *string_p, /**< string */
                                  size_t string_length) /**< string length */

--- a/jerry-core/parser/js/js-parser-mem.c
+++ b/jerry-core/parser/js/js-parser-mem.c
@@ -52,7 +52,7 @@ parser_malloc (parser_context_t *context_p, /**< context */
 /**
  * Free memory allocated by parser_malloc.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 parser_free (void *ptr, /**< pointer to free */
              size_t size) /**< size of the memory block */
 {
@@ -92,7 +92,7 @@ parser_free_local (void *ptr, /**< pointer to free */
 /**
  * Free the dynamically allocated buffer stored in the context
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 parser_free_allocated_buffer (parser_context_t *context_p) /**< context */
 {
   if (context_p->u.allocated_buffer_p != NULL)
@@ -644,7 +644,7 @@ parser_stack_pop (parser_context_t *context_p, /**< context */
 /**
  * Initialize stack iterator.
  */
-inline void
+extern inline void
 parser_stack_iterator_init (parser_context_t *context_p, /**< context */
                             parser_stack_iterator_t *iterator) /**< iterator */
 {
@@ -657,7 +657,7 @@ parser_stack_iterator_init (parser_context_t *context_p, /**< context */
  *
  * @return byte
  */
-inline uint8_t
+extern inline uint8_t
 parser_stack_iterator_read_uint8 (parser_stack_iterator_t *iterator) /**< iterator */
 {
   JERRY_ASSERT (iterator->current_position > 0 && iterator->current_position <= PARSER_STACK_PAGE_SIZE);

--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -115,7 +115,7 @@ scanner_malloc (parser_context_t *context_p, /**< context */
 /**
  * Free memory allocated by scanner_malloc.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_free (void *ptr, /**< pointer to free */
               size_t size) /**< size of the memory block */
 {
@@ -268,7 +268,7 @@ scanner_insert_info_before (parser_context_t *context_p, /**< context */
 /**
  * Release the next scanner info.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_release_next (parser_context_t *context_p, /**< context */
                       size_t size) /**< size of the memory block */
 {
@@ -281,7 +281,7 @@ scanner_release_next (parser_context_t *context_p, /**< context */
 /**
  * Set the active scanner info to the next scanner info.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_set_active (parser_context_t *context_p) /**< context */
 {
   scanner_info_t *scanner_info_p = context_p->next_scanner_info_p;
@@ -294,7 +294,7 @@ scanner_set_active (parser_context_t *context_p) /**< context */
 /**
  * Set the next scanner info to the active scanner info.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_revert_active (parser_context_t *context_p) /**< context */
 {
   scanner_info_t *scanner_info_p = context_p->active_scanner_info_p;
@@ -307,7 +307,7 @@ scanner_revert_active (parser_context_t *context_p) /**< context */
 /**
  * Release the active scanner info.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_release_active (parser_context_t *context_p, /**< context */
                         size_t size) /**< size of the memory block */
 {
@@ -1453,7 +1453,7 @@ scanner_add_custom_literal (parser_context_t *context_p, /**< context */
  *
  * @return pointer to the literal
  */
-inline lexer_lit_location_t * JERRY_ATTR_ALWAYS_INLINE
+extern inline lexer_lit_location_t * JERRY_ATTR_ALWAYS_INLINE
 scanner_add_literal (parser_context_t *context_p, /**< context */
                      scanner_context_t *scanner_context_p) /**< scanner context */
 {
@@ -1468,7 +1468,7 @@ scanner_add_literal (parser_context_t *context_p, /**< context */
  *
  * @return pointer to the literal
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_add_reference (parser_context_t *context_p, /**< context */
                        scanner_context_t *scanner_context_p) /**< scanner context */
 {
@@ -2837,7 +2837,7 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
 /**
  * Get location from context.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_get_location (scanner_location_t *location_p, /**< location */
                       parser_context_t *context_p) /**< context */
 {
@@ -2849,7 +2849,7 @@ scanner_get_location (scanner_location_t *location_p, /**< location */
 /**
  * Set context location.
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 scanner_set_location (parser_context_t *context_p, /**< context */
                       scanner_location_t *location_p) /**< location */
 {
@@ -2861,7 +2861,7 @@ scanner_set_location (parser_context_t *context_p, /**< context */
 /**
  * Get the real map_to value.
  */
-inline uint16_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint16_t JERRY_ATTR_ALWAYS_INLINE
 scanner_decode_map_to (parser_scope_stack_t *stack_item_p) /**< scope stack item */
 {
   JERRY_ASSERT (stack_item_p->map_from != PARSER_SCOPE_STACK_FUNC);

--- a/jerry-core/parser/regexp/re-bytecode.c
+++ b/jerry-core/parser/regexp/re-bytecode.c
@@ -38,7 +38,7 @@ re_initialize_regexp_bytecode (re_compiler_ctx_t *re_ctx_p) /**< RegExp bytecode
   re_ctx_p->bytecode_size = initial_size;
 } /* re_initialize_regexp_bytecode */
 
-inline uint32_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 re_bytecode_size (re_compiler_ctx_t *re_ctx_p) /**< RegExp bytecode context */
 {
   return (uint32_t) re_ctx_p->bytecode_size;
@@ -101,7 +101,7 @@ re_insert_byte (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
 /**
  * Get a single byte and icnrease bytecode position.
  */
-inline uint8_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint8_t JERRY_ATTR_ALWAYS_INLINE
 re_get_byte (const uint8_t **bc_p) /**< pointer to bytecode start */
 {
   return *((*bc_p)++);
@@ -110,7 +110,7 @@ re_get_byte (const uint8_t **bc_p) /**< pointer to bytecode start */
 /**
  * Append a RegExp opcode
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 re_append_opcode (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
                   const re_opcode_t opcode) /**< input opcode */
 {
@@ -120,7 +120,7 @@ re_append_opcode (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
 /**
  * Insert a RegExp opcode
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 re_insert_opcode (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
                   const uint32_t offset, /**< distance from the start of the container */
                   const re_opcode_t opcode) /**< input opcode */
@@ -133,7 +133,7 @@ re_insert_opcode (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
  *
  * @return current RegExp opcode
  */
-inline re_opcode_t JERRY_ATTR_ALWAYS_INLINE
+extern inline re_opcode_t JERRY_ATTR_ALWAYS_INLINE
 re_get_opcode (const uint8_t **bc_p) /**< pointer to bytecode start */
 {
   return (re_opcode_t) re_get_byte (bc_p);
@@ -196,7 +196,7 @@ re_decode_u32 (const uint8_t *src_p) /**< source */
  *
  * @return encoded value size
  */
-inline static size_t JERRY_ATTR_ALWAYS_INLINE
+static inline size_t JERRY_ATTR_ALWAYS_INLINE
 re_get_encoded_value_size (uint32_t value) /**< value */
 {
   if (JERRY_LIKELY (value <= RE_VALUE_1BYTE_MAX))
@@ -254,7 +254,7 @@ re_insert_value (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
  *
  * @return decoded value
  */
-inline uint32_t JERRY_ATTR_ALWAYS_INLINE
+extern inline uint32_t JERRY_ATTR_ALWAYS_INLINE
 re_get_value (const uint8_t **bc_p) /** refence to bytecode pointer */
 {
   uint32_t value = *(*bc_p)++;
@@ -330,7 +330,7 @@ re_insert_char (re_compiler_ctx_t *re_ctx_p, /**< RegExp bytecode context */
  *
  * @return decoded character
  */
-inline lit_code_point_t JERRY_ATTR_ALWAYS_INLINE
+extern inline lit_code_point_t JERRY_ATTR_ALWAYS_INLINE
 re_get_char (const uint8_t **bc_p, /**< reference to bytecode pointer */
              bool unicode) /**< full unicode mode */
 {

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -48,7 +48,7 @@
  * @return ECMA_VALUE_ERROR - if no the operation fails
  *         ECMA_VALUE_EMPTY - otherwise
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 vm_var_decl (ecma_object_t *lex_env_p, /**< target lexical environment */
              ecma_string_t *var_name_str_p, /**< variable name */
              bool is_configurable_bindings) /**< true if the binding can be deleted */
@@ -94,7 +94,7 @@ vm_var_decl (ecma_object_t *lex_env_p, /**< target lexical environment */
  * @return ECMA_VALUE_ERROR - if no the operation fails
  *         ECMA_VALUE_EMPTY - otherwise
  */
-inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
 vm_set_var (ecma_object_t *lex_env_p, /**< target lexical environment */
             ecma_string_t *var_name_str_p, /**< variable name */
             bool is_strict, /**< true, if the engine is in strict mode */
@@ -1245,7 +1245,7 @@ opfunc_create_implicit_class_constructor (uint8_t opcode) /**< current cbc opcod
 /**
  * Set the [[HomeObject]] attribute of the given functon object
  */
-inline void JERRY_ATTR_ALWAYS_INLINE
+extern inline void JERRY_ATTR_ALWAYS_INLINE
 opfunc_set_home_object (ecma_object_t *func_p, /**< function object */
                         ecma_object_t *parent_env_p) /**< parent environment */
 {

--- a/jerry-core/vm/vm-utils.c
+++ b/jerry-core/vm/vm-utils.c
@@ -45,7 +45,7 @@ vm_is_strict_mode (void)
  *                without 'this' argument,
  *         false - otherwise
  */
-inline bool JERRY_ATTR_ALWAYS_INLINE
+extern inline bool JERRY_ATTR_ALWAYS_INLINE
 vm_is_direct_eval_form_call (void)
 {
   return (JERRY_CONTEXT (status_flags) & ECMA_STATUS_DIRECT_EVAL) != 0;


### PR DESCRIPTION
Fixes ENABLE_AMALGAM need FORCE set to ON when building with MSVC

Using following regexp to rename JERRY_ATTR_ALWAYS_INLINE to JERRY_ALWAYS_INLINE:

" inline ((const |)[a-zA-Z0-9_]+(\s+\*)?)(\s+JERRY_ATTR_CONST|\s+JERRY_ATTR_PURE|\s+JERRY_ATTR_HOT)?\s*JERRY_ATTR_ALWAYS_INLINE"
" JERRY_ALWAYS_INLINE \1\4"

So that we can implement always inline function on different compiler properly;
especially bring up the gap between MSVC and GNU
The always inline for GNU and MSVC are different:
GNU
```
#define JERRY_ALWAYS_INLINE inline __attribute__((always_inline))
```
MSVC
```
#define JERRY_ALWAYS_INLINE __forceinline
```

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
