### PR TITLE
Add missing version info to API docs

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3885,6 +3885,8 @@ jerry_value_as_integer (const jerry_value_t value);
   - 0, if value is not a number
   - integer representation of the number, otherwise
 
+*New in version 2.4*.
+
 **Example**
 
 ```c
@@ -3914,6 +3916,8 @@ jerry_value_as_int32 (const jerry_value_t value);
   - 0, if value is not a number
   - int32 representation of the number, otherwise
 
+*New in version 2.4*.
+
 **Example**
 
 ```c
@@ -3942,6 +3946,8 @@ jerry_value_as_uint32 (const jerry_value_t value);
 - return
   - 0, if value is not a number
   - uint32 representation of the number, otherwise
+
+*New in version 2.4*.
 
 **Example**
 
@@ -4118,6 +4124,8 @@ jerry_from_property_descriptor (const jerry_property_descriptor_t *src_prop_desc
   - [jerry_value_t](#jerry_value_t)
   - jerry value - if success
   - value marked with error flag - otherwise
+
+*New in version 2.4*.
 
 **Example**
 
@@ -7675,6 +7683,8 @@ jerry_object_get_property_names (jerry_value_t obj_val,
 - return value
   - array containing the filtered property keys in successful operation
   - error marked with error flag, otherwise
+
+*New in version 2.4*.
 
 **Example**
 


### PR DESCRIPTION
A few new methods did not have the version info to describe
in which version were they introduced.