### PR TITLE
Proxy.[[Set]] should reject falsish trap result in strict mode

### DIFF
--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -1264,6 +1264,11 @@ ecma_proxy_object_set (ecma_object_t *obj_p, /**< proxy object */
   /* 11. */
   if (!boolean_trap_result)
   {
+    if (is_strict)
+    {
+      return ecma_raise_type_error (ECMA_ERR_MSG ("Proxy trap returned falsish"));
+    }
+
     return ECMA_VALUE_FALSE;
   }
 

--- a/tests/jerry/es.next/regression-test-issue-4398.js
+++ b/tests/jerry/es.next/regression-test-issue-4398.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var get = [];
+var constructor = Function();
+constructor[Symbol.species] = Object;
+var p = new Proxy({ constructor: constructor, flags: '', exec: function() { return null; } }, { set: function (x) { this.set = x === 42; } });
+
+try {
+  RegExp.prototype[Symbol.split].call(p, 7996);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}

--- a/tests/jerry/es.next/symbol-search.js
+++ b/tests/jerry/es.next/symbol-search.js
@@ -250,11 +250,16 @@ var handler = {
 };
 
 var p = new Proxy(r, handler);
-assert (search.call(p, "bba") === 2);
+try {
+  search.call(p, "bba");
+  assert (false);
+} catch (e) {
+  assert (e instanceof TypeError);
+}
 
-assert (get_calls.join(",") === "lastIndex,exec,lastIndex");
-assert (set_calls.join(",") === "lastIndex,lastIndex");
-assert (r.lastIndex === 3.14);
+assert (get_calls.join(",") === "lastIndex");
+assert (set_calls.join(",") === "lastIndex");
+assert (r.lastIndex === 0);
 
 var o = {
   get lastIndex() {


### PR DESCRIPTION
This patch fixes #4398.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
