### PR TITLE
--engine parameter should be a file

### DIFF
--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -426,7 +426,8 @@ def run_test262_test_suite(options):
 
         test_cmd = util.get_python_cmd_prefix() + [
             settings.TEST262_RUNNER_SCRIPT,
-            '--engine', get_binary_path(build_dir_path) + " --test262-object",
+            '--engine', get_binary_path(build_dir_path),
+            '--test262-object',
             '--test-dir', settings.TEST262_TEST_SUITE_DIR
         ]
 

--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -37,6 +37,8 @@ def get_arguments():
                         help='Execution runtime (e.g. qemu)')
     parser.add_argument('--engine', metavar='FILE', required=True,
                         help='JerryScript binary to run tests with')
+    parser.add_argument('--test262-object', action='store_true', default=False,
+                        help='JerryScript engine create test262 object')
     parser.add_argument('--test-dir', metavar='DIR', required=True,
                         help='Directory contains test262 test suite')
     group = parser.add_mutually_exclusive_group(required=True)
@@ -182,6 +184,8 @@ def main(args):
         util.set_timezone('Pacific Standard Time')
 
     command = (args.runtime + ' ' + args.engine).strip()
+    if args.test262_object:
+        command += ' --test262-object'
 
     kwargs = {}
     if sys.version_info.major >= 3:


### PR DESCRIPTION
The --test262-object option should be passed independently,
otherwise os.path.dirname(args.engine) in tools\runners\run-test-suite-test262.py
makes no sense

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
