### PR TITLE
Don't use property list pointer to store Proxy flags

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -2166,8 +2166,8 @@ do \
  * Description of Proxy objects.
  *
  * A Proxy object's property list is used to store extra information:
- *  * The "header.u1.property_list_cp" 1st tag bit stores the IsCallable information.
- *  * The "header.u1.property_list_cp" 2nd tag bit stores the IsConstructor information.
+ *  * The "header.u2.prototype_cp" 1st tag bit stores the IsCallable information.
+ *  * The "header.u2.prototype_cp" 2nd tag bit stores the IsConstructor information.
  */
 typedef struct
 {

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -106,7 +106,7 @@ ecma_op_object_is_callable (ecma_object_t *obj_p) /**< ecma object */
 #if ENABLED (JERRY_BUILTIN_PROXY)
   if (ECMA_OBJECT_TYPE_IS_PROXY (type))
   {
-    return ECMA_GET_FIRST_BIT_FROM_POINTER_TAG (obj_p->u1.property_list_cp) != 0;
+    return ECMA_GET_FIRST_BIT_FROM_POINTER_TAG (obj_p->u2.prototype_cp) != 0;
   }
 #endif /* ENABLED (JERRY_BUILTIN_PROXY) */
 
@@ -215,7 +215,7 @@ ecma_object_check_constructor (ecma_object_t *obj_p) /**< ecma object */
 #if ENABLED (JERRY_BUILTIN_PROXY)
   if (ECMA_OBJECT_TYPE_IS_PROXY (type))
   {
-    if (ECMA_GET_SECOND_BIT_FROM_POINTER_TAG (obj_p->u1.property_list_cp) == 0)
+    if (ECMA_GET_SECOND_BIT_FROM_POINTER_TAG (obj_p->u2.prototype_cp) == 0)
     {
       return ECMA_ERR_MSG ("Proxy target is not a constructor.");
     }

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -60,9 +60,8 @@ ecma_proxy_create (ecma_value_t target, /**< proxy target */
 
   /* ES2015: 5 - 6. */
   /* ES11+: 3 - 4. */
-  ecma_object_t *obj_p = ecma_create_object (ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE),
-                                             sizeof (ecma_proxy_object_t),
-                                             ECMA_OBJECT_TYPE_PROXY);
+  /* A Proxy does not have [[Prototype]] value as per standard */
+  ecma_object_t *obj_p = ecma_create_object (NULL, sizeof (ecma_proxy_object_t), ECMA_OBJECT_TYPE_PROXY);
 
   ecma_proxy_object_t *proxy_obj_p = (ecma_proxy_object_t *) obj_p;
 
@@ -70,13 +69,13 @@ ecma_proxy_create (ecma_value_t target, /**< proxy target */
   /* ES11+: 5. */
   if (ecma_op_is_callable (target))
   {
-    ECMA_SET_FIRST_BIT_TO_POINTER_TAG (obj_p->u1.property_list_cp);
+    ECMA_SET_FIRST_BIT_TO_POINTER_TAG (obj_p->u2.prototype_cp);
 
     /* ES2015: 7.b. */
     /* ES11+: 5.b. */
     if (ecma_is_constructor (target))
     {
-      ECMA_SET_SECOND_BIT_TO_POINTER_TAG (obj_p->u1.property_list_cp);
+      ECMA_SET_SECOND_BIT_TO_POINTER_TAG (obj_p->u2.prototype_cp);
     }
   }
 

--- a/tests/jerry/es.next/regression-test-issue-4396.js
+++ b/tests/jerry/es.next/regression-test-issue-4396.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function demo() {
+}
+
+var proxy = new Proxy(demo, {});
+var weakset = new WeakSet();
+
+/* Internal: WeakSet adds an extra internal property to the proxy object. */
+weakset.add(proxy);


### PR DESCRIPTION
Proxy flags (IsCallable, IsConstructor) can't be stored on the
property list compressed pointer. As adding a Proxy to a WeakSet
would add a property to the Proxy object causing failures down the line.

The prototype internal "slot" can be used to store there flags as
it is not used in case of Proxies (as per standard).

Fixes: #4396
Fixes: #4399