### PR TITLE
Fix inherited property type check in ordinary object.[[Set]]

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1509,7 +1509,8 @@ ecma_op_object_put_with_receiver (ecma_object_t *object_p, /**< the object */
                                                                             &property_ref,
                                                                             ECMA_PROPERTY_GET_NO_OPTIONS);
 
-      if (inherited_property != ECMA_PROPERTY_TYPE_NOT_FOUND)
+      if (inherited_property != ECMA_PROPERTY_TYPE_NOT_FOUND
+          && inherited_property != ECMA_PROPERTY_TYPE_NOT_FOUND_AND_STOP)
       {
         if (ECMA_PROPERTY_GET_TYPE (inherited_property) == ECMA_PROPERTY_TYPE_NAMEDACCESSOR)
         {

--- a/tests/jerry/es.next/regression-test-issue-4405.js
+++ b/tests/jerry/es.next/regression-test-issue-4405.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var arr = [1];
+
+var ta = new Int8Array(arr);
+Object.setPrototypeOf(arr, ta);
+arr[1] = 2;
+
+try {
+  ta = new Int8Array(arr);
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #4405.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu