### PR TITLE
Fix template memory leak when debugger is running

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1410,6 +1410,18 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
       }
     }
 
+#if JERRY_ESNEXT
+    if (bytecode_p->status_flags & CBC_CODE_FLAGS_HAS_TAGGED_LITERALS)
+    {
+      ecma_collection_t *collection_p = ecma_compiled_code_get_tagged_template_collection (bytecode_p);
+
+      /* Since the objects in the tagged template collection are not strong referenced anymore by the compiled code
+         we can treat them as 'new' objects. */
+      JERRY_CONTEXT (ecma_gc_new_objects) += collection_p->item_count * 2;
+      ecma_collection_free_template_literal (collection_p);
+    }
+#endif /* JERRY_ESNEXT */
+
 #if JERRY_DEBUGGER
     if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
         && !(bytecode_p->status_flags & CBC_CODE_FLAGS_DEBUGGER_IGNORE)
@@ -1443,18 +1455,6 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
       return;
     }
 #endif /* JERRY_DEBUGGER */
-
-#if JERRY_ESNEXT
-    if (bytecode_p->status_flags & CBC_CODE_FLAGS_HAS_TAGGED_LITERALS)
-    {
-      ecma_collection_t *collection_p = ecma_compiled_code_get_tagged_template_collection (bytecode_p);
-
-      /* Since the objects in the tagged template collection are not strong referenced anymore by the compiled code
-         we can treat them as 'new' objects. */
-      JERRY_CONTEXT (ecma_gc_new_objects) += collection_p->item_count * 2;
-      ecma_collection_free_template_literal (collection_p);
-    }
-#endif /* JERRY_ESNEXT */
 
 #if JERRY_MEM_STATS
     jmem_stats_free_byte_code_bytes (((size_t) bytecode_p->size) << JMEM_ALIGNMENT_LOG);

--- a/tests/debugger/do_next.cmd
+++ b/tests/debugger/do_next.cmd
@@ -1,3 +1,8 @@
 next
 next
+n
+n
+next
+n
+next
 c

--- a/tests/debugger/do_next.expected
+++ b/tests/debugger/do_next.expected
@@ -2,8 +2,19 @@ Connecting to: localhost:5001
 Stopped at tests/debugger/do_next.js:15
 (jerry-debugger) next
 out: next test
-Stopped at tests/debugger/do_next.js:17
+Stopped at tests/debugger/do_next.js:28
 (jerry-debugger) next
-out: var cat
-Stopped at tests/debugger/do_next.js:18
+out: Func
+Stopped at tests/debugger/do_next.js:30
+(jerry-debugger) n
+Stopped at tests/debugger/do_next.js:33
+(jerry-debugger) n
+out: Func
+Stopped at tests/debugger/do_next.js:35
+(jerry-debugger) next
+Stopped at tests/debugger/do_next.js:39
+(jerry-debugger) n
+Stopped at tests/debugger/do_next.js:40
+(jerry-debugger) next
+Stopped at tests/debugger/do_next.js:42
 (jerry-debugger) c

--- a/tests/debugger/do_next.js
+++ b/tests/debugger/do_next.js
@@ -14,15 +14,29 @@
 
 print("next test");
 
-print ("var cat");
-var cat = 'cat';
-
 function test()
 {
   function f()
   {
     return 0;
   }
+
+  print("Func");
+  return f;
 }
 
-test();
+var f = test(),
+    g,
+    h = f();
+
+{
+  let a = test(),
+      b,
+      c = a();
+}
+
+
+eval("(function () {} `a`)")
+gc();
+
+f();


### PR DESCRIPTION
The problem is, that the test does not fail without the fix, because `run-debugger-test.sh` ignores the crash of the background process, and returns with success.