### PR TITLE
Reduce memory consumption of Promise objects

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -4288,13 +4288,12 @@ jerry_resolve_or_reject_promise (jerry_value_t promise, /**< the promise value *
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (error_value_msg_p)));
   }
 
-  ecma_promise_object_t *promise_p = (ecma_promise_object_t *) ecma_get_object_from_value (promise);
-  ecma_value_t function = is_resolve ? promise_p->resolve : promise_p->reject;
+  if (is_resolve)
+  {
+    return ecma_fulfill_promise_with_checks (promise, argument);
+  }
 
-  return ecma_op_function_call (ecma_get_object_from_value (function),
-                                ECMA_VALUE_UNDEFINED,
-                                &argument,
-                                1);
+  return ecma_reject_promise_with_checks (promise, argument);
 #else /* !JERRY_BUILTIN_PROMISE */
   JERRY_UNUSED (promise);
   JERRY_UNUSED (argument);

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -353,14 +353,6 @@ ecma_gc_mark_promise_object (ecma_extended_object_t *ext_object_p) /**< extended
   /* Mark all reactions. */
   ecma_promise_object_t *promise_object_p = (ecma_promise_object_t *) ext_object_p;
 
-  if (!ecma_is_value_empty (promise_object_p->resolve))
-  {
-    JERRY_ASSERT (ecma_is_value_object (promise_object_p->resolve)
-                  && ecma_is_value_object (promise_object_p->reject));
-    ecma_gc_set_object_visited (ecma_get_object_from_value (promise_object_p->resolve));
-    ecma_gc_set_object_visited (ecma_get_object_from_value (promise_object_p->reject));
-  }
-
   ecma_collection_t *collection_p = promise_object_p->reactions;
 
   if (collection_p != NULL)

--- a/jerry-core/ecma/operations/ecma-promise-object.h
+++ b/jerry-core/ecma/operations/ecma-promise-object.h
@@ -54,8 +54,6 @@ typedef struct
 {
   ecma_extended_object_t header; /**< extended object part */
   ecma_collection_t *reactions; /**< list of promise reactions */
-  ecma_value_t resolve; /**< resolve function */
-  ecma_value_t reject; /**< reject function */
 } ecma_promise_object_t;
 
 /**
@@ -100,6 +98,8 @@ uint16_t ecma_promise_get_flags (ecma_object_t *promise_p);
 ecma_value_t ecma_promise_get_result (ecma_object_t *promise_p);
 void ecma_reject_promise (ecma_value_t promise, ecma_value_t reason);
 void ecma_fulfill_promise (ecma_value_t promise, ecma_value_t value);
+ecma_value_t ecma_reject_promise_with_checks (ecma_value_t promise, ecma_value_t reason);
+ecma_value_t ecma_fulfill_promise_with_checks (ecma_value_t promise, ecma_value_t value);
 ecma_object_t *ecma_promise_new_capability (ecma_value_t constructor, ecma_value_t parent);
 ecma_value_t ecma_promise_reject_or_resolve (ecma_value_t this_arg, ecma_value_t value, bool is_resolve);
 ecma_value_t ecma_promise_then (ecma_value_t promise, ecma_value_t on_fulfilled, ecma_value_t on_rejected);
@@ -124,7 +124,7 @@ ecma_value_t ecma_op_get_capabilities_executor_cb (ecma_object_t *function_obj_p
 ecma_value_t ecma_promise_finally (ecma_value_t promise, ecma_value_t on_finally);
 void ecma_promise_async_then (ecma_value_t promise, ecma_value_t executable_object);
 ecma_value_t ecma_promise_async_await (ecma_extended_object_t *async_generator_object_p, ecma_value_t value);
-void ecma_promise_create_resolving_functions (ecma_promise_object_t *object_p);
+ecma_value_t ecma_promise_run_executor (ecma_object_t *promise_p, ecma_value_t executor, ecma_value_t this_value);
 
 uint32_t ecma_promise_remaining_inc_or_dec (ecma_value_t remaining, bool is_inc);
 


### PR DESCRIPTION
No need to keep a reference to resolver functions. Unused resolvers are cleaned up sooner by GC.