### PR TITLE
Remove new target workaround from super call

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1183,30 +1183,13 @@ ecma_op_implicit_constructor_handler_heritage_cb (const ecma_value_t function_ob
 
   if (ecma_is_value_object (result))
   {
-    ecma_value_t proto_value = ecma_op_object_get_by_magic_id (JERRY_CONTEXT (current_new_target),
-                                                               LIT_MAGIC_STRING_PROTOTYPE);
-    if (ECMA_IS_VALUE_ERROR (proto_value))
+    ecma_value_t fields_value = opfunc_init_class_fields (function_obj, result);
+
+    if (ECMA_IS_VALUE_ERROR (fields_value))
     {
       ecma_free_value (result);
       result = ECMA_VALUE_ERROR;
     }
-    else
-    {
-      if (ecma_is_value_object (proto_value))
-      {
-        ECMA_SET_POINTER (ecma_get_object_from_value (result)->u2.prototype_cp,
-                          ecma_get_object_from_value (proto_value));
-      }
-
-      ecma_value_t fields_value = opfunc_init_class_fields (function_obj, result);
-
-      if (ECMA_IS_VALUE_ERROR (fields_value))
-      {
-        ecma_free_value (result);
-        result = ECMA_VALUE_ERROR;
-      }
-    }
-    ecma_free_value (proto_value);
   }
 
   ecma_deref_object (super_ctor_p);

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -606,23 +606,6 @@ vm_super_call (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
                                                    arguments_p,
                                                    arguments_list_len);
 
-    if (ecma_is_value_object (completion_value))
-    {
-      ecma_value_t proto_value = ecma_op_object_get_by_magic_id (JERRY_CONTEXT (current_new_target),
-                                                                 LIT_MAGIC_STRING_PROTOTYPE);
-      if (ECMA_IS_VALUE_ERROR (proto_value))
-      {
-        ecma_free_value (completion_value);
-        completion_value = ECMA_VALUE_ERROR;
-      }
-      else if (ecma_is_value_object (proto_value))
-      {
-        ECMA_SET_POINTER (ecma_get_object_from_value (completion_value)->u2.prototype_cp,
-                          ecma_get_object_from_value (proto_value));
-      }
-      ecma_free_value (proto_value);
-    }
-
     if (!ECMA_IS_VALUE_ERROR (completion_value) && ecma_op_this_binding_is_initialized (environment_record_p))
     {
       ecma_free_value (completion_value);

--- a/tests/jerry/es.next/regression-test-issue-4446.js
+++ b/tests/jerry/es.next/regression-test-issue-4446.js
@@ -1,0 +1,31 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class Base {
+  constructor() {
+      return new Proxy(this, {
+          defineProperty(target, p, desc) {
+              return Reflect.defineProperty(target, p, desc);
+          }
+      });
+  }
+}
+
+let computedKey = "test";
+class BasicTPK extends Base {
+  [computedKey] = "basic";
+}
+
+let instance = new BasicTPK;
+assert(instance instanceof BasicTPK);


### PR DESCRIPTION
After #4372 and #4369 all builtin constructors have new target support.

This patch fixes #4446.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu