### PR TITLE
Native modules should be unlinked state after creation

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -977,7 +977,6 @@ jerry_native_module_create (jerry_native_module_evaluate_callback_t callback, /*
 
   ecma_module_t *module_p = ecma_module_create ();
 
-  module_p->header.u.cls.u1.module_state = JERRY_MODULE_STATE_LINKED;
   module_p->header.u.cls.u2.module_flags |= ECMA_MODULE_IS_NATIVE;
   module_p->scope_p = scope_p;
   module_p->local_exports_p = local_exports_p;

--- a/jerry-core/ecma/base/ecma-module.c
+++ b/jerry-core/ecma/base/ecma-module.c
@@ -936,12 +936,14 @@ restart:
 
     if (current_module_p->scope_p == NULL)
     {
+      JERRY_ASSERT (!(current_module_p->header.u.cls.u2.module_flags & ECMA_MODULE_IS_NATIVE));
+
       /* Initialize scope for handling circular references. */
       ecma_value_t result = vm_init_module_scope (current_module_p);
 
       if (ECMA_IS_VALUE_ERROR (result))
       {
-        module_p->header.u.cls.u1.module_state = JERRY_MODULE_STATE_ERROR;
+        current_module_p->header.u.cls.u1.module_state = JERRY_MODULE_STATE_ERROR;
         goto error;
       }
 

--- a/tests/unit-core/test-module.c
+++ b/tests/unit-core/test-module.c
@@ -379,7 +379,7 @@ main (void)
 
   module = jerry_native_module_create (NULL, NULL, 0);
   TEST_ASSERT (!jerry_value_is_error (module));
-  TEST_ASSERT (jerry_module_get_state (module) == JERRY_MODULE_STATE_LINKED);
+  TEST_ASSERT (jerry_module_get_state (module) == JERRY_MODULE_STATE_UNLINKED);
 
   result = jerry_native_module_get_export (object, number);
   TEST_ASSERT (jerry_value_is_error (result));
@@ -396,7 +396,11 @@ main (void)
 
   module = jerry_native_module_create (NULL, &export, 1);
   TEST_ASSERT (!jerry_value_is_error (module));
-  TEST_ASSERT (jerry_module_get_state (module) == JERRY_MODULE_STATE_LINKED);
+  TEST_ASSERT (jerry_module_get_state (module) == JERRY_MODULE_STATE_UNLINKED);
+
+  result = jerry_module_link (module, NULL, NULL);
+  TEST_ASSERT (jerry_value_is_boolean (result) && jerry_get_boolean_value (result));
+  jerry_release_value (result);
 
   result = jerry_module_evaluate (module);
   TEST_ASSERT (jerry_value_is_undefined (result));


### PR DESCRIPTION
This patch fixes my misunderstanding