### PR TITLE
Add info to external pointer free callback

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -696,11 +696,11 @@ typedef jerry_value_t (*jerry_external_handler_t) (const jerry_call_info_t *call
 
 - [jerry_create_external_function](#jerry_create_external_function)
 
-## jerry_object_native_free_callback_t
+## jerry_value_free_callback_t
 
 **Summary**
 
-Native free callback of an object. It is used in `jerry_object_native_info_t` and for external Array buffers.
+Native free callback of generic value types.
 
 *Note*:
  - Referred values by this method must have at least 1 reference. (Correct API usage satisfies this condition)
@@ -708,17 +708,45 @@ Native free callback of an object. It is used in `jerry_object_native_info_t` an
 **Prototype**
 
 ```c
-typedef void (*jerry_object_native_free_callback_t) (void *native_p);
+typedef void (*jerry_value_free_callback_t) (void *native_p);
 ```
+
+*New in version [[NEXT_RELEASE]]*.
+
+**See also**
+
+- [jerry_create_external_string](#jerry_create_external_string)
+- [jerry_create_external_string_sz](#jerry_create_external_string_sz)
+- [jerry_create_arraybuffer_external](#jerry_create_arraybuffer_external)
+
+## jerry_object_native_free_callback_t
+
+**Summary**
+
+Native free callback of an object. The callback receives both the memory pointer and the type
+information passed to [jerry_set_object_native_pointer](#jerry_set_object_native_pointer).
+
+*Note*:
+ - Referred values by this method must have at least 1 reference. (Correct API usage satisfies this condition)
+
+**Prototype**
+
+```c
+typedef void (*jerry_object_native_free_callback_t) (void *native_p, struct jerry_object_native_info_t *info_p);
+```
+
+- `native_p` - native pointer passed to [jerry_set_object_native_pointer](#jerry_set_object_native_pointer).
+- `info_p` - native type info passed to [jerry_set_object_native_pointer](#jerry_set_object_native_pointer).
 
 *New in version 2.0*: Renamed from `jerry_object_free_callback_t`.
 
 *Changed in version 2.2*: API calls are once again allowed. (See note)
 
+*Changed in version [[NEXT_RELEASE]]*: `info_p` argument is added
+
 **See also**
 
 - [jerry_object_native_info_t](#jerry_object_native_info_t)
-- [jerry_create_arraybuffer_external](#jerry_create_arraybuffer_external)
 
 ## jerry_error_object_created_callback_t
 
@@ -5655,7 +5683,7 @@ so the user can release the buffer which was provided.
 jerry_value_t
 jerry_create_arraybuffer_external (const jerry_length_t size
                                    uint8_t *buffer_p,
-                                   jerry_object_native_free_callback_t free_cb);
+                                   jerry_value_free_callback_t free_cb);
 ```
 
 - `size` - size of the buffer to use **in bytes** (should not be 0)
@@ -5666,6 +5694,8 @@ jerry_create_arraybuffer_external (const jerry_length_t size
   - if the `size` is zero or `buffer_p` is a null pointer this will return an empty ArrayBuffer.
 
 *New in version 2.0*.
+
+*Changed in version [[NEXT_RELEASE]]*: type of `free_cb` has been changed.
 
 **Example**
 
@@ -6473,7 +6503,7 @@ is no longer needed.
 ```c
 jerry_value_t
 jerry_create_external_string (const jerry_char_t *str_p,
-                              jerry_object_native_free_callback_t free_cb)
+                              jerry_value_free_callback_t free_cb)
 ```
 
 - `str_p` - non-null pointer to string
@@ -6481,6 +6511,8 @@ jerry_create_external_string (const jerry_char_t *str_p,
 - return value - value of the created string
 
 *New in version 2.4*.
+
+*Changed in version [[NEXT_RELEASE]]*: type of `free_cb` has been changed.
 
 **Example**
 
@@ -6519,7 +6551,7 @@ is no longer needed.
 jerry_value_t
 jerry_create_external_string_sz (const jerry_char_t *str_p,
                                  jerry_size_t str_size,
-                                 jerry_object_native_free_callback_t free_cb)
+                                 jerry_value_free_callback_t free_cb)
 ```
 
 - `str_p` - non-null pointer to string
@@ -6528,6 +6560,8 @@ jerry_create_external_string_sz (const jerry_char_t *str_p,
 - return value - value of the created string
 
 *New in version 2.4*.
+
+*Changed in version [[NEXT_RELEASE]]*: type of `free_cb` has been changed.
 
 **Example**
 
@@ -8416,8 +8450,11 @@ typedef struct
 #define SECRET_INFO ((void *) 42)
 
 static void
-buffer_native_freecb (void *native_p)
+buffer_native_freecb (void *native_p,
+                      jerry_object_native_info_t *info_p)
 {
+  (void) info_p;
+
   char *data_p = ((buffer_native_object_t*)native_p)->data_p;
 
   if (data_p != NULL)
@@ -8429,14 +8466,21 @@ buffer_native_freecb (void *native_p)
 }
 
 static void
-shape_native_freecb (void *native_p)
+shape_native_freecb (void *native_p,
+                     jerry_object_native_info_t *info_p)
 {
+  (void) info_p;
+
   free (native_p);
 }
 
 static void
-destructor_freecb (void *native_p)
+destructor_freecb (void *native_p,
+                   jerry_object_native_info_t *info_p)
 {
+  (void) native_p;
+  (void) info_p;
+
    printf("Note: the object has been freed\n");
 }
 
@@ -8988,8 +9032,11 @@ typedef struct
   int match_foo_value;
 } find_object_data_t;
 
-static void native_freecb (void *native_p)
+static void native_freecb (void *native_p,
+                           jerry_object_native_info_t *info_p)
 {
+  (void) info_p;
+
   /* `native_p` was allocated via malloc. */
   free (native_p);
 } /* native_freecb */

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -2474,7 +2474,7 @@ jerry_create_string_sz (const jerry_char_t *str_p, /**< pointer to string */
  */
 jerry_value_t
 jerry_create_external_string (const jerry_char_t *str_p, /**< pointer to string */
-                              jerry_object_native_free_callback_t free_cb) /**< free callback */
+                              jerry_value_free_callback_t free_cb) /**< free callback */
 {
   return jerry_create_external_string_sz (str_p, lit_zt_utf8_string_size ((lit_utf8_byte_t *) str_p), free_cb);
 } /* jerry_create_external_string */
@@ -2490,7 +2490,7 @@ jerry_create_external_string (const jerry_char_t *str_p, /**< pointer to string 
 jerry_value_t
 jerry_create_external_string_sz (const jerry_char_t *str_p, /**< pointer to string */
                                  jerry_size_t str_size, /**< string size */
-                                 jerry_object_native_free_callback_t free_cb) /**< free callback */
+                                 jerry_value_free_callback_t free_cb) /**< free callback */
 {
   jerry_assert_api_available ();
 
@@ -4022,7 +4022,7 @@ jerry_objects_foreach_by_native_info (const jerry_object_native_info_t *native_i
     {
       native_pointer_p = ecma_get_native_pointer_value (iter_p, (void *) native_info_p);
       if (native_pointer_p
-          && !foreach_p (ecma_make_object_value (iter_p), native_pointer_p->data_p, user_data_p))
+          && !foreach_p (ecma_make_object_value (iter_p), native_pointer_p->native_p, user_data_p))
       {
         return true;
       }
@@ -4066,7 +4066,7 @@ jerry_get_object_native_pointer (const jerry_value_t obj_val, /**< object to get
 
   if (out_native_pointer_p != NULL)
   {
-    *out_native_pointer_p = native_pointer_p->data_p;
+    *out_native_pointer_p = native_pointer_p->native_p;
   }
 
   return true;
@@ -5209,7 +5209,7 @@ jerry_create_arraybuffer (const jerry_length_t size) /**< size of the ArrayBuffe
 jerry_value_t
 jerry_create_arraybuffer_external (const jerry_length_t size, /**< size of the buffer to used */
                                    uint8_t *buffer_p, /**< buffer to use as the ArrayBuffer's backing */
-                                   jerry_object_native_free_callback_t free_cb) /**< buffer free callback */
+                                   jerry_value_free_callback_t free_cb) /**< buffer free callback */
 {
   jerry_assert_api_available ();
 
@@ -5222,9 +5222,7 @@ jerry_create_arraybuffer_external (const jerry_length_t size, /**< size of the b
   }
   else
   {
-    arraybuffer = ecma_arraybuffer_new_object_external (size,
-                                                        buffer_p,
-                                                        (ecma_object_native_free_callback_t) free_cb);
+    arraybuffer = ecma_arraybuffer_new_object_external (size, buffer_p, free_cb);
   }
 
   return jerry_return (ecma_make_object_value (arraybuffer));

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -299,27 +299,22 @@ typedef ecma_value_t (*ecma_native_handler_t) (const struct jerry_call_info_t *c
                                                const uint32_t args_count);
 
 /**
- * Native free callback of an object.
- */
-typedef void (*ecma_object_native_free_callback_t) (void *native_p);
-
-/**
- * Type information of a native pointer.
+ * Representation of native pointer data.
  */
 typedef struct
 {
-  ecma_object_native_free_callback_t free_cb; /**< the free callback of the native pointer */
-} ecma_object_native_info_t;
+  void *native_p; /**< points to the data of the object */
+  jerry_object_native_info_t *info_p; /**< native info */
+} ecma_native_pointer_t;
 
 /**
- * Representation for native pointer data.
+ * Representation of native pointer data chain.
  */
-typedef struct ecma_native_pointer_t
+typedef struct ecma_native_pointer_chain_t
 {
-  void *data_p; /**< points to the data of the object */
-  ecma_object_native_info_t *info_p; /**< native info */
-  struct ecma_native_pointer_t *next_p; /**< points to the next ecma_native_pointer_t element */
-} ecma_native_pointer_t;
+  ecma_native_pointer_t data; /**< pointer data */
+  struct ecma_native_pointer_chain_t *next_p; /**< next in the list */
+} ecma_native_pointer_chain_t;
 
 /**
  * Option bits for ecma_parse_options_t.
@@ -415,7 +410,7 @@ typedef enum
   ECMA_PROPERTY_FLAG_CONFIGURABLE = (1u << 0), /**< property is configurable */
   ECMA_PROPERTY_FLAG_ENUMERABLE = (1u << 1), /**< property is enumerable */
   ECMA_PROPERTY_FLAG_WRITABLE = (1u << 2), /**< property is writable */
-
+  ECMA_PROPERTY_FLAG_SINGLE_EXTERNAL = (1u << 2), /**< only one external pointer is assigned to this object */
   ECMA_PROPERTY_FLAG_DELETED = (1u << 3), /**< property is deleted */
   ECMA_FAST_ARRAY_FLAG = (1u << 3), /**< array is fast array */
   ECMA_PROPERTY_FLAG_LCACHED = (1u << 4), /**< property is lcached */
@@ -1849,7 +1844,7 @@ typedef struct
 typedef struct
 {
   ecma_long_string_t header;
-  ecma_object_native_free_callback_t free_cb; /**< free callback */
+  jerry_value_free_callback_t free_cb; /**< free callback */
 } ecma_external_string_t;
 
 /**
@@ -2101,7 +2096,7 @@ typedef struct
 {
   ecma_extended_object_t extended_object; /**< extended object part */
   void *buffer_p; /**< external buffer pointer */
-  ecma_object_native_free_callback_t free_cb; /**< the free callback for the above buffer pointer */
+  jerry_value_free_callback_t free_cb; /**<  the free callback for the above buffer pointer */
 } ecma_arraybuffer_external_info;
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers-string.c
+++ b/jerry-core/ecma/base/ecma-helpers-string.c
@@ -455,7 +455,7 @@ ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *string
 ecma_string_t *
 ecma_new_ecma_external_string_from_cesu8 (const lit_utf8_byte_t *string_p, /**< cesu-8 string */
                                           lit_utf8_size_t string_size, /**< string size */
-                                          ecma_object_native_free_callback_t free_cb) /**< free callback */
+                                          jerry_value_free_callback_t free_cb) /**< free callback */
 {
   JERRY_ASSERT (string_p != NULL || string_size == 0);
   JERRY_ASSERT (lit_is_valid_cesu8_string (string_p, string_size));

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -303,7 +303,7 @@ ecma_string_t *ecma_new_ecma_string_from_utf8 (const lit_utf8_byte_t *string_p, 
 ecma_string_t *ecma_new_ecma_string_from_utf8_converted_to_cesu8 (const lit_utf8_byte_t *string_p,
                                                                   lit_utf8_size_t string_size);
 ecma_string_t *ecma_new_ecma_external_string_from_cesu8 (const lit_utf8_byte_t *string_p, lit_utf8_size_t string_size,
-                                                         ecma_object_native_free_callback_t free_cb);
+                                                         jerry_value_free_callback_t free_cb);
 ecma_string_t *ecma_new_ecma_string_from_code_unit (ecma_char_t code_unit);
 #if JERRY_ESNEXT
 ecma_string_t *ecma_new_ecma_string_from_code_units (ecma_char_t first_code_unit, ecma_char_t second_code_unit);

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -76,7 +76,7 @@ ecma_arraybuffer_new_object (uint32_t length) /**< length of the arraybuffer */
 ecma_object_t *
 ecma_arraybuffer_new_object_external (uint32_t length, /**< length of the buffer_p to use */
                                       void *buffer_p, /**< pointer for ArrayBuffer's buffer backing */
-                                      ecma_object_native_free_callback_t free_cb) /**< buffer free callback */
+                                      jerry_value_free_callback_t free_cb) /**< buffer free callback */
 {
   ecma_object_t *prototype_obj_p = ecma_builtin_get (ECMA_BUILTIN_ID_ARRAYBUFFER_PROTOTYPE);
   ecma_object_t *object_p = ecma_create_object (prototype_obj_p,

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -38,7 +38,7 @@ ecma_arraybuffer_new_object (uint32_t lengh);
 ecma_object_t *
 ecma_arraybuffer_new_object_external (uint32_t length,
                                       void *buffer_p,
-                                      ecma_object_native_free_callback_t free_cb);
+                                      jerry_value_free_callback_t free_cb);
 lit_utf8_byte_t * JERRY_ATTR_PURE
 ecma_arraybuffer_get_buffer (ecma_object_t *obj_p);
 uint32_t JERRY_ATTR_PURE

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -190,9 +190,9 @@ jerry_value_t jerry_create_string_sz_from_utf8 (const jerry_char_t *str_p, jerry
 jerry_value_t jerry_create_string (const jerry_char_t *str_p);
 jerry_value_t jerry_create_string_sz (const jerry_char_t *str_p, jerry_size_t str_size);
 jerry_value_t jerry_create_external_string (const jerry_char_t *str_p,
-                                            jerry_object_native_free_callback_t free_cb);
+                                            jerry_value_free_callback_t free_cb);
 jerry_value_t jerry_create_external_string_sz (const jerry_char_t *str_p, jerry_size_t str_size,
-                                               jerry_object_native_free_callback_t free_cb);
+                                               jerry_value_free_callback_t free_cb);
 jerry_value_t jerry_create_symbol (const jerry_value_t value);
 jerry_value_t jerry_create_bigint (const uint64_t *digits_p, uint32_t size, bool sign);
 jerry_value_t jerry_create_undefined (void);
@@ -351,7 +351,7 @@ bool jerry_value_is_arraybuffer (const jerry_value_t value);
 jerry_value_t jerry_create_arraybuffer (const jerry_length_t size);
 jerry_value_t jerry_create_arraybuffer_external (const jerry_length_t size,
                                                  uint8_t *buffer_p,
-                                                 jerry_object_native_free_callback_t free_cb);
+                                                 jerry_value_free_callback_t free_cb);
 jerry_length_t jerry_arraybuffer_write (const jerry_value_t value,
                                         jerry_length_t offset,
                                         const uint8_t *buf_p,

--- a/jerry-core/include/jerryscript-types.h
+++ b/jerry-core/include/jerryscript-types.h
@@ -278,9 +278,19 @@ typedef jerry_value_t (*jerry_external_handler_t) (const jerry_call_info_t *call
                                                    const jerry_length_t args_count);
 
 /**
+ * Native free callback of generic value types.
+ */
+typedef void (*jerry_value_free_callback_t) (void *native_p);
+
+/**
+ * Forward definition of jerry_object_native_info_t.
+ */
+struct jerry_object_native_info_t;
+
+/**
  * Native free callback of an object.
  */
-typedef void (*jerry_object_native_free_callback_t) (void *native_p);
+typedef void (*jerry_object_native_free_callback_t) (void *native_p, struct jerry_object_native_info_t *info_p);
 
 /**
  * Decorator callback for Error objects. The decorator can create
@@ -374,7 +384,7 @@ typedef void *(*jerry_context_alloc_t) (size_t size, void *cb_data_p);
 /**
  * Type information of a native pointer.
  */
-typedef struct
+typedef struct jerry_object_native_info_t
 {
   jerry_object_native_free_callback_t free_cb; /**< the free callback of the native pointer */
 } jerry_object_native_info_t;

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/AnalogIn-js.cpp
@@ -22,7 +22,8 @@
  *
  * Called if/when the AnalogIn is GC'ed.
  */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(AnalogIn)(void* void_ptr) {
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(AnalogIn)(void* void_ptr, jerry_object_native_info_t *info_p) {
+    (void) info_p;
     delete static_cast<AnalogIn*>(void_ptr);
 }
 

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/DigitalOut-js.cpp
@@ -22,7 +22,8 @@
  *
  * Called if/when the DigitalOut is GC'ed.
  */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalOut)(void* void_ptr) {
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(DigitalOut)(void* void_ptr, jerry_object_native_info_t *info_p) {
+    (void) info_p;
     delete static_cast<DigitalOut*>(void_ptr);
 }
 

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/I2C-js.cpp
@@ -23,7 +23,8 @@
  *
  * Called if/when the I2C object is GC'ed.
  */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(I2C) (void *void_ptr) {
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(I2C) (void *void_ptr, jerry_object_native_info_t *info_p) {
+    (void) info_p;
     delete static_cast<I2C*>(void_ptr);
 }
 

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/InterruptIn-js.cpp
@@ -23,7 +23,8 @@
  *
  * Called if/when the InterruptIn object is GC'ed.
  */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(InterruptIn) (void *void_ptr) {
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(InterruptIn) (void *void_ptr, jerry_object_native_info_t *info_p) {
+    (void) info_p;
     InterruptIn *native_ptr = static_cast<InterruptIn*>(void_ptr);
 
     native_ptr->rise(0);

--- a/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut-js.cpp
+++ b/targets/mbedos5/jerryscript-mbed/jerryscript-mbed-drivers/source/PwmOut-js.cpp
@@ -22,7 +22,8 @@
  *
  * Called if/when the PwmOut is GC'ed.
  */
-void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut)(void* void_ptr) {
+void NAME_FOR_CLASS_NATIVE_DESTRUCTOR(PwmOut)(void* void_ptr, jerry_object_native_info_t *info_p) {
+    (void) info_p;
     delete static_cast<PwmOut*>(void_ptr);
 }
 

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -106,18 +106,22 @@ handler_throw_test (const jerry_call_info_t *call_info_p, /**< call information 
 } /* handler_throw_test */
 
 static void
-handler_construct_1_freecb (void *native_p)
+handler_construct_1_freecb (void *native_p, /**< native pointer */
+                            jerry_object_native_info_t *info_p) /**< native info */
 {
   TEST_ASSERT ((uintptr_t) native_p == (uintptr_t) 0x0000000000000000ull);
+  TEST_ASSERT (info_p->free_cb == handler_construct_1_freecb);
   printf ("ok object free callback\n");
 
   test_api_is_free_callback_was_called = true;
 } /* handler_construct_1_freecb */
 
 static void
-handler_construct_2_freecb (void *native_p)
+handler_construct_2_freecb (void *native_p, /**< native pointer */
+                            jerry_object_native_info_t *info_p) /**< native info */
 {
   TEST_ASSERT ((uintptr_t) native_p == (uintptr_t) 0x0012345678abcdefull);
+  TEST_ASSERT (info_p->free_cb == handler_construct_2_freecb);
   printf ("ok object free callback\n");
 
   test_api_is_free_callback_was_called = true;

--- a/tests/unit-core/test-native-pointer.c
+++ b/tests/unit-core/test-native-pointer.c
@@ -22,9 +22,11 @@ static void *global_p = (void *) &global_int;
 static int global_counter = 0;
 
 static void
-native_free_callback (void *native_p) /**< native pointer */
+native_free_callback (void *native_p, /**< native pointer */
+                      jerry_object_native_info_t *info_p) /**< native info */
 {
   (void) native_p;
+  TEST_ASSERT (info_p->free_cb == native_free_callback);
   global_counter++;
 } /* native_free_callback */
 

--- a/tests/unit-core/test-objects-foreach.c
+++ b/tests/unit-core/test-objects-foreach.c
@@ -132,9 +132,11 @@ test_internal_prop (void)
 
 static int test_data = 1;
 
-static void free_test_data (void *data_p)
+static void free_test_data (void *native_p, /**< native pointer */
+                            jerry_object_native_info_t *info_p) /**< native info */
 {
-  TEST_ASSERT ((int *) data_p == &test_data);
+  TEST_ASSERT ((int *) native_p == &test_data);
+  TEST_ASSERT (info_p->free_cb == free_test_data);
 } /* free_test_data */
 
 static const jerry_object_native_info_t test_info =

--- a/tests/unit-core/test-proxy.c
+++ b/tests/unit-core/test-proxy.c
@@ -150,11 +150,13 @@ struct test_data
 };
 
 static void
-proxy_native_freecb (void *user_p)
+proxy_native_freecb (void *native_p, /**< native pointer */
+                     jerry_object_native_info_t *info_p) /**< native info */
 {
-  TEST_ASSERT (user_p != NULL);
-  struct test_data *native_p = (struct test_data *) user_p;
-  native_p->value = -1;
+  TEST_ASSERT (native_p != NULL);
+  TEST_ASSERT (info_p->free_cb == proxy_native_freecb);
+  struct test_data *data_p = (struct test_data *) native_p;
+  data_p->value = -1;
 } /* proxy_native_freecb */
 
 static const jerry_object_native_info_t proxy_native_info =

--- a/tests/unit-ext/test-ext-autorelease.c
+++ b/tests/unit-ext/test-ext-autorelease.c
@@ -24,10 +24,12 @@
 static int native_free_cb_call_count;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =

--- a/tests/unit-ext/test-ext-handle-scope-escape.c
+++ b/tests/unit-ext/test-ext-handle-scope-escape.c
@@ -24,10 +24,12 @@
 static int native_free_cb_call_count;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =

--- a/tests/unit-ext/test-ext-handle-scope-handle-prelist-escape.c
+++ b/tests/unit-ext/test-ext-handle-scope-handle-prelist-escape.c
@@ -27,10 +27,12 @@ static size_t native_free_cb_call_count;
 static const size_t handle_count = JERRYX_HANDLE_PRELIST_SIZE + 1;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =

--- a/tests/unit-ext/test-ext-handle-scope-handle-prelist.c
+++ b/tests/unit-ext/test-ext-handle-scope-handle-prelist.c
@@ -27,10 +27,12 @@ static size_t native_free_cb_call_count;
 static const size_t handle_count = JERRYX_HANDLE_PRELIST_SIZE * 2;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =

--- a/tests/unit-ext/test-ext-handle-scope-nested.c
+++ b/tests/unit-ext/test-ext-handle-scope-nested.c
@@ -27,10 +27,12 @@
 static int native_free_cb_call_count;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =

--- a/tests/unit-ext/test-ext-handle-scope-remove.c
+++ b/tests/unit-ext/test-ext-handle-scope-remove.c
@@ -24,10 +24,12 @@
 static int native_free_cb_call_count;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =

--- a/tests/unit-ext/test-ext-handle-scope-root.c
+++ b/tests/unit-ext/test-ext-handle-scope-root.c
@@ -25,10 +25,12 @@ static int native_free_cb_call_count;
 static int reusing_times = 10;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =

--- a/tests/unit-ext/test-ext-handle-scope.c
+++ b/tests/unit-ext/test-ext-handle-scope.c
@@ -24,10 +24,12 @@
 static int native_free_cb_call_count;
 
 static void
-native_free_cb (void *native_p)
+native_free_cb (void *native_p, /**< native pointer */
+                jerry_object_native_info_t *info_p) /**< native info */
 {
-  ++native_free_cb_call_count;
   (void) native_p;
+  (void) info_p;
+  ++native_free_cb_call_count;
 } /* native_free_cb */
 
 static const jerry_object_native_info_t native_info =


### PR DESCRIPTION
Furthermore reduce memory consumption when only one external pointer is assigned to an object.