### PR TITLE
Improve ecma_reject to give more detailed error messages

### DIFF
--- a/jerry-core/ecma/operations/ecma-array-object.c
+++ b/jerry-core/ecma/operations/ecma-array-object.c
@@ -970,9 +970,8 @@ ecma_delete_array_properties (ecma_object_t *object_p, /**< object */
 ecma_value_t
 ecma_op_array_object_set_length (ecma_object_t *object_p, /**< the array object */
                                  ecma_value_t new_value, /**< new length value */
-                                 uint32_t flags) /**< configuration options */
+                                 uint16_t flags) /**< property descriptor flags */
 {
-  bool is_throw = (flags & ECMA_PROP_IS_THROW) != 0;
   ecma_number_t new_len_num;
   ecma_value_t completion = ecma_op_to_number (new_value, &new_len_num);
 
@@ -1006,7 +1005,7 @@ ecma_op_array_object_set_length (ecma_object_t *object_p, /**< the array object 
                | ECMA_PROP_IS_GET_DEFINED
                | ECMA_PROP_IS_SET_DEFINED))
   {
-    return ecma_reject (is_throw);
+    return ecma_raise_property_redefinition (ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH), flags);
   }
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
@@ -1029,14 +1028,14 @@ ecma_op_array_object_set_length (ecma_object_t *object_p, /**< the array object 
       }
       else if (!ecma_is_property_writable ((ecma_property_t) ext_object_p->u.array.length_prop_and_hole_count))
       {
-        return ecma_reject (is_throw);
+        return ecma_raise_property_redefinition (ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH), flags);
       }
     }
     return ECMA_VALUE_TRUE;
   }
   else if (!ecma_is_property_writable ((ecma_property_t) ext_object_p->u.array.length_prop_and_hole_count))
   {
-    return ecma_reject (is_throw);
+    return ecma_raise_property_redefinition (ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH), flags);
   }
 
   uint32_t current_len_uint32 = new_len_uint32;
@@ -1067,7 +1066,8 @@ ecma_op_array_object_set_length (ecma_object_t *object_p, /**< the array object 
   {
     return ECMA_VALUE_TRUE;
   }
-  return ecma_reject (is_throw);
+
+  return ecma_raise_property_redefinition (ecma_get_magic_string (LIT_MAGIC_STRING_LENGTH), flags);
 } /* ecma_op_array_object_set_length */
 
 /**
@@ -1159,7 +1159,7 @@ ecma_op_array_object_define_own_property (ecma_object_t *object_p, /**< the arra
   if (update_length
       && !ecma_is_property_writable ((ecma_property_t) ext_object_p->u.array.length_prop_and_hole_count))
   {
-    return ecma_reject (property_desc_p->flags & ECMA_PROP_IS_THROW);
+    return ecma_raise_property_redefinition (property_name_p, property_desc_p->flags);
   }
 
   ecma_property_descriptor_t prop_desc;
@@ -1174,7 +1174,7 @@ ecma_op_array_object_define_own_property (ecma_object_t *object_p, /**< the arra
 
   if (ecma_is_value_false (completition))
   {
-    return ecma_reject (property_desc_p->flags & ECMA_PROP_IS_THROW);
+    return ecma_raise_property_redefinition (property_name_p, property_desc_p->flags);
   }
 
   if (update_length)

--- a/jerry-core/ecma/operations/ecma-array-object.h
+++ b/jerry-core/ecma/operations/ecma-array-object.h
@@ -113,7 +113,7 @@ ecma_op_create_array_iterator (ecma_object_t *obj_p,
 #endif /* JERRY_ESNEXT */
 
 ecma_value_t
-ecma_op_array_object_set_length (ecma_object_t *object_p, ecma_value_t new_value, uint32_t flags);
+ecma_op_array_object_set_length (ecma_object_t *object_p, ecma_value_t new_value, uint16_t flags);
 
 ecma_value_t
 ecma_op_array_object_define_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,

--- a/jerry-core/ecma/operations/ecma-objects-general.h
+++ b/jerry-core/ecma/operations/ecma-objects-general.h
@@ -26,7 +26,6 @@
  * @{
  */
 
-ecma_value_t ecma_reject (bool is_throw);
 ecma_object_t *ecma_op_create_object_object_noarg (void);
 ecma_object_t *ecma_op_create_object_object_noarg_and_set_prototype (ecma_object_t *object_prototype_p);
 

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -27,6 +27,35 @@
  * @{
  */
 
+#if JERRY_ERROR_MESSAGES
+/**
+ * Reject with TypeError depending on 'is_throw' with the given format
+ */
+#define ECMA_REJECT_WITH_FORMAT(is_throw, msg, ...) \
+  ((is_throw) ? ecma_raise_standard_error_with_format (ECMA_ERROR_TYPE, (msg), __VA_ARGS__) : ECMA_VALUE_FALSE)
+
+/**
+ * Reject with TypeError depending on 'is_throw' with the given message
+ */
+#define ECMA_REJECT(is_throw, msg) \
+  ((is_throw) ? ecma_raise_type_error (msg) : ECMA_VALUE_FALSE)
+#else /* !JERRY_ERROR_MESSAGES */
+/**
+ * Reject with TypeError depending on is_throw flags wit the given format
+ */
+#define ECMA_REJECT_WITH_FORMAT(is_throw, msg, ...) \
+  ECMA_REJECT((is_throw), (msg))
+
+/**
+ * Reject with TypeError depending on is_throw flags wit the given message
+ */
+#define ECMA_REJECT(is_throw, msg) \
+  ((is_throw) ? ecma_raise_type_error (NULL) : ECMA_VALUE_FALSE)
+#endif /* JERRY_ERROR_MESSAGES */
+
+ecma_value_t ecma_raise_property_redefinition (ecma_string_t *property_name_p, uint16_t flags);
+ecma_value_t ecma_raise_readonly_assignment (ecma_string_t *property_name_p, bool is_throw);
+
 ecma_property_t ecma_op_object_get_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
                                                  ecma_property_ref_t *property_ref_p, uint32_t options);
 bool ecma_op_ordinary_object_has_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p);

--- a/jerry-core/ecma/operations/ecma-typedarray-object.h
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.h
@@ -66,9 +66,9 @@ bool ecma_is_typedarray (ecma_value_t target);
 void ecma_op_typedarray_list_lazy_property_names (ecma_object_t *obj_p,
                                                   ecma_collection_t *prop_names_p,
                                                   ecma_property_counter_t *prop_counter_p);
-ecma_value_t ecma_op_typedarray_define_index_prop (ecma_object_t *obj_p,
-                                                   uint32_t index,
-                                                   const ecma_property_descriptor_t *property_desc_p);
+ecma_value_t ecma_op_typedarray_define_own_property (ecma_object_t *obj_p,
+                                                     ecma_string_t *prop_name_p,
+                                                     const ecma_property_descriptor_t *property_desc_p);
 ecma_value_t ecma_op_create_typedarray_with_type_and_length (ecma_typedarray_type_t typedarray_id,
                                                              uint32_t array_length);
 ecma_typedarray_info_t ecma_typedarray_get_info (ecma_object_t *typedarray_p);


### PR DESCRIPTION
Note: TypedArray.[[DefineOwnProperty]] has been slightly reworked (without semantical changes) for better error messages.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik frobert@inf.u-szeged.hu
