### PR TITLE
Remove class id storing for class objects

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -728,7 +728,6 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
           }
 #if JERRY_BUILTIN_TYPEDARRAY
           case ECMA_OBJECT_CLASS_TYPEDARRAY:
-          case ECMA_OBJECT_CLASS_TYPEDARRAY_WITH_INFO:
           {
             ecma_gc_set_object_visited (ecma_typedarray_get_arraybuffer (object_p));
             break;
@@ -770,28 +769,28 @@ ecma_gc_mark (ecma_object_t *object_p) /**< object to mark from */
           case ECMA_OBJECT_CLASS_CONTAINER:
           {
 #if JERRY_BUILTIN_MAP
-            if (ext_object_p->u.cls.u2.id == LIT_MAGIC_STRING_MAP_UL)
+            if (ext_object_p->u.cls.u2.container_id == LIT_MAGIC_STRING_MAP_UL)
             {
               ecma_gc_mark_map_object (object_p);
               break;
             }
 #endif /* JERRY_BUILTIN_MAP */
 #if JERRY_BUILTIN_WEAKMAP
-            if (ext_object_p->u.cls.u2.id == LIT_MAGIC_STRING_WEAKMAP_UL)
+            if (ext_object_p->u.cls.u2.container_id == LIT_MAGIC_STRING_WEAKMAP_UL)
             {
               ecma_gc_mark_weakmap_object (object_p);
               break;
             }
 #endif /* JERRY_BUILTIN_WEAKMAP */
 #if JERRY_BUILTIN_SET
-            if (ext_object_p->u.cls.u2.id == LIT_MAGIC_STRING_SET_UL)
+            if (ext_object_p->u.cls.u2.container_id == LIT_MAGIC_STRING_SET_UL)
             {
               ecma_gc_mark_set_object (object_p);
               break;
             }
 #endif /* JERRY_BUILTIN_SET */
 #if JERRY_BUILTIN_WEAKSET
-            JERRY_ASSERT (ext_object_p->u.cls.u2.id == LIT_MAGIC_STRING_WEAKSET_UL);
+            JERRY_ASSERT (ext_object_p->u.cls.u2.container_id == LIT_MAGIC_STRING_WEAKSET_UL);
 #endif /* JERRY_BUILTIN_WEAKSET */
             break;
           }
@@ -1591,9 +1590,12 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
           break;
         }
 #if JERRY_BUILTIN_TYPEDARRAY
-        case ECMA_OBJECT_CLASS_TYPEDARRAY_WITH_INFO:
+        case ECMA_OBJECT_CLASS_TYPEDARRAY:
         {
-          ext_object_size = sizeof (ecma_extended_typedarray_object_t);
+          if (ext_object_p->u.cls.u2.typedarray_flags & ECMA_TYPEDARRAY_IS_EXTENDED)
+          {
+            ext_object_size = sizeof (ecma_extended_typedarray_object_t);
+          }
           break;
         }
 #endif /* JERRY_BUILTIN_TYPEDARRAY */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date.c
@@ -739,7 +739,6 @@ ecma_builtin_date_create (ecma_number_t tv)
   ecma_date_object_t *date_object_p = (ecma_date_object_t *) obj_p;
   date_object_p->header.u.cls.type = ECMA_OBJECT_CLASS_DATE;
   date_object_p->header.u.cls.u1.date_flags = ECMA_DATE_TZA_NONE;
-  date_object_p->header.u.cls.u2.id = LIT_MAGIC_STRING_DATE_UL;
   date_object_p->header.u.cls.u3.tza = 0;
   date_object_p->date_value = tv;
 #else /* !JERRY_ESNEXT */
@@ -751,7 +750,6 @@ ecma_builtin_date_create (ecma_number_t tv)
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_DATE;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_DATE_UL;
   ECMA_SET_INTERNAL_VALUE_POINTER (ext_object_p->u.cls.u3.date, date_value_p);
 #endif /* JERRY_ESNEXT */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-weakref.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-weakref.c
@@ -82,7 +82,6 @@ ecma_builtin_weakref_dispatch_construct (const ecma_value_t *arguments_list_p, /
   ecma_deref_object (proto_p);
   ecma_extended_object_t *ext_obj_p = (ecma_extended_object_t *) object_p;
   ext_obj_p->u.cls.type = ECMA_OBJECT_CLASS_WEAKREF;
-  ext_obj_p->u.cls.u2.id = LIT_MAGIC_STRING_WEAKREF_UL;
   ext_obj_p->u.cls.u3.target = arguments_list_p[0];
   ecma_op_object_set_weak (ecma_get_object_from_value (arguments_list_p[0]), object_p);
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtins.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtins.c
@@ -464,7 +464,6 @@ ecma_instantiate_builtin (ecma_global_object_t *global_object_p, /**< global obj
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
       ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_STRING;
-      ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_STRING_UL;
       ext_object_p->u.cls.u3.value = ecma_make_magic_string_value (LIT_MAGIC_STRING__EMPTY);
       break;
     }
@@ -477,7 +476,6 @@ ecma_instantiate_builtin (ecma_global_object_t *global_object_p, /**< global obj
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
       ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_NUMBER;
-      ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_NUMBER_UL;
       ext_object_p->u.cls.u3.value = ecma_make_integer_value (0);
       break;
     }
@@ -490,7 +488,6 @@ ecma_instantiate_builtin (ecma_global_object_t *global_object_p, /**< global obj
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
       ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_BOOLEAN;
-      ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_BOOLEAN_UL;
       ext_object_p->u.cls.u3.value = ECMA_VALUE_FALSE;
       break;
     }
@@ -504,7 +501,6 @@ ecma_instantiate_builtin (ecma_global_object_t *global_object_p, /**< global obj
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
       ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_DATE;
-      ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_DATE_UL;
 
       ecma_number_t *prim_prop_num_value_p = ecma_alloc_number ();
       *prim_prop_num_value_p = ecma_number_make_nan ();
@@ -520,7 +516,6 @@ ecma_instantiate_builtin (ecma_global_object_t *global_object_p, /**< global obj
       ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) obj_p;
 
       ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_REGEXP;
-      ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_REGEXP_UL;
 
       re_compiled_code_t *bc_p = re_compile_bytecode (ecma_get_magic_string (LIT_MAGIC_STRING_EMPTY_NON_CAPTURE_GROUP),
                                                       RE_FLAG_EMPTY);

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1863,8 +1863,8 @@ ecma_builtin_typedarray_prototype_dispatch_routine (uint8_t builtin_routine_id, 
     }
     case ECMA_TYPEDARRAY_PROTOTYPE_ROUTINE_TO_STRING_TAG_GETTER:
     {
-      ecma_extended_object_t *obj_p = (ecma_extended_object_t *) typedarray_p;
-      return ecma_make_magic_string_value (obj_p->u.cls.u2.id);
+      ecma_extended_object_t *object_p = (ecma_extended_object_t *) typedarray_p;
+      return ecma_make_magic_string_value (ecma_get_typedarray_magic_string_id (object_p->u.cls.u1.typedarray_type));
     }
     default:
     {

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.c
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.c
@@ -55,7 +55,6 @@ ecma_arraybuffer_new_object (uint32_t length) /**< length of the arraybuffer */
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_ARRAY_BUFFER;
   ext_object_p->u.cls.u1.array_buffer_flags = ECMA_ARRAYBUFFER_INTERNAL_MEMORY;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_ARRAY_BUFFER_UL;
   ext_object_p->u.cls.u3.length = length;
 
   lit_utf8_byte_t *buf = (lit_utf8_byte_t *) (ext_object_p + 1);
@@ -87,7 +86,6 @@ ecma_arraybuffer_new_object_external (uint32_t length, /**< length of the buffer
   ecma_arraybuffer_external_info *array_object_p = (ecma_arraybuffer_external_info *) object_p;
   array_object_p->extended_object.u.cls.type = ECMA_OBJECT_CLASS_ARRAY_BUFFER;
   array_object_p->extended_object.u.cls.u1.array_buffer_flags = ECMA_ARRAYBUFFER_EXTERNAL_MEMORY;
-  array_object_p->extended_object.u.cls.u2.id = LIT_MAGIC_STRING_ARRAY_BUFFER_UL;
   array_object_p->extended_object.u.cls.u3.length = length;
 
   array_object_p->buffer_p = buffer_p;

--- a/jerry-core/ecma/operations/ecma-bigint-object.c
+++ b/jerry-core/ecma/operations/ecma-bigint-object.c
@@ -53,7 +53,6 @@ ecma_op_create_bigint_object (ecma_value_t arg) /**< argument passed to the toOb
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_BIGINT;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_BIGINT_UL;
   ext_object_p->u.cls.u3.value = ecma_copy_value (arg);
 
   return ecma_make_object_value (object_p);

--- a/jerry-core/ecma/operations/ecma-boolean-object.c
+++ b/jerry-core/ecma/operations/ecma-boolean-object.c
@@ -72,7 +72,6 @@ ecma_op_create_boolean_object (ecma_value_t arg) /**< argument passed to the Boo
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_BOOLEAN;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_BOOLEAN_UL;
   ext_object_p->u.cls.u3.value = ecma_make_boolean_value (boolean_value);
 
 #if JERRY_ESNEXT

--- a/jerry-core/ecma/operations/ecma-container-object.c
+++ b/jerry-core/ecma/operations/ecma-container-object.c
@@ -318,7 +318,7 @@ ecma_op_container_free_entries (ecma_object_t *object_p) /**< collection object 
   ecma_collection_t *container_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
                                                                     map_object_p->u.cls.u3.value);
 
-  switch (map_object_p->u.cls.u2.id)
+  switch (map_object_p->u.cls.u2.container_id)
   {
 #if JERRY_BUILTIN_WEAKSET
     case LIT_MAGIC_STRING_WEAKSET_UL:
@@ -390,7 +390,7 @@ ecma_op_container_create (const ecma_value_t *arguments_list_p, /**< arguments l
   ecma_extended_object_t *map_obj_p = (ecma_extended_object_t *) object_p;
   map_obj_p->u.cls.type = ECMA_OBJECT_CLASS_CONTAINER;
   map_obj_p->u.cls.u1.container_flags = ECMA_CONTAINER_FLAGS_EMPTY;
-  map_obj_p->u.cls.u2.id = (uint16_t) lit_id;
+  map_obj_p->u.cls.u2.container_id = (uint16_t) lit_id;
 
   if (lit_id == LIT_MAGIC_STRING_WEAKMAP_UL || lit_id == LIT_MAGIC_STRING_WEAKSET_UL)
   {
@@ -568,7 +568,7 @@ ecma_op_container_get_object (ecma_value_t this_arg, /**< this argument */
     ecma_object_t *map_object_p = ecma_get_object_from_value (this_arg);
 
     if (ecma_object_class_is (map_object_p, ECMA_OBJECT_CLASS_CONTAINER)
-        && ((ecma_extended_object_t *) map_object_p)->u.cls.u2.id == lit_id)
+        && ((ecma_extended_object_t *) map_object_p)->u.cls.u2.container_id == lit_id)
     {
       return (ecma_extended_object_t *) map_object_p;
     }
@@ -882,11 +882,11 @@ ecma_op_container_remove_weak_entry (ecma_object_t *object_p, /**< internal cont
   ecma_collection_t *container_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
                                                                     map_object_p->u.cls.u3.value);
 
-  ecma_value_t *entry_p = ecma_op_internal_buffer_find (container_p, key_arg, map_object_p->u.cls.u2.id);
+  ecma_value_t *entry_p = ecma_op_internal_buffer_find (container_p, key_arg, map_object_p->u.cls.u2.container_id);
 
   JERRY_ASSERT (entry_p != NULL);
 
-  ecma_op_internal_buffer_delete (container_p, (ecma_container_pair_t *) entry_p, map_object_p->u.cls.u2.id);
+  ecma_op_internal_buffer_delete (container_p, (ecma_container_pair_t *) entry_p, map_object_p->u.cls.u2.container_id);
 } /* ecma_op_container_remove_weak_entry */
 
 #if JERRY_ESNEXT
@@ -1008,7 +1008,7 @@ ecma_op_container_iterator_next (ecma_value_t this_val, /**< this argument */
   }
 
   ecma_extended_object_t *map_object_p = (ecma_extended_object_t *) (ecma_get_object_from_value (iterated_value));
-  lit_magic_string_id_t lit_id = map_object_p->u.cls.u2.id;
+  lit_magic_string_id_t lit_id = map_object_p->u.cls.u2.container_id;
 
   ecma_collection_t *container_p = ECMA_GET_INTERNAL_VALUE_POINTER (ecma_collection_t,
                                                                     map_object_p->u.cls.u3.value);

--- a/jerry-core/ecma/operations/ecma-conversion.c
+++ b/jerry-core/ecma/operations/ecma-conversion.c
@@ -533,7 +533,6 @@ ecma_op_to_object (ecma_value_t value) /**< ecma value */
   ecma_check_value_type_is_spec_defined (value);
   ecma_builtin_id_t proto_id = ECMA_BUILTIN_ID_OBJECT_PROTOTYPE;
   uint8_t class_type;
-  uint16_t class_id;
 
   if (ecma_is_value_number (value))
   {
@@ -541,7 +540,6 @@ ecma_op_to_object (ecma_value_t value) /**< ecma value */
     proto_id =  ECMA_BUILTIN_ID_NUMBER_PROTOTYPE;
 #endif /* JERRY_BUILTIN_NUMBER */
     class_type = ECMA_OBJECT_CLASS_NUMBER;
-    class_id = LIT_MAGIC_STRING_NUMBER_UL;
   }
   else if (ecma_is_value_string (value))
   {
@@ -549,7 +547,6 @@ ecma_op_to_object (ecma_value_t value) /**< ecma value */
     proto_id = ECMA_BUILTIN_ID_STRING_PROTOTYPE;
 #endif /* JERRY_BUILTIN_STRING */
     class_type = ECMA_OBJECT_CLASS_STRING;
-    class_id = LIT_MAGIC_STRING_STRING_UL;
   }
   else if (ecma_is_value_object (value))
   {
@@ -560,7 +557,6 @@ ecma_op_to_object (ecma_value_t value) /**< ecma value */
   {
     proto_id = ECMA_BUILTIN_ID_SYMBOL_PROTOTYPE;
     class_type = ECMA_OBJECT_CLASS_SYMBOL;
-    class_id = LIT_MAGIC_STRING_SYMBOL_UL;
   }
 #endif /* JERRY_ESNEXT */
 #if JERRY_BUILTIN_BIGINT
@@ -583,7 +579,6 @@ ecma_op_to_object (ecma_value_t value) /**< ecma value */
       proto_id = ECMA_BUILTIN_ID_BOOLEAN_PROTOTYPE;
 #endif /* JERRY_BUILTIN_BOOLEAN */
       class_type = ECMA_OBJECT_CLASS_BOOLEAN;
-      class_id = LIT_MAGIC_STRING_BOOLEAN_UL;
     }
   }
 
@@ -593,7 +588,6 @@ ecma_op_to_object (ecma_value_t value) /**< ecma value */
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.cls.type = class_type;
-  ext_object_p->u.cls.u2.id = class_id;
   ext_object_p->u.cls.u3.value = ecma_copy_value_if_not_object (value);
 
   return ecma_make_object_value (object_p);

--- a/jerry-core/ecma/operations/ecma-dataview-object.c
+++ b/jerry-core/ecma/operations/ecma-dataview-object.c
@@ -146,7 +146,6 @@ ecma_op_dataview_create (const ecma_value_t *arguments_list_p, /**< arguments li
   /* 11 - 14. */
   ecma_dataview_object_t *dataview_obj_p = (ecma_dataview_object_t *) object_p;
   dataview_obj_p->header.u.cls.type = ECMA_OBJECT_CLASS_DATAVIEW;
-  dataview_obj_p->header.u.cls.u2.id = LIT_MAGIC_STRING_DATAVIEW_UL;
   dataview_obj_p->header.u.cls.u3.length = view_byte_length;
   dataview_obj_p->buffer_p = buffer_p;
   dataview_obj_p->byte_offset = (uint32_t) offset;

--- a/jerry-core/ecma/operations/ecma-exceptions.c
+++ b/jerry-core/ecma/operations/ecma-exceptions.c
@@ -155,7 +155,6 @@ ecma_new_standard_error (jerry_error_t error_type, /**< native error type */
                                                        ECMA_OBJECT_TYPE_CLASS);
 
   ((ecma_extended_object_t *) new_error_obj_p)->u.cls.type = ECMA_OBJECT_CLASS_ERROR;
-  ((ecma_extended_object_t *) new_error_obj_p)->u.cls.u2.id = LIT_MAGIC_STRING_ERROR_UL;
 
   if (message_string_p != NULL)
   {

--- a/jerry-core/ecma/operations/ecma-number-object.c
+++ b/jerry-core/ecma/operations/ecma-number-object.c
@@ -76,7 +76,6 @@ ecma_op_create_number_object (ecma_value_t arg) /**< argument passed to the Numb
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_NUMBER;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_NUMBER_UL;
 
   /* Pass reference (no need to free conv_to_num_completion). */
   ext_object_p->u.cls.u3.value = conv_to_num_completion;

--- a/jerry-core/ecma/operations/ecma-promise-object.c
+++ b/jerry-core/ecma/operations/ecma-promise-object.c
@@ -507,7 +507,6 @@ ecma_op_create_promise_object (ecma_value_t executor, /**< the executor function
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_PROMISE;
   /* 5 */
   ext_object_p->u.cls.u1.promise_flags = ECMA_PROMISE_IS_PENDING;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_PROMISE_UL;
   ext_object_p->u.cls.u3.value = ECMA_VALUE_UNDEFINED;
 
   /* 6-8. */
@@ -765,7 +764,6 @@ ecma_promise_new_capability (ecma_value_t constructor, /**< constructor function
 
   ecma_promise_capabality_t *capability_p = (ecma_promise_capabality_t *) capability_obj_p;
   capability_p->header.u.cls.type = ECMA_OBJECT_CLASS_PROMISE_CAPABILITY;
-  capability_p->header.u.cls.u2.id = LIT_MAGIC_STRING_OBJECT_UL;
   capability_p->header.u.cls.u3.promise = ECMA_VALUE_UNDEFINED;
   capability_p->resolve = ECMA_VALUE_UNDEFINED;
   capability_p->reject = ECMA_VALUE_UNDEFINED;

--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -285,7 +285,6 @@ ecma_op_regexp_initialize (ecma_object_t *regexp_obj_p, /**< RegExp object */
 #endif /* JERRY_ESNEXT */
 
   ext_obj_p->u.cls.type = ECMA_OBJECT_CLASS_REGEXP;
-  ext_obj_p->u.cls.u2.id = LIT_MAGIC_STRING_REGEXP_UL;
   ECMA_SET_INTERNAL_VALUE_POINTER (ext_obj_p->u.cls.u3.value, bc_p);
 } /* ecma_op_regexp_initialize */
 

--- a/jerry-core/ecma/operations/ecma-string-object.c
+++ b/jerry-core/ecma/operations/ecma-string-object.c
@@ -86,7 +86,6 @@ ecma_op_create_string_object (const ecma_value_t *arguments_list_p, /**< list of
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_STRING;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_STRING_UL;
   ext_object_p->u.cls.u3.value = prim_value;
 
 #if JERRY_ESNEXT

--- a/jerry-core/ecma/operations/ecma-symbol-object.c
+++ b/jerry-core/ecma/operations/ecma-symbol-object.c
@@ -91,7 +91,6 @@ ecma_op_create_symbol_object (const ecma_value_t value) /**< symbol value */
 
   ecma_extended_object_t *ext_object_p = (ecma_extended_object_t *) object_p;
   ext_object_p->u.cls.type = ECMA_OBJECT_CLASS_SYMBOL;
-  ext_object_p->u.cls.u2.id = LIT_MAGIC_STRING_SYMBOL_UL;
   ext_object_p->u.cls.u3.value = ecma_copy_value (value);
 
   return ecma_make_object_value (object_p);

--- a/jerry-core/ecma/operations/ecma-typedarray-object.h
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.h
@@ -29,6 +29,7 @@
  */
 
 uint8_t ecma_typedarray_helper_get_shift_size (ecma_typedarray_type_t typedarray_id);
+lit_magic_string_id_t ecma_get_typedarray_magic_string_id (ecma_typedarray_type_t typedarray_id);
 ecma_typedarray_getter_fn_t ecma_get_typedarray_getter_fn (ecma_typedarray_type_t typedarray_id);
 ecma_typedarray_setter_fn_t ecma_get_typedarray_setter_fn (ecma_typedarray_type_t typedarray_id);
 ecma_value_t ecma_get_typedarray_element (lit_utf8_byte_t *src_p,


### PR DESCRIPTION
The two bytes which stored the id is free to use. Currently the only exception is containers.