### PR TITLE
Make the whole GH Actions Notification job conditional

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -210,9 +210,9 @@ jobs:
 
   Notification:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.repository == 'jerryscript-project/jerryscript'
     steps:
       - uses: rectalogic/notify-irc@v1
-        if: github.event_name == 'push' && github.repository == 'jerryscript-project/jerryscript'
         with:
           channel: '#jerryscript'
           nickname: jerryscript-notification


### PR DESCRIPTION
Don't even start the job if the workflow event is not a push to the
master repo.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
