### PR TITLE
build: Support cmake -DPYTHON=python3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,11 @@
 cmake_minimum_required (VERSION 2.8.12)
 project (Jerry C)
 
+if(NOT DEFINED PYTHON)
+  set(PYTHON "python")
+endif()
 # Determining version
-execute_process(COMMAND python ${CMAKE_SOURCE_DIR}/tools/version.py
+execute_process(COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tools/version.py
                 OUTPUT_VARIABLE JERRY_VERSION
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -488,7 +488,7 @@ if(ENABLE_AMALGAM)
   set(AMALGAM_CONFIG_H "${CMAKE_BINARY_DIR}/amalgam/jerryscript-config.h")
 
   add_custom_command(OUTPUT ${AMALGAM_CORE_C} ${AMALGAM_CORE_H}
-                     COMMAND python ${CMAKE_SOURCE_DIR}/tools/amalgam.py
+                     COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tools/amalgam.py
                              --jerry-core
                              --output-dir ${CMAKE_BINARY_DIR}/amalgam
                      DEPENDS ${SOURCE_CORE_FILES}

--- a/jerry-math/CMakeLists.txt
+++ b/jerry-math/CMakeLists.txt
@@ -71,7 +71,7 @@ if(ENABLE_AMALGAM)
   set(AMALGAM_MATH_H "${CMAKE_BINARY_DIR}/amalgam/math.h")
 
   add_custom_command(OUTPUT ${AMALGAM_MATH_C} ${AMALGAM_MATH_H}
-                     COMMAND python ${CMAKE_SOURCE_DIR}/tools/amalgam.py
+                     COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tools/amalgam.py
                              --jerry-math
                              --output-dir ${CMAKE_BINARY_DIR}/amalgam
                      DEPENDS ${SOURCE_MATH}

--- a/jerry-port/default/CMakeLists.txt
+++ b/jerry-port/default/CMakeLists.txt
@@ -41,7 +41,7 @@ if(ENABLE_AMALGAM)
   set(AMALGAM_PORT_H "${CMAKE_BINARY_DIR}/amalgam/jerryscript-port-default.h")
 
   add_custom_command(OUTPUT ${AMALGAM_PORT_C} ${AMALGAM_PORT_H}
-                     COMMAND python ${CMAKE_SOURCE_DIR}/tools/amalgam.py
+                     COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/tools/amalgam.py
                              --jerry-port-default
                              --output-dir ${CMAKE_BINARY_DIR}/amalgam
                      DEPENDS ${SOURCE_PORT_DEFAULT}


### PR DESCRIPTION
This will help debian packaging of iotjs

JerryScript-DCO-1.0-Signed-off-by: Philippe Coval rzr@users.sf.net
Cc: @zherczeg
Cc: @LaszloLango
Cc: @akosthekiss
