### PR TITLE
Fix "Invalid postfix operation" errors

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -302,7 +302,14 @@ parser_emit_unary_lvalue_opcode (parser_context_t *context_p, /**< context */
 
 #if JERRY_ESNEXT
     parser_check_invalid_new_target (context_p, opcode);
-    parser_raise_error (context_p, PARSER_ERR_INVALID_LHS_POSTFIX_OP);
+    if (opcode == CBC_PRE_INCR || opcode == CBC_PRE_DECR)
+    {
+      parser_raise_error (context_p, PARSER_ERR_INVALID_LHS_PREFIX_OP);
+    }
+    else
+    {
+      parser_raise_error (context_p, PARSER_ERR_INVALID_LHS_POSTFIX_OP);
+    }
 #else /* JERRY_ESNEXT */
     parser_emit_cbc_ext (context_p, CBC_EXT_THROW_REFERENCE_ERROR);
 #endif /* JERRY_ESNEXT */

--- a/jerry-core/parser/js/js-parser-util.c
+++ b/jerry-core/parser/js/js-parser-util.c
@@ -1110,6 +1110,10 @@ parser_error_to_string (parser_error_t error) /**< error code */
     {
       return "Invalid left-hand side expression in postfix operation";
     }
+    case PARSER_ERR_INVALID_LHS_PREFIX_OP:
+    {
+      return "Invalid left-hand side expression in prefix operation";
+    }
     case PARSER_ERR_INVALID_LHS_FOR_LOOP:
     {
       return "Invalid left-hand-side in for-loop";

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -94,6 +94,7 @@ typedef enum
   PARSER_ERR_DUPLICATED_PROTO,                        /**< duplicated __proto__ fields are not allowed */
   PARSER_ERR_INVALID_LHS_ASSIGNMENT,                  /**< invalid LeftHandSide in assignment */
   PARSER_ERR_INVALID_LHS_POSTFIX_OP,                  /**< invalid LeftHandSide expression in postfix operation */
+  PARSER_ERR_INVALID_LHS_PREFIX_OP,                   /**< invalid LeftHandSide expression in prefix operation */
   PARSER_ERR_INVALID_LHS_FOR_LOOP,                    /**< invalid LeftHandSide in for-loop */
 #endif /* JERRY_ESNEXT */
   PARSER_ERR_DELETE_IDENT_NOT_ALLOWED,                /**< identifier delete is not allowed in strict mode */


### PR DESCRIPTION
`--(-a);` returned with a postfix error before this patch.
The changes introduce a new warning for prefix errors, and
returns with the corresponding one based on current opcode.

JerryScript-DCO-1.0-Signed-off-by: Bela Toth tbela@inf.u-szeged.hu