### PR TITLE
Fix VM stack size calculation for class initializer assignments

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2533,6 +2533,13 @@ parser_parse_class_fields (parser_context_t *context_p) /**< context */
     if (class_field_type & PARSER_CLASS_FIELD_NORMAL)
     {
       parser_emit_cbc_literal (context_p, CBC_ASSIGN_PROP_THIS_LITERAL, literal_index);
+
+      /* Prepare stack slot for assignment property reference base. Needed by vm.c */
+      if (context_p->stack_limit == context_p->stack_depth)
+      {
+        context_p->stack_limit++;
+        JERRY_ASSERT (context_p->stack_limit <= PARSER_MAXIMUM_STACK_LIMIT);
+      }
     }
     else
     {

--- a/tests/jerry/es.next/regression-test-issue-4413.js
+++ b/tests/jerry/es.next/regression-test-issue-4413.js
@@ -1,0 +1,18 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert((new (class C2 { x = 5 })).x === 5);
+assert((new (class C2 { x = {} + {} })).x === "[object Object][object Object]");
+assert((new (class C2 { ["foo"] = 5; x = {} + {} })).foo === 5);
+assert((new (class C2 { ["foo"] = 5; x = 6 })).foo === 5);


### PR DESCRIPTION
This patch fixes #4413 and fixes #4241.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
