### PR TITLE
Update jerry debugger test-runner

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -363,6 +363,8 @@ vm_run_eval (ecma_compiled_code_t *bytecode_data_p, /**< byte-code data */
     {
       if (JERRY_UNLIKELY (lex_env_p->u2.outer_reference_cp == JMEM_CP_NULL))
       {
+        ecma_bytecode_deref (bytecode_data_p);
+        ecma_free_value (this_binding);
         return ecma_raise_range_error (ECMA_ERR_MSG ("Invalid scope chain index for eval"));
       }
 

--- a/tools/runners/run-debugger-test.sh
+++ b/tools/runners/run-debugger-test.sh
@@ -37,6 +37,7 @@ fi
 
 echo "$START_DEBUG_SERVER"
 eval "$START_DEBUG_SERVER"
+JERRY_PID=$!
 sleep 1s
 
 RESULT_TEMP=`mktemp ${TEST_CASE}.out.XXXXXXXXXX`
@@ -53,7 +54,9 @@ STATUS_CODE=$?
 
 rm -f ${RESULT_TEMP}
 
-if [ ${STATUS_CODE} -ne 0 ]
+wait $JERRY_PID
+JERRY_EXIT_CODE=$?
+if [ ${STATUS_CODE} -ne 0 ] || [ ${JERRY_EXIT_CODE} -gt 1 ]
 then
   echo -e "${TERM_RED}FAIL: ${TEST_CASE}${TERM_NORMAL}\n"
 else


### PR DESCRIPTION
Now the test-runner will check the jerry (server) return code.

Fixed do_eval_at TC crash if jerry was build with --debug option.

JerryScript-DCO-1.0-Signed-off-by: bence gabor kis kisbg@inf.u-szeged.hu
