### PR TITLE
Make install_jerry work with MinGW

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -269,7 +269,7 @@ def make_jerry(arguments):
     return proc.returncode
 
 def install_jerry(arguments):
-    install_target = 'INSTALL' if sys.platform == 'win32' else 'install'
+    install_target = 'INSTALL' if os.path.exists(os.path.join(arguments.builddir, 'Jerry.sln')) else 'install'
     make_cmd = ['cmake', '--build', arguments.builddir, '--config', arguments.build_type, '--target', install_target]
     return subprocess.call(make_cmd)
 


### PR DESCRIPTION
On windows, the generator can be Visual Studio or Ninja, when targeting mingw,
the generator can be Ninja or Makefile, they both use 'install' instead MSVC 'INSTALL',
so check the solution file for MSVC

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
