### PR TITLE
Replace isnan with inequality check to avoid conversion warning in older Clang

### DIFF
--- a/jerry-ext/arg/arg-transform-functions.c
+++ b/jerry-ext/arg/arg-transform-functions.c
@@ -132,7 +132,7 @@ jerryx_arg_helper_process_double (double *d, /**< [in, out] the number to be pro
                                   double max, /**< the max value for clamping */
                                   jerryx_arg_int_option_t option) /**< the converting policies */
 {
-  if (isnan (*d))
+  if (*d != *d) /* isnan (*d) triggers conversion warning on clang<9 */
   {
     return jerry_create_error (JERRY_ERROR_TYPE,
                                (jerry_char_t *) "The number is NaN.");


### PR DESCRIPTION
With `CC=clang tools/build.py --clean --lto=off` (Clang 8.0.0, Linux 4.15.0-128-generic x86_64, Ubuntu 18.04.5 LTS), the build fails with the following diagnostics:

```
jerryscript/jerry-ext/arg/arg-transform-functions.c:135:14: error: implicit conversion loses floating-point precision: 'double' to 'float' [-Werror,-Wimplicit-float-conversion]
  if (isnan (*d))
      ~~~~~~~^~~
/usr/include/math.h:644:46: note: expanded from macro 'isnan'
#  define isnan(x) __MATH_TG ((x), __isnan, (x))
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/usr/include/math.h:559:16: note: expanded from macro '__MATH_TG'
   ? FUNC ## f ARGS                             \
     ~~~~~~~~~ ^~~~
```

It seems that the issue was in Clang: https://bugs.llvm.org/show_bug.cgi?id=35268 . (Confirmed to be fixed in Clang 9, but earlier versions are still affected.)
