### PR TITLE
Fix lookahead in lexer_check_numbers

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -1330,8 +1330,11 @@ lexer_check_numbers (parser_context_t *context_p, /**< context */
     if (*source_p != source_end_p && *source_p[0] == LIT_CHAR_UNDERSCORE)
     {
       *source_p += 1;
-      if (is_legacy || *source_p[0] == LIT_CHAR_UNDERSCORE
-          || *source_p[0] > digit_max || *source_p[0] < LIT_CHAR_0)
+      if (is_legacy
+          || *source_p == source_end_p
+          || *source_p[0] == LIT_CHAR_UNDERSCORE
+          || *source_p[0] > digit_max
+          || *source_p[0] < LIT_CHAR_0)
       {
         parser_raise_error (context_p, PARSER_ERR_INVALID_UNDERSCORE_IN_NUMBER);
       }

--- a/tests/jerry/es.next/regression-test-issue-4375.js
+++ b/tests/jerry/es.next/regression-test-issue-4375.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval("1_");
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #4375.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu