### PR TITLE
Revise implementation of jerry_port_get_local_time_zone_adjustment on Win32

### DIFF
--- a/tests/jerry/date-getters.js
+++ b/tests/jerry/date-getters.js
@@ -97,6 +97,7 @@ assert (isNaN (d.getTimezoneOffset()));
 /* 5. test case */
 assert (new Date(2013, -1).getMonth() === 11);
 assert (new Date(-2, -2).getFullYear() === -3);
+assert (new Date(30888, 2).getFullYear() === 30888);
 assert (new Date(-1, -1).getFullYear() === -2);
 assert (new Date(-1, -1, -1).getMonth() === 10);
 assert (new Date(-1, -1, -1, -1).getDate() === 28);


### PR DESCRIPTION
Handle is_utc and not is_utc properly.
Handle the limitation of Win32 date API properly.

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
