### PR TITLE
Fixes the Clang compiler caused deadloop issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,11 @@ if(USING_GCC OR USING_CLANG)
   endif()
   jerry_add_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations shadow strict-prototypes undef old-style-definition)
   jerry_add_compile_flags(-Wno-stack-protector -Wno-attributes -Werror)
+
+  # When clang do tail optimization calling to ecma_op_object_get_with_receiver,
+  # the stack size will not increase. Use -fno-optimize-sibling-calls
+  # to disable the tail optimization.
+  jerry_add_compile_flags(-fno-optimize-sibling-calls)
 endif()
 
 if(USING_GCC)

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -79,6 +79,9 @@ JERRY_UNITTESTS_OPTIONS = [
 
 # Test options for jerry-tests
 JERRY_TESTS_OPTIONS = [
+    Options('jerry_tests-es.next',
+            OPTIONS_COMMON + OPTIONS_PROFILE_ESNEXT + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT
+            + OPTIONS_MEM_STRESS),
     Options('jerry_tests-es.next-debug',
             OPTIONS_COMMON + OPTIONS_PROFILE_ESNEXT + OPTIONS_DEBUG + OPTIONS_STACK_LIMIT + OPTIONS_GC_MARK_LIMIT
             + OPTIONS_MEM_STRESS),


### PR DESCRIPTION
Clang mis-optimization tail calling to ecma_op_object_get_with_receiver:
When ecma_op_object_get_with_receiver are called, the stack size will not increase.

That's cause testcase tests/jerry/es.next/regression-test-issue-3785.js to be deadloop
instead of stack overflow exception.

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
