### PR TITLE
Rework external function handlers

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -603,6 +603,29 @@ typedef struct
 
 - [jerry_get_memory_stats](#jerry_get_memory_stats)
 
+## jerry_call_info_t
+
+**Summary**
+
+Call related information passed to [jerry_external_handler_t](#jerry_external_handler_t).
+
+**Prototype**
+
+```c
+typedef struct jerry_call_info_t
+{
+  jerry_value_t function; /**< invoked function object */
+  jerry_value_t this_value; /**< this value passed to the function  */
+  jerry_value_t new_target; /**< current new target value, undefined for non-constructor calls */
+} jerry_call_info_t;
+```
+
+*New in version [[NEXT_RELEASE]]*.
+
+**See also**
+
+- [jerry_external_handler_t](#jerry_external_handler_t)
+
 ## jerry_external_handler_t
 
 **Summary**
@@ -612,14 +635,13 @@ Type of an external function handler
 **Prototype**
 
 ```c
-typedef jerry_value_t (*jerry_external_handler_t) (const jerry_value_t function_obj,
-                                                   const jerry_value_t this_val,
+typedef jerry_value_t (*jerry_external_handler_t) (const jerry_call_info_t *call_info_p,
                                                    const jerry_value_t args_p[],
                                                    const jerry_length_t args_count);
 ```
 
-- `function_object` - the JavaScript function object which was invoked.
-- `this_val` - the `this` value provided for the function call.
+- `call_info_p` - pointer to a [jerry_call_info_t](#jerry_call_info_t)
+                  structure which holds call related information.
 - `args_p` - the function arguments, array of JavaScript values.
 - `args_count` - the number of arguments.
 - return value
@@ -2830,8 +2852,7 @@ jerry_binary_operation (jerry_binary_operation_t op,
 #include "jerryscript.h"
 
 static jerry_value_t
-my_constructor (const jerry_value_t func_val,
-                const jerry_value_t this_val,
+my_constructor (const jerry_call_info_t *call_info_p,
                 const jerry_value_t argv[],
                 const jerry_length_t argc)
 {
@@ -5161,12 +5182,11 @@ jerry_create_external_function (jerry_external_handler_t handler_p);
 #include "jerryscript.h"
 
 static jerry_value_t
-handler (const jerry_value_t function_obj,
-         const jerry_value_t this_val,
+handler (const jerry_call_info_t *call_info_p,
          const jerry_value_t args_p[],
          const jerry_length_t args_cnt)
 {
-  printf ("native handler called!\n");
+  printf ("Native handler called!\n");
 
   return jerry_create_boolean (true);
 }
@@ -7139,8 +7159,7 @@ Registering a getter/setter property via the `jerry_define_own_property` method:
 static int counter = 0;
 
 static jerry_value_t
-method_getter (const jerry_value_t this_obj,
-               const jerry_value_t func_obj,
+method_getter (const jerry_call_info_t *call_info_p,
                const jerry_value_t args[],
                const jerry_length_t argc)
 {
@@ -7151,8 +7170,7 @@ method_getter (const jerry_value_t this_obj,
 }
 
 static jerry_value_t
-method_setter (const jerry_value_t this_obj,
-               const jerry_value_t func_obj,
+method_setter (const jerry_call_info_t *call_info_p,
                const jerry_value_t args[],
                const jerry_length_t argc)
 {
@@ -9052,8 +9070,7 @@ jerry_get_backtrace (uint32_t max_depth);
 #include "jerryscript.h"
 
 static jerry_value_t
-backtrace_handler (const jerry_value_t function_obj,
-                   const jerry_value_t this_val,
+backtrace_handler (const jerry_call_info_t *call_info_p,
                    const jerry_value_t args_p[],
                    const jerry_length_t args_count)
 {
@@ -9178,13 +9195,11 @@ backtrace_callback (jerry_backtrace_frame_t *frame_p,
 }
 
 static jerry_value_t
-backtrace_handler (const jerry_value_t function_obj,
-                   const jerry_value_t this_val,
+backtrace_handler (const jerry_call_info_t *call_info_p,
                    const jerry_value_t args_p[],
                    const jerry_length_t args_count)
 {
-  (void) function_obj;
-  (void) this_val;
+  (void) call_info_p;
   (void) args_p;
   (void) args_count;
 
@@ -9594,8 +9609,7 @@ jerry_get_resource_name (jerry_value_t value);
 #include "jerryscript.h"
 
 static jerry_value_t
-resource_name_handler (const jerry_value_t function_obj,
-                       const jerry_value_t this_val,
+resource_name_handler (const jerry_call_info_t *call_info_p,
                        const jerry_value_t args_p[],
                        const jerry_length_t args_count)
 {
@@ -9654,139 +9668,6 @@ main (void)
 **See also**
 
 - [jerry_create_external_function](#jerry_create_external_function)
-
-## jerry_get_new_target
-
-**Summary**
-
-Returns the current "new.target" JavaScript function at the call site.
-
-If used outside of a native C function it will return "undefined" value.
-
-*Notes*:
-- Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
-is no longer needed.
-- This feature depends on build option (`JERRY_ESNEXT`) and can be checked
-  in runtime with the `JERRY_FEATURE_SYMBOL` feature enum value (as symbols are enabled in case of ES.next),
-  see: [jerry_is_feature_enabled](#jerry_is_feature_enabled).
-- If the ES.next mode is not enabled this method will always return the "undefined" value.
-
-**Prototype**
-
-```c
-jerry_value_t
-jerry_get_new_target (void);
-```
-- return
-  - "undefined" - if at the call site it was not a constructor call.
-  - function object - if the current call site is in a constructor call.
-
-*New in version 2.2*.
-
-**Example 1**
-
-[doctest]: # (name="02.API-REFERENCE-jsnewtarget-01.c")
-
-```c
-#include <stdio.h>
-#include <string.h>
-#include <jerryscript.h>
-
-static jerry_value_t
-demo_handler (const jerry_value_t func_obj_val,
-              const jerry_value_t this_val,
-              const jerry_value_t args_p[],
-              const jerry_length_t args_cnt)
-{
-  jerry_value_t new_target = jerry_get_new_target ();
-
-  /* new_target is the "demo" JS function object */
-  if (jerry_value_get_type (new_target) == JERRY_TYPE_FUNCTION)
-  {
-    printf ("This is a construct call\r\n");
-  }
-
-  jerry_release_value (new_target);
-
-  return jerry_create_undefined ();
-}
-
-int
-main (int argc, char** argv)
-{
-  jerry_init (JERRY_INIT_EMPTY);
-
-  jerry_value_t function_val = jerry_create_external_function (demo_handler);
-
-  jerry_value_t ret_val = jerry_construct_object (function_val, NULL, 0);
-
-  jerry_release_value (ret_val);
-  jerry_release_value (function_val);
-
-  jerry_cleanup ();
-  return 0;
-}
-```
-
-**Example 2**
-
-[doctest]: # (name="02.API-REFERENCE-jsnewtarget-02.c")
-
-```c
-#include <stdio.h>
-#include <string.h>
-#include <jerryscript.h>
-
-static jerry_value_t
-demo_handler (const jerry_value_t func_obj_val,
-              const jerry_value_t this_val,
-              const jerry_value_t args_p[],
-              const jerry_length_t args_cnt)
-{
-  jerry_value_t new_target = jerry_get_new_target ();
-
-  /* new_target is a JS function object */
-  if (jerry_value_get_type (new_target) == JERRY_TYPE_FUNCTION)
-  {
-    printf ("This is a construct call\r\n");
-  }
-
-  jerry_release_value (new_target);
-
-  return jerry_create_undefined ();
-}
-
-int
-main (int argc, char** argv)
-{
-  jerry_init (JERRY_INIT_EMPTY);
-
-  /* register C method */
-  jerry_value_t global_obj_val = jerry_get_global_object ();
-  jerry_value_t function_val = jerry_create_external_function (demo_handler);
-  jerry_value_t function_name_val = jerry_create_string ((const jerry_char_t *) "demo");
-  jerry_value_t result_val = jerry_set_property (global_obj_val, function_name_val, function_val);
-  jerry_release_value (result_val);
-  jerry_release_value (function_name_val);
-  jerry_release_value (function_val);
-  jerry_release_value (global_obj_val);
-
-  /* Invoke C method via JS */
-  const char *src = "new demo ()";
-  jerry_value_t ret_val = jerry_eval ((const jerry_char_t *) src,
-                                      strlen (src),
-                                      JERRY_PARSE_NO_OPTS);
-
-  jerry_release_value (ret_val);
-
-  jerry_cleanup ();
-  return 0;
-}
-```
-
-**See also**
-
-- [jerry_construct_object](#jerry_construct_object)
 
 # Functions for realm objects
 

--- a/docs/03.API-EXAMPLE.md
+++ b/docs/03.API-EXAMPLE.md
@@ -214,8 +214,7 @@ The `api-example-4.c` file should contain the following code:
 #include "jerryscript.h"
 
 static jerry_value_t
-print_handler (const jerry_value_t function_object,
-               const jerry_value_t function_this,
+print_handler (const jerry_call_info_t *call_info_p,
                const jerry_value_t arguments[],
                const jerry_length_t argument_count)
 {
@@ -316,8 +315,7 @@ The `api-example-5.c` file should contain the following code:
 #include "jerryscript.h"
 
 static jerry_value_t
-print_handler (const jerry_value_t function_object,
-               const jerry_value_t function_this,
+print_handler (const jerry_call_info_t *call_info_p,
                const jerry_value_t arguments[],
                const jerry_length_t arguments_count)
 {
@@ -851,8 +849,7 @@ struct my_struct
  * Get a string from a native object
  */
 static jerry_value_t
-get_msg_handler (const jerry_value_t func_value, /**< function object */
-                 const jerry_value_t this_value, /**< this arg */
+get_msg_handler (const jerry_call_info_t *call_info_p, /**< call information */
                  const jerry_value_t *args_p, /**< function arguments */
                  const jerry_length_t args_cnt) /**< number of function arguments */
 {
@@ -955,8 +952,7 @@ Use the following code for `api-example-10.c`:
  * Add param to 'this.x'
  */
 static jerry_value_t
-add_handler (const jerry_value_t func_value, /**< function object */
-             const jerry_value_t this_val, /**< this arg */
+add_handler (const jerry_call_info_t *call_info_p, /**< call information */
              const jerry_value_t args_p[], /**< function arguments */
              const jerry_length_t args_cnt) /**< number of function arguments */
 {
@@ -965,7 +961,7 @@ add_handler (const jerry_value_t func_value, /**< function object */
 
   /* Get 'this.x' */
   jerry_value_t prop_name = jerry_create_string ((const jerry_char_t *) "x");
-  jerry_value_t x_val = jerry_get_property (this_val, prop_name);
+  jerry_value_t x_val = jerry_get_property (call_info_p->this_value, prop_name);
 
   if (!jerry_value_is_error (x_val))
   {
@@ -977,7 +973,7 @@ add_handler (const jerry_value_t func_value, /**< function object */
     jerry_value_t res_val = jerry_create_number (x + d);
 
     /* Set the new value of 'this.x' */
-    jerry_release_value (jerry_set_property (this_val, prop_name, res_val));
+    jerry_release_value (jerry_set_property (call_info_p->this_value, prop_name, res_val));
     jerry_release_value (res_val);
   }
 

--- a/docs/10.EXT-REFERENCE-HANDLER.md
+++ b/docs/10.EXT-REFERENCE-HANDLER.md
@@ -267,8 +267,7 @@ jerryx_set_properties (const jerry_value_t target_object,
 #include "jerryscript-ext/handler.h"
 
 static jerry_value_t
-handler (const jerry_value_t function_obj,
-         const jerry_value_t this_val,
+handler (const jerry_call_info_t *call_info_p,
          const jerry_value_t args_p[],
          const jerry_length_t args_cnt)
 {
@@ -331,8 +330,7 @@ when setting a property entry:
 #include "jerryscript-ext/handler.h"
 
 static jerry_value_t
-handler (const jerry_value_t function_obj,
-         const jerry_value_t this_val,
+handler (const jerry_call_info_t *call_info_p,
          const jerry_value_t args_p[],
          const jerry_length_t args_cnt)
 {

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -4836,34 +4836,6 @@ jerry_get_resource_name (const jerry_value_t value) /**< jerry api value */
 } /* jerry_get_resource_name */
 
 /**
- * Access the "new.target" value.
- *
- * The "new.target" value depends on the current call site. That is
- * this method will only have a function object result if, at the call site
- * it was called inside a constructor method invoked with "new".
- *
- * @return "undefined" - if at the call site it was not a constructor call.
- *         function object - if the current call site is in a constructor call.
- */
-jerry_value_t
-jerry_get_new_target (void)
-{
-#if JERRY_ESNEXT
-  ecma_object_t *current_new_target_p = JERRY_CONTEXT (current_new_target_p);
-
-  if (current_new_target_p == NULL)
-  {
-    return jerry_create_undefined ();
-  }
-
-  ecma_ref_object (current_new_target_p);
-  return ecma_make_object_value (current_new_target_p);
-#else /* !JERRY_ESNEXT */
-  return jerry_create_undefined ();
-#endif /* JERRY_ESNEXT */
-} /* jerry_get_new_target */
-
-/**
  * Replaces the currently active realm with another realm.
  *
  * The replacement should be temporary, and the original realm must be

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -297,10 +297,14 @@ enum
 typedef ecma_value_t (*ecma_vm_exec_stop_callback_t) (void *user_p);
 
 /**
+ * Forward definition of jerry_call_info_t.
+ */
+struct jerry_call_info_t;
+
+/**
  * Type of an external function handler.
  */
-typedef ecma_value_t (*ecma_native_handler_t) (const ecma_value_t function_obj,
-                                               const ecma_value_t this_val,
+typedef ecma_value_t (*ecma_native_handler_t) (const struct jerry_call_info_t *call_info_p,
                                                const ecma_value_t args_p[],
                                                const uint32_t args_count);
 
@@ -880,6 +884,13 @@ typedef struct
   uint32_t continue_instantiated_bitset[1]; /**< bit set for instantiated properties */
 #endif /* JERRY_BUILTIN_REALMS */
 } ecma_built_in_props_t;
+
+/**
+ * Type of a built-in function handler.
+ */
+typedef ecma_value_t (*ecma_builtin_handler_t) (ecma_object_t *function_obj_p,
+                                                const ecma_value_t args_p[],
+                                                const uint32_t args_count);
 
 #if JERRY_BUILTIN_REALMS
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-handlers.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-handlers.c
@@ -20,14 +20,14 @@
 #include "ecma-builtin-handlers.h"
 #include "ecma-promise-object.h"
 
-static const ecma_native_handler_t ecma_native_handlers[] =
+static const ecma_builtin_handler_t ecma_native_handlers[] =
 {
 #define ECMA_NATIVE_HANDLER(id, handler, length) handler,
 #include "ecma-builtin-handlers.inc.h"
 #undef ECMA_NATIVE_HANDLER
 };
 
-static const uint8_t  ecma_native_handler_lengths[] =
+static const uint8_t ecma_native_handler_lengths[] =
 {
 #define ECMA_NATIVE_HANDLER(id, handler, length) length,
 #include "ecma-builtin-handlers.inc.h"
@@ -39,7 +39,7 @@ static const uint8_t  ecma_native_handler_lengths[] =
  *
  * return Function pointer of the handler
  */
-ecma_native_handler_t
+ecma_builtin_handler_t
 ecma_builtin_handler_get (ecma_native_handler_id_t id) /**< handler id */
 {
   JERRY_ASSERT (id != ECMA_NATIVE_HANDLER_START && id < ECMA_NATIVE_HANDLER__COUNT);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-handlers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-handlers.h
@@ -42,7 +42,7 @@ typedef enum
   ECMA_NATIVE_HANDLER_FLAGS_PROMISE_ALREADY_RESOLVED = (1 << 2),
 } ecma_native_handler_flags_t;
 
-ecma_native_handler_t
+ecma_builtin_handler_t
 ecma_builtin_handler_get (ecma_native_handler_id_t id);
 uint8_t
 ecma_builtin_handler_get_length (ecma_native_handler_id_t id);

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -1481,8 +1481,8 @@ ecma_builtin_dispatch_call (ecma_object_t *obj_p, /**< built-in object */
 #if JERRY_ESNEXT
     if (JERRY_UNLIKELY (ext_obj_p->u.built_in.id == ECMA_BUILTIN_ID_HANDLER))
     {
-      ecma_native_handler_t handler = ecma_builtin_handler_get (ext_obj_p->u.built_in.routine_id);
-      return handler (ecma_make_object_value (obj_p), this_arg_value, arguments_list_p, arguments_list_len);
+      ecma_builtin_handler_t handler = ecma_builtin_handler_get (ext_obj_p->u.built_in.routine_id);
+      return handler (obj_p, arguments_list_p, arguments_list_len);
     }
 #endif /* !JERRY_ESNEXT */
 

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1227,9 +1227,19 @@ ecma_op_function_call_native (ecma_object_t *func_obj_p, /**< Function object */
                                                                      native_function_p->realm_value);
 #endif /* JERRY_BUILTIN_REALMS */
 
+  jerry_call_info_t call_info;
+  call_info.function = ecma_make_object_value (func_obj_p);
+  call_info.this_value = this_arg_value;
+
+#if JERRY_ESNEXT
+  ecma_object_t *new_target_p = JERRY_CONTEXT (current_new_target_p);
+  call_info.new_target = (new_target_p == NULL) ? ECMA_VALUE_UNDEFINED : ecma_make_object_value (new_target_p);
+#else /* JERRY_ESNEXT */
+  call_info.new_target = ECMA_VALUE_UNDEFINED;
+#endif /* JERRY_ESNEXT */
+
   JERRY_ASSERT (native_function_p->native_handler_cb != NULL);
-  ecma_value_t ret_value = native_function_p->native_handler_cb (ecma_make_object_value (func_obj_p),
-                                                                 this_arg_value,
+  ecma_value_t ret_value = native_function_p->native_handler_cb (&call_info,
                                                                  arguments_list_p,
                                                                  arguments_list_len);
 #if JERRY_BUILTIN_REALMS

--- a/jerry-core/ecma/operations/ecma-promise-object.h
+++ b/jerry-core/ecma/operations/ecma-promise-object.h
@@ -112,32 +112,23 @@ void ecma_fulfill_promise (ecma_value_t promise, ecma_value_t value);
 ecma_object_t *ecma_promise_new_capability (ecma_value_t constructor);
 ecma_value_t ecma_promise_reject_or_resolve (ecma_value_t this_arg, ecma_value_t value, bool is_resolve);
 ecma_value_t ecma_promise_then (ecma_value_t promise, ecma_value_t on_fulfilled, ecma_value_t on_rejected);
-ecma_value_t ecma_value_thunk_helper_cb (const ecma_value_t function_obj,
-                                         const ecma_value_t this_val,
-                                         const ecma_value_t args_p[],
-                                         const uint32_t args_count);
-ecma_value_t ecma_value_thunk_thrower_cb (const ecma_value_t function_obj,
-                                          const ecma_value_t this_val,
-                                          const ecma_value_t args_p[],
-                                          const uint32_t args_count);
-ecma_value_t ecma_promise_then_finally_cb (const ecma_value_t function_obj,
-                                           const ecma_value_t this_val,
-                                           const ecma_value_t args_p[],
-                                           const uint32_t args_count);
-ecma_value_t ecma_promise_catch_finally_cb (const ecma_value_t function_obj,
-                                            const ecma_value_t this_val,
-                                            const ecma_value_t args_p[],
-                                            const uint32_t args_count);
-ecma_value_t
-ecma_promise_reject_handler (const ecma_value_t function,
-                             const ecma_value_t this_arg,
-                             const ecma_value_t argv[],
-                             const uint32_t argc);
-ecma_value_t
-ecma_promise_resolve_handler (const ecma_value_t function,
-                              const ecma_value_t this_arg,
-                              const ecma_value_t argv[],
-                              const uint32_t argc);
+
+ecma_value_t ecma_value_thunk_helper_cb (ecma_object_t *function_obj_p,
+                                         const ecma_value_t args_p[], const uint32_t args_count);
+ecma_value_t ecma_value_thunk_thrower_cb (ecma_object_t *function_obj_p,
+                                          const ecma_value_t args_p[], const uint32_t args_count);
+ecma_value_t ecma_promise_then_finally_cb (ecma_object_t *function_obj_p,
+                                           const ecma_value_t args_p[], const uint32_t args_count);
+ecma_value_t ecma_promise_catch_finally_cb (ecma_object_t *function_obj_p,
+                                            const ecma_value_t args_p[], const uint32_t args_count);
+ecma_value_t ecma_promise_reject_handler (ecma_object_t *function_obj_p,
+                                          const ecma_value_t argv[], const uint32_t args_count);
+ecma_value_t ecma_promise_resolve_handler (ecma_object_t *function_obj_p,
+                                           const ecma_value_t argv[], const uint32_t args_count);
+ecma_value_t ecma_promise_all_handler_cb (ecma_object_t *function_obj_p,
+                                          const ecma_value_t args_p[], const uint32_t args_count);
+ecma_value_t ecma_op_get_capabilities_executor_cb (ecma_object_t *function_obj_p,
+                                                   const ecma_value_t args_p[], const uint32_t args_count);
 
 ecma_value_t ecma_promise_finally (ecma_value_t promise, ecma_value_t on_finally);
 void ecma_promise_async_then (ecma_value_t promise, ecma_value_t executable_object);
@@ -145,11 +136,6 @@ ecma_value_t ecma_promise_async_await (ecma_extended_object_t *async_generator_o
 void ecma_promise_create_resolving_functions (ecma_promise_object_t *object_p);
 
 uint32_t ecma_promise_remaining_inc_or_dec (ecma_value_t remaining, bool is_inc);
-ecma_value_t ecma_promise_all_handler_cb (const ecma_value_t function_obj, const ecma_value_t this_val,
-                                          const ecma_value_t args_p[], const uint32_t args_count);
-
-ecma_value_t ecma_op_get_capabilities_executor_cb (const ecma_value_t function_obj, const ecma_value_t this_val,
-                                                   const ecma_value_t args_p[], const uint32_t args_count);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -104,17 +104,14 @@ ecma_proxy_create (ecma_value_t target, /**< proxy target */
  * @return ECMA_VALUE_UNDEFINED
  */
 ecma_value_t
-ecma_proxy_revoke_cb (const ecma_value_t function_obj, /**< the function itself */
-                      const ecma_value_t this_val, /**< this_arg of the function */
+ecma_proxy_revoke_cb (ecma_object_t *function_obj_p, /**< function object */
                       const ecma_value_t args_p[], /**< argument list */
                       const uint32_t args_count) /**< argument number */
 {
-  JERRY_UNUSED_3 (this_val, args_p, args_count);
-
-  ecma_object_t *func_obj_p = ecma_get_object_from_value (function_obj);
+  JERRY_UNUSED_2 (args_p, args_count);
 
   /* 1. */
-  ecma_revocable_proxy_object_t *rev_proxy_p = (ecma_revocable_proxy_object_t *) func_obj_p;
+  ecma_revocable_proxy_object_t *rev_proxy_p = (ecma_revocable_proxy_object_t *) function_obj_p;
 
   /* 2. */
   if (ecma_is_value_null (rev_proxy_p->proxy))

--- a/jerry-core/ecma/operations/ecma-proxy-object.h
+++ b/jerry-core/ecma/operations/ecma-proxy-object.h
@@ -37,8 +37,7 @@ ecma_proxy_create_revocable (ecma_value_t target,
                              ecma_value_t handler);
 
 ecma_value_t
-ecma_proxy_revoke_cb (const ecma_value_t function_obj,
-                      const ecma_value_t this_val,
+ecma_proxy_revoke_cb (ecma_object_t *function_obj_p,
                       const ecma_value_t args_p[],
                       const uint32_t args_count);
 

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -34,12 +34,12 @@ extern "C"
 /**
  * Major version of JerryScript API.
  */
-#define JERRY_API_MAJOR_VERSION 2
+#define JERRY_API_MAJOR_VERSION 3
 
 /**
  * Minor version of JerryScript API.
  */
-#define JERRY_API_MINOR_VERSION 4
+#define JERRY_API_MINOR_VERSION 0
 
 /**
  * Patch version of JerryScript API.
@@ -248,10 +248,19 @@ typedef struct
 } jerry_heap_stats_t;
 
 /**
+ * Call related information passed to jerry_external_handler_t.
+ */
+typedef struct jerry_call_info_t
+{
+  jerry_value_t function; /**< invoked function object */
+  jerry_value_t this_value; /**< this value passed to the function  */
+  jerry_value_t new_target; /**< current new target value, undefined for non-constructor calls */
+} jerry_call_info_t;
+
+/**
  * Type of an external function handler.
  */
-typedef jerry_value_t (*jerry_external_handler_t) (const jerry_value_t function_obj,
-                                                   const jerry_value_t this_val,
+typedef jerry_value_t (*jerry_external_handler_t) (const jerry_call_info_t *call_info_p,
                                                    const jerry_value_t args_p[],
                                                    const jerry_length_t args_count);
 
@@ -814,7 +823,6 @@ bool jerry_backtrace_is_strict (jerry_backtrace_frame_t *frame_p);
  */
 void jerry_set_vm_exec_stop_callback (jerry_vm_exec_stop_callback_t stop_cb, void *user_p, uint32_t frequency);
 jerry_value_t jerry_get_resource_name (const jerry_value_t value);
-jerry_value_t jerry_get_new_target (void);
 
 /**
  * Array buffer components.

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1059,8 +1059,7 @@ opfunc_add_computed_field (ecma_value_t class_object, /**< class object */
  *         ECMA_VALUE_UNDEFINED - otherwise
  */
 static ecma_value_t
-ecma_op_implicit_constructor_handler_cb (const ecma_value_t function_obj, /**< the function itself */
-                                         const ecma_value_t this_val, /**< this_arg of the function */
+ecma_op_implicit_constructor_handler_cb (const jerry_call_info_t *call_info_p, /**< call information */
                                          const ecma_value_t args_p[], /**< argument list */
                                          const uint32_t args_count) /**< argument number */
 {
@@ -1071,7 +1070,7 @@ ecma_op_implicit_constructor_handler_cb (const ecma_value_t function_obj, /**< t
     return ecma_raise_type_error (ECMA_ERR_MSG ("Class constructor cannot be invoked without 'new'"));
   }
 
-  return opfunc_init_class_fields (function_obj, this_val);
+  return opfunc_init_class_fields (call_info_p->function, call_info_p->this_value);
 } /* ecma_op_implicit_constructor_handler_cb */
 
 /**
@@ -1083,19 +1082,16 @@ ecma_op_implicit_constructor_handler_cb (const ecma_value_t function_obj, /**< t
  *         result of the super call - otherwise
  */
 static ecma_value_t
-ecma_op_implicit_constructor_handler_heritage_cb (const ecma_value_t function_obj, /**< the function itself */
-                                                  const ecma_value_t this_val, /**< this_arg of the function */
+ecma_op_implicit_constructor_handler_heritage_cb (const jerry_call_info_t *call_info_p, /**< call information */
                                                   const ecma_value_t args_p[], /**< argument list */
                                                   const uint32_t args_count) /**< argument number */
 {
-  JERRY_UNUSED (this_val);
-
   if (JERRY_CONTEXT (current_new_target_p) == NULL)
   {
     return ecma_raise_type_error (ECMA_ERR_MSG ("Class constructor cannot be invoked without 'new'"));
   }
 
-  ecma_object_t *func_obj_p = ecma_get_object_from_value (function_obj);
+  ecma_object_t *func_obj_p = ecma_get_object_from_value (call_info_p->function);
   ecma_value_t super_ctor = ecma_op_function_get_super_constructor (func_obj_p);
 
   if (ECMA_IS_VALUE_ERROR (super_ctor))
@@ -1112,7 +1108,7 @@ ecma_op_implicit_constructor_handler_heritage_cb (const ecma_value_t function_ob
 
   if (ecma_is_value_object (result))
   {
-    ecma_value_t fields_value = opfunc_init_class_fields (function_obj, result);
+    ecma_value_t fields_value = opfunc_init_class_fields (call_info_p->function, result);
 
     if (ECMA_IS_VALUE_ERROR (fields_value))
     {

--- a/jerry-ext/handler/handler-assert.c
+++ b/jerry-ext/handler/handler-assert.c
@@ -29,13 +29,11 @@
  *         Note that the function does not return otherwise.
  */
 jerry_value_t
-jerryx_handler_assert_fatal (const jerry_value_t func_obj_val, /**< function object */
-                             const jerry_value_t this_p, /**< this arg */
+jerryx_handler_assert_fatal (const jerry_call_info_t *call_info_p, /**< call information */
                              const jerry_value_t args_p[], /**< function arguments */
                              const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
 
   if (args_cnt == 1
       && jerry_value_is_boolean (args_p[0])
@@ -100,13 +98,11 @@ jerryx_handler_assert_fatal (const jerry_value_t func_obj_val, /**< function obj
  *         error - otherwise.
  */
 jerry_value_t
-jerryx_handler_assert_throw (const jerry_value_t func_obj_val, /**< function object */
-                             const jerry_value_t this_p, /**< this arg */
+jerryx_handler_assert_throw (const jerry_call_info_t *call_info_p, /**< call information */
                              const jerry_value_t args_p[], /**< function arguments */
                              const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
 
   if (args_cnt == 1
       && jerry_value_is_boolean (args_p[0])
@@ -125,10 +121,9 @@ jerryx_handler_assert_throw (const jerry_value_t func_obj_val, /**< function obj
  *         Note that the function does not return otherwise.
  */
 jerry_value_t
-jerryx_handler_assert (const jerry_value_t func_obj_val, /**< function object */
-                       const jerry_value_t this_p, /**< this arg */
+jerryx_handler_assert (const jerry_call_info_t *call_info_p, /**< call information */
                        const jerry_value_t args_p[], /**< function arguments */
                        const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  return jerryx_handler_assert_fatal (func_obj_val, this_p, args_p, args_cnt);
+  return jerryx_handler_assert_fatal (call_info_p, args_p, args_cnt);
 } /* jerryx_handler_assert */

--- a/jerry-ext/handler/handler-gc.c
+++ b/jerry-ext/handler/handler-gc.c
@@ -21,13 +21,11 @@
  * @return undefined.
  */
 jerry_value_t
-jerryx_handler_gc (const jerry_value_t func_obj_val, /**< function object */
-                   const jerry_value_t this_p, /**< this arg */
+jerryx_handler_gc (const jerry_call_info_t *call_info_p, /**< call information */
                    const jerry_value_t args_p[], /**< function arguments */
                    const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
 
   jerry_gc_mode_t mode = ((args_cnt > 0 && jerry_value_to_boolean (args_p[0])) ? JERRY_GC_PRESSURE_HIGH
                                                                                : JERRY_GC_PRESSURE_LOW);

--- a/jerry-ext/handler/handler-print.c
+++ b/jerry-ext/handler/handler-print.c
@@ -37,13 +37,11 @@
  *         error - otherwise.
  */
 jerry_value_t
-jerryx_handler_print (const jerry_value_t func_obj_val, /**< function object */
-                      const jerry_value_t this_p, /**< this arg */
+jerryx_handler_print (const jerry_call_info_t *call_info_p, /**< call information */
                       const jerry_value_t args_p[], /**< function arguments */
                       const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
 
   const char * const null_str = "\\u0000";
 

--- a/jerry-ext/handler/handler-resource-name.c
+++ b/jerry-ext/handler/handler-resource-name.c
@@ -26,13 +26,11 @@
  *         - "<anonymous>", otherwise
  */
 jerry_value_t
-jerryx_handler_resource_name (const jerry_value_t func_obj_val, /**< function object */
-                              const jerry_value_t this_p, /**< this arg */
+jerryx_handler_resource_name (const jerry_call_info_t *call_info_p, /**< call information */
                               const jerry_value_t args_p[], /**< function arguments */
                               const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
 
   jerry_value_t undefined_value = jerry_create_undefined ();
   jerry_value_t resource_name = jerry_get_resource_name (args_cnt > 0 ? args_p[0] : undefined_value);

--- a/jerry-ext/include/jerryscript-ext/handler.h
+++ b/jerry-ext/include/jerryscript-ext/handler.h
@@ -34,17 +34,17 @@ jerry_value_t jerryx_handler_register_global (const jerry_char_t *name_p,
  * Common external function handlers
  */
 
-jerry_value_t jerryx_handler_assert_fatal (const jerry_value_t func_obj_val, const jerry_value_t this_p,
+jerry_value_t jerryx_handler_assert_fatal (const jerry_call_info_t *call_info_p,
                                            const jerry_value_t args_p[], const jerry_length_t args_cnt);
-jerry_value_t jerryx_handler_assert_throw (const jerry_value_t func_obj_val, const jerry_value_t this_p,
+jerry_value_t jerryx_handler_assert_throw (const jerry_call_info_t *call_info_p,
                                            const jerry_value_t args_p[], const jerry_length_t args_cnt);
-jerry_value_t jerryx_handler_assert (const jerry_value_t func_obj_val, const jerry_value_t this_p,
+jerry_value_t jerryx_handler_assert (const jerry_call_info_t *call_info_p,
                                      const jerry_value_t args_p[], const jerry_length_t args_cnt);
-jerry_value_t jerryx_handler_gc (const jerry_value_t func_obj_val, const jerry_value_t this_p,
+jerry_value_t jerryx_handler_gc (const jerry_call_info_t *call_info_p,
                                  const jerry_value_t args_p[], const jerry_length_t args_cnt);
-jerry_value_t jerryx_handler_print (const jerry_value_t func_obj_val, const jerry_value_t this_p,
+jerry_value_t jerryx_handler_print (const jerry_call_info_t *call_info_p,
                                     const jerry_value_t args_p[], const jerry_length_t args_cnt);
-jerry_value_t jerryx_handler_resource_name (const jerry_value_t func_obj_val, const jerry_value_t this_p,
+jerry_value_t jerryx_handler_resource_name (const jerry_call_info_t *call_info_p,
                                             const jerry_value_t args_p[], const jerry_length_t args_cnt);
 
 /**

--- a/jerry-main/main-jerry.c
+++ b/jerry-main/main-jerry.c
@@ -273,10 +273,7 @@ restart:
       }
 
       const jerry_value_t args[] = { ret_value };
-      jerry_value_t ret_val_print = jerryx_handler_print (jerry_create_undefined (),
-                                                          jerry_create_undefined (),
-                                                          args,
-                                                          1);
+      jerry_value_t ret_val_print = jerryx_handler_print (NULL, args, 1);
       jerry_release_value (ret_val_print);
       jerry_release_value (ret_value);
       ret_value = jerry_run_all_enqueued_jobs ();

--- a/jerry-main/main-utils.c
+++ b/jerry-main/main-utils.c
@@ -45,13 +45,11 @@ main_register_global_function (const char *name_p, /**< name of the function */
 } /* main_register_global_function */
 
 static jerry_value_t
-main_create_realm (const jerry_value_t func_obj_val, /**< function object */
-                   const jerry_value_t this_p, /**< this arg */
+main_create_realm (const jerry_call_info_t *call_info_p, /**< call information */
                    const jerry_value_t args_p[], /**< function arguments */
                    const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
   (void) args_p; /* unused */
   (void) args_cnt; /* unused */
   return jerry_create_realm ();
@@ -86,13 +84,11 @@ test262_register_function (jerry_value_t test262_obj, /** $262 object */
  *         value marked with error flag - otherwise
  */
 static jerry_value_t
-test262_detach_array_buffer (const jerry_value_t func_obj_val, /**< function object */
-                             const jerry_value_t this_p, /**< this arg */
+test262_detach_array_buffer (const jerry_call_info_t *call_info_p, /**< call information */
                              const jerry_value_t args_p[], /**< function arguments */
                              const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
 
   if (args_cnt < 1 || !jerry_value_is_arraybuffer (args_p[0]))
   {
@@ -112,13 +108,11 @@ test262_detach_array_buffer (const jerry_value_t func_obj_val, /**< function obj
  * @return completion of the script parsing and execution.
  */
 static jerry_value_t
-test262_eval_script (const jerry_value_t func_obj_val, /**< function object */
-                     const jerry_value_t this_p, /**< this arg */
+test262_eval_script (const jerry_call_info_t *call_info_p, /**< call information */
                      const jerry_value_t args_p[], /**< function arguments */
                      const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
 
   if (args_cnt < 1 || !jerry_value_is_string (args_p[0]))
   {
@@ -159,13 +153,11 @@ create_test262 (jerry_value_t global_obj);
  * @return a new $262 object
  */
 static jerry_value_t
-test262_create_realm (const jerry_value_t func_obj_val, /**< function object */
-                      const jerry_value_t this_p, /**< this arg */
+test262_create_realm (const jerry_call_info_t *call_info_p, /**< call information */
                       const jerry_value_t args_p[], /**< function arguments */
                       const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  (void) func_obj_val; /* unused */
-  (void) this_p; /* unused */
+  (void) call_info_p; /* unused */
   (void) args_p; /* unused */
   (void) args_cnt; /* unused */
 

--- a/targets/esp8266/user/jerry_extapi.c
+++ b/targets/esp8266/user/jerry_extapi.c
@@ -26,10 +26,9 @@
 
 #define DELCARE_HANDLER(NAME) \
 static jerry_value_t \
-NAME ## _handler (const jerry_value_t  function_obj_val __UNUSED__, \
-                  const jerry_value_t  this_val __UNUSED__, \
-                  const jerry_value_t  args_p[], \
-                  const jerry_length_t  args_cnt)
+NAME ## _handler (const jerry_call_info_t *call_info_p __UNUSED__, \
+                  const jerry_value_t args_p[], \
+                  const jerry_length_t args_cnt)
 
 #define REGISTER_HANDLER(NAME) \
   register_native_function ( # NAME, NAME ## _handler)

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn-js.cpp
@@ -47,7 +47,7 @@ DECLARE_CLASS_FUNCTION(AnalogIn, read) {
 
     // Extract native AnalogIn pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -72,7 +72,7 @@ DECLARE_CLASS_FUNCTION(AnalogIn, read_u16) {
 
     // Extract native AnalogIn pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut-js.cpp
@@ -50,7 +50,7 @@ DECLARE_CLASS_FUNCTION(DigitalOut, write) {
 
     // Extract native DigitalOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -77,7 +77,7 @@ DECLARE_CLASS_FUNCTION(DigitalOut, read) {
 
     // Extract native DigitalOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -101,7 +101,7 @@ DECLARE_CLASS_FUNCTION(DigitalOut, is_connected) {
 
     // Extract native DigitalOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C-js.cpp
@@ -49,7 +49,7 @@ DECLARE_CLASS_FUNCTION(I2C, frequency) {
 
     // Unwrap native I2C object
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -91,7 +91,7 @@ DECLARE_CLASS_FUNCTION(I2C, read) {
     if (args_count == 1) {
         CHECK_ARGUMENT_TYPE_ALWAYS(I2C, read, 0, number);
         void *void_ptr;
-        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+        bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
         if (!has_ptr) {
             return jerry_create_error(JERRY_ERROR_TYPE,
@@ -112,7 +112,7 @@ DECLARE_CLASS_FUNCTION(I2C, read) {
         CHECK_ARGUMENT_TYPE_ON_CONDITION(I2C, read, 3, boolean, (args_count == 4));
 
         void *void_ptr;
-        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+        bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
         if (!has_ptr) {
             return jerry_create_error(JERRY_ERROR_TYPE,
@@ -186,7 +186,7 @@ DECLARE_CLASS_FUNCTION(I2C, write) {
 
         // Extract native I2C object
         void *void_ptr;
-        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+        bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
         if (!has_ptr) {
             return jerry_create_error(JERRY_ERROR_TYPE,
@@ -209,7 +209,7 @@ DECLARE_CLASS_FUNCTION(I2C, write) {
 
         // Extract native I2C object
         void *void_ptr;
-        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+        bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
         if (!has_ptr) {
             return jerry_create_error(JERRY_ERROR_TYPE,
@@ -249,7 +249,7 @@ DECLARE_CLASS_FUNCTION(I2C, start) {
 
     // Extract native I2C object
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -272,7 +272,7 @@ DECLARE_CLASS_FUNCTION(I2C, stop) {
 
     // Extract native I2C object
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
@@ -53,7 +53,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
     // Detach the rise callback when InterruptIn::rise(null) is called
     if (jerry_value_is_null(args[0])) {
         void *void_ptr;
-        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+        bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
         if (!has_ptr) {
             return jerry_create_error(JERRY_ERROR_TYPE,
@@ -63,7 +63,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
         InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
         jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_rise");
-        jerry_value_t cb_func = jerry_get_property(this_obj, property_name);
+        jerry_value_t cb_func = jerry_get_property(call_info_p->this_value, property_name);
         jerry_release_value(property_name);
 
         // Only drop the callback if it exists
@@ -82,7 +82,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
     CHECK_ARGUMENT_TYPE_ALWAYS(InterruptIn, rise, 0, function);
 
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -99,7 +99,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, rise) {
 
     // Keep track of our callback internally.
     jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_rise");
-    jerry_release_value(jerry_set_property(this_obj, property_name, f));
+    jerry_release_value(jerry_set_property(call_info_p->this_value, property_name, f));
     jerry_release_value(property_name);
 
     return jerry_create_undefined();
@@ -118,7 +118,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
     // Detach the fall callback when InterruptIn::fall(null) is called
     if (jerry_value_is_null(args[0])) {
         void *void_ptr;
-        bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+        bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
         if (!has_ptr) {
             return jerry_create_error(JERRY_ERROR_TYPE,
@@ -128,7 +128,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
         InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
         jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_fall");
-        jerry_value_t cb_func = jerry_get_property(this_obj, property_name);
+        jerry_value_t cb_func = jerry_get_property(call_info_p->this_value, property_name);
         jerry_release_value(property_name);
 
         // Only drop the callback if it exists
@@ -147,7 +147,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
     CHECK_ARGUMENT_TYPE_ALWAYS(InterruptIn, fall, 0, function);
 
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -164,7 +164,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, fall) {
 
     // Keep track of our callback internally.
     jerry_value_t property_name = jerry_create_string((const jerry_char_t*)"cb_fall");
-    jerry_release_value(jerry_set_property(this_obj, property_name, f));
+    jerry_release_value(jerry_set_property(call_info_p->this_value, property_name, f));
     jerry_release_value(property_name);
 
     return jerry_create_undefined();
@@ -182,7 +182,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, mode) {
     CHECK_ARGUMENT_TYPE_ALWAYS(InterruptIn, mode, 0, number);
 
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -206,7 +206,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, disable_irq) {
     CHECK_ARGUMENT_COUNT(InterruptIn, disable_irq, (args_count == 0));
 
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -228,7 +228,7 @@ DECLARE_CLASS_FUNCTION(InterruptIn, enable_irq) {
     CHECK_ARGUMENT_COUNT(InterruptIn, enable_irq, (args_count == 0));
 
     void *void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut-js.cpp
@@ -52,7 +52,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, write) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -85,7 +85,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, read) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -113,7 +113,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, period) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -139,7 +139,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, period_ms) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -165,7 +165,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, period_us) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -191,7 +191,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -217,7 +217,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth_ms) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,
@@ -243,7 +243,7 @@ DECLARE_CLASS_FUNCTION(PwmOut, pulsewidth_us) {
 
     // Extract native PwmOut pointer
     void* void_ptr;
-    bool has_ptr = jerry_get_object_native_pointer(this_obj, &void_ptr, &native_obj_type_info);
+    bool has_ptr = jerry_get_object_native_pointer(call_info_p->this_value, &void_ptr, &native_obj_type_info);
 
     if (!has_ptr) {
         return jerry_create_error(JERRY_ERROR_TYPE,

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setInterval-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setInterval-js.cpp
@@ -32,7 +32,7 @@ DECLARE_GLOBAL_FUNCTION(setInterval) {
 
     int id = mbed::js::EventLoop::getInstance().getQueue().call_every(interval, jerry_call_function, args[0], jerry_create_null(), (jerry_value_t*)NULL, 0);
 
-    jerry_value_t result = jerry_set_property_by_index(function_obj_p, id, args[0]);
+    jerry_value_t result = jerry_set_property_by_index(call_info_p->function, id, args[0]);
 
     if (jerry_value_is_error(result)) {
         jerry_release_value(result);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setTimeout-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/setTimeout-js.cpp
@@ -32,7 +32,7 @@ DECLARE_GLOBAL_FUNCTION(setTimeout) {
 
     int id = mbed::js::EventLoop::getInstance().getQueue().call_in(interval, jerry_call_function, args[0], jerry_create_null(), (jerry_value_t*)NULL, 0);
 
-    jerry_value_t result = jerry_set_property_by_index(function_obj_p, id, args[0]);
+    jerry_value_t result = jerry_set_property_by_index(call_info_p->function, id, args[0]);
 
     if (jerry_value_is_error(result)) {
         jerry_release_value(result);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/wrappers.h
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-util/wrappers.h
@@ -29,8 +29,7 @@
 // Global functions
 #define DECLARE_GLOBAL_FUNCTION(NAME) \
 jerry_value_t \
-NAME_FOR_GLOBAL_FUNCTION(NAME) (const jerry_value_t function_obj_p, \
-                  const jerry_value_t  this_obj, \
+NAME_FOR_GLOBAL_FUNCTION(NAME) (const jerry_call_info_t *call_info_p, \
                   const jerry_value_t    args[], \
                   const jerry_length_t   args_count)
 
@@ -43,8 +42,7 @@ NAME_FOR_GLOBAL_FUNCTION(NAME) (const jerry_value_t function_obj_p, \
 // Class constructors
 #define DECLARE_CLASS_CONSTRUCTOR(CLASS) \
 jerry_value_t \
-NAME_FOR_CLASS_CONSTRUCTOR(CLASS) (const jerry_value_t function_obj, \
-                  const jerry_value_t    this_obj, \
+NAME_FOR_CLASS_CONSTRUCTOR(CLASS) (const jerry_call_info_t *call_info_p, \
                   const jerry_value_t    args[], \
                   const jerry_length_t   args_count)
 
@@ -54,8 +52,7 @@ NAME_FOR_CLASS_CONSTRUCTOR(CLASS) (const jerry_value_t function_obj, \
 // Class functions
 #define DECLARE_CLASS_FUNCTION(CLASS, NAME) \
 jerry_value_t \
-NAME_FOR_CLASS_FUNCTION(CLASS, NAME) (const jerry_value_t function_obj, \
-                  const jerry_value_t  this_obj, \
+NAME_FOR_CLASS_FUNCTION(CLASS, NAME) (const jerry_call_info_t *call_info_p, \
                   const jerry_value_t    args[], \
                   const jerry_length_t   args_count)
 

--- a/tests/unit-core/test-abort.c
+++ b/tests/unit-core/test-abort.c
@@ -19,13 +19,11 @@
 #include "test-common.h"
 
 static jerry_value_t
-callback_func (const jerry_value_t function_obj,
-               const jerry_value_t this_val,
+callback_func (const jerry_call_info_t *call_info_p,
                const jerry_value_t args_p[],
                const jerry_length_t args_count)
 {
-  JERRY_UNUSED (function_obj);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_count);
 

--- a/tests/unit-core/test-api-binary-operations-instanceof.c
+++ b/tests/unit-core/test-api-binary-operations-instanceof.c
@@ -28,13 +28,11 @@ typedef struct
 } test_entry_t;
 
 static jerry_value_t
-my_constructor (const jerry_value_t func_val, /**< function */
-                const jerry_value_t this_val, /**< this */
+my_constructor (const jerry_call_info_t *call_info_p, /**< call information */
                 const jerry_value_t argv[], /**< arguments */
                 const jerry_length_t argc) /**< number of arguments */
 {
-  (void) func_val;
-  (void) this_val;
+  (void) call_info_p;
   (void) argv;
   (void) argc;
   return jerry_create_undefined ();

--- a/tests/unit-core/test-api-functiontype.c
+++ b/tests/unit-core/test-api-functiontype.c
@@ -30,13 +30,11 @@ typedef struct
 #define ENTRY_IF(TYPE, VALUE, FEATURE, ASYNC) { TYPE, VALUE, jerry_is_feature_enabled (FEATURE), ASYNC }
 #define EVALUATE(BUFF) (jerry_eval ((BUFF), sizeof ((BUFF)) - 1, JERRY_PARSE_NO_OPTS))
 static jerry_value_t
-test_ext_function (const jerry_value_t function_obj, /**< function object */
-                   const jerry_value_t this_val, /**< function this value */
+test_ext_function (const jerry_call_info_t *call_info_p, /**< call information */
                    const jerry_value_t args_p[], /**< array of arguments */
                    const jerry_length_t args_cnt) /**< number of arguments */
 {
-  (void) function_obj;
-  (void) this_val;
+  (void) call_info_p;
   (void) args_p;
   (void) args_cnt;
   return jerry_create_boolean (true);

--- a/tests/unit-core/test-api-objecttype.c
+++ b/tests/unit-core/test-api-objecttype.c
@@ -29,13 +29,11 @@ typedef struct
 #define ENTRY_IF(TYPE, VALUE, FEATURE) { TYPE, VALUE, jerry_is_feature_enabled (FEATURE) }
 #define EVALUATE(BUFF) (jerry_eval ((BUFF), sizeof ((BUFF)) - 1, JERRY_PARSE_NO_OPTS))
 static jerry_value_t
-test_ext_function (const jerry_value_t function_obj, /**< function object */
-                   const jerry_value_t this_val, /**< function this value */
+test_ext_function (const jerry_call_info_t *call_info_p, /**< call information */
                    const jerry_value_t args_p[], /**< array of arguments */
                    const jerry_length_t args_cnt) /**< number of arguments */
 {
-  (void) function_obj;
-  (void) this_val;
+  (void) call_info_p;
   (void) args_p;
   (void) args_cnt;
   return jerry_create_boolean (true);

--- a/tests/unit-core/test-api-value-type.c
+++ b/tests/unit-core/test-api-value-type.c
@@ -27,13 +27,11 @@ typedef struct
 #define ENTRY(TYPE, VALUE) { TYPE, VALUE }
 
 static jerry_value_t
-test_ext_function (const jerry_value_t function_obj, /**< function object */
-                   const jerry_value_t this_val, /**< function this value */
+test_ext_function (const jerry_call_info_t *call_info_p, /**< call information */
                    const jerry_value_t args_p[], /**< array of arguments */
                    const jerry_length_t args_cnt) /**< number of arguments */
 {
-  (void) function_obj;
-  (void) this_val;
+  (void) call_info_p;
   (void) args_p;
   (void) args_cnt;
   return jerry_create_boolean (true);

--- a/tests/unit-core/test-arraybuffer.c
+++ b/tests/unit-core/test-arraybuffer.c
@@ -38,13 +38,11 @@ register_js_value (const char *name_p, /**< name of the function */
 } /* register_js_value */
 
 static jerry_value_t
-assert_handler (const jerry_value_t func_obj_val, /**< function object */
-                const jerry_value_t this_val, /**< this arg */
+assert_handler (const jerry_call_info_t *call_info_p, /**< call information */
                 const jerry_value_t args_p[], /**< function arguments */
                 const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   if (args_cnt > 0
       && jerry_value_is_boolean (args_p[0])

--- a/tests/unit-core/test-backtrace.c
+++ b/tests/unit-core/test-backtrace.c
@@ -18,13 +18,11 @@
 #include "test-common.h"
 
 static jerry_value_t
-backtrace_handler (const jerry_value_t function_obj, /**< function object */
-                   const jerry_value_t this_val, /**< this value */
+backtrace_handler (const jerry_call_info_t *call_info_p, /**< call information */
                    const jerry_value_t args_p[], /**< argument list */
                    const jerry_length_t args_count) /**< argument count */
 {
-  JERRY_UNUSED (function_obj);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   uint32_t max_depth = 0;
 
@@ -98,13 +96,11 @@ backtrace_callback (jerry_backtrace_frame_t *frame_p, /* frame information */
 } /* backtrace_callback */
 
 static jerry_value_t
-capture_handler (const jerry_value_t function_obj, /**< function object */
-                 const jerry_value_t this_val, /**< this value */
+capture_handler (const jerry_call_info_t *call_info_p, /**< call information */
                  const jerry_value_t args_p[], /**< argument list */
                  const jerry_length_t args_count) /**< argument count */
 {
-  JERRY_UNUSED (function_obj);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_count);
 

--- a/tests/unit-core/test-json.c
+++ b/tests/unit-core/test-json.c
@@ -19,13 +19,11 @@
 #include "test-common.h"
 
 static jerry_value_t
-custom_to_json (const jerry_value_t func_obj_val, /**< function object */
-                const jerry_value_t this_val, /**< this value */
+custom_to_json (const jerry_call_info_t *call_info_p, /**< call information */
                 const jerry_value_t args_p[], /**< arguments list */
                 const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_cnt);
 

--- a/tests/unit-core/test-native-instanceof.c
+++ b/tests/unit-core/test-native-instanceof.c
@@ -19,13 +19,11 @@
 static const char instanceof_source[] = "var x = function(o, c) {return (o instanceof c);}; x";
 
 static jerry_value_t
-external_function (const jerry_value_t function_obj,
-                   const jerry_value_t this_arg,
+external_function (const jerry_call_info_t *call_info_p,
                    const jerry_value_t args_p[],
                    const jerry_size_t args_count)
 {
-  (void) function_obj;
-  (void) this_arg;
+  (void) call_info_p;
   (void) args_p;
   (void) args_count;
 

--- a/tests/unit-core/test-promise.c
+++ b/tests/unit-core/test-promise.c
@@ -36,13 +36,11 @@ static const jerry_char_t s1[] = "resolved";
 static const jerry_char_t s2[] = "rejected";
 
 static jerry_value_t
-create_promise1_handler (const jerry_value_t func_obj_val, /**< function object */
-                         const jerry_value_t this_val, /**< this value */
+create_promise1_handler (const jerry_call_info_t *call_info_p, /**< call information */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_cnt);
 
@@ -53,13 +51,11 @@ create_promise1_handler (const jerry_value_t func_obj_val, /**< function object 
 } /* create_promise1_handler */
 
 static jerry_value_t
-create_promise2_handler (const jerry_value_t func_obj_val, /**< function object */
-                         const jerry_value_t this_val, /**< this value */
+create_promise2_handler (const jerry_call_info_t *call_info_p, /**< call information */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_cnt);
 
@@ -70,13 +66,11 @@ create_promise2_handler (const jerry_value_t func_obj_val, /**< function object 
 } /* create_promise2_handler */
 
 static jerry_value_t
-assert_handler (const jerry_value_t func_obj_val, /**< function object */
-                const jerry_value_t this_val, /**< this arg */
+assert_handler (const jerry_call_info_t *call_info_p, /**< call information */
                 const jerry_value_t args_p[], /**< function arguments */
                 const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   count_in_assert++;
 

--- a/tests/unit-core/test-proxy.c
+++ b/tests/unit-core/test-proxy.c
@@ -58,13 +58,11 @@ assert (pdemo.value === 13);
 static int demo_value = 0;
 
 static jerry_value_t
-handler_get (const jerry_value_t function_obj, /**< function object */
-                   const jerry_value_t this_val, /**< this arg */
-                   const jerry_value_t args_p[], /**< function arguments */
-                   const jerry_length_t args_count) /**< number of function arguments */
+handler_get (const jerry_call_info_t *call_info_p, /**< call information */
+             const jerry_value_t args_p[], /**< function arguments */
+             const jerry_length_t args_count) /**< number of function arguments */
 {
-  JERRY_UNUSED (function_obj);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   TEST_ASSERT (args_count == 3);
   TEST_ASSERT (jerry_value_is_object (args_p[0])); /* target */
@@ -84,13 +82,11 @@ handler_get (const jerry_value_t function_obj, /**< function object */
 } /* handler_get */
 
 static jerry_value_t
-handler_set (const jerry_value_t function_obj, /**< function object */
-                   const jerry_value_t this_val, /**< this arg */
-                   const jerry_value_t args_p[], /**< function arguments */
-                   const jerry_length_t args_count) /**< number of function arguments */
+handler_set (const jerry_call_info_t *call_info_p, /**< call information */
+             const jerry_value_t args_p[], /**< function arguments */
+             const jerry_length_t args_count) /**< number of function arguments */
 {
-  JERRY_UNUSED (function_obj);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_count);
 
@@ -167,13 +163,11 @@ static const jerry_object_native_info_t proxy_native_info =
 };
 
 static jerry_value_t
-proxy_native_handler_get (const jerry_value_t function_obj, /**< function object */
-                          const jerry_value_t this_val, /**< this arg */
+proxy_native_handler_get (const jerry_call_info_t *call_info_p, /**< call information */
                           const jerry_value_t args_p[], /**< function arguments */
                           const jerry_length_t args_count) /**< number of function arguments */
 {
-  JERRY_UNUSED (function_obj);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   TEST_ASSERT (args_count == 3);
 
   /* 3rd argument (Receiver) should be the Proxy here. */

--- a/tests/unit-core/test-regression-3588.c
+++ b/tests/unit-core/test-regression-3588.c
@@ -22,13 +22,11 @@
  * Empty constructor
  */
 static jerry_value_t
-construct_handler (const jerry_value_t func_obj_val, /**< function object */
-                   const jerry_value_t this_val, /**< this arg */
+construct_handler (const jerry_call_info_t *call_info_p, /**< call information */
                    const jerry_value_t args_p[], /**< function arguments */
                    const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   TEST_ASSERT (args_cnt == 1);
   TEST_ASSERT (jerry_get_number_value (args_p[0]) == 1.0);

--- a/tests/unit-core/test-resource-name.c
+++ b/tests/unit-core/test-resource-name.c
@@ -18,13 +18,11 @@
 #include "test-common.h"
 
 static jerry_value_t
-resource_name_handler (const jerry_value_t function_obj, /**< function object */
-                       const jerry_value_t this_val, /**< this value */
+resource_name_handler (const jerry_call_info_t *call_info_p, /**< call information */
                        const jerry_value_t args_p[], /**< argument list */
                        const jerry_length_t args_count) /**< argument count */
 {
-  (void) function_obj;
-  (void) this_val;
+  (void) call_info_p;
 
   jerry_value_t undefined_value = jerry_create_undefined ();
   jerry_value_t resource_name = jerry_get_resource_name (args_count > 0 ? args_p[0] : undefined_value);

--- a/tests/unit-core/test-special-proxy.c
+++ b/tests/unit-core/test-special-proxy.c
@@ -18,13 +18,11 @@
 #include "test-common.h"
 
 static jerry_value_t
-create_special_proxy_handler (const jerry_value_t function_obj, /**< function object */
-                              const jerry_value_t this_val, /**< this value */
+create_special_proxy_handler (const jerry_call_info_t *call_info_p, /**< call information */
                               const jerry_value_t args_p[], /**< argument list */
                               const jerry_length_t args_count) /**< argument count */
 {
-  JERRY_UNUSED (function_obj);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   if (args_count < 2)
   {

--- a/tests/unit-core/test-typedarray.c
+++ b/tests/unit-core/test-typedarray.c
@@ -50,13 +50,11 @@ register_js_value (const char *name_p, /**< name of the function */
 } /* register_js_value */
 
 static jerry_value_t
-assert_handler (const jerry_value_t func_obj_val, /**< function object */
-                const jerry_value_t this_val, /**< this arg */
+assert_handler (const jerry_call_info_t *call_info_p, /**< call information */
                 const jerry_value_t args_p[], /**< function arguments */
                 const jerry_length_t args_cnt) /**< number of function arguments */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   if (jerry_value_is_boolean (args_p[0])
       && jerry_get_boolean_value (args_p[0]))

--- a/tests/unit-ext/module/jerry-module-test.c
+++ b/tests/unit-ext/module/jerry-module-test.c
@@ -138,13 +138,11 @@ static const jerryx_module_resolver_t *resolvers[3] =
 };
 
 static jerry_value_t
-handle_clear_require_cache (const jerry_value_t js_function,
-                            const jerry_value_t this_val,
+handle_clear_require_cache (const jerry_call_info_t *call_info_p,
                             const jerry_value_t args_p[],
                             const jerry_length_t args_count)
 {
-  (void) js_function;
-  (void) this_val;
+  (void) call_info_p;
   (void) args_count;
 
   TEST_ASSERT (args_count == 1);
@@ -154,13 +152,11 @@ handle_clear_require_cache (const jerry_value_t js_function,
 } /* handle_clear_require_cache */
 
 static jerry_value_t
-handle_require (const jerry_value_t js_function,
-                const jerry_value_t this_val,
+handle_require (const jerry_call_info_t *call_info_p,
                 const jerry_value_t args_p[],
                 const jerry_length_t args_count)
 {
-  (void) js_function;
-  (void) this_val;
+  (void) call_info_p;
   (void) args_count;
 
   jerry_value_t return_value = 0;

--- a/tests/unit-ext/test-ext-arg.c
+++ b/tests/unit-ext/test-ext-arg.c
@@ -106,13 +106,10 @@ static int validator_restore_count = 0;
  *
  */
 static jerry_value_t
-test_validator1_handler (const jerry_value_t func_obj_val, /**< function object */
-                         const jerry_value_t this_val, /**< this value */
+test_validator1_handler (const jerry_call_info_t *call_info_p, /**< call information */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-
   bool arg1;
   double arg2 = 0.0;
   char arg3[5] = "1234";
@@ -132,7 +129,7 @@ test_validator1_handler (const jerry_value_t func_obj_val, /**< function object 
     jerryx_arg_function (&arg4, JERRYX_ARG_OPTIONAL)
   };
 
-  jerry_value_t is_ok = jerryx_arg_transform_this_and_args (this_val,
+  jerry_value_t is_ok = jerryx_arg_transform_this_and_args (call_info_p->this_value,
                                                             args_p,
                                                             args_cnt,
                                                             mapping,
@@ -210,13 +207,10 @@ my_custom_transform (jerryx_arg_js_iterator_t *js_arg_iter_p, /**< available JS 
  *   arg1: should pass the custom tranform function.
  */
 static jerry_value_t
-test_validator2_handler (const jerry_value_t func_obj_val, /**< function object */
-                         const jerry_value_t this_val, /**< this value */
+test_validator2_handler (const jerry_call_info_t *call_info_p, /**< call information */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-
   my_type_a_t *thing_p;
 
   jerryx_arg_t mapping[] =
@@ -227,7 +221,7 @@ test_validator2_handler (const jerry_value_t func_obj_val, /**< function object 
     jerryx_arg_custom (NULL, 5, my_custom_transform)
   };
 
-  jerry_value_t is_ok = jerryx_arg_transform_this_and_args (this_val,
+  jerry_value_t is_ok = jerryx_arg_transform_this_and_args (call_info_p->this_value,
                                                             args_p,
                                                             args_cnt,
                                                             mapping,
@@ -256,14 +250,10 @@ test_validator2_handler (const jerry_value_t func_obj_val, /**< function object 
  *
  */
 static jerry_value_t
-test_validator3_handler (const jerry_value_t func_obj_val, /**< function object */
-                         const jerry_value_t this_val, /**< this value */
+test_validator3_handler (const jerry_call_info_t *call_info_p, /**< call information */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
-
-  JERRY_UNUSED (func_obj_val);
-
   bool arg1 = false;
   bool arg2 = false;
 
@@ -277,7 +267,7 @@ test_validator3_handler (const jerry_value_t func_obj_val, /**< function object 
     jerryx_arg_boolean (&arg2, JERRYX_ARG_COERCE, JERRYX_ARG_OPTIONAL),
   };
 
-  jerry_value_t is_ok = jerryx_arg_transform_this_and_args (this_val,
+  jerry_value_t is_ok = jerryx_arg_transform_this_and_args (call_info_p->this_value,
                                                             args_p,
                                                             args_cnt,
                                                             mapping,
@@ -323,13 +313,11 @@ test_validator3_handler (const jerry_value_t func_obj_val, /**< function object 
  * Calling jerryx_arg_transform_object_properties directly.
  */
 static jerry_value_t
-test_validator_prop1_handler (const jerry_value_t func_obj_val, /**< function object */
-                              const jerry_value_t this_val, /**< this value */
+test_validator_prop1_handler (const jerry_call_info_t *call_info_p, /**< call information */
                               const jerry_value_t args_p[], /**< arguments list */
                               const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_cnt);
 
   bool native1 = false;
@@ -366,13 +354,11 @@ test_validator_prop1_handler (const jerry_value_t func_obj_val, /**< function ob
  * using jerryx_arg_object_properties.
  */
 static jerry_value_t
-test_validator_prop2_handler (const jerry_value_t func_obj_val, /**< function object */
-                              const jerry_value_t this_val, /**< this value */
+test_validator_prop2_handler (const jerry_call_info_t *call_info_p, /**< call information */
                               const jerry_value_t args_p[], /**< arguments list */
                               const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   bool native1 = false;
   double native2 = 0;
@@ -416,13 +402,11 @@ test_validator_prop2_handler (const jerry_value_t func_obj_val, /**< function ob
 } /* test_validator_prop2_handler */
 
 static jerry_value_t
-test_validator_prop3_handler (const jerry_value_t func_obj_val, /**< function object */
-                              const jerry_value_t this_val, /**< this value */
+test_validator_prop3_handler (const jerry_call_info_t *call_info_p, /**< call information */
                               const jerry_value_t args_p[], /**< arguments list */
                               const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_cnt);
 
   bool native1 = false;
@@ -456,13 +440,11 @@ test_validator_prop3_handler (const jerry_value_t func_obj_val, /**< function ob
  * args_p[0-2] are uint8, args_p[3-5] are int8, args_p[6-8] are uint32, args_p[9-11] are int32.
  */
 static jerry_value_t
-test_validator_int1_handler (const jerry_value_t func_obj_val, /**< function object */
-                             const jerry_value_t this_val, /**< this value */
+test_validator_int1_handler (const jerry_call_info_t *call_info_p, /**< call information */
                              const jerry_value_t args_p[], /**< arguments list */
                              const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   uint8_t num0, num1, num2;
   int8_t num3, num4, num5;
@@ -511,13 +493,11 @@ test_validator_int1_handler (const jerry_value_t func_obj_val, /**< function obj
 } /* test_validator_int1_handler */
 
 static jerry_value_t
-test_validator_int2_handler (const jerry_value_t func_obj_val, /**< function object */
-                             const jerry_value_t this_val, /**< this value */
+test_validator_int2_handler (const jerry_call_info_t *call_info_p, /**< call information */
                              const jerry_value_t args_p[], /**< arguments list */
                              const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   int8_t num0, num1, num2, num3, num4, num5, num6, num7, num8, num9;
   num8 = 123;
@@ -561,13 +541,11 @@ test_validator_int2_handler (const jerry_value_t func_obj_val, /**< function obj
 } /* test_validator_int2_handler */
 
 static jerry_value_t
-test_validator_int3_handler (const jerry_value_t func_obj_val, /**< function object */
-                             const jerry_value_t this_val, /**< this value */
+test_validator_int3_handler (const jerry_call_info_t *call_info_p, /**< call information */
                              const jerry_value_t args_p[], /**< arguments list */
                              const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   int8_t num0;
 
@@ -590,13 +568,11 @@ test_validator_int3_handler (const jerry_value_t func_obj_val, /**< function obj
 } /* test_validator_int3_handler */
 
 static jerry_value_t
-test_validator_array1_handler (const jerry_value_t func_obj_val, /**< function object */
-                               const jerry_value_t this_val, /**< this value */
+test_validator_array1_handler (const jerry_call_info_t *call_info_p, /**< call information */
                                const jerry_value_t args_p[], /**< arguments list */
                                const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   double native1 = 0;
   double native2 = 0;
@@ -636,13 +612,11 @@ test_validator_array1_handler (const jerry_value_t func_obj_val, /**< function o
 } /* test_validator_array1_handler */
 
 static jerry_value_t
-test_validator_array2_handler (const jerry_value_t func_obj_val, /**< function object */
-                               const jerry_value_t this_val, /**< this value */
+test_validator_array2_handler (const jerry_call_info_t *call_info_p, /**< call information */
                                const jerry_value_t args_p[], /**< arguments list */
                                const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
   JERRY_UNUSED (args_cnt);
 
   double native1 = 0;
@@ -794,13 +768,11 @@ jerry_arg_to_double_or_bool_t (jerryx_arg_js_iterator_t *js_arg_iter_p,
  * order doesn't matter (so we'll call it twice with the orders reversed).
 */
 static jerry_value_t
-test_validator_restore_handler (const jerry_value_t func_obj_val, /**< function object */
-                                const jerry_value_t this_val, /**< this value */
+test_validator_restore_handler (const jerry_call_info_t *call_info_p, /**< call information */
                                 const jerry_value_t args_p[], /**< arguments list */
                                 const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
-  JERRY_UNUSED (this_val);
+  JERRY_UNUSED (call_info_p);
 
   double_or_bool_t arg1;
   double_or_bool_t arg2;
@@ -853,19 +825,17 @@ test_utf8_string (void)
 } /* test_utf8_string */
 
 static jerry_value_t
-create_object_a_handler (const jerry_value_t func_obj_val, /**< function object */
-                         const jerry_value_t this_val, /**< this value */
+create_object_a_handler (const jerry_call_info_t *call_info_p, /**< call information */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_cnt);
 
-  TEST_ASSERT (jerry_value_is_object (this_val));
+  TEST_ASSERT (jerry_value_is_object (call_info_p->this_value));
 
   my_thing_a.x = 1;
-  jerry_set_object_native_pointer (this_val,
+  jerry_set_object_native_pointer (call_info_p->this_value,
                                    &my_thing_a,
                                    &thing_a_info);
 
@@ -873,19 +843,17 @@ create_object_a_handler (const jerry_value_t func_obj_val, /**< function object 
 } /* create_object_a_handler */
 
 static jerry_value_t
-create_object_b_handler (const jerry_value_t func_obj_val, /**< function object */
-                         const jerry_value_t this_val, /**< this value */
+create_object_b_handler (const jerry_call_info_t *call_info_p, /**< call information */
                          const jerry_value_t args_p[], /**< arguments list */
                          const jerry_length_t args_cnt) /**< arguments length */
 {
-  JERRY_UNUSED (func_obj_val);
   JERRY_UNUSED (args_p);
   JERRY_UNUSED (args_cnt);
 
-  TEST_ASSERT (jerry_value_is_object (this_val));
+  TEST_ASSERT (jerry_value_is_object (call_info_p->this_value));
 
   my_thing_b.x = false;
-  jerry_set_object_native_pointer (this_val,
+  jerry_set_object_native_pointer (call_info_p->this_value,
                                    &my_thing_b,
                                    &thing_b_info);
 

--- a/tests/unit-ext/test-ext-method-register.c
+++ b/tests/unit-ext/test-ext-method-register.c
@@ -24,13 +24,11 @@
 #include <string.h>
 
 static jerry_value_t
-method_hello (const jerry_value_t jfunc,  /**< function object */
-              const jerry_value_t jthis,  /**< function this */
+method_hello (const jerry_call_info_t *call_info_p, /**< call information */
               const jerry_value_t jargv[], /**< arguments */
               const jerry_length_t jargc) /**< number of arguments */
 {
-  (void) jfunc;
-  (void) jthis;
+  (void) call_info_p;
   (void) jargv;
   return jerry_create_number (jargc);
 } /* method_hello */


### PR DESCRIPTION
Instead of a fixed number of arguments, a call info structure is passed to the handlers, which can be extended in the future without breaknig the API. This structure holds new.target value, so its getter function is removed.