### PR TITLE
Rework export default parsing

### DIFF
--- a/jerry-core/parser/js/js-scanner-internal.h
+++ b/jerry-core/parser/js/js-scanner-internal.h
@@ -119,6 +119,9 @@ typedef enum
   SCAN_STACK_FOR_START_PATTERN,            /**< possible assignment pattern for "for" iterator */
   SCAN_STACK_USE_ASYNC,                    /**< an "async" identifier is used */
 #endif /* ENABLED (JERRY_ESNEXT) */
+#if ENABLED (JERRY_MODULE_SYSTEM)
+  SCAN_STACK_EXPORT_DEFAULT,               /**< scan primary expression after export default */
+#endif /* ENABLED (JERRY_MODULE_SYSTEM) */
 } scan_stack_modes_t;
 
 /**
@@ -336,11 +339,6 @@ typedef enum
  */
 #define SCANNER_LITERAL_POOL_MAY_HAVE_ARGUMENTS(status_flags) \
   (!((status_flags) & (SCANNER_LITERAL_POOL_CLASS_NAME | SCANNER_LITERAL_POOL_CLASS_FIELD)))
-
-/**
- * The class name is the *default* class name
- */
-#define SCANNER_LITERAL_POOL_DEFAULT_CLASS_NAME SCANNER_LITERAL_POOL_HAS_SUPER_REFERENCE
 
 #else /* !ENABLED (JERRY_ESNEXT) */
 

--- a/tests/jerry/es.next/module-export-01.mjs
+++ b/tests/jerry/es.next/module-export-01.mjs
@@ -17,8 +17,8 @@ export {};
 export {a as aa,};
 export {b as bb, c as cc};
 export {d};
-export var x = 42;
-export function f(a) {return a;};
+export var x = 40;
+export function f(a) {return a;} x++; /* test auto semicolon insertion */
 export class Dog {
   constructor (name) {
     this.name = name;
@@ -27,7 +27,7 @@ export class Dog {
   speak() {
     return this.name + " barks."
   }
-};
+} x++; /* test auto semicolon insertion */
 export default "default";
 
 var a = "a";

--- a/tests/jerry/es.next/module-export-default-1.mjs
+++ b/tests/jerry/es.next/module-export-default-1.mjs
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let counter = 0.1;
+export default function* g() { return "foo1"; } counter++; /* test auto semicolon insertion */
+export {counter};

--- a/tests/jerry/es.next/module-export-default-2.mjs
+++ b/tests/jerry/es.next/module-export-default-2.mjs
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let counter = 1.1;
+export default async function* g() { return "foo2"; } counter++; /* test auto semicolon insertion */
+export {counter};

--- a/tests/jerry/es.next/module-export-default-3.mjs
+++ b/tests/jerry/es.next/module-export-default-3.mjs
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let counter = 2.1;
+export default async function g() { return "foo3"; } counter++; /* test auto semicolon insertion */
+export {counter};

--- a/tests/jerry/es.next/module-export-default-4.mjs
+++ b/tests/jerry/es.next/module-export-default-4.mjs
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var async = "foo4";
+
+export default async;

--- a/tests/jerry/es.next/module-export-default-5.mjs
+++ b/tests/jerry/es.next/module-export-default-5.mjs
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default _ => "foo5";

--- a/tests/jerry/es.next/module-export-default-6.mjs
+++ b/tests/jerry/es.next/module-export-default-6.mjs
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default async _ => "foo6";

--- a/tests/jerry/es.next/module-export-default-7.mjs
+++ b/tests/jerry/es.next/module-export-default-7.mjs
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default async (a, b) => a + b;

--- a/tests/jerry/es.next/module-export-default-8.mjs
+++ b/tests/jerry/es.next/module-export-default-8.mjs
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let counter = 7.1;
+export default class A { static x = "foo8" } counter++; /* test auto semicolon insertion */
+export {counter};

--- a/tests/jerry/es.next/module-export-default-9.mjs
+++ b/tests/jerry/es.next/module-export-default-9.mjs
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+let counter = 8.1;
+export default class { static x = "foo9" } counter++; /* test auto semicolon insertion */
+export {counter};

--- a/tests/jerry/es.next/module-export-default-main.mjs
+++ b/tests/jerry/es.next/module-export-default-main.mjs
@@ -1,0 +1,83 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import foo1, { counter as bar1 } from "./module-export-default-1.mjs"
+import foo2, { counter as bar2 } from "./module-export-default-2.mjs"
+import foo3, { counter as bar3 } from "./module-export-default-3.mjs"
+import foo4 from "./module-export-default-4.mjs"
+import foo5 from "./module-export-default-5.mjs"
+import foo6 from "./module-export-default-6.mjs"
+import foo7 from "./module-export-default-7.mjs"
+import foo8, { counter as bar8 } from "./module-export-default-8.mjs"
+import foo9, { counter as bar9 } from "./module-export-default-9.mjs"
+
+let async_queue_expected = ["foo2", "foo3", "foo6", "foo7"];
+let async_queue = [];
+
+(function() {
+  assert(foo1().next().value === "foo1");
+  assert(bar1 === 1.1);
+})();
+
+(async function() {
+  async_queue.push((await foo2().next()).value);
+  assert(bar2 === 2.1);
+})();
+
+(async function() {
+  async_queue.push(await foo3());
+  assert(bar3 === 3.1);
+})();
+
+(function() {
+  assert(foo4 === "foo4");
+})();
+
+(function() {
+  assert(foo5() === "foo5");
+})();
+
+(async function() {
+  async_queue.push(await foo6());
+})();
+
+(async function() {
+  async_queue.push(await foo7("foo", "7"));
+})();
+
+(function() {
+  assert(foo8.x === "foo8");
+  assert(bar8 === 8.1);
+})();
+
+(function() {
+  assert(foo9.x === "foo9");
+  assert(bar9 === 9.1);
+})();
+
+Array.prototype.assertArrayEqual = function(expected) {
+  assert(this.length === expected.length);
+  print(this);
+  print(expected);
+
+  for (var i = 0; i < this.length; i++) {
+    assert(this[i] === expected[i]);
+  }
+}
+
+let global = new Function('return this;')();
+
+global.__checkAsync = function() {
+  async_queue.assertArrayEqual(async_queue_expected);
+}

--- a/tests/jerry/fail/module-export-default-arrow.mjs
+++ b/tests/jerry/fail/module-export-default-arrow.mjs
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default () => 1, 5;

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -390,11 +390,8 @@
   <test id="language/identifiers/start-unicode-9.0.0.js"><reason></reason></test>
   <test id="language/literals/regexp/unicode-escape-nls-err.js"><reason></reason></test>
   <test id="language/literals/string/legacy-octal-escape-sequence-prologue-strict.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-cls-semi.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-dflt-cls-anon-semi.js"><reason></reason></test>
   <test id="language/module-code/eval-export-dflt-cls-anon.js"><reason></reason></test>
   <test id="language/module-code/eval-export-dflt-cls-name-meth.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-dflt-cls-named-semi.js"><reason></reason></test>
   <test id="language/module-code/eval-export-dflt-cls-named.js"><reason></reason></test>
   <test id="language/module-code/eval-export-dflt-expr-cls-anon.js"><reason></reason></test>
   <test id="language/module-code/eval-export-dflt-expr-cls-name-meth.js"><reason></reason></test>
@@ -405,12 +402,6 @@
   <test id="language/module-code/eval-export-dflt-expr-gen-anon.js"><reason></reason></test>
   <test id="language/module-code/eval-export-dflt-expr-gen-named.js"><reason></reason></test>
   <test id="language/module-code/eval-export-dflt-expr-in.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-dflt-fun-anon-semi.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-dflt-fun-named-semi.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-dflt-gen-anon-semi.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-dflt-gen-named-semi.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-fun-semi.js"><reason></reason></test>
-  <test id="language/module-code/eval-export-gen-semi.js"><reason></reason></test>
   <test id="language/module-code/eval-gtbndng-indirect-trlng-comma.js"><reason></reason></test>
   <test id="language/module-code/eval-gtbndng-indirect-update-as.js"><reason></reason></test>
   <test id="language/module-code/eval-gtbndng-indirect-update-dflt.js"><reason></reason></test>


### PR DESCRIPTION
- Remove SCANNER_LITERAL_POOL_DEFAULT_CLASS_NAME workaround
- Add async and generator function support
- Fix auto semicolon insertion after export statement
- fixes #4150.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu