### PR TITLE
Fix MinGW compilation errors in jerry-ext

### DIFF
--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -62,7 +62,7 @@ target_link_libraries(${JERRY_EXT_NAME} jerry-core)
 
 set(JERRY_EXT_PKGCONFIG_LIBS)
 
-if(USING_MSVC AND JERRY_DEBUGGER)
+if("${PLATFORM}" STREQUAL "WINDOWS" AND JERRY_DEBUGGER)
   target_link_libraries(${JERRY_EXT_NAME} ws2_32)
   set(JERRY_EXT_PKGCONFIG_LIBS -lws2_32)
 endif()

--- a/jerry-ext/handle-scope/handle-scope-allocator.c
+++ b/jerry-ext/handle-scope/handle-scope-allocator.c
@@ -126,7 +126,7 @@ jerryx_handle_scope_get_child (jerryx_handle_scope_t *scope)
   {
     return (jerryx_handle_scope_t *) jerryx_handle_scope_pool.start;
   }
-  long idx = JERRYX_HANDLE_SCOPE_PRELIST_IDX (scope);
+  ptrdiff_t idx = JERRYX_HANDLE_SCOPE_PRELIST_IDX (scope);
   if (idx < 0)
   {
     return NULL;

--- a/jerry-port/default/default-module.c
+++ b/jerry-port/default/default-module.c
@@ -127,7 +127,7 @@ jerry_port_normalize_path (const char *in_path_p,   /**< input file path */
     char *dir_p = (char *) malloc (_MAX_DIR);
 
     _splitpath_s (base_file_p, drive, _MAX_DRIVE, dir_p, _MAX_DIR, NULL, 0, NULL, 0);
-    const size_t drive_len = strnlen (&drive, _MAX_DRIVE);
+    const size_t drive_len = strnlen (drive, _MAX_DRIVE);
     const size_t dir_len = strnlen (dir_p, _MAX_DIR);
     base_drive_dir_len = drive_len + dir_len;
     path_p = (char *) malloc (base_drive_dir_len + in_path_len + 1);


### PR DESCRIPTION
mingw also need linkage to ws2_32, try define socket types for unix/win32 for compat reason
and fixes https://github.com/jerryscript-project/jerryscript/issues/4512

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
