### PR TITLE
Use approxEq to judge double compare in math-cbrt.js

### DIFF
--- a/tests/jerry/es.next/math-cbrt.js
+++ b/tests/jerry/es.next/math-cbrt.js
@@ -20,6 +20,11 @@ function isSameZero (x, y)
   return x === 0 && (1 / x) === (1 / y);
 }
 
+function approxEq (x, y)
+{
+  return Math.abs(x - y) <= Number.EPSILON * 2
+}
+
 assert(isNaN(Math.cbrt(NaN)));
 assert(isSameZero(Math.cbrt(p_zero), p_zero));
 assert(isSameZero(Math.cbrt(n_zero), n_zero));
@@ -29,5 +34,5 @@ assert(Math.cbrt(Number.NEGATIVE_INFINITY) === Number.NEGATIVE_INFINITY);
 assert(Math.cbrt(1.0) === 1.0);
 assert(Math.cbrt(-1.0) === -1.0);
 
-// assert(Math.cbrt(27.0) === 3.0); // FIXME: unstable, depending on compiler and libm
-assert(Math.cbrt(0.001) === 0.1);
+assert(approxEq(Math.cbrt(27.0), 3.0));
+assert(approxEq(Math.cbrt(0.001), 0.1));


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
