### PR TITLE
Fix bytecode emitting for invalid regexp literals

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2916,7 +2916,8 @@ lexer_construct_function_object (parser_context_t *context_p, /**< context */
  * Construct a regular expression object.
  *
  * Note: In ESNEXT the constructed literal's type can be LEXER_STRING_LITERAL which represents
- * invalid pattern. The string literal contains the thrown error message.
+ * invalid pattern. In this case the lit_object's index contains the thrown error message literal.
+ * Otherwise a new literal is appended to the end of the literal pool.
  */
 void
 lexer_construct_regexp_object (parser_context_t *context_p, /**< context */

--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -2178,15 +2178,15 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
     {
       lexer_construct_regexp_object (context_p, false);
 
-      uint16_t literal_index = (uint16_t) (context_p->literal_count - 1);
-
 #if ENABLED (JERRY_ESNEXT)
       if (JERRY_UNLIKELY (context_p->lit_object.literal_p->type == LEXER_STRING_LITERAL))
       {
-        parser_emit_cbc_ext_literal (context_p, CBC_EXT_THROW_SYNTAX_ERROR, literal_index);
+        parser_emit_cbc_ext_literal (context_p, CBC_EXT_THROW_SYNTAX_ERROR, context_p->lit_object.index);
         break;
       }
 #endif /* ENABLED (JERRY_ESNEXT) */
+
+      uint16_t literal_index = (uint16_t) (context_p->literal_count - 1);
 
       if (context_p->last_cbc_opcode == CBC_PUSH_LITERAL)
       {

--- a/tests/jerry/es.next/regression-test-issue-4408.js
+++ b/tests/jerry/es.next/regression-test-issue-4408.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  /(?<=^abc)def/;
+} catch(e) {
+  assert(e instanceof SyntaxError);
+}
+
+try {
+  /(?a)/;
+} catch(e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #4408.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
