### PR TITLE
Make all dynamic memory allocations via core API functions in jerry-ext

### DIFF
--- a/jerry-ext/handle-scope/handle-scope-allocator.c
+++ b/jerry-ext/handle-scope/handle-scope-allocator.c
@@ -157,7 +157,8 @@ jerryx_handle_scope_alloc (void)
   }
   else
   {
-    jerryx_handle_scope_dynamic_t *dy_scope = malloc (sizeof (jerryx_handle_scope_dynamic_t));
+    jerryx_handle_scope_dynamic_t *dy_scope;
+    dy_scope = (jerryx_handle_scope_dynamic_t *) jerry_heap_alloc (sizeof (jerryx_handle_scope_dynamic_t));
     JERRYX_ASSERT (dy_scope != NULL);
     dy_scope->child = NULL;
 
@@ -216,7 +217,7 @@ jerryx_handle_scope_free (jerryx_handle_scope_t *scope)
     {
       dy_scope->parent->child = dy_scope->child;
     }
-    free (dy_scope);
+    jerry_heap_free (dy_scope, sizeof (jerryx_handle_scope_dynamic_t));
     return;
   }
   /**

--- a/jerry-ext/handle-scope/handle-scope.c
+++ b/jerry-ext/handle-scope/handle-scope.c
@@ -48,7 +48,7 @@ jerryx_handle_scope_release_handles (jerryx_handle_scope scope)
     {
       jerry_release_value (a_handle->jval);
       jerryx_handle_t *sibling = a_handle->sibling;
-      free (a_handle);
+      jerry_heap_free (a_handle, sizeof (jerryx_handle_t));
       a_handle = sibling;
     }
     scope->handle_ptr = NULL;
@@ -134,7 +134,7 @@ jerryx_hand_scope_escape_handle_from_prelist (jerryx_handle_scope scope, size_t 
     jerryx_handle_t *handle = scope->handle_ptr;
     scope->handle_ptr = handle->sibling;
     scope->handle_prelist[idx] = handle->jval;
-    free (handle);
+    jerry_heap_free (handle, sizeof (jerryx_handle_t));
     return jval;
   }
 
@@ -313,7 +313,7 @@ jerryx_handle_scope_add_handle_to (jerryx_handle_t *handle, jerryx_handle_scope 
   {
     ++scope->prelist_handle_count;
     jerry_value_t jval = handle->jval;
-    free (handle);
+    jerry_heap_free (handle, sizeof (jerryx_handle_t));
     scope->handle_prelist[prelist_handle_count] = jval;
     return jval;
   }
@@ -341,7 +341,7 @@ jerryx_create_handle_in_scope (jerry_value_t jval, jerryx_handle_scope scope)
     ++scope->prelist_handle_count;
     return jval;
   }
-  jerryx_handle_t *handle = malloc (sizeof (jerryx_handle_t));
+  jerryx_handle_t *handle = (jerryx_handle_t *) jerry_heap_alloc (sizeof (jerryx_handle_t));
   JERRYX_ASSERT (handle != NULL);
   handle->jval = jval;
 


### PR DESCRIPTION
Direct calls to `malloc` and `free` should be avoided,
`jerry_heap_alloc` and `jerry_heap_free` should be used in their
place. Build-time configuration should decide whether those calls
manage dynamic memory on the engine's heap or on the system heap.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
