### PR TITLE
Rename 'this' to 'this_arg' in function arguments

### DIFF
--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -279,11 +279,11 @@ ecma_fulfill_promise (ecma_value_t promise, /**< promise */
  */
 ecma_value_t
 ecma_promise_reject_handler (const ecma_value_t function, /**< the function itself */
-                             const ecma_value_t this, /**< this_arg of the function */
+                             const ecma_value_t this_arg, /**< this_arg of the function */
                              const ecma_value_t argv[], /**< argument list */
                              const uint32_t argc) /**< argument number */
 {
-  JERRY_UNUSED (this);
+  JERRY_UNUSED (this_arg);
   ecma_promise_resolver_t *function_p = (ecma_promise_resolver_t *) ecma_get_object_from_value (function);
 
   /* 1. */
@@ -313,11 +313,11 @@ ecma_promise_reject_handler (const ecma_value_t function, /**< the function itse
  */
 ecma_value_t
 ecma_promise_resolve_handler (const ecma_value_t function, /**< the function itself */
-                              const ecma_value_t this, /**< this_arg of the function */
+                              const ecma_value_t this_arg, /**< this_arg of the function */
                               const ecma_value_t argv[], /**< argument list */
                               const uint32_t argc) /**< argument number */
 {
-  JERRY_UNUSED (this);
+  JERRY_UNUSED (this_arg);
   ecma_promise_resolver_t *function_p = (ecma_promise_resolver_t *) ecma_get_object_from_value (function);
 
   /* 1. */

--- a/jerry-core/ecma/operations/ecma-promise-object.h
+++ b/jerry-core/ecma/operations/ecma-promise-object.h
@@ -129,12 +129,12 @@ ecma_value_t ecma_promise_catch_finally_cb (const ecma_value_t function_obj,
                                             const uint32_t args_count);
 ecma_value_t
 ecma_promise_reject_handler (const ecma_value_t function,
-                             const ecma_value_t this,
+                             const ecma_value_t this_arg,
                              const ecma_value_t argv[],
                              const uint32_t argc);
 ecma_value_t
 ecma_promise_resolve_handler (const ecma_value_t function,
-                              const ecma_value_t this,
+                              const ecma_value_t this_arg,
                               const ecma_value_t argv[],
                               const uint32_t argc);
 


### PR DESCRIPTION
'this' is a restricted keyword in C++ so it's a good practice to avoid it's usage as an identifier.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
