### PR TITLE
logging the crash properly when running test262-harness.py

### DIFF
--- a/tools/runners/test262-harness.py
+++ b/tools/runners/test262-harness.py
@@ -434,6 +434,12 @@ class TestResult(object):
     def report_outcome(self, long_format):
         name = self.case.get_name()
         mode = self.case.get_mode()
+
+        if self.exit_code != 0 and self.exit_code != 1:
+            sys.stderr.write(u"===%s failed in %s with negative:%s===\n"
+                             % (name, mode, self.case.get_negative_type()))
+            self.write_output(sys.stderr)
+
         if self.has_unexpected_outcome():
             if self.case.is_negative():
                 print("=== %s passed in %s, but was expected to fail ===" % (name, mode))


### PR DESCRIPTION
When running tests262 cases, the jerry program may exit with error code other than 1,
that's means a crash or JERRY_ASSERT triggered and should be resolved, so dump the test
name and stderr/stdout for tracking those crash in CI.

Depends on https://github.com/jerryscript-project/jerryscript/pull/4492

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
