### PR TITLE
Unify asserts in jerry-ext

### DIFF
--- a/jerry-ext/arg/arg.c
+++ b/jerry-ext/arg/arg.c
@@ -13,17 +13,13 @@
  * limitations under the License.
  */
 
-#include "arg-internal.h"
 #include "jerryscript-ext/arg.h"
 #include "jerryscript.h"
-
-#define JERRYX_STATIC_ASSERT(x, msg) \
-  enum { static_assertion_failed_ ## msg = 1 / (!!(x)) }
+#include "arg-internal.h"
+#include "jext-common.h"
 
 JERRYX_STATIC_ASSERT (sizeof (jerryx_arg_int_option_t) <= sizeof (((jerryx_arg_t *) 0)->extra_info),
                       jerryx_arg_number_options_t_must_fit_into_extra_info);
-
-#undef JERRYX_STATIC_ASSERT
 
 /**
  * Validate the JS arguments and assign them to the native arguments.

--- a/jerry-ext/handle-scope/handle-scope-allocator.c
+++ b/jerry-ext/handle-scope/handle-scope-allocator.c
@@ -15,6 +15,7 @@
 
 #include <stdlib.h>
 #include "handle-scope-internal.h"
+#include "jext-common.h"
 
 static jerryx_handle_scope_t jerryx_handle_scope_root =
 {
@@ -157,7 +158,7 @@ jerryx_handle_scope_alloc (void)
   else
   {
     jerryx_handle_scope_dynamic_t *dy_scope = malloc (sizeof (jerryx_handle_scope_dynamic_t));
-    JERRYX_HANDLE_SCOPE_ASSERT (dy_scope != NULL);
+    JERRYX_ASSERT (dy_scope != NULL);
     dy_scope->child = NULL;
 
     if (jerryx_handle_scope_pool.count != JERRYX_SCOPE_PRELIST_SIZE)

--- a/jerry-ext/handle-scope/handle-scope-internal.h
+++ b/jerry-ext/handle-scope/handle-scope-internal.h
@@ -25,21 +25,6 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-#define JERRYX_HANDLE_SCOPE_ASSERT(x) \
-  do \
-  { \
-    if (!(x)) \
-    { \
-      jerry_port_log (JERRY_LOG_LEVEL_ERROR, \
-                      "JerryXHandleScope: Assertion '%s' failed at %s(%s):%lu.\n", \
-                      #x, \
-                      __FILE__, \
-                      __func__, \
-                      (unsigned long) __LINE__); \
-      jerry_port_fatal (ERR_FAILED_INTERNAL_ASSERTION); \
-    } \
-  } while (0)
-
 /** MARK: - handle-scope-allocator.c */
 typedef struct jerryx_handle_scope_pool_s jerryx_handle_scope_pool_t;
 /**

--- a/jerry-ext/handle-scope/handle-scope.c
+++ b/jerry-ext/handle-scope/handle-scope.c
@@ -15,6 +15,9 @@
 
 #include <stdlib.h>
 #include "handle-scope-internal.h"
+#include "jext-common.h"
+
+JERRYX_STATIC_ASSERT (JERRYX_SCOPE_PRELIST_SIZE < 32, JERRYX_SCOPE_PRELIST_SIZE_MUST_BE_LESS_THAN_SIZE_OF_UINT8_T);
 
 /**
  * Opens a new handle scope and attach it to current global scope as a child scope.
@@ -339,7 +342,7 @@ jerryx_create_handle_in_scope (jerry_value_t jval, jerryx_handle_scope scope)
     return jval;
   }
   jerryx_handle_t *handle = malloc (sizeof (jerryx_handle_t));
-  JERRYX_HANDLE_SCOPE_ASSERT (handle != NULL);
+  JERRYX_ASSERT (handle != NULL);
   handle->jval = jval;
 
   handle->sibling = scope->handle_ptr;

--- a/jerry-ext/include/jerryscript-ext/handle-scope.h
+++ b/jerry-ext/include/jerryscript-ext/handle-scope.h
@@ -31,12 +31,6 @@ extern "C"
 #define JERRYX_SCOPE_PRELIST_SIZE 20
 #endif
 
-#define STATIC_ASSERT(COND,MSG) typedef char static_assertion_##MSG[(COND)?1:-1]
-
-STATIC_ASSERT (JERRYX_SCOPE_PRELIST_SIZE < 32, JERRYX_SCOPE_PRELIST_SIZE_must_be_less_than_size_of_uint8_t);
-
-#undef STATIC_ASSERT
-
 typedef struct jerryx_handle_t jerryx_handle_t;
 /**
  * Dynamically allocated handle in the scopes.


### PR DESCRIPTION
Some components of the jerry-ext library re-declared their own
assert and/or static assert macros. No need to re-invent the wheel
all the time. This patch makes all components use the assert macros
defined in jext-common.h. This also makes maintenance easier.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
