### PR TITLE
Disable the debug popup on win32/msvc.

### DIFF
--- a/jerry-main/main-unix.c
+++ b/jerry-main/main-unix.c
@@ -17,6 +17,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined (_WIN32)
+#include <crtdbg.h>
+#include <Windows.h>
+#endif
 
 #include "jerryscript.h"
 #include "jerryscript-ext/debugger.h"
@@ -60,7 +64,22 @@ main (int argc,
 
   main_args_t arguments;
   arguments.sources_p = sources_p;
-
+#if defined (_WIN32)
+  if (!IsDebuggerPresent ())
+  {
+    /* Disable all of the possible ways Windows conspires to make automated
+     testing impossible. */
+#if defined (_MSC_VER)
+    _set_error_mode (_OUT_TO_STDERR);
+    _CrtSetReportMode (_CRT_WARN, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile (_CRT_WARN, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode (_CRT_ERROR, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile (_CRT_ERROR, _CRTDBG_FILE_STDERR);
+    _CrtSetReportMode (_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+    _CrtSetReportFile (_CRT_ASSERT, _CRTDBG_FILE_STDERR);
+#endif
+  }
+#endif
   main_parse_args (argc, argv, &arguments);
 
 #if defined (JERRY_EXTERNAL_CONTEXT) && (JERRY_EXTERNAL_CONTEXT == 1)


### PR DESCRIPTION

For not popup dialog when crash happend on MSVC/win32
related issue: https://github.com/jerryscript-project/jerryscript/issues/4463


JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
