### PR TITLE
Fixes unit-test-date-helpers failure on win32

### DIFF
--- a/tests/unit-core/test-date-helpers.c
+++ b/tests/unit-core/test-date-helpers.c
@@ -102,14 +102,14 @@ main (void)
 
   /* ecma_number_t ecma_date_make_day (year, month, date) */
 
-  TEST_ASSERT (ecma_date_make_day (1970, 0, 1) == 0);
-  TEST_ASSERT (ecma_date_make_day (1970, -1, 1) == -2678400000);
-  TEST_ASSERT (ecma_date_make_day (1970, 0, 2.5) == 86400000);
-  TEST_ASSERT (ecma_date_make_day (1970, 1, 35) == 5616000000);
-  TEST_ASSERT (ecma_date_make_day (1970, 13, 35) == 37152000000);
-  TEST_ASSERT (ecma_date_make_day (2016, 2, 1) == 1456790400000);
-  TEST_ASSERT (ecma_date_make_day (2016, 8, 31) == 1475280000000);
-  TEST_ASSERT (ecma_date_make_day (2016, 9, 1) == 1475280000000);
+  TEST_ASSERT (ecma_date_make_day (1970, 0, 1) == 0LL);
+  TEST_ASSERT (ecma_date_make_day (1970, -1, 1) == -2678400000LL);
+  TEST_ASSERT (ecma_date_make_day (1970, 0, 2.5) == 86400000LL);
+  TEST_ASSERT (ecma_date_make_day (1970, 1, 35) == 5616000000LL);
+  TEST_ASSERT (ecma_date_make_day (1970, 13, 35) == 37152000000LL);
+  TEST_ASSERT (ecma_date_make_day (2016, 2, 1) == 1456790400000LL);
+  TEST_ASSERT (ecma_date_make_day (2016, 8, 31) == 1475280000000LL);
+  TEST_ASSERT (ecma_date_make_day (2016, 9, 1) == 1475280000000LL);
 
   /* ecma_number_t ecma_date_make_date (day, time) */
 


### PR DESCRIPTION
[  22/  76] FAIL (3221226505): build\tests\unittests-es5.1-math\tests\MinSizeRel\unit-test-date-helpers.exe
================================================
TEST: Assertion 'ecma_date_make_day (1970, -1, 1) == -2678400000' failed at (main)D:\a\jerryscript\jerryscript\tests\unit-core\test-date-helpers.c:110.

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
