### PR TITLE
Python debugger support for Python 3 (in addition to Python 2)

### DIFF
--- a/jerry-debugger/jerry_client_rawpacket.py
+++ b/jerry-debugger/jerry_client_rawpacket.py
@@ -15,8 +15,19 @@
 # limitations under the License.
 
 import struct
+import sys
 
 MAX_BUFFER_SIZE = 256
+
+
+if sys.version_info.major >= 3:
+    def safe_ord(c):
+        if isinstance(c, int):
+            return c
+        return ord(c)
+else:
+	safe_ord = ord
+
 
 class RawPacket(object):
     """ Simplified transmission layer. """
@@ -70,7 +81,7 @@ class RawPacket(object):
 
         while True:
             if len(self.data_buffer) >= 1:
-                size = ord(self.data_buffer[0])
+                size = safe_ord(self.data_buffer[0])
                 if size == 0:
                     raise Exception("Unexpected data frame")
 

--- a/jerry-debugger/jerry_client_websocket.py
+++ b/jerry-debugger/jerry_client_websocket.py
@@ -15,10 +15,23 @@
 # limitations under the License.
 
 import struct
+import sys
 
 MAX_BUFFER_SIZE = 128
 WEBSOCKET_BINARY_FRAME = 2
 WEBSOCKET_FIN_BIT = 0x80
+
+
+if sys.version_info.major >= 3:
+    # pylint: disable=invalid-name
+    _ord_orig = ord
+    def _ord_compat(c):
+        if isinstance(c, int):
+            return c
+        return _ord_orig(c)
+    # pylint: disable=redefined-builtin
+    ord = _ord_compat
+
 
 class WebSocket(object):
     def __init__(self, protocol):
@@ -92,7 +105,7 @@ class WebSocket(object):
         """ Send message. """
         message = struct.pack(byte_order + "BBI",
                               WEBSOCKET_BINARY_FRAME | WEBSOCKET_FIN_BIT,
-                              WEBSOCKET_FIN_BIT + struct.unpack(byte_order + "B", packed_data[0])[0],
+                              WEBSOCKET_FIN_BIT + struct.unpack(byte_order + "B", packed_data[0:1])[0],
                               0) + packed_data[1:]
 
         self.__send_data(message)


### PR DESCRIPTION
- Added safe_ord compatibility to pass through int arguments
- Fixed JerryDebugger to decode bytes as utf8 strings when necessary
- Fixed WebSocket send_message method to use packed_data[0:1] bytes slice

JerryScript-DCO-1.0-Signed-off-by: Zac Medico <zmedico@gmail.com>
