### PR TITLE
Fix strict mode 'let' keyword check in parse for-statement

### DIFF
--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -1220,6 +1220,12 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
         || context_p->token.type == LEXER_KEYW_LET
         || context_p->token.type == LEXER_KEYW_CONST)
     {
+      if (context_p->next_scanner_info_p->type == SCANNER_TYPE_LET_EXPRESSION)
+      {
+        JERRY_ASSERT (context_p->status_flags & PARSER_IS_STRICT);
+        parser_raise_error (context_p, PARSER_ERR_STRICT_IDENT_NOT_ALLOWED);
+      }
+
       token_type = context_p->token.type;
       has_context = context_p->next_scanner_info_p->source_p == context_p->source_p;
       JERRY_ASSERT (!has_context || context_p->next_scanner_info_p->type == SCANNER_TYPE_BLOCK);
@@ -1558,6 +1564,12 @@ parser_parse_for_statement_start (parser_context_t *context_p) /**< context */
       {
         if (context_p->next_scanner_info_p->source_p == source_p)
         {
+          if (context_p->next_scanner_info_p->type == SCANNER_TYPE_LET_EXPRESSION)
+          {
+            JERRY_ASSERT (context_p->status_flags & PARSER_IS_STRICT);
+            parser_raise_error (context_p, PARSER_ERR_STRICT_IDENT_NOT_ALLOWED);
+          }
+
           parser_push_block_context (context_p, true);
         }
         /* FALLTHRU */

--- a/tests/jerry/fail/regression-test-issue-4188-4190-4195.js
+++ b/tests/jerry/fail/regression-test-issue-4188-4190-4195.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default a;
+for (let


### PR DESCRIPTION
This patch fixes #4190 and fixes #4195 and fixes #4188.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu