### PR TITLE
Fix reference count management in %TypedArray%.prototype.reduce{Right}

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -276,7 +276,7 @@ ecma_builtin_typedarray_prototype_reduce_with_direction (ecma_value_t this_arg, 
       return ecma_raise_type_error (ECMA_ERR_MSG ("Initial value cannot be undefined."));
     }
 
-    return arguments_list_p[1];
+    return ecma_copy_value (arguments_list_p[1]);
   }
 
   JERRY_ASSERT (info_p->length > 0);

--- a/tests/jerry/es.next/regression-test-issue-4397.js
+++ b/tests/jerry/es.next/regression-test-issue-4397.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function f () {
+  RegExp("[\\s-a]", "u");
+}
+
+var arr = new Float64Array();
+assert(arr.reduceRight(SyntaxError, f, 'RegExp("[\\s-a]", "u"): ') === f);


### PR DESCRIPTION
This patch fixes #4397.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
