### PR TITLE
Add missing error check for for-in HasNext check

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -4036,6 +4036,11 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
             result = ecma_op_object_has_property (object_p, prop_name_p);
 
+            if (ECMA_IS_VALUE_ERROR (result))
+            {
+              goto error;
+            }
+
             if (JERRY_LIKELY (ecma_is_value_true (result)))
             {
               byte_code_p = byte_code_start_p + branch_offset;

--- a/tests/jerry/es.next/regression-test-issue-4464.js
+++ b/tests/jerry/es.next/regression-test-issue-4464.js
@@ -1,0 +1,41 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = [3.3, 2.2, 1];
+
+try {
+a.sort(function() {
+    var o = new Proxy({
+        get foo() {
+            return eval("function");
+        },
+        set foo(arg) {
+            return s2 = s3
+        }
+    }, {
+        has: true,
+        get: function() {
+            a = true;
+            return 30;
+        }
+    });
+    o.x = 43;
+    var result = "";
+    for (var p in o)
+        result += o[p];
+});
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #4464.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu