### PR TITLE
Fix error instance query if the error is from a Proxy

### DIFF
--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -170,7 +170,7 @@ ecma_new_standard_error (ecma_standard_error_t error_type) /**< native error typ
 ecma_standard_error_t
 ecma_get_error_type (ecma_object_t *error_object) /**< possible error object */
 {
-  if (error_object->u2.prototype_cp == JMEM_CP_NULL)
+  if (error_object->u2.prototype_cp == JMEM_CP_NULL || ECMA_OBJECT_IS_PROXY (error_object))
   {
     return ECMA_ERROR_NONE;
   }

--- a/tests/jerry/es.next/regression-test-issue-4440.js
+++ b/tests/jerry/es.next/regression-test-issue-4440.js
@@ -1,0 +1,36 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var handler = {
+  get: function(target, key) {
+    assert(typeof(target) === 'function');
+    assert(key === 'dummy');
+    return 42;
+  }
+};
+
+try {
+  throw new Proxy(Function(), handler);
+  assert(false);
+} catch (ex) {
+  /* 'ex' is the Proxy */
+  assert(typeof(ex) === 'function');
+  assert(ex.dummy === 42);
+}
+
+try {
+  throw new Proxy(EvalError(), { });
+} catch (ex) {
+  assert(ex instanceof EvalError);
+}


### PR DESCRIPTION
When accessing an error's type there is no need to check the Proxy
prototype (as there is none).

Fixes: #4440