### PR TITLE
exclude test-ext-autorelease.c in SOURCE_UNIT_TEST_EXT_MODULES properly

### DIFF
--- a/tests/unit-ext/CMakeLists.txt
+++ b/tests/unit-ext/CMakeLists.txt
@@ -35,7 +35,7 @@ set(SOURCE_UNIT_TEST_EXT_MODULES
 
 # Disable test-ext-autorelease.c if compiler is MSVC, because MSVC doesn't support cleanup attribute.
 if(USING_MSVC)
-  list(REMOVE_ITEM SOURCE_UNIT_TEST_EXT_MODULES ${CMAKE_CURRENT_SOURCE_DIR}/test-ext-autorelease.c)
+  list(REMOVE_ITEM SOURCE_UNIT_TEST_EXT_MODULES test-ext-autorelease.c)
 endif()
 
 # Unit tests declaration


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
