### PR TITLE
Return early when checking logical operators

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -2937,6 +2937,13 @@ parser_check_invalid_logical_op (parser_context_t *context_p, /**< context */
       parser_raise_error (context_p, PARSER_ERR_INVALID_NULLISH_COALESCING);
     }
 
+    /* If a logical operator is found, and there is no SyntaxError, the scan can be terminated
+     * since there was no SyntaxError when the logical operator was pushed onto the stack. */
+    if (token == LEXER_LOGICAL_OR || token == LEXER_LOGICAL_AND || token == LEXER_NULLISH_COALESCING)
+    {
+      return;
+    }
+
     parser_stack_iterator_skip (&iterator, sizeof (uint8_t));
   }
 } /* parser_check_invalid_logical_op */


### PR DESCRIPTION
Story: `(1 || 1 || 1)` reported uninitialized data read in valgrind.

The issue was: when logical binary operators are pushed onto the stack, a space for branch target is also pushed:
`parser_stack_push (context_p, &branch, sizeof (parser_branch_t));`

This structure is not initialized, and parser_check_invalid_logical_op checks these bytes, and may throw SyntaxErrors.

When I was thinking how to fix this, I realized I can return early if a logical operator is encountered. E.g. if the parser searches `||` or `&&` and it encounters a `??`, that means there was no SyntaxError when the `??` was pushed, so there was no `||` or `&&` before `??`. Hence we can simply return. This is much simpler than skipping the bytes and continue the search.