### PR TITLE
Fix stdout encoding for python2 and python3 in test262-harness.py

### DIFF
--- a/tools/runners/test262-harness.py
+++ b/tools/runners/test262-harness.py
@@ -382,6 +382,15 @@ def is_windows():
     return (actual_platform == 'Windows') or (actual_platform == 'Microsoft')
 
 
+def write_text_to(target, text):
+    if sys.version_info >= (3, 0):
+        target.buffer.write(text.encode(target.encoding or "utf8", "ignore"))
+        target.buffer.flush()
+    else:
+        target.write(text.encode("utf8", errors="ignore"))
+        target.flush()
+
+
 class TempFile(object):
 
     def __init__(self, suffix="", prefix="tmp", text=False):
@@ -452,12 +461,12 @@ class TestResult(object):
     def write_output(self, target):
         out = self.stdout.strip()
         if out:
-            target.write("--- output --- \n %s" % out)
+            write_text_to(target, u"--- output --- \n%s\n" % out)
         error = self.stderr.strip()
         if error:
-            target.write("--- errors ---  \n %s" % error)
+            write_text_to(target, u"--- errors ---  \n%s\n" % error)
 
-        target.write("\n--- exit code: %d ---\n" % self.exit_code)
+        write_text_to(target, u"\n--- exit code: %d ---\n" % self.exit_code)
 
     def has_failed(self):
         return self.exit_code != 0


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "C:\work\study\languages\typescript\jerryscript\tools\runners\test262-harness.py", line 1019, in <module>
    sys.exit(main())
  File "C:\work\study\languages\typescript\jerryscript\tools\runners\test262-harness.py", line 1009, in main
    code = test_suite.run(options.command, args,
  File "C:\work\study\languages\typescript\jerryscript\tools\runners\test262-harness.py", line 930, in run
    progress.has_run(result)
  File "C:\work\study\languages\typescript\jerryscript\tools\runners\test262-harness.py", line 753, in has_run
    result.report_outcome(True)
  File "C:\work\study\languages\typescript\jerryscript\tools\runners\test262-harness.py", line 492, in report_outcome
    self.write_output(sys.stdout)
  File "C:\work\study\languages\typescript\jerryscript\tools\runners\test262-harness.py", line 506, in write_output
    target.write("--- errors ---  \n %s" % error)
UnicodeEncodeError: 'gbk' codec can't encode character '\xab' in position 52: illegal multibyte sequence
...............................................=== Summary - updating excludelist ===
```

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
