### PR TITLE
Remove unnecessary ecma_deref_ecma_string in regExpStringIterator

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-string-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-string-iterator-prototype.c
@@ -121,7 +121,6 @@ ecma_builtin_regexp_string_iterator_prototype_object_next (ecma_value_t this_val
 
     if (JERRY_UNLIKELY (matched_str_p == NULL))
     {
-      ecma_deref_ecma_string (matched_str_p);
       goto free_variables;
     }
 

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -92,7 +92,6 @@
   <test id="built-ins/Object/keys/order-after-define-property.js"><reason></reason></test>
   <test id="built-ins/Proxy/preventExtensions/trap-is-undefined-target-is-proxy.js"><reason></reason></test>
   <test id="built-ins/Proxy/setPrototypeOf/toboolean-trap-result-false.js"><reason></reason></test>
-  <test id="built-ins/RegExpStringIteratorPrototype/next/custom-regexpexec-match-get-0-tostring-throws.js"><reason></reason></test>
   <test id="built-ins/String/prototype/matchAll/regexp-is-undefined.js"><reason></reason></test>
   <test id="built-ins/String/prototype/normalize/form-is-not-valid-throws.js"><reason></reason></test>
   <test id="built-ins/String/prototype/normalize/length.js"><reason></reason></test>


### PR DESCRIPTION
JerryScript-DCO-1.0-Signed-off-by: bence gabor kis kisbg@inf.u-szeged.hu
