### PR TITLE
Trying to fixes module-resource-name.js win32

### DIFF
--- a/tests/jerry/es.next/module-resource-name.js
+++ b/tests/jerry/es.next/module-resource-name.js
@@ -14,14 +14,14 @@
 
 import { getName, getNamePromise } from "./module-resource-name-export.mjs"
 
-assert(getName().endsWith("/module-resource-name-export.mjs") === true);
+assert(getName().endsWith("module-resource-name-export.mjs"));
 
 var collector = {};
 getNamePromise(collector).then(() => { collector["end"] = resourceName(); });
 
 function __checkAsync() {
-  assert(collector["start"].endsWith("/module-resource-name-export.mjs") === true);
-  assert(collector["middle"].endsWith("/module-resource-name-export.mjs") === true);
-  assert(collector["end"].endsWith("/module-resource-name.js") === true);
+  assert(collector["start"].endsWith("module-resource-name-export.mjs"));
+  assert(collector["middle"].endsWith("module-resource-name-export.mjs"));
+  assert(collector["end"].endsWith("module-resource-name.js"));
   assert(Object.keys(collector).length === 3);
 }


### PR DESCRIPTION
Try to fix the following testcases on win32:


```
[ 237/1146] FAIL (3221226505): tests\jerry\es.next\module-resource-name.js
================================================
Script Error: assertion failed
Script backtrace (top 5):
 0: C:\work\study\languages     ypescript\jerryscript   ests/jerry\es.next\module-resource-name.js:17

================================================

[summary] build\tests\jerry_tests-es.next\local\bin\jerry.exe tests\jerry

TOTAL: 1146
PASS: 1145
FAIL: 1

Success: 99%
```

See also https://github.com/lygstate/jerryscript/runs/1713796124?check_suite_focus=true
After revise default-module.c, I found the debugger'result path currently all to be relative path, not absolute path
That's not easy to locate the exact file place when debugging.


JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
