### PR TITLE
Use C99 flexible array member notation in parser memory struct

### DIFF
--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -330,7 +330,7 @@ typedef struct
 typedef struct parser_mem_page_t
 {
   struct parser_mem_page_t *next_p;           /**< next page */
-  uint8_t bytes[1];                           /**< memory bytes */
+  uint8_t bytes[];                            /**< memory bytes, C99 flexible array member */
 } parser_mem_page_t;
 
 /**


### PR DESCRIPTION
The usage of a single byte sized array as a flexible array member can lead to
compiler/analyzer errors or warnings. Not specifying the size in the array is
correct as per C99 standard.

Flexible array members are defined in the C Standard, 6.7.2.1 (ISO/IEC 9899:1999).
