### PR TITLE
Fix the include directory in the pkgconfig of the math lib

### DIFF
--- a/jerry-math/libjerry-math.pc.in
+++ b/jerry-math/libjerry-math.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/lib
-includedir=${prefix}/include/jerry-math
+includedir=${prefix}/include/jerryscript-math
 
 Name: libjerry-math
 Description: JerryScript: lightweight JavaScript engine (minimal math library)


### PR DESCRIPTION
The pkgconfig specified `include/jerry-math` as the include
directory, but cmake installs header to `include/jerryscript-math`.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
