### PR TITLE
Refactoring time-related default port implementations

### DIFF
--- a/jerry-port/default/CMakeLists.txt
+++ b/jerry-port/default/CMakeLists.txt
@@ -59,31 +59,6 @@ endif()
 # (should only be necessary if we used compiler default libc but not checking that)
 set(DEFINES_PORT_DEFAULT _BSD_SOURCE _DEFAULT_SOURCE)
 
-INCLUDE (CheckStructHasMember)
-# CHECK_STRUCT_HAS_MEMBER works by trying to compile some C code that accesses the
-# given field of the given struct. However, our default compiler options break this
-# C code, so turn a couple of them off for this.
-if(USING_GCC OR USING_CLANG)
-  set(CMAKE_REQUIRED_FLAGS "-Wno-error=strict-prototypes -Wno-error=old-style-definition -Wno-error=unused-value")
-endif()
-# tm.tm_gmtoff is non-standard, so glibc doesn't expose it in c99 mode
-# (our default). Define some macros to expose it anyway.
-set(CMAKE_REQUIRED_DEFINITIONS "-D_BSD_SOURCE -D_DEFAULT_SOURCE")
-CHECK_STRUCT_HAS_MEMBER ("struct tm" tm_gmtoff time.h HAVE_TM_GMTOFF)
-if(HAVE_TM_GMTOFF)
-  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_TM_GMTOFF)
-endif()
-
-# Sleep function availability check
-INCLUDE (CheckIncludeFiles)
-CHECK_INCLUDE_FILES (time.h HAVE_TIME_H)
-CHECK_INCLUDE_FILES (unistd.h HAVE_UNISTD_H)
-if(HAVE_TIME_H)
-  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_TIME_H)
-elseif(HAVE_UNISTD_H)
-  set(DEFINES_PORT_DEFAULT ${DEFINES_PORT_DEFAULT} HAVE_UNISTD_H)
-endif()
-
 # Default Jerry port implementation library
 add_library(${JERRY_PORT_DEFAULT_NAME} ${SOURCE_PORT_DEFAULT})
 target_include_directories(${JERRY_PORT_DEFAULT_NAME} PUBLIC ${INCLUDE_PORT_DEFAULT})

--- a/jerry-port/default/default-debugger.c
+++ b/jerry-port/default/default-debugger.c
@@ -21,9 +21,7 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#elif defined (HAVE_TIME_H)
-#include <time.h>
-#elif defined (HAVE_UNISTD_H)
+#else /* !_WIN32 */
 #include <unistd.h>
 #endif /* _WIN32 */
 
@@ -31,22 +29,14 @@
 #include "jerryscript-port-default.h"
 
 /**
- * Default implementation of jerry_port_sleep. Uses 'nanosleep' or 'usleep' if
- * available on the system, does nothing otherwise.
+ * Default implementation of jerry_port_sleep. Uses 'usleep' if available on the
+ * system, does nothing otherwise.
  */
 void jerry_port_sleep (uint32_t sleep_time) /**< milliseconds to sleep */
 {
 #ifdef _WIN32
   Sleep (sleep_time);
-#elif defined (HAVE_TIME_H)
-  struct timespec sleep_timespec;
-  sleep_timespec.tv_sec = (time_t) sleep_time / 1000;
-  sleep_timespec.tv_nsec = ((long int) sleep_time % 1000) * 1000000L;
-
-  nanosleep (&sleep_timespec, NULL);
-#elif defined (HAVE_UNISTD_H)
+#else /* !_WIN32 */
   usleep ((useconds_t) sleep_time * 1000);
-#else
-  (void) sleep_time;
-#endif /* HAVE_TIME_H */
+#endif /* _WIN32 */
 } /* jerry_port_sleep */


### PR DESCRIPTION
In the non-Windows code paths:
- New approach to compute TZA without the need for GNU-specific
  `struct tm.tm_gmtoff`.
- Always using `usleep` to sleep. (No real need for `nanosleep` as
  port API has sleep granularity of milliseconds.)
- Not checking for "time.h" at build configuration time as that
  header is mandated by the C standard.
- Not checking for "unistd.h" at build configuration time as that
  header is mandated by the POSIX standard (the default port is
  targeting POSIX systems -- and Windows).
- Fixing some macro guards.

JerryScript-DCO-1.0-Signed-off-by: Akos Kiss akiss@inf.u-szeged.hu
