### PR TITLE
Move ARM and target checks to Github Actions from Travis

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -125,3 +125,85 @@ jobs:
           $RUNNER -q --jerry-tests
           --buildoptions=--compile-flag=-fsanitize=undefined,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--debug,--system-allocator=on,--linker-flag=-fuse-ld=gold
           --skip-list=parser-oom.js,parser-oom2.js
+
+  Linux_ARMv7l_Tests:
+    runs-on: ubuntu-latest
+    env:
+      RUNTIME: qemu-arm-static
+      TIMEOUT: 300
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt update
+      - run: sudo apt install gcc-arm-linux-gnueabihf libc6-dev-armhf-cross qemu-user-static
+      - run: >-
+          $RUNNER -q --jerry-tests
+          --buildoptions=--toolchain=cmake/toolchain_linux_armv7l.cmake,--linker-flag=-static
+
+  Linux_AArch64_Tests:
+    runs-on: ubuntu-latest
+    env:
+      RUNTIME: qemu-aarch64-static
+      TIMEOUT: 300
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt update
+      - run: sudo apt install gcc-aarch64-linux-gnu libc6-dev-armhf-cross qemu-user-static
+      - run: >-
+          $RUNNER -q --jerry-tests
+          --buildoptions=--toolchain=cmake/toolchain_linux_aarch64.cmake,--linker-flag=-static
+
+  MbedOS5_K64F_Build_Test:
+    runs-on: ubuntu-18.04 # needed due to ppa:team-gcc-arm-embedded/ppa
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8' # needed due to 'intelhex' module
+      - run: sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
+      - run: sudo apt update
+      - run: sudo apt install gcc-arm-embedded python3-setuptools
+      - run: make -f ./targets/mbedos5/Makefile.travis install
+      - run: make -f ./targets/mbedos5/Makefile.travis script
+
+  Zephyr_Arduino_101_Build_Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - run: sudo apt update
+      - run: sudo apt install gperf dfu-util device-tree-compiler
+      - run: make -f ./targets/zephyr/Makefile.travis install
+      - run: make -f ./targets/zephyr/Makefile.travis script
+
+  NuttX_STM32F4_Build_Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt update
+      - run: sudo apt install gcc-arm-none-eabi libnewlib-arm-none-eabi gperf
+      - run: make -f ./targets/nuttx-stm32f4/Makefile.travis install-noapt
+      - run: make -f ./targets/nuttx-stm32f4/Makefile.travis script
+
+  RIOT_STM32F4_Build_Test:
+    runs-on: ubuntu-18.04 # needed due to ppa:team-gcc-arm-embedded/ppa
+    env:
+      CC: clang
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
+      - run: sudo apt update
+      - run: sudo apt install clang gcc-arm-embedded gcc-multilib
+      - run: make -f ./targets/riot-stm32f4/Makefile.travis install-noapt
+      - run: make -f ./targets/riot-stm32f4/Makefile.travis script
+
+  ESP8266_Build_Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '2.7' # needed due to ESP8266_RTOS_SDK/tools/gen_appbin.py
+      - run: make -f ./targets/esp8266/Makefile.travis install-noapt
+      - run: make -f ./targets/esp8266/Makefile.travis script

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,6 @@ script: tools/run-tests.py $OPTS
 # All the job definitions in the matrix.
 matrix:
   include:
-    - name: "Linux/ARM Build & Correctness Tests"
-      env:
-        - OPTS="--quiet --jerry-tests --toolchain=cmake/toolchain_linux_armv7l.cmake --buildoptions=--linker-flag=-static"
-        - RUNTIME=qemu-arm-static
-        - TIMEOUT=300
-      addons:
-        apt:
-          packages: [gcc-arm-linux-gnueabihf, libc6-dev-armhf-cross, qemu-user-static]
-
-    - name: "Linux/AArch64 Native Build & Correctness Tests"
-      arch: arm64
-      env:
-        - OPTS="--quiet --jerry-tests --buildoptions=--linker-flag=-static"
-        - TIMEOUT=300
-
     - name: "Coverity Scan & SonarQube"
       env:
         # Declaration of the encrypted COVERITY_SCAN_TOKEN, created via the
@@ -46,50 +31,6 @@ matrix:
       cache:
         directories:
           - '${HOME}/.sonar/cache'
-
-    - name: "Mbed OS 5/K64F Build Test"
-      addons:
-        apt:
-          sources:
-            - sourceline: ppa:team-gcc-arm-embedded/ppa
-          packages: [gcc-arm-embedded]
-      language: python # NOTE: only way to ensure python>=2.7.10 on Trusty image
-      python: 3.6
-      install: make -f ./targets/mbedos5/Makefile.travis install
-      script: make -f ./targets/mbedos5/Makefile.travis script
-
-    - name: "Zephyr/Arduino 101 Build Test"
-      language: python # NOTE: only way to ensure python>=2.7.10 on Trusty image
-      python: 3.6
-      install: make -f ./targets/zephyr/Makefile.travis install-noapt
-      script: make -f ./targets/zephyr/Makefile.travis script
-      addons:
-        apt:
-          packages: [gperf, dfu-util, device-tree-compiler]
-
-    - name: "NuttX/STM32F4 Build Test"
-      install: make -f targets/nuttx-stm32f4/Makefile.travis install-noapt
-      script: make -f targets/nuttx-stm32f4/Makefile.travis script
-      addons:
-        apt:
-          packages: [gcc-arm-none-eabi, libnewlib-arm-none-eabi, gperf]
-
-    - name: "RIOT/STM32F4 Build Test"
-      install: make -f ./targets/riot-stm32f4/Makefile.travis install-noapt
-      script: make -f ./targets/riot-stm32f4/Makefile.travis script
-      compiler: clang-3.9
-      addons:
-        apt:
-          sources:
-            - sourceline: ppa:team-gcc-arm-embedded/ppa
-          packages: [clang-3.9, gcc-arm-embedded, gcc-multilib]
-
-    - name: "ESP8266 Build Test"
-      install: make -f ./targets/esp8266/Makefile.travis install-noapt
-      script: make -f ./targets/esp8266/Makefile.travis script
-      addons:
-        apt:
-          packages: [wget]
 
   fast_finish: true
 

--- a/targets/riot-stm32f4/Makefile.travis
+++ b/targets/riot-stm32f4/Makefile.travis
@@ -23,11 +23,11 @@ all:
 
 # Install cross-compiler via apt.
 install-apt-get-deps:
-	sudo apt-get install -q -y clang-3.9 gcc-arm-embedded gcc-multilib
+	sudo apt-get install -q -y clang gcc-arm-embedded gcc-multilib
 
 # Fetch RIOT OS repository.
 install-clone-riot:
-	git clone git://github.com/RIOT-OS/RIOT.git ../RIOT -b 2019.01
+	git clone git://github.com/RIOT-OS/RIOT.git ../RIOT -b 2020.01
 
 # Perform all the necessary (JerryScript-independent) installation steps.
 install-noapt: install-clone-riot


### PR DESCRIPTION
Note: For easier porting RIOT-STM32F4 target is updated to their latest release.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
