### PR TITLE
Fix prototype chain traversing

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -62,6 +62,8 @@ ecma_value_t ecma_op_object_define_own_property (ecma_object_t *obj_p, ecma_stri
 ecma_value_t ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, ecma_string_t *property_name_p,
                                                          ecma_property_descriptor_t *prop_desc_p);
 ecma_value_t ecma_op_object_has_instance (ecma_object_t *obj_p, ecma_value_t value);
+ecma_object_t *ecma_op_object_get_prototype_of (ecma_object_t *obj_p);
+
 ecma_value_t ecma_op_object_is_prototype_of (ecma_object_t *base_p, ecma_object_t *target_p);
 ecma_collection_t * ecma_op_object_get_enumerable_property_names (ecma_object_t *obj_p,
                                                                   ecma_enumerable_property_names_options_t option);

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -229,31 +229,6 @@ ecma_proxy_object_find (ecma_object_t *obj_p, /**< proxy object */
 } /* ecma_proxy_object_find */
 
 /**
- * Convert the result of the ecma_proxy_object_get_prototype_of to compressed pointer
- *
- * Note: if `proto` is non-null, the reference from the object is released
- *
- * @return compressed pointer to the `proto` value
- */
-jmem_cpointer_t
-ecma_proxy_object_prototype_to_cp (ecma_value_t proto) /**< ECMA_VALUE_NULL or object */
-{
-  JERRY_ASSERT (ecma_is_value_null (proto) || ecma_is_value_object (proto));
-
-  if (ecma_is_value_null (proto))
-  {
-    return JMEM_CP_NULL;
-  }
-
-  jmem_cpointer_t proto_cp;
-  ecma_object_t *proto_obj_p = ecma_get_object_from_value (proto);
-  ECMA_SET_POINTER (proto_cp, proto_obj_p);
-  ecma_deref_object (proto_obj_p);
-
-  return proto_cp;
-} /* ecma_proxy_object_prototype_to_cp */
-
-/**
  * Helper method for validate the proxy object
  *
  * @return proxy trap - if the validation is successful

--- a/jerry-core/ecma/operations/ecma-proxy-object.h
+++ b/jerry-core/ecma/operations/ecma-proxy-object.h
@@ -41,9 +41,6 @@ ecma_proxy_revoke_cb (const ecma_value_t function_obj,
                       const ecma_value_t args_p[],
                       const uint32_t args_count);
 
-jmem_cpointer_t
-ecma_proxy_object_prototype_to_cp (ecma_value_t proto);
-
 ecma_value_t
 ecma_proxy_object_find (ecma_object_t *obj_p,
                         ecma_string_t *prop_name_p);

--- a/tests/jerry/es.next/regression-test-issue-4445.js
+++ b/tests/jerry/es.next/regression-test-issue-4445.js
@@ -1,0 +1,60 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Keeping test as it is due to the fact this was triggered via a gc related issue
+
+var a= ["", "\0", "\t", "\n", "\v", "\f", "\r", " ", "\u00a0", "\u2028", "\u2029", "\ufeff"]
+Array.prototype[4] = 10;
+
+function Test()
+{
+  a.sort(function() {
+    var A = function() { };
+    A.prototype.x = 42;
+    var o = new Proxy({
+        "3": {
+          writable:false,
+          value:20
+        }
+      }, /*handler*/ {
+        getPrototypeOf: function (val, size, ch) {
+          var result = new String(val);
+          if (ch == null) {
+            ch = " ";
+          }
+          while (result.length < size) {
+            result = ch + result;
+          }
+          return result;
+        }
+      }
+    );
+
+    o.x = 43;
+    var result = "";
+    for (var p in o) {
+        result += o[p];
+    }
+    return a | 0;
+  });
+
+  throw new EvalError("error");
+}
+
+try {
+  Test();
+  assert(false);
+} catch (ex) {
+  assert (ex instanceof EvalError);
+}


### PR DESCRIPTION
After the introduction of the Proxy builtin object there was
a possibility to traverse the prototype chain with an invalid object.
The prototype was freed before it's data/properties were queried resulting
in accessing invalid information.

By forcing the allocator to always do a gc (`--mem-stres-test=on` build option)
it was possible to trigger the issue without complicated tests.

New internal method:
* `ecma_op_object_get_prototype_of` which always returns the prototype
  of an object and the return value must be freed (if it is valid).

Updated prototype chain traversing in:
* `jerry_object_get_property_names`
* `ecma_builtin_object_prototype_lookup_getter_setter`
* `ecma_op_function_has_instance`
* `ecma_op_function_get_super_constructor`
* `ecma_op_object_is_prototype_of`
* `ecma_op_object_enumerate`

Removed method `ecma_proxy_object_prototype_to_cp`

Fixes: #4445
