### PR TITLE
Fixes timezone get on win32

### DIFF
--- a/tools/runners/util.py
+++ b/tools/runners/util.py
@@ -37,7 +37,7 @@ def set_timezone_and_exit(timezone):
 
 def get_timezone():
     assert sys.platform == 'win32', "get_timezone is Windows only function"
-    return subprocess.check_output(['cmd', '/S', '/C', 'tzutil', '/g'])
+    return subprocess.check_output(['cmd', '/S', '/C', 'tzutil', '/g'], universal_newlines=True)
 
 
 def set_sighdl_to_reset_timezone(timezone):


### PR DESCRIPTION
Traceback (most recent call last):
  File "D:\a\jerryscript\jerryscript\tools\runners/run-test-suite-test262.py", line 234, in <module>
    sys.exit(main(get_arguments()))
  File "D:\a\jerryscript\jerryscript\tools\runners/run-test-suite-test262.py", line 225, in main
    util.set_timezone(original_timezone)
  File "D:\a\jerryscript\jerryscript\tools\runners\util.py", line 29, in set_timezone
    subprocess.call(['cmd', '/S', '/C', 'tzutil', '/s', timezone])
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 339, in call
    with Popen(*popenargs, **kwargs) as p:
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 800, in __init__
    restore_signals, start_new_session)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 1148, in _execute_child
    args = list2cmdline(args)
  File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 555, in list2cmdline
    needquote = (" " in arg) or ("\t" in arg) or not arg
TypeError: a bytes-like object is required, not 'str'

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
