### PR TITLE
Tagged template literal array should be marked after construction

### DIFF
--- a/jerry-core/parser/js/js-parser-tagged-template-literal.c
+++ b/jerry-core/parser/js/js-parser-tagged-template-literal.c
@@ -110,6 +110,16 @@ parser_new_tagged_template_literal (ecma_object_t **raw_strings_p) /**< [out] ra
   ecma_object_t *template_obj_p = ecma_op_new_array_object (0);
   *raw_strings_p = ecma_op_new_array_object (0);
 
+  ecma_extended_object_t *template_ext_obj_p = (ecma_extended_object_t *) template_obj_p;
+  ecma_extended_object_t *raw_ext_obj_p = (ecma_extended_object_t *) *raw_strings_p;
+
+  const uint8_t flags = ECMA_PROPERTY_TYPE_VIRTUAL | ECMA_PROPERTY_FLAG_WRITABLE | ECMA_FAST_ARRAY_FLAG;
+  JERRY_ASSERT (template_ext_obj_p->u.array.length_prop_and_hole_count == flags);
+  JERRY_ASSERT (raw_ext_obj_p->u.array.length_prop_and_hole_count == flags);
+
+  template_ext_obj_p->u.array.length_prop_and_hole_count = flags | ECMA_ARRAY_TEMPLATE_LITERAL;
+  raw_ext_obj_p->u.array.length_prop_and_hole_count = flags | ECMA_ARRAY_TEMPLATE_LITERAL;
+
   ecma_builtin_helper_def_prop (template_obj_p,
                                 ecma_get_magic_string (LIT_MAGIC_STRING_RAW),
                                 ecma_make_object_value (*raw_strings_p),
@@ -125,11 +135,9 @@ static void
 parser_tagged_template_literal_freeze_array (ecma_object_t *obj_p)
 {
   JERRY_ASSERT (ecma_get_object_type (obj_p) == ECMA_OBJECT_TYPE_ARRAY);
-
   ecma_op_ordinary_object_prevent_extensions (obj_p);
   ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) obj_p;
   ext_obj_p->u.array.length_prop_and_hole_count &= (uint32_t) ~ECMA_PROPERTY_FLAG_WRITABLE;
-  ext_obj_p->u.array.length_prop_and_hole_count |= ECMA_ARRAY_TEMPLATE_LITERAL;
 } /* parser_tagged_template_literal_freeze_array */
 
 /**

--- a/tests/jerry/es.next/regression-test-issue-4385.js
+++ b/tests/jerry/es.next/regression-test-issue-4385.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval('P`${*\x10$');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #4385.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu