### PR TITLE
Bound function 'length' property should be early initialized

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -301,7 +301,8 @@ ecma_builtin_function_prototype_object_bind (ecma_object_t *this_arg_obj_p , /**
     ecma_deref_object (prototype_obj_p);
   }
 
-  ecma_value_t target_length = ecma_make_integer_value (0);
+  bound_func_p->target_length = ecma_make_integer_value (0);
+
   ecma_string_t *len_string = ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH);
   ecma_property_descriptor_t prop_desc;
   ecma_value_t status = ecma_op_object_get_own_property_descriptor (this_arg_obj_p,
@@ -332,12 +333,10 @@ ecma_builtin_function_prototype_object_bind (ecma_object_t *this_arg_obj_p , /**
     {
       ecma_number_t len_num;
       ecma_op_to_integer (len_value, &len_num);
-      target_length = ecma_make_number_value (len_num);
+      bound_func_p->target_length = ecma_make_number_value (len_num);
     }
     ecma_free_value (len_value);
   }
-
-  bound_func_p->target_length = target_length;
 
   /* 12. */
   ecma_value_t name_value = ecma_op_object_get_by_magic_id (this_arg_obj_p, LIT_MAGIC_STRING_NAME);

--- a/tests/jerry/es.next/regression-test-issue-4402.js
+++ b/tests/jerry/es.next/regression-test-issue-4402.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var p = new Proxy(Function(), { get: function closure() { eval("o.p.y"); delete closure; return closure == arguments.callee && !(new String(undefined)); }});
+
+try {
+  Function.prototype.bind.call(p);
+  assert(false);
+} catch (e) {
+  assert(e instanceof ReferenceError);
+}


### PR DESCRIPTION
This patch fixes #4402.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu