### PR TITLE
Export assignment expression must not track variables

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -967,7 +967,7 @@ parser_parse_class (parser_context_t *context_p, /**< context */
 
 #if JERRY_MODULE_SYSTEM
     parser_module_append_export_name (context_p);
-    context_p->status_flags &= (uint32_t) ~(PARSER_MODULE_STORE_IDENT);
+    context_p->status_flags &= (uint32_t) ~PARSER_MODULE_STORE_IDENT;
 #endif /* JERRY_MODULE_SYSTEM */
 
     lexer_next_token (context_p);
@@ -2045,15 +2045,6 @@ parser_parse_unary_expression (parser_context_t *context_p, /**< context */
         lexer_construct_literal_object (context_p,
                                         &context_p->token.lit_location,
                                         context_p->token.lit_location.type);
-
-#if JERRY_MODULE_SYSTEM
-        if ((context_p->status_flags & PARSER_MODULE_STORE_IDENT)
-            && type == LEXER_IDENT_LITERAL)
-        {
-          context_p->module_identifier_lit_p = context_p->lit_object.literal_p;
-          context_p->status_flags &= (uint32_t) ~(PARSER_MODULE_STORE_IDENT);
-        }
-#endif /* JERRY_MODULE_SYSTEM */
       }
       else if (type == LEXER_NUMBER_LITERAL)
       {

--- a/jerry-core/parser/js/js-parser-statm.c
+++ b/jerry-core/parser/js/js-parser-statm.c
@@ -2587,6 +2587,8 @@ parser_parse_export_statement (parser_context_t *context_p) /**< context */
         context_p->token.lit_location.type = LEXER_IDENT_LITERAL;
         parser_emit_cbc_literal_from_token (context_p, CBC_PUSH_LITERAL);
 
+        /* Do not overwrite this identifier. */
+        context_p->status_flags &= (uint32_t) ~PARSER_MODULE_STORE_IDENT;
         context_p->module_identifier_lit_p = context_p->lit_object.literal_p;
 
         /* Fake an assignment to the default identifier */

--- a/tests/jerry/es.next/module-export-default-10.mjs
+++ b/tests/jerry/es.next/module-export-default-10.mjs
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export default function f() { return 1.5 }
+export function g(v) { f = v; return "X" }

--- a/tests/jerry/es.next/module-export-default-main.mjs
+++ b/tests/jerry/es.next/module-export-default-main.mjs
@@ -21,6 +21,7 @@ import foo6 from "./module-export-default-6.mjs"
 import foo7 from "./module-export-default-7.mjs"
 import foo8, { counter as bar8 } from "./module-export-default-8.mjs"
 import foo9, { counter as bar9 } from "./module-export-default-9.mjs"
+import foo10, { g as bar10 } from "./module-export-default-10.mjs"
 
 let async_queue_expected = ["foo2", "foo3", "foo6", "foo7"];
 let async_queue = [];
@@ -64,6 +65,13 @@ let async_queue = [];
 (function() {
   assert(foo9.x === "foo9");
   assert(bar9 === 9.1);
+})();
+
+(function() {
+  var o = {}
+  assert(foo10() === 1.5);
+  assert(bar10(o) === "X");
+  assert(foo10 === o);
 })();
 
 Array.prototype.assertArrayEqual = function(expected) {

--- a/tests/jerry/es.next/module-namespace-01.mjs
+++ b/tests/jerry/es.next/module-namespace-01.mjs
@@ -26,5 +26,6 @@ assert(o.b === undefined);
 assert(o.c(val) === "c")
 assert(o.d === "d")
 
-assert(o.default === val)
-assert(def === val)
+assert(o.a === val);
+assert(o.default === 8.5)
+assert(def === 8.5)

--- a/tests/jerry/es.next/module-namespace-02.mjs
+++ b/tests/jerry/es.next/module-namespace-02.mjs
@@ -14,6 +14,7 @@
  */
 
 import def, {a} from "./module-namespace-03.mjs"
+/* Nothing is tracked, only the result value is exported. */
 export default def
 export {a}
 

--- a/tests/jerry/es.next/module-namespace-03.mjs
+++ b/tests/jerry/es.next/module-namespace-03.mjs
@@ -15,7 +15,13 @@
 
 export var a = 2.5
 export var b = 4
-export var c = function(v) { def = v; return "c" }
+export var c = function(v) {
+  assert(def === 0);
+  a = v;
+  return "c"
+}
 
 var def = 8.5
+/* Nothing is tracked, only the result value is exported. */
 export default def
+def = 0


### PR DESCRIPTION
Only export the result of the assignment expression. This value cannot be changed later.