### PR TITLE
Rework resolving references and namespace creation in modules

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -865,16 +865,13 @@ jerry_module_get_namespace (const jerry_value_t module_val) /**< module */
     return jerry_throw (ecma_raise_type_error (ECMA_ERR_MSG (ecma_error_not_module_p)));
   }
 
-  if (module_p->namespace_object_p == NULL)
+  if (module_p->header.u.cls.u1.module_state < JERRY_MODULE_STATE_LINKED
+      || module_p->header.u.cls.u1.module_state > JERRY_MODULE_STATE_EVALUATED)
   {
-    if (module_p->header.u.cls.u1.module_state < JERRY_MODULE_STATE_LINKED
-        || module_p->header.u.cls.u1.module_state > JERRY_MODULE_STATE_EVALUATED)
-    {
-      return jerry_throw (ecma_raise_range_error (ECMA_ERR_MSG ("Namespace object cannot be created")));
-    }
-
-    ecma_module_create_namespace_object (module_p);
+    return jerry_throw (ecma_raise_range_error (ECMA_ERR_MSG ("Namespace object is not available")));
   }
+
+  JERRY_ASSERT (module_p->namespace_object_p != NULL);
 
   ecma_ref_object (module_p->namespace_object_p);
   return ecma_make_object_value (module_p->namespace_object_p);

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -1061,7 +1061,7 @@ typedef struct
       {
         uint16_t formal_params_number; /**< for arguments: formal parameters number */
 #if JERRY_MODULE_SYSTEM
-        uint8_t module_flags; /**< Module flags */
+        uint16_t module_flags; /**< Module flags */
 #endif /* JERRY_MODULE_SYSTEM */
 #if JERRY_ESNEXT
         uint16_t iterator_index; /**< for %Iterator%: [[%Iterator%NextIndex]] property */

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -482,8 +482,7 @@ ecma_property_value_t *
 ecma_create_named_accessor_property (ecma_object_t *object_p, ecma_string_t *name_p, ecma_object_t *get_p,
                                      ecma_object_t *set_p, uint8_t prop_attributes, ecma_property_t **out_prop_p);
 #if JERRY_MODULE_SYSTEM
-void ecma_create_named_reference_property (ecma_object_t *object_p, ecma_string_t *name_p,
-                                           ecma_property_t *property_p);
+void ecma_create_named_reference_property (ecma_object_t *object_p, ecma_string_t *name_p, ecma_value_t reference);
 #endif /* JERRY_MODULE_SYSTEM */
 ecma_property_t *
 ecma_find_named_property (ecma_object_t *obj_p, ecma_string_t *name_p);
@@ -502,8 +501,8 @@ void ecma_set_named_accessor_property_getter (ecma_object_t *object_p, ecma_prop
 void ecma_set_named_accessor_property_setter (ecma_object_t *object_p, ecma_property_value_t *prop_value_p,
                                               ecma_object_t *setter_p);
 #if JERRY_MODULE_SYSTEM
-ecma_property_value_t *
-ecma_get_property_value_from_named_reference (ecma_property_value_t *reference_p);
+ecma_value_t ecma_property_to_reference (ecma_property_t *property_p);
+ecma_property_value_t *ecma_get_property_value_from_named_reference (ecma_property_value_t *reference_p);
 #endif /* JERRY_MODULE_SYSTEM */
 bool ecma_is_property_writable (ecma_property_t property);
 void ecma_set_property_writable_attr (ecma_property_t *property_p, bool is_writable);

--- a/jerry-core/ecma/base/ecma-module.h
+++ b/jerry-core/ecma/base/ecma-module.h
@@ -29,6 +29,7 @@
 typedef enum
 {
   ECMA_MODULE_IS_NATIVE = (1 << 0), /**< native module */
+  ECMA_MODULE_HAS_NAMESPACE = (1 << 1), /**< namespace object has been initialized */
 } ecma_module_flags_t;
 
 /**
@@ -92,21 +93,13 @@ typedef struct ecma_module_node
 } ecma_module_node_t;
 
 /**
- *  A record that can be used to store {module, identifier} pairs
- */
-typedef struct ecma_module_record
-{
-  ecma_module_t *module_p;  /**< module */
-  ecma_string_t *name_p;    /**< identifier name */
-} ecma_module_record_t;
-
-/**
  *  A list of module records that can be used to identify circular imports during resolution
  */
 typedef struct ecma_module_resolve_set
 {
   struct ecma_module_resolve_set *next_p; /**< next in linked list */
-  ecma_module_record_t record;            /**< module record */
+  ecma_module_t *module_p;  /**< module */
+  ecma_string_t *name_p;    /**< identifier name */
 } ecma_module_resolve_set_t;
 
 /**
@@ -130,7 +123,6 @@ ecma_value_t ecma_module_evaluate (ecma_module_t *module_p);
 
 ecma_module_t *ecma_module_create (void);
 void ecma_module_cleanup_context (void);
-ecma_value_t ecma_module_create_namespace_object (ecma_module_t *module_p);
 
 void ecma_module_release_module_names (ecma_module_names_t *module_name_p);
 void ecma_module_release_module (ecma_module_t *module_p);

--- a/tests/jerry/es.next/module-circular-05.mjs
+++ b/tests/jerry/es.next/module-circular-05.mjs
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {a} from "./module-circular-06.mjs"
+assert(a === 6.5)

--- a/tests/jerry/es.next/module-circular-06.mjs
+++ b/tests/jerry/es.next/module-circular-06.mjs
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export {b as a} from "./module-circular-07.mjs";
+import {b} from "./module-circular-07.mjs"
+assert(b === 6.5 || b === undefined)

--- a/tests/jerry/es.next/module-circular-07.mjs
+++ b/tests/jerry/es.next/module-circular-07.mjs
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export * from "./module-circular-08.mjs"
+export * from "./module-circular-09.mjs"

--- a/tests/jerry/es.next/module-circular-08.mjs
+++ b/tests/jerry/es.next/module-circular-08.mjs
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export {a as b} from "./module-circular-06.mjs"

--- a/tests/jerry/es.next/module-circular-09.mjs
+++ b/tests/jerry/es.next/module-circular-09.mjs
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export var b = 6.5

--- a/tests/jerry/es.next/module-export-09.mjs
+++ b/tests/jerry/es.next/module-export-09.mjs
@@ -1,0 +1,25 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Test sorting order */
+
+export let
+  c = 4,
+  bc = 3,
+  ddd = 6,
+  dddd = 7,
+  bb = 2,
+  dd = 5,
+  a = 1

--- a/tests/jerry/es.next/module-import-06.mjs
+++ b/tests/jerry/es.next/module-import-06.mjs
@@ -1,0 +1,32 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as namespace from "module-export-09.mjs"
+
+assert(JSON.stringify(namespace) === '{"a":1,"bb":2,"bc":3,"c":4,"dd":5,"ddd":6,"dddd":7}')
+
+try {
+  namespace = 8
+  assert(false)
+} catch (e) {
+  assert(e instanceof TypeError)
+}
+
+try {
+  namespace += 8
+  assert(false)
+} catch (e) {
+  assert(e instanceof TypeError)
+}

--- a/tests/unit-core/test-module.c
+++ b/tests/unit-core/test-module.c
@@ -64,16 +64,18 @@ create_module (int id) /**< module id */
 
   if (id == 0)
   {
-    result = jerry_parse ((jerry_char_t *) "", 0, &module_parse_options);
+    jerry_char_t source[] = "export var a = 7";
+
+    result = jerry_parse (source, sizeof (source) - 1, &module_parse_options);
   }
   else
   {
-    jerry_char_t source[] = "import a from 'XX_module.mjs'";
+    jerry_char_t source[] = "export {a} from 'XX_module.mjs'";
 
-    TEST_ASSERT (id >= 1 && id <= 99 && source[15] == 'X' && source[16] == 'X');
+    TEST_ASSERT (id >= 1 && id <= 99 && source[17] == 'X' && source[18] == 'X');
 
-    source[15] = (jerry_char_t) ((id / 10) + '0');
-    source[16] = (jerry_char_t) ((id % 10) + '0');
+    source[17] = (jerry_char_t) ((id / 10) + '0');
+    source[18] = (jerry_char_t) ((id % 10) + '0');
 
     result = jerry_parse (source, sizeof (source) - 1, &module_parse_options);
   }


### PR DESCRIPTION
- Properties of namespace objects are ordered in lexical order
- The namespace object is created and imports are bound during linking phase
- Namespace imports are changed to read-only
- Reduced memory consumption