### PR TITLE
Fix uninitialized data in create native property

### DIFF
--- a/jerry-core/ecma/base/ecma-helpers-external-pointers.c
+++ b/jerry-core/ecma/base/ecma-helpers-external-pointers.c
@@ -127,6 +127,7 @@ ecma_create_native_pointer_property (ecma_object_t *obj_p, /**< object to create
 
       new_item_p = (ecma_native_pointer_chain_t *) jmem_heap_alloc_block (sizeof (ecma_native_pointer_chain_t));
       item_p->next_p = new_item_p;
+      new_item_p->next_p = NULL;
 
       native_pointer_p = &new_item_p->data;
     }

--- a/tests/unit-core/test-native-pointer.c
+++ b/tests/unit-core/test-native-pointer.c
@@ -40,6 +40,11 @@ static const jerry_object_native_info_t native_info_2 =
   .free_cb = NULL,
 };
 
+static const jerry_object_native_info_t native_info_3 =
+{
+  .free_cb = NULL,
+};
+
 static void
 check_native_info (jerry_value_t object_value, /**< object value */
                    const jerry_object_native_info_t *native_info_p, /**< native info */
@@ -110,6 +115,39 @@ main (void)
 
   TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_1));
   TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_2));
+
+  jerry_set_object_native_pointer (object_value, global_p, &native_info_1);
+  jerry_set_object_native_pointer (object_value, NULL, &native_info_2);
+  jerry_set_object_native_pointer (object_value, global_p, &native_info_3);
+
+  check_native_info (object_value, &native_info_1, global_p);
+  check_native_info (object_value, &native_info_2, NULL);
+  check_native_info (object_value, &native_info_3, global_p);
+
+  TEST_ASSERT (jerry_delete_object_native_pointer (object_value, &native_info_1));
+  TEST_ASSERT (jerry_delete_object_native_pointer (object_value, &native_info_2));
+  TEST_ASSERT (jerry_delete_object_native_pointer (object_value, &native_info_3));
+
+  TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_1));
+  TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_2));
+  TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_3));
+
+  jerry_set_object_native_pointer (object_value, NULL, &native_info_1);
+  jerry_set_object_native_pointer (object_value, global_p, &native_info_2);
+  jerry_set_object_native_pointer (object_value, NULL, &native_info_3);
+
+  check_native_info (object_value, &native_info_1, NULL);
+  check_native_info (object_value, &native_info_2, global_p);
+  check_native_info (object_value, &native_info_3, NULL);
+
+  /* Reversed delete order. */
+  TEST_ASSERT (jerry_delete_object_native_pointer (object_value, &native_info_3));
+  TEST_ASSERT (jerry_delete_object_native_pointer (object_value, &native_info_2));
+  TEST_ASSERT (jerry_delete_object_native_pointer (object_value, &native_info_1));
+
+  TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_1));
+  TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_2));
+  TEST_ASSERT (!jerry_get_object_native_pointer (object_value, NULL, &native_info_3));
 
   jerry_release_value (object_value);
 


### PR DESCRIPTION
The extra tests does not necessary trigger the issue, since the member is often initialized to 0.