### PR TITLE
Move get_platform_cmd_prefix into util.py

### DIFF
--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -25,6 +25,12 @@ import subprocess
 import sys
 import settings
 
+if sys.version_info.major >= 3:
+    import runners.util as util  # pylint: disable=import-error
+else:
+    sys.path.append(os.path.dirname(os.path.realpath(__file__)) + '/runners')
+    import util
+
 OUTPUT_DIR = os.path.join(settings.PROJECT_DIR, 'build', 'tests')
 
 Options = collections.namedtuple('Options', ['name', 'build_args', 'test_args', 'skip'])
@@ -255,11 +261,6 @@ def report_skip(job):
         sys.stderr.write(' (%s)' % job.skip)
     sys.stderr.write('%s\n' % TERM_NORMAL)
 
-def get_platform_cmd_prefix():
-    if sys.platform == 'win32':
-        return ['cmd', '/S', '/C']
-    return []
-
 def create_binary(job, options):
     build_args = job.build_args[:]
     if options.buildoptions:
@@ -267,7 +268,7 @@ def create_binary(job, options):
             if option not in build_args:
                 build_args.append(option)
 
-    build_cmd = get_platform_cmd_prefix()
+    build_cmd = util.get_python_cmd_prefix()
     build_cmd.append(settings.BUILD_SCRIPT)
     build_cmd.extend(build_args)
 
@@ -336,7 +337,7 @@ def iterate_test_runner_jobs(jobs, options):
         else:
             tested_hashes[bin_hash] = build_dir_path
 
-        test_cmd = get_platform_cmd_prefix()
+        test_cmd = util.get_python_cmd_prefix()
         test_cmd.extend([settings.TEST_RUNNER_SCRIPT, '--engine', bin_path])
 
         yield job, ret_build, test_cmd
@@ -430,7 +431,7 @@ def run_test262_test_suite(options):
             print("\n%sBuild failed%s\n" % (TERM_RED, TERM_NORMAL))
             break
 
-        test_cmd = get_platform_cmd_prefix() + [
+        test_cmd = util.get_python_cmd_prefix() + [
             settings.TEST262_RUNNER_SCRIPT,
             '--engine', get_binary_path(build_dir_path) + " --test262-object",
             '--test-dir', settings.TEST262_TEST_SUITE_DIR
@@ -477,7 +478,7 @@ def run_unittests(options):
 
 
         ret_test |= run_check(
-            get_platform_cmd_prefix() +
+            util.get_python_cmd_prefix() +
             [settings.UNITTEST_RUNNER_SCRIPT] +
             [os.path.join(build_dir_path, 'tests', build_config)] +
             (["-q"] if options.quiet else [])

--- a/tools/runners/run-test-suite.py
+++ b/tools/runners/run-test-suite.py
@@ -73,12 +73,6 @@ def get_tests(test_dir, test_list, skip_list):
     return [test for test in tests if filter_tests(test)]
 
 
-def get_platform_cmd_prefix():
-    if sys.platform == 'win32':
-        return ['cmd', '/S', '/C']
-    return []
-
-
 def execute_test_command(test_cmd):
     kwargs = {}
     if sys.version_info.major >= 3:
@@ -124,7 +118,7 @@ def main(args):
 
 
 def run_normal_tests(args, tests):
-    test_cmd = get_platform_cmd_prefix()
+    test_cmd = util.get_platform_cmd_prefix()
     if args.runtime:
         test_cmd.append(args.runtime)
     test_cmd.extend([args.engine, '--call-on-exit', '__checkAsync'])
@@ -154,8 +148,8 @@ def run_normal_tests(args, tests):
 
 
 def run_snapshot_tests(args, tests):
-    execute_snapshot_cmd = get_platform_cmd_prefix()
-    generate_snapshot_cmd = get_platform_cmd_prefix()
+    execute_snapshot_cmd = util.get_platform_cmd_prefix()
+    generate_snapshot_cmd = util.get_platform_cmd_prefix()
     if args.runtime:
         execute_snapshot_cmd.append(args.runtime)
         generate_snapshot_cmd.append(args.runtime)

--- a/tools/runners/util.py
+++ b/tools/runners/util.py
@@ -65,3 +65,14 @@ def print_test_result(tested, total, is_passed, passed_string, test_path, is_sna
 
     color = TERM_GREEN if is_passed else TERM_RED
     print("[%4d/%4d] %s%s: %s%s%s" % (tested, total, color, passed_string, test_path, snapshot_string, TERM_NORMAL))
+
+
+def get_platform_cmd_prefix():
+    if sys.platform == 'win32':
+        return ['cmd', '/S', '/C']
+    return []
+
+
+def get_python_cmd_prefix():
+    # python script doesn't have execute permission on github actions windows runner
+    return get_platform_cmd_prefix() + [sys.executable or 'python']


### PR DESCRIPTION
get_platform_cmd_prefix implement multiple times in multiple function.
Also add function get_python_cmd_prefix, call to python script always
add python command so that on windows, the python script doesn't have
executable permission also can be called.

Now it's can be reviewed independently

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
