### PR TITLE
Add ${PYTHON_EXECUTABLE} for "Generating doctests"

### DIFF
--- a/tests/unit-doc/CMakeLists.txt
+++ b/tests/unit-doc/CMakeLists.txt
@@ -85,7 +85,7 @@ endif()
 # Add custom command to run doctest generator if any of the MarkDown sources
 # changes.
 add_custom_command(
-  COMMAND ${GEN_DOCTEST} -d ${CMAKE_CURRENT_BINARY_DIR} ${DOC_FILES}
+  COMMAND ${PYTHON_EXECUTABLE} ${GEN_DOCTEST} -d ${CMAKE_CURRENT_BINARY_DIR} ${DOC_FILES}
   DEPENDS ${GEN_DOCTEST} ${DOC_FILES}
   OUTPUT ${DOCTEST_COMPILE} ${DOCTEST_LINK} ${DOCTEST_RUN}
   COMMENT "Generating doctests"


### PR DESCRIPTION
On win32, the ${PYTHON_EXECUTABLE} should be specified, otherwise the python script
can not be executed properly.

```
C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Microsoft\VC\v160\Microsoft.CppCommon.targets(238,5): warning MSB8065: Custom build for item "D:\a\jerryscript\jerryscript\build\tests\doctests-es.next\CMakeFiles\664065a56ee5d1a2edb8ca8fe389b745\02.API-REFERENCE2.c.rule" succeeded, but specified output "d:\a\jerryscript\jerryscript\build\tests\doctests-es.next\tests\unit-doc\07.debugger2.c" has not been created. This may cause incremental build to work incorrectly. [D:\a\jerryscript\jerryscript\build\tests\doctests-es.next\tests\unit-doc\all-doc-files.vcxproj]

```

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
