### PR TITLE
Remove jerryscript.h dependency from core

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -53,6 +53,9 @@
 JERRY_STATIC_ASSERT (sizeof (jerry_value_t) == sizeof (ecma_value_t),
                      size_of_jerry_value_t_must_be_equal_to_size_of_ecma_value_t);
 
+JERRY_STATIC_ASSERT (sizeof (jerry_call_info_t) == sizeof (ecma_call_info_t),
+                     size_of_jerry_call_info_t_must_be_equal_to_size_of_ecma_call_info_t);
+
 JERRY_STATIC_ASSERT ((int) ECMA_ERROR_NONE == (int) JERRY_ERROR_NONE
                      && (int) ECMA_ERROR_COMMON == (int) JERRY_ERROR_COMMON
                      && (int) ECMA_ERROR_EVAL == (int) JERRY_ERROR_EVAL
@@ -106,6 +109,33 @@ JERRY_STATIC_ASSERT ((int) RE_FLAG_GLOBAL == (int) JERRY_REGEXP_FLAG_GLOBAL
 JERRY_STATIC_ASSERT ((int) ECMA_PROMISE_IS_PENDING == (int) JERRY_PROMISE_STATE_PENDING
                      && (int) ECMA_PROMISE_IS_FULFILLED == (int) JERRY_PROMISE_STATE_FULFILLED,
                      promise_internal_state_matches_external);
+
+JERRY_STATIC_ASSERT((int) ECMA_PROMISE_EVENT_CREATE == (int) JERRY_PROMISE_EVENT_CREATE
+                    && (int) ECMA_PROMISE_EVENT_RESOLVE == (int) JERRY_PROMISE_EVENT_RESOLVE
+                    && (int) ECMA_PROMISE_EVENT_REJECT == (int) JERRY_PROMISE_EVENT_REJECT
+                    && (int) ECMA_PROMISE_EVENT_RESOLVE_FULFILLED == (int) JERRY_PROMISE_EVENT_RESOLVE_FULFILLED
+                    && (int) ECMA_PROMISE_EVENT_REJECT_FULFILLED == (int) JERRY_PROMISE_EVENT_REJECT_FULFILLED
+                    && ((int) ECMA_PROMISE_EVENT_REJECT_WITHOUT_HANDLER
+                        == (int) JERRY_PROMISE_EVENT_REJECT_WITHOUT_HANDLER)
+                    && (int) ECMA_PROMISE_EVENT_CATCH_HANDLER_ADDED == (int) JERRY_PROMISE_EVENT_CATCH_HANDLER_ADDED
+                    && (int) ECMA_PROMISE_EVENT_BEFORE_REACTION_JOB == (int) JERRY_PROMISE_EVENT_BEFORE_REACTION_JOB
+                    && (int) ECMA_PROMISE_EVENT_AFTER_REACTION_JOB == (int) JERRY_PROMISE_EVENT_AFTER_REACTION_JOB
+                    && (int) ECMA_PROMISE_EVENT_ASYNC_AWAIT == (int) JERRY_PROMISE_EVENT_ASYNC_AWAIT
+                    && (int) ECMA_PROMISE_EVENT_ASYNC_BEFORE_RESOLVE == (int) JERRY_PROMISE_EVENT_ASYNC_BEFORE_RESOLVE
+                    && (int) ECMA_PROMISE_EVENT_ASYNC_BEFORE_REJECT == (int) JERRY_PROMISE_EVENT_ASYNC_BEFORE_REJECT
+                    && (int) ECMA_PROMISE_EVENT_ASYNC_AFTER_RESOLVE == (int) JERRY_PROMISE_EVENT_ASYNC_AFTER_RESOLVE
+                    && (int) ECMA_PROMISE_EVENT_ASYNC_AFTER_REJECT == (int) JERRY_PROMISE_EVENT_ASYNC_AFTER_REJECT,
+                    ecma_promise_event_type_t_must_be_equal_to_jerry_promise_event_type_t);
+
+JERRY_STATIC_ASSERT ((int) ECMA_PROMISE_EVENT_FILTER_DISABLE == (int) JERRY_PROMISE_EVENT_FILTER_DISABLE
+                     && (int) ECMA_PROMISE_EVENT_FILTER_MAIN == (int) JERRY_PROMISE_EVENT_FILTER_MAIN
+                     && (int) ECMA_PROMISE_EVENT_FILTER_ERROR == (int) JERRY_PROMISE_EVENT_FILTER_ERROR
+                     && (int) ECMA_PROMISE_EVENT_FILTER_REACTION_JOB == (int) JERRY_PROMISE_EVENT_FILTER_REACTION_JOB
+                     && (int) ECMA_PROMISE_EVENT_FILTER_ASYNC_MAIN == (int) JERRY_PROMISE_EVENT_FILTER_ASYNC_MAIN
+                     && ((int) ECMA_PROMISE_EVENT_FILTER_ASYNC_REACTION_JOB
+                         == (int) JERRY_PROMISE_EVENT_FILTER_ASYNC_REACTION_JOB),
+                     ecma_promise_event_filter_t_must_be_equal_to_jerry_promise_event_filter_t);
+
 #endif /* JERRY_BUILTIN_PROMISE */
 
 /**
@@ -2137,7 +2167,7 @@ jerry_create_external_function (jerry_external_handler_t handler_p) /**< pointer
 {
   jerry_assert_api_available ();
 
-  ecma_object_t *func_obj_p = ecma_op_create_external_function_object (handler_p);
+  ecma_object_t *func_obj_p = ecma_op_create_external_function_object ((ecma_native_handler_t) handler_p);
   return ecma_make_object_value (func_obj_p);
 } /* jerry_create_external_function */
 
@@ -4863,7 +4893,7 @@ jerry_backtrace_get_location (jerry_backtrace_frame_t *frame_p) /**< frame point
     frame_p->location.resource_name = ecma_get_resource_name (context_p->shared_p->bytecode_header_p);
     frame_p->location.line = context_p->current_line;
     frame_p->location.column = 1;
-    return &frame_p->location;
+    return (jerry_backtrace_location_t *) &frame_p->location;
   }
 #endif /* JERRY_LINE_INFO */
 

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -22,7 +22,6 @@
 #include "ecma-function-object.h"
 #include "ecma-objects.h"
 #include "jcontext.h"
-#include "jerryscript-port.h"
 #include "lit-char-helpers.h"
 
 #if JERRY_DEBUGGER

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -136,7 +136,7 @@ ecma_ref_object_inline (ecma_object_t *object_p) /**< object */
   }
   else
   {
-    jerry_fatal (ERR_REF_COUNT_LIMIT);
+    jerry_fatal (JERRY_ERR_REF_COUNT_LIMIT);
   }
 } /* ecma_ref_object_inline */
 
@@ -1998,7 +1998,7 @@ ecma_gc_run (void)
 /**
  * Try to free some memory (depending on memory pressure).
  *
- * When called with JMEM_PRESSURE_FULL, the engine will be terminated with ERR_OUT_OF_MEMORY.
+ * When called with JMEM_PRESSURE_FULL, the engine will be terminated with JERRY_ERR_OUT_OF_MEMORY.
  */
 void
 ecma_free_unused_memory (jmem_pressure_t pressure) /**< current pressure */
@@ -2092,7 +2092,7 @@ ecma_free_unused_memory (jmem_pressure_t pressure) /**< current pressure */
   }
   else if (JERRY_UNLIKELY (pressure == JMEM_PRESSURE_FULL))
   {
-    jerry_fatal (ERR_OUT_OF_MEMORY);
+    jerry_fatal (JERRY_ERR_OUT_OF_MEMORY);
   }
   else
   {

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -725,7 +725,7 @@ ecma_append_chars_to_string (ecma_string_t *string1_p, /**< base ecma-string */
   /* Poor man's carry flag check: it is impossible to allocate this large string. */
   if (new_size < (cesu8_string1_size | cesu8_string2_size))
   {
-    jerry_fatal (ERR_OUT_OF_MEMORY);
+    jerry_fatal (JERRY_ERR_OUT_OF_MEMORY);
   }
 
   lit_magic_string_id_t magic_string_id;
@@ -867,7 +867,7 @@ ecma_ref_ecma_string_non_direct (ecma_string_t *string_p) /**< string descriptor
   }
   else
   {
-    jerry_fatal (ERR_REF_COUNT_LIMIT);
+    jerry_fatal (JERRY_ERR_REF_COUNT_LIMIT);
   }
 } /* ecma_ref_ecma_string_non_direct */
 

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1207,7 +1207,7 @@ ecma_ref_extended_primitive (ecma_extended_primitive_t *primitve_p) /**< extende
   }
   else
   {
-    jerry_fatal (ERR_REF_COUNT_LIMIT);
+    jerry_fatal (JERRY_ERR_REF_COUNT_LIMIT);
   }
 } /* ecma_ref_extended_primitive */
 
@@ -1348,7 +1348,7 @@ ecma_bytecode_ref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
   /* Abort program if maximum reference number is reached. */
   if (bytecode_p->refs >= UINT16_MAX)
   {
-    jerry_fatal (ERR_REF_COUNT_LIMIT);
+    jerry_fatal (JERRY_ERR_REF_COUNT_LIMIT);
   }
 
   bytecode_p->refs++;

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -83,7 +83,7 @@ ecma_finalize (void)
     ecma_gc_run ();
     if (++runs >= JERRY_GC_LOOP_LIMIT)
     {
-      jerry_fatal (ERR_UNTERMINATED_GC_LOOPS);
+      jerry_fatal (JERRY_ERR_UNTERMINATED_GC_LOOPS);
     }
   }
   while (JERRY_CONTEXT (ecma_gc_new_objects) != 0);

--- a/jerry-core/ecma/base/ecma-literal-storage.c
+++ b/jerry-core/ecma/base/ecma-literal-storage.c
@@ -688,7 +688,7 @@ ecma_snapshot_get_literal (const uint8_t *literal_base_p, /**< literal start */
 
     if (bigint_p == NULL)
     {
-      jerry_fatal (ERR_OUT_OF_MEMORY);
+      jerry_fatal (JERRY_ERR_OUT_OF_MEMORY);
     }
 
     /* Only the sign bit can differ. */

--- a/jerry-core/ecma/base/ecma-module.c
+++ b/jerry-core/ecma/base/ecma-module.c
@@ -14,8 +14,8 @@
  */
 
 #include "jcontext.h"
-#include "jerryscript.h"
 
+#include "jerryscript-port.h"
 #include "ecma-exceptions.h"
 #include "ecma-function-object.h"
 #include "ecma-gc.h"
@@ -206,7 +206,7 @@ ecma_module_initialize_context (const ecma_parse_options_t *options_p) /**< conf
   ecma_string_t *path_p = ecma_get_magic_string (LIT_MAGIC_STRING_RESOURCE_ANON);
 
   if (options_p != NULL
-      && (options_p->options & JERRY_PARSE_HAS_RESOURCE)
+      && (options_p->options & ECMA_PARSE_HAS_RESOURCE)
       && options_p->resource_name_length > 0)
   {
     const lit_utf8_byte_t *path_str_chars_p = options_p->resource_name_p;
@@ -1027,7 +1027,7 @@ ecma_module_parse (ecma_module_t *module_p) /**< module */
 
   ecma_compiled_code_t *bytecode_p = parser_parse_script (NULL,
                                                           0,
-                                                          (jerry_char_t *) source_p,
+                                                          (const uint8_t *) source_p,
                                                           source_size,
                                                           ECMA_PARSE_STRICT_MODE | ECMA_PARSE_MODULE,
                                                           &parse_options);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -16,6 +16,7 @@
 #include <math.h>
 
 #include "jcontext.h"
+#include "jerryscript-port.h"
 #include "ecma-function-object.h"
 #include "ecma-alloc.h"
 #include "ecma-builtin-helpers.h"

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-date.c
@@ -15,6 +15,7 @@
 
 #include <math.h>
 
+#include "jerryscript-port.h"
 #include "ecma-alloc.h"
 #include "ecma-builtin-helpers.h"
 #include "ecma-exceptions.h"

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1226,7 +1226,7 @@ ecma_op_function_call_native (ecma_object_t *func_obj_p, /**< Function object */
                                                                      native_function_p->realm_value);
 #endif /* JERRY_BUILTIN_REALMS */
 
-  jerry_call_info_t call_info;
+  ecma_call_info_t call_info;
   call_info.function = ecma_make_object_value (func_obj_p);
   call_info.this_value = this_arg_value;
 

--- a/jerry-core/ecma/operations/ecma-jobqueue.c
+++ b/jerry-core/ecma/operations/ecma-jobqueue.c
@@ -188,10 +188,10 @@ ecma_process_promise_reaction_job (ecma_job_promise_reaction_t *job_p) /**< the 
   capability_p = (ecma_promise_capabality_t *) ecma_get_object_from_value (job_p->capability);
 
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_REACTION_JOB))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_REACTION_JOB))
   {
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-    JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_BEFORE_REACTION_JOB,
+    JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_BEFORE_REACTION_JOB,
                                       capability_p->header.u.class_prop.u.promise,
                                       ECMA_VALUE_UNDEFINED,
                                       JERRY_CONTEXT (promise_callback_user_p));
@@ -246,10 +246,10 @@ ecma_process_promise_reaction_job (ecma_job_promise_reaction_t *job_p) /**< the 
   ecma_free_value (handler_result);
 
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_REACTION_JOB))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_REACTION_JOB))
   {
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-    JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_AFTER_REACTION_JOB,
+    JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_AFTER_REACTION_JOB,
                                       capability_p->header.u.class_prop.u.promise,
                                       ECMA_VALUE_UNDEFINED,
                                       JERRY_CONTEXT (promise_callback_user_p));
@@ -271,13 +271,13 @@ static ecma_value_t
 ecma_process_promise_async_reaction_job (ecma_job_promise_async_reaction_t *job_p) /**< the job to be operated */
 {
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ASYNC_REACTION_JOB))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ASYNC_REACTION_JOB))
   {
-    jerry_promise_event_type_t type = JERRY_PROMISE_EVENT_ASYNC_BEFORE_RESOLVE;
+    uint32_t type = ECMA_PROMISE_EVENT_ASYNC_BEFORE_RESOLVE;
 
     if (ecma_job_queue_get_type (&job_p->header) == ECMA_JOB_PROMISE_ASYNC_REACTION_REJECTED)
     {
-      type = JERRY_PROMISE_EVENT_ASYNC_BEFORE_REJECT;
+      type = ECMA_PROMISE_EVENT_ASYNC_BEFORE_REJECT;
     }
 
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
@@ -373,13 +373,13 @@ ecma_process_promise_async_reaction_job (ecma_job_promise_async_reaction_t *job_
 free_job:
 
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ASYNC_REACTION_JOB))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ASYNC_REACTION_JOB))
   {
-    jerry_promise_event_type_t type = JERRY_PROMISE_EVENT_ASYNC_AFTER_RESOLVE;
+    uint32_t type = ECMA_PROMISE_EVENT_ASYNC_AFTER_RESOLVE;
 
     if (ecma_job_queue_get_type (&job_p->header) == ECMA_JOB_PROMISE_ASYNC_REACTION_REJECTED)
     {
-      type = JERRY_PROMISE_EVENT_ASYNC_AFTER_REJECT;
+      type = ECMA_PROMISE_EVENT_ASYNC_AFTER_REJECT;
     }
 
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -195,10 +195,10 @@ ecma_reject_promise (ecma_value_t promise, /**< promise */
   JERRY_ASSERT (ecma_promise_get_flags (obj_p) & ECMA_PROMISE_IS_PENDING);
 
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_MAIN))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_MAIN))
   {
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-    JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_REJECT,
+    JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_REJECT,
                                       promise,
                                       reason,
                                       JERRY_CONTEXT (promise_callback_user_p));
@@ -221,10 +221,10 @@ ecma_reject_promise (ecma_value_t promise, /**< promise */
   {
     ((ecma_extended_object_t *) obj_p)->u.class_prop.extra_info |= ECMA_PROMISE_UNHANDLED_REJECT;
 
-    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ERROR))
+    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ERROR))
     {
       JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-      JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_REJECT_WITHOUT_HANDLER,
+      JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_REJECT_WITHOUT_HANDLER,
                                         promise,
                                         reason,
                                         JERRY_CONTEXT (promise_callback_user_p));
@@ -282,10 +282,10 @@ ecma_fulfill_promise (ecma_value_t promise, /**< promise */
   }
 
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_MAIN))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_MAIN))
   {
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-    JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_RESOLVE,
+    JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_RESOLVE,
                                       promise,
                                       value,
                                       JERRY_CONTEXT (promise_callback_user_p));
@@ -327,10 +327,10 @@ ecma_reject_promise_with_checks (ecma_value_t promise, /**< promise */
   if (JERRY_UNLIKELY (ecma_is_resolver_already_called (promise_obj_p)))
   {
 #if JERRY_PROMISE_CALLBACK
-    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ERROR))
+    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ERROR))
     {
       JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-      JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_REJECT_FULFILLED,
+      JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_REJECT_FULFILLED,
                                         promise,
                                         reason,
                                         JERRY_CONTEXT (promise_callback_user_p));
@@ -367,10 +367,10 @@ ecma_fulfill_promise_with_checks (ecma_value_t promise, /**< promise */
   if (JERRY_UNLIKELY (ecma_is_resolver_already_called (promise_obj_p)))
   {
 #if JERRY_PROMISE_CALLBACK
-    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ERROR))
+    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ERROR))
     {
       JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-      JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_RESOLVE_FULFILLED,
+      JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_RESOLVE_FULFILLED,
                                         promise,
                                         value,
                                         JERRY_CONTEXT (promise_callback_user_p));
@@ -514,10 +514,10 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
   promise_object_p->reactions = reactions;
 
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_MAIN))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_MAIN))
   {
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-    JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_CREATE,
+    JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_CREATE,
                                       ecma_make_object_value (object_p),
                                       parent,
                                       JERRY_CONTEXT (promise_callback_user_p));
@@ -959,10 +959,10 @@ ecma_promise_do_then (ecma_value_t promise, /**< the promise which call 'then' *
     {
       promise_p->header.u.class_prop.extra_info &= (uint16_t) ~ECMA_PROMISE_UNHANDLED_REJECT;
 
-      if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ERROR))
+      if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ERROR))
       {
         JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-        JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_CATCH_HANDLER_ADDED,
+        JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_CATCH_HANDLER_ADDED,
                                           promise,
                                           ECMA_VALUE_UNDEFINED,
                                           JERRY_CONTEXT (promise_callback_user_p));
@@ -1242,10 +1242,10 @@ ecma_promise_async_then (ecma_value_t promise, /**< promise object */
                          ecma_value_t executable_object) /**< executable object of the async function */
 {
 #if JERRY_PROMISE_CALLBACK
-  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ASYNC_MAIN))
+  if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ASYNC_MAIN))
   {
     JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-    JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_ASYNC_AWAIT,
+    JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_ASYNC_AWAIT,
                                       executable_object,
                                       promise,
                                       JERRY_CONTEXT (promise_callback_user_p));
@@ -1274,10 +1274,10 @@ ecma_promise_async_then (ecma_value_t promise, /**< promise object */
   {
     ((ecma_extended_object_t *) promise_obj_p)->u.class_prop.extra_info &= (uint16_t) ~ECMA_PROMISE_UNHANDLED_REJECT;
 
-    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & JERRY_PROMISE_EVENT_FILTER_ERROR))
+    if (JERRY_UNLIKELY (JERRY_CONTEXT (promise_callback_filters) & ECMA_PROMISE_EVENT_FILTER_ERROR))
     {
       JERRY_ASSERT (JERRY_CONTEXT (promise_callback) != NULL);
-      JERRY_CONTEXT (promise_callback) (JERRY_PROMISE_EVENT_CATCH_HANDLER_ADDED,
+      JERRY_CONTEXT (promise_callback) (ECMA_PROMISE_EVENT_CATCH_HANDLER_ADDED,
                                         promise,
                                         ECMA_VALUE_UNDEFINED,
                                         JERRY_CONTEXT (promise_callback_user_p));

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -308,7 +308,7 @@ ecma_proxy_object_get_prototype_of (ecma_object_t *obj_p) /**< proxy object */
     return ecma_raise_type_error (ECMA_ERR_MSG ("Trap returned neither object nor null"));
   }
 
-  if (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION)
+  if (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION)
   {
     return handler_proto;
   }
@@ -422,7 +422,7 @@ ecma_proxy_object_set_prototype_of (ecma_object_t *obj_p, /**< proxy object */
 
   ecma_free_value (trap_result);
 
-  if (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION)
+  if (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION)
   {
     return ecma_make_boolean_value (boolean_trap_result);
   }
@@ -522,7 +522,7 @@ ecma_proxy_object_is_extensible (ecma_object_t *obj_p) /**< proxy object */
 
   ecma_free_value (trap_result);
 
-  if (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION)
+  if (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION)
   {
     return ecma_make_boolean_value (boolean_trap_result);
   }
@@ -622,7 +622,7 @@ ecma_proxy_object_prevent_extensions (ecma_object_t *obj_p) /**< proxy object */
 
   /* 10. */
   if (boolean_trap_result
-      && !(obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION))
+      && !(obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION))
   {
     ecma_value_t target_is_ext = ecma_builtin_object_object_is_extensible (target_obj_p);
 
@@ -704,7 +704,7 @@ ecma_proxy_object_get_own_property_descriptor (ecma_object_t *obj_p, /**< proxy 
     return ecma_raise_type_error (ECMA_ERR_MSG ("Trap is neither an object nor undefined"));
   }
 
-  if (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION)
+  if (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION)
   {
     if (ecma_is_value_undefined (trap_result))
     {
@@ -915,7 +915,7 @@ ecma_proxy_object_define_own_property (ecma_object_t *obj_p, /**< proxy object *
     return ECMA_VALUE_FALSE;
   }
 
-  if (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION)
+  if (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION)
   {
     return ECMA_VALUE_TRUE;
   }
@@ -1067,7 +1067,7 @@ ecma_proxy_object_has (ecma_object_t *obj_p, /**< proxy object */
 
   /* 11. */
   if (!boolean_trap_result
-      && !(obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION))
+      && !(obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION))
   {
     ecma_property_descriptor_t target_desc;
 
@@ -1160,7 +1160,7 @@ ecma_proxy_object_get (ecma_object_t *obj_p, /**< proxy object */
 
   /* 10. */
   if (ECMA_IS_VALUE_ERROR (trap_result)
-      || (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION))
+      || (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION))
   {
     return trap_result;
   }
@@ -1285,7 +1285,7 @@ ecma_proxy_object_set (ecma_object_t *obj_p, /**< proxy object */
     return ECMA_VALUE_FALSE;
   }
 
-  if (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION)
+  if (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION)
   {
     return ECMA_VALUE_TRUE;
   }
@@ -1399,7 +1399,7 @@ ecma_proxy_object_delete_property (ecma_object_t *obj_p, /**< proxy object */
     return ECMA_VALUE_FALSE;
   }
 
-  if (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION)
+  if (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION)
   {
     return ECMA_VALUE_TRUE;
   }
@@ -1613,7 +1613,7 @@ ecma_proxy_object_own_property_keys (ecma_object_t *obj_p) /**< proxy object */
   ecma_free_value (trap_result_array);
 
   if (trap_result == NULL
-      || (obj_p->u2.prototype_cp & JERRY_PROXY_SKIP_RESULT_VALIDATION))
+      || (obj_p->u2.prototype_cp & ECMA_PROXY_SKIP_RESULT_VALIDATION))
   {
     return trap_result;
   }

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -331,7 +331,7 @@ typedef bool (*jerry_objects_foreach_by_native_info_t) (const jerry_value_t obje
 /**
  * User context item manager
  */
-typedef struct
+typedef struct jerry_context_data_manager_t
 {
   /**
    * Callback responsible for initializing a context item, or NULL to zero out the memory. This is called lazily, the
@@ -853,7 +853,7 @@ typedef enum
 /**
  * Notification callback for tracking Promise and async function operations.
  */
-typedef void (*jerry_promise_callback_t) (jerry_promise_event_type_t event_type,
+typedef void (*jerry_promise_callback_t) (uint32_t event_type,
                                           const jerry_value_t object, const jerry_value_t value,
                                           void *user_p);
 

--- a/jerry-core/jcontext/jcontext.c
+++ b/jerry-core/jcontext/jcontext.c
@@ -123,7 +123,7 @@ jcontext_take_exception (void)
 /**
  * Global context.
  */
-jerry_context_t jerry_global_context;
+struct jerry_context_t jerry_global_context;
 
 #if !JERRY_SYSTEM_ALLOCATOR
 

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -23,12 +23,9 @@
 #include "ecma-builtins.h"
 #include "ecma-helpers.h"
 #include "ecma-jobqueue.h"
-#include "jerryscript-port.h"
 #include "jmem.h"
 #include "re-bytecode.h"
 #include "vm-defines.h"
-#include "jerryscript.h"
-#include "jerryscript-debugger-transport.h"
 #include "js-parser-internal.h"
 
 /** \addtogroup context Context
@@ -97,7 +94,7 @@ typedef struct jmem_heap_t jmem_heap_t;
 typedef struct jerry_context_data_header
 {
   struct jerry_context_data_header *next_p; /**< pointer to next context item */
-  const jerry_context_data_manager_t *manager_p; /**< manager responsible for deleting this item */
+  const struct jerry_context_data_manager_t *manager_p; /**< manager responsible for deleting this item */
 } jerry_context_data_header_t;
 
 #define JERRY_CONTEXT_DATA_HEADER_USER_DATA(item_p) \
@@ -157,7 +154,7 @@ struct jerry_context_t
   vm_frame_ctx_t *vm_top_context_p; /**< top (current) interpreter context */
   jerry_context_data_header_t *context_data_p; /**< linked list of user-provided context-specific pointers */
   void *error_object_created_callback_user_p; /**< user pointer for error_object_update_callback_p */
-  jerry_error_object_created_callback_t error_object_created_callback_p; /**< decorator callback for Error objects */
+  ecma_error_object_created_callback_t error_object_created_callback_p; /**< decorator callback for Error objects */
   size_t ecma_gc_objects_number; /**< number of currently allocated objects */
   size_t ecma_gc_new_objects; /**< number of newly allocated objects since last GC session */
   size_t jmem_heap_allocated_size; /**< size of allocated regions */
@@ -186,7 +183,7 @@ struct jerry_context_t
 #if JERRY_PROMISE_CALLBACK
   uint32_t promise_callback_filters; /**< reported event types for promise callback */
   void *promise_callback_user_p; /**< user pointer for promise callback */
-  jerry_promise_callback_t promise_callback; /**< user function for tracking Promise object operations */
+  ecma_promise_callback_t promise_callback; /**< user function for tracking Promise object operations */
 #endif /* JERRY_PROMISE_CALLBACK */
 #endif /* JERRY_BUILTIN_PROMISE */
 
@@ -273,7 +270,7 @@ struct jmem_heap_t
 /**
  * Global context.
  */
-extern jerry_context_t jerry_global_context;
+extern struct jerry_context_t jerry_global_context;
 
 /**
  * Config-independent name for context.

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -261,8 +261,8 @@ jmem_heap_alloc (const size_t size) /**< size of requested block */
  * Note:
  *    Each failed allocation attempt tries to reclaim memory with an increasing pressure,
  *    up to 'max_pressure', or until a sufficient memory block is found. When JMEM_PRESSURE_FULL
- *    is reached, the engine is terminated with ERR_OUT_OF_MEMORY. The `max_pressure` argument
- *    can be used to limit the maximum pressure, and prevent the engine from terminating.
+ *    is reached, the engine is terminated with JERRY_ERR_OUT_OF_MEMORY. The `max_pressure`
+ *    argument can be used to limit the maximum pressure, and prevent the engine from terminating.
  *
  * @return NULL, if the required memory size is 0 or not enough memory
  *         pointer to the allocated memory block, if allocation is successful
@@ -313,7 +313,7 @@ jmem_heap_alloc_block_internal (const size_t size) /**< required memory size */
  * Allocation of memory block, reclaiming unused memory if there is not enough.
  *
  * Note:
- *      If a sufficiently sized block can't be found, the engine will be terminated with ERR_OUT_OF_MEMORY.
+ *      If a sufficiently sized block can't be found, the engine will be terminated with JERRY_ERR_OUT_OF_MEMORY.
  *
  * @return NULL, if the required memory is 0
  *         pointer to allocated memory block, otherwise

--- a/jerry-core/jmem/jmem.h
+++ b/jerry-core/jmem/jmem.h
@@ -112,7 +112,7 @@ typedef uint32_t jmem_cpointer_tag_t;
  * until enough memory is freed to fulfill the allocation request.
  *
  * If not enough memory is freed and JMEM_PRESSURE_FULL is reached,
- * then the engine is shut down with ERR_OUT_OF_MEMORY.
+ * then the engine is shut down with JERRY_ERR_OUT_OF_MEMORY.
  */
 typedef enum
 {
@@ -197,7 +197,7 @@ void * JERRY_ATTR_PURE jmem_decompress_pointer (uintptr_t compressed_pointer);
  * If requested number of elements is zero, assign NULL to the variable.
  *
  * Warning:
- *         if there is not enough memory on the heap, shutdown engine with ERR_OUT_OF_MEMORY.
+ *         if there is not enough memory on the heap, shutdown engine with JERRY_ERR_OUT_OF_MEMORY.
  */
 #define JMEM_DEFINE_LOCAL_ARRAY(var_name, number, type) \
 { \

--- a/jerry-core/jrt/jrt-fatals.c
+++ b/jerry-core/jrt/jrt-fatals.c
@@ -17,6 +17,7 @@
  * Implementation of exit with specified status code.
  */
 
+#include "jerryscript-port.h"
 #include "jrt.h"
 #include "jrt-libc-includes.h"
 
@@ -27,32 +28,32 @@
  * and call assertion fail handler.
  */
 void JERRY_ATTR_NORETURN
-jerry_fatal (jerry_fatal_code_t code) /**< status code */
+jerry_fatal (jerry_fatal_error_t code) /**< status code */
 {
 #ifndef JERRY_NDEBUG
   switch (code)
   {
-    case ERR_OUT_OF_MEMORY:
+    case JERRY_ERR_OUT_OF_MEMORY:
     {
       JERRY_ERROR_MSG ("Error: ERR_OUT_OF_MEMORY\n");
       break;
     }
-    case ERR_REF_COUNT_LIMIT:
+    case JERRY_ERR_REF_COUNT_LIMIT:
     {
       JERRY_ERROR_MSG ("Error: ERR_REF_COUNT_LIMIT\n");
       break;
     }
-    case ERR_UNTERMINATED_GC_LOOPS:
+    case JERRY_ERR_UNTERMINATED_GC_LOOPS:
     {
       JERRY_ERROR_MSG ("Error: ERR_UNTERMINATED_GC_LOOPS\n");
       break;
     }
-    case ERR_DISABLED_BYTE_CODE:
+    case JERRY_ERR_DISABLED_BYTE_CODE:
     {
       JERRY_ERROR_MSG ("Error: ERR_DISABLED_BYTE_CODE\n");
       break;
     }
-    case ERR_FAILED_INTERNAL_ASSERTION:
+    case JERRY_ERR_FAILED_INTERNAL_ASSERTION:
     {
       JERRY_ERROR_MSG ("Error: ERR_FAILED_INTERNAL_ASSERTION\n");
       break;
@@ -60,7 +61,7 @@ jerry_fatal (jerry_fatal_code_t code) /**< status code */
   }
 #endif /* !JERRY_NDEBUG */
 
-  jerry_port_fatal (code);
+  jerry_port_fatal ((jerry_fatal_code_t) code);
 
   /* to make compiler happy for some RTOS: 'control reaches end of non-void function' */
   while (true)
@@ -84,7 +85,7 @@ jerry_assert_fail (const char *assertion, /**< assertion condition string */
                    function,
                    (unsigned long) line);
 
-  jerry_fatal (ERR_FAILED_INTERNAL_ASSERTION);
+  jerry_fatal (JERRY_ERR_FAILED_INTERNAL_ASSERTION);
 } /* jerry_assert_fail */
 
 /**
@@ -100,6 +101,6 @@ jerry_unreachable (const char *file, /**< file name */
                    function,
                    (unsigned long) line);
 
-  jerry_fatal (ERR_FAILED_INTERNAL_ASSERTION);
+  jerry_fatal (JERRY_ERR_FAILED_INTERNAL_ASSERTION);
 } /* jerry_unreachable */
 #endif /* !JERRY_NDEBUG */

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -20,7 +20,7 @@
 #include <string.h>
 
 #include "config.h"
-#include "jerryscript-port.h"
+#include "jerryscript-compiler.h"
 #include "jrt-types.h"
 
 /*
@@ -107,9 +107,21 @@ jerry_unreachable (const char *file, const char *function, const uint32_t line);
 #endif /* !JERRY_NDEBUG */
 
 /**
+ * Error codes
+ */
+typedef enum
+{
+  JERRY_ERR_OUT_OF_MEMORY = 10,
+  JERRY_ERR_REF_COUNT_LIMIT = 12,
+  JERRY_ERR_DISABLED_BYTE_CODE = 13,
+  JERRY_ERR_UNTERMINATED_GC_LOOPS = 14,
+  JERRY_ERR_FAILED_INTERNAL_ASSERTION = 120
+} jerry_fatal_error_t;
+
+/**
  * Exit on fatal error
  */
-void JERRY_ATTR_NORETURN jerry_fatal (jerry_fatal_code_t code);
+void JERRY_ATTR_NORETURN jerry_fatal (jerry_fatal_error_t code);
 
 /*
  * Logging

--- a/jerry-core/parser/js/js-parser-module.c
+++ b/jerry-core/parser/js/js-parser-module.c
@@ -17,7 +17,6 @@
 
 #if JERRY_MODULE_SYSTEM
 #include "jcontext.h"
-#include "jerryscript-port.h"
 
 #include "ecma-function-object.h"
 #include "ecma-gc.h"

--- a/jerry-core/vm/vm-defines.h
+++ b/jerry-core/vm/vm-defines.h
@@ -158,7 +158,9 @@ struct jerry_backtrace_frame_internal_t
 {
   vm_frame_ctx_t *context_p; /**< context pointer */
   uint8_t frame_type; /**< frame type */
-  jerry_backtrace_location_t location; /**< location information */
+#if JERRY_LINE_INFO
+  ecma_backtrace_location_t location; /**< location information */
+#endif /* JERRY_LINE_INFO */
   ecma_value_t function; /**< function reference */
 };
 

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -4642,7 +4642,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
         {
           JERRY_ASSERT (VM_OC_GROUP_GET_INDEX (opcode_data) == VM_OC_NONE);
 
-          jerry_fatal (ERR_DISABLED_BYTE_CODE);
+          jerry_fatal (JERRY_ERR_DISABLED_BYTE_CODE);
         }
       }
 


### PR DESCRIPTION
Currently jrt.h includes jerryscript-port.h, which includes jerryscript-core.h. That essentially means the whole project sees the api. And more and more code exploited this. This includes a lot of my code, so I decided to remove this dependency. This patch is not completed (even fails to build), but shows how this could be fixed.

Problem is, I am not sure I like this direction. A lot of definition needs to be duplicated. Some callbacks passes structures / enums around, and needed ugly type casts. And it is easy to break something.

So this duplicating thing was acceptable when the api was small, but as it gets more complex, it does not really grows well. So what about accepting that the api is part of ecma-globals.h, and everybody can access it. Or maybe split the api to defintions and function definitions, and only the former is part of ecma-globals.h. No jerry.c function should be called form the core code, never.

So the point of this work is start a discussion, and also provide how the current status would look like if it would be correctly implemented.