### PR TITLE
Update API docs for 2.4 release

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -31,7 +31,7 @@ Enum that contains JerryScript API value types:
 
 *New in version 2.0*.
 
-*Changed in [[NEXT_RELEASE]]*: Added `JERRY_TYPE_BIGINT` value.
+*Changed in version 2.4*: Added `JERRY_TYPE_BIGINT` value.
 
 ## jerry_object_type_t
 
@@ -56,7 +56,7 @@ Enum that contains JerryScript **object** value types:
  - JERRY_OBJECT_TYPE_GENERATOR - Generator object
  - JERRY_OBJECT_TYPE_BIGINT - BigInt object
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 ## jerry_function_type_t
 
@@ -69,7 +69,7 @@ Enum that contains JerryScript **function** value types:
  - JERRY_FUNCTION_TYPE_ARROW - Arrow fuction
  - JERRY_FUNCTION_TYPE_GENERATOR - Generator function object
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 ## jerry_iterator_type_t
 
@@ -81,7 +81,7 @@ Enum that contains JerryScript **iterator** value types:
  - JERRY_ITERATOR_TYPE_MAP - Map iterator
  - JERRY_ITERATOR_TYPE_SET - Set iterator
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 ## jerry_property_filter_t
 
@@ -97,7 +97,7 @@ Enum that contains JerryScript **property filter** options bits:
  - JERRY_PROPERTY_FILTER_EXLCUDE_INTEGER_INDICES - Exclude property key if it is an integer index
  - JERRY_PROPERTY_FILTER_INTEGER_INDICES_AS_NUMBER - By default integer index property keys are converted to string. Enabling this flags keeps integer index property keys as numbers
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 ## jerry_error_t
 
@@ -149,9 +149,9 @@ Possible compile time enabled feature types:
 
 *New in version 2.0*.
 
-*Changed in version 2.3* : Added `JERRY_FEATURE_WEAKMAP`, `JERRY_FEATURE_WEAKSET` values.
+*Changed in version 2.3*: Added `JERRY_FEATURE_WEAKMAP`, `JERRY_FEATURE_WEAKSET` values.
 
-+*Changed in [[NEXT_RELEASE]]*: Added `JERRY_FEATURE_BIGINT`, `JERRY_FEATURE_REALM` values.
+*Changed in version 2.4*: Added `JERRY_FEATURE_BIGINT`, `JERRY_FEATURE_REALM` values.
 
 ## jerry_container_type_t
 
@@ -182,7 +182,7 @@ Well-known symbols:
  - JERRY_SYMBOL_TO_STRING_TAG - @@toStringTag well-known symbol
  - JERRY_SYMBOL_UNSCOPABLES - @@unscopables well-known symbol
 
- *New in version [[NEXT_RELEASE]]*.
+ *New in version 2.4*.
 
 ## jerry_regexp_flags_t
 
@@ -202,7 +202,8 @@ RegExp object optional flags:
 
 
 *New in version 2.0*.
-*Changed in version[[NEXT_RELEASE]]* : Added `JERRY_REGEXP_FLAG_STICKY`, `JERRY_REGEXP_FLAG_UNICODE` , `JERRY_REGEXP_FLAG_DOTALL` values.
+
+*Changed in version 2.4*: Added `JERRY_REGEXP_FLAG_STICKY`, `JERRY_REGEXP_FLAG_UNICODE` , `JERRY_REGEXP_FLAG_DOTALL` values.
 
 
 ## jerry_parse_opts_t
@@ -215,6 +216,7 @@ Option bits for [jerry_parse](#jerry_parse) and
  - JERRY_PARSE_MODULE - parse source as an ECMAScript module
 
 *New in version 2.0*.
+
 *Changed in version 2.4: Added `JERRY_PARSE_MODULE`.*
 
 ## jerry_gc_mode_t
@@ -598,8 +600,6 @@ Error object.
  - The callback function cannot be called recursively, so the Error objects created
    when the callback is running are not updated.
 
-*New in version [[NEXT_RELEASE]]*.
-
 **Prototype**
 
 ```c
@@ -608,6 +608,8 @@ typedef void (*jerry_error_object_created_callback_t) (const jerry_value_t error
 
 - `error_object` - the newly created Error object.
 - `user_p` - pointer passed to [jerry_set_error_object_created_callback](#jerry_set_error_object_created_callback).
+
+*New in version 2.4*.
 
 **See also**
 
@@ -791,7 +793,7 @@ TypedArray support is not in the engine.
 
 *New in version 2.0*.
 
-*Changed in version [[NEXT_RELEASE]]*: Added `JERRY_TYPEDARRAY_BIGINT64`, `JERRY_TYPEDARRAY_BIGUINT64` values.
+*Changed in version 2.4*: Added `JERRY_TYPEDARRAY_BIGINT64`, `JERRY_TYPEDARRAY_BIGUINT64` values.
 
 **See also**
 
@@ -1894,6 +1896,8 @@ jerry_value_is_async_function (const jerry_value_t value)
   - true, if the given `jerry_value_t` is an async function
   - false, otherwise
 
+*New in version 2.4*.
+
 **Example**
 
 ```c
@@ -2253,7 +2257,7 @@ jerry_value_is_bigint (const jerry_value_t value)
   - true, if the given `jerry_value_t` is a BigInt
   - false, otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -2515,7 +2519,7 @@ jerry_object_get_type (const jerry_value_t value);
 - return value
   - One of the [jerry_object_type_t](#jerry_object_type_t) value.
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -2558,7 +2562,7 @@ jerry_function_get_type (const jerry_value_t value);
 
 Note: For non-function parameters `JERRY_FUNCTION_TYPE_NONE` is returned.
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -2602,7 +2606,7 @@ jerry_iterator_get_type (const jerry_value_t value);
 
 Note: For non-iterator parameters `JERRY_ITERATOR_TYPE_NONE` is returned.
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -3040,7 +3044,7 @@ void jerry_set_error_object_created_callback (jerry_error_object_created_callbac
                disables the operation
 - `user_p` - pointer passed to the callback function, can be NULL
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -3839,7 +3843,7 @@ jerry_value_to_bigint (const jerry_value_t value);
   - converted BigInt value, if success
   - thrown error, otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -4165,7 +4169,7 @@ jerry_to_property_descriptor (jerry_value_t obj_value, jerry_property_descriptor
   - true, if success
   - thrown error, otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -4288,7 +4292,7 @@ jerry_get_well_known_symbol (jerry_well_known_symbol_t symbol);
   - undefined value - if invalid well-known symbol was requested
   - well-known symbol value, otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -4348,7 +4352,7 @@ jerry_get_symbol_description (const jerry_value_t value);
   - string or undefined value containing the symbol's description - if success
   - thrown error, otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -4477,7 +4481,7 @@ jerry_get_bigint_size_in_digits (jerry_value_t value)
   - number of digits (can be zero for BigInt zero)
   - if value is not a BigInt value, it returns with zero
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -4540,7 +4544,7 @@ jerry_get_bigint_digits (jerry_value_t value, uint64_t *digits_p, uint32_t size,
 - `sign_p` - the boolean passed to the function is set to false when the BigInt
              is positive, and set to true otherwise (this parameter can be NULL)
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -4603,7 +4607,7 @@ jerry_get_proxy_target (jerry_value_t proxy_value)
   - type error - if proxy_value is not a Proxy object
   - target object - otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -5573,7 +5577,7 @@ jerry_create_external_string (const jerry_char_t *str_p,
 - `free_cb` - optional callback which is called right before the string is freed
 - return value - value of the created string
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -5620,7 +5624,7 @@ jerry_create_external_string_sz (const jerry_char_t *str_p,
 - `free_cb` - optional callback which is called right before the string is freed
 - return value - value of the created string
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -5729,7 +5733,7 @@ jerry_create_bigint (const uint64_t *digits_p, uint32_t size, bool sign)
   - value of the created bigint, if success
   - thrown error, otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -6127,7 +6131,7 @@ jerry_create_realm (void);
 
 - return value - realm object value
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -9064,7 +9068,7 @@ jerry_get_backtrace_from (uint32_t max_depth, jerry_value_t ignored_function);
 - return value
   - a newly constructed JS array
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -9437,7 +9441,7 @@ jerry_set_realm (jerry_value_t realm_value);
   - previous realm value - if the passed value is a realm
   - exception - otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -9482,7 +9486,7 @@ jerry_realm_get_this (jerry_value_t realm_value)
   - type error - if realm_value is not a realm
   - 'this' binding object - otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 
@@ -9529,7 +9533,7 @@ jerry_realm_set_this (jerry_value_t realm_value, jerry_value_t this_value)
   - type error - if realm_value is not a realm or this_value is not object
   - true - otherwise
 
-*New in version [[NEXT_RELEASE]]*.
+*New in version 2.4*.
 
 **Example**
 


### PR DESCRIPTION
Replace the [[NEXT_VERSION]] entries with the exact version number
in the API reference documentation.
