### PR TITLE
Support shared user data for scripts

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -243,6 +243,7 @@ Option bits for [jerry_parse_options_t](#jerry_parse_options_t).
  - JERRY_PARSE_MODULE - Parse source as an ECMAScript module
  - JERRY_PARSE_HAS_RESOURCE - `resource_name_p` and `resource_name_length` fields are valid
  - JERRY_PARSE_HAS_START - `start_line` and `start_column` fields are valid
+ - JERRY_PARSE_HAS_USER_VALUE - `user_value` field is valid
 
 *New in version [[NEXT_RELEASE]]*.
 
@@ -310,6 +311,10 @@ Flags for [jerry_exec_snapshot](#jerry_exec_snapshot) functions:
  - JERRY_SNAPSHOT_EXEC_COPY_DATA - copy snapshot data into memory (see below)
  - JERRY_SNAPSHOT_EXEC_ALLOW_STATIC - allow executing static snapshots
  - JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION - load snapshot as function instead of executing it
+ - JERRY_SNAPSHOT_EXEC_HAS_RESOURCE - resource_name_p and resource_name_length fields are valid
+                                      in [jerry_exec_snapshot_option_values_t](#jerry_exec_snapshot_option_values_t)
+ - JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE - user_value field is valid
+                                        in [jerry_exec_snapshot_option_values_t](#jerry_exec_snapshot_option_values_t)
 
 *Changed in version [[NEXT_RELEASE]]*: The `JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION` value is added,
                                        which replaces the `jerry_load_function_snapshot` function.
@@ -536,6 +541,8 @@ typedef struct
                                 *   if JERRY_PARSE_HAS_RESOURCE is set in options */
   uint32_t start_line; /**< start line of the source code if JERRY_PARSE_HAS_START is set in options */
   uint32_t start_column; /**< start column of the source code if JERRY_PARSE_HAS_START is set in options */
+  jerry_value_t user_value; /**< user value assigned to all functions created by this script including eval
+                             *   calls executed by the script if JERRY_PARSE_HAS_USER_VALUE is set in options */
 } jerry_parse_options_t;
 ```
 
@@ -547,6 +554,7 @@ typedef struct
 - [jerry_parse_function](#jerry_parse_function)
 - [jerry_generate_snapshot](#jerry_generate_snapshot)
 - [jerry_generate_function_snapshot](#jerry_generate_function_snapshot)
+- [jerry_exec_snapshot](#jerry_exec_snapshot)
 - [jerry_parse_option_enable_feature_t](#jerry_parse_option_enable_feature_t)
 
 ## jerry_property_descriptor_t
@@ -1230,6 +1238,33 @@ TypedArray support is not in the engine.
 
 - [jerry_get_typedarray_type](#jerry_get_typedarray_type)
 
+
+## jerry_exec_snapshot_option_values_t
+
+**Summary**
+
+Various configuration options for [jerry_exec_snapshot](#jerry_exec_snapshot)
+
+**Prototype**
+
+```c
+typedef struct
+{
+  const jerry_char_t *resource_name_p; /**< resource name (usually a file name)
+                                        *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
+  size_t resource_name_length; /**< length of resource name
+                                *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
+  jerry_value_t user_value; /**< user value assigned to all functions created by this script including
+                             *   eval calls executed by the script if JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE
+                             *   is set in exec_snapshot_opts */
+} jerry_exec_snapshot_option_values_t;
+```
+
+*New in version [[NEXT_RELEASE]]*.
+
+**See also**
+
+- [jerry_exec_snapshot](#jerry_exec_snapshot)
 
 # General engine functions
 
@@ -10221,18 +10256,23 @@ jerry_value_t
 jerry_exec_snapshot (const uint32_t *snapshot_p,
                      size_t snapshot_size,
                      size_t func_index,
-                     uint32_t exec_snapshot_opts);
+                     uint32_t exec_snapshot_opts,
+                     const jerry_exec_snapshot_option_values_t *options_values_p);
 ```
 
 - `snapshot_p` - pointer to snapshot.
 - `snapshot_size` - size of snapshot in bytes.
 - `func_index` - index of executed function.
 - `exec_snapshot_opts` - any combination of [jerry_exec_snapshot_opts_t](#jerry_exec_snapshot_opts_t) flags.
+- `options_values_p` - additional loadig options, can be NULL if not used. The fields are described in
+                       [jerry_exec_snapshot_option_values_t](#jerry_exec_snapshot_option_values_t).
 - return value
   - result of bytecode, if run was successful.
   - thrown error, otherwise (an error is reported if the snapshot execution feature is not enabled).
 
 *Changed in version 2.0*: Added `func_index` and `exec_snapshot_opts` arguments. Removed the `copy_bytecode` last argument.
+
+*Changed in version [[NEXT_RELEASE]]*: Added `options_p` argument.
 
 **Example 1**
 
@@ -10269,7 +10309,8 @@ main (void)
   jerry_value_t res = jerry_exec_snapshot (snapshot_buffer,
                                            snapshot_size,
                                            0,
-                                           0);
+                                           0,
+                                           NULL);
 
   /* 'res' now contains 'string from snapshot' */
   jerry_release_value (res);
@@ -10317,7 +10358,8 @@ main (void)
   jerry_value_t func = jerry_exec_snapshot (snapshot_buffer,
                                             snapshot_size,
                                             0,
-                                            JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION);
+                                            JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION,
+                                            NULL);
   /* 'func' can be used now as a function object. */
 
   jerry_value_t this_value = jerry_create_undefined ();
@@ -11140,6 +11182,74 @@ main (void)
 **See also**
 
 - [jerry_create_external_function](#jerry_create_external_function)
+
+## jerry_get_user_value
+
+**Summary**
+
+Returns the user value assigned to a script / module / function. This value is
+set by the parser when the JERRY_PARSE_HAS_USER_VALUE flag is set in the `options`
+member of the [jerry_parse_options_t](#jerry_parse_options_t) structure.
+
+*Notes*:
+- Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+is no longer needed.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerry_get_user_value (const jerry_value_t value);
+```
+- `value` - script / module / function value which executes JavaScript
+            code (native modules / functions do not have user value).
+- return
+  - user value - if available,
+  - undefined - otherwise
+
+*New in version [[NEXT_RELEASE]]*.
+
+**Example**
+
+```c
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  const jerry_char_t script[] = "function abc() {} abc";
+
+  jerry_value user_value = jerry_create_object ();
+
+  jerry_parse_options_t parse_options;
+  parse_options.options = ECMA_PARSE_HAS_USER_VALUE;
+  parse_options.user_value = user_value;
+
+  jerry_value_t parsed_code = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (user_value);
+
+  /* The jerry_get_user_value returns the object which
+   * was created by jerry_create_object before. */
+
+  jerry_value user_value = jerry_get_user_value (parsed_code);
+  jerry_release_value (parsed_code);
+
+  jerry_release_value (user_value);
+  jerry_cleanup ();
+  return 0;
+}
+```
+
+**See also**
+
+- [jerry_parse](#jerry_parse)
+- [jerry_parse_function](#jerry_parse_function)
+- [jerry_generate_snapshot](#jerry_generate_snapshot)
+- [jerry_generate_function_snapshot](#jerry_generate_function_snapshot)
+- [jerry_exec_snapshot](#jerry_exec_snapshot)
+
 
 # Functions for realm objects
 

--- a/jerry-core/api/jerry-snapshot.h
+++ b/jerry-core/api/jerry-snapshot.h
@@ -45,8 +45,7 @@ typedef enum
 {
   /* 8 bits are reserved for dynamic features */
   JERRY_SNAPSHOT_HAS_REGEX_LITERAL = (1u << 0), /**< byte code has regex literal */
-  JERRY_SNAPSHOT_HAS_REALM_VALUE = (1u << 1), /**< byte code has realm value */
-  JERRY_SNAPSHOT_HAS_CLASS_LITERAL = (1u << 2), /**< byte code has class literal */
+  JERRY_SNAPSHOT_HAS_CLASS_LITERAL = (1u << 1), /**< byte code has class literal */
   /* 24 bits are reserved for compile time features */
   JERRY_SNAPSHOT_FOUR_BYTE_CPOINTER = (1u << 8) /**< deprecated, an unused placeholder now */
 } jerry_snapshot_global_flags_t;

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -393,7 +393,8 @@ jerry_parse (const jerry_char_t *source_p, /**< script source */
   uint32_t allowed_parse_options = (JERRY_PARSE_STRICT_MODE
                                     | JERRY_PARSE_MODULE
                                     | JERRY_PARSE_HAS_RESOURCE
-                                    | JERRY_PARSE_HAS_START);
+                                    | JERRY_PARSE_HAS_START
+                                    | JERRY_PARSE_HAS_USER_VALUE);
 
   if (options_p != NULL && (options_p->options & ~allowed_parse_options) != 0)
   {
@@ -493,7 +494,8 @@ jerry_parse_function (const jerry_char_t *arg_list_p, /**< script source */
 
   uint32_t allowed_parse_options = (JERRY_PARSE_STRICT_MODE
                                     | JERRY_PARSE_HAS_RESOURCE
-                                    | JERRY_PARSE_HAS_START);
+                                    | JERRY_PARSE_HAS_START
+                                    | JERRY_PARSE_HAS_USER_VALUE);
 
   if (options_p != NULL && (options_p->options & ~allowed_parse_options) != 0)
   {
@@ -5380,6 +5382,36 @@ jerry_get_resource_name (const jerry_value_t value) /**< jerry api value */
   JERRY_UNUSED (value);
   return ecma_make_magic_string_value (LIT_MAGIC_STRING_RESOURCE_ANON);
 } /* jerry_get_resource_name */
+
+/**
+ * Returns the user value assigned to a script / module / function.
+ *
+ * Note:
+ *    This value is usually set by the parser when
+ *    the JERRY_PARSE_HAS_USER_VALUE flag is passed.
+ *
+ * @return user value
+ */
+jerry_value_t
+jerry_get_user_value (const jerry_value_t value) /**< jerry api value */
+{
+  const ecma_compiled_code_t *bytecode_p = ecma_bytecode_get_from_value (value);
+
+  if (bytecode_p == NULL)
+  {
+    return ECMA_VALUE_UNDEFINED;
+  }
+
+  ecma_value_t script_value = ((cbc_uint8_arguments_t *) bytecode_p)->script_value;
+  cbc_script_t *script_p = ECMA_GET_INTERNAL_VALUE_POINTER (cbc_script_t, script_value);
+
+  if (CBC_SCRIPT_GET_TYPE (script_p) == CBC_SCRIPT_GENERIC)
+  {
+    return ECMA_VALUE_UNDEFINED;
+  }
+
+  return ecma_copy_value (((cbc_script_user_t *) script_p)->user_value);
+} /* jerry_get_user_value */
 
 /**
  * Replaces the currently active realm with another realm.

--- a/jerry-core/ecma/base/ecma-helpers.h
+++ b/jerry-core/ecma/base/ecma-helpers.h
@@ -532,6 +532,7 @@ void ecma_raise_error_from_error_reference (ecma_value_t value);
 
 void ecma_bytecode_ref (ecma_compiled_code_t *bytecode_p);
 void ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p);
+const ecma_compiled_code_t *ecma_bytecode_get_from_value (ecma_value_t value);
 ecma_value_t *ecma_compiled_code_resolve_arguments_start (const ecma_compiled_code_t *bytecode_header_p);
 #if JERRY_ESNEXT
 ecma_value_t *ecma_compiled_code_resolve_function_name (const ecma_compiled_code_t *bytecode_header_p);

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -759,29 +759,17 @@ ecma_op_function_get_compiled_code (ecma_extended_object_t *function_p) /**< fun
 extern inline ecma_global_object_t * JERRY_ATTR_ALWAYS_INLINE
 ecma_op_function_get_realm (const ecma_compiled_code_t *bytecode_header_p) /**< byte code header */
 {
-  ecma_value_t realm_value;
-
-  if (bytecode_header_p->status_flags & CBC_CODE_FLAGS_UINT16_ARGUMENTS)
-  {
-    cbc_uint16_arguments_t *args_p = (cbc_uint16_arguments_t *) bytecode_header_p;
-    realm_value = args_p->realm_value;
-  }
-  else
-  {
-    cbc_uint8_arguments_t *args_p = (cbc_uint8_arguments_t *) bytecode_header_p;
-    realm_value = args_p->realm_value;
-  }
-
 #if JERRY_SNAPSHOT_EXEC
-  if (JERRY_LIKELY (realm_value != JMEM_CP_NULL))
+  if (JERRY_UNLIKELY (bytecode_header_p->status_flags & CBC_CODE_FLAGS_STATIC_FUNCTION))
   {
-    return ECMA_GET_INTERNAL_VALUE_POINTER (ecma_global_object_t, realm_value);
+    return (ecma_global_object_t *) ecma_builtin_get_global ();
   }
-
-  return (ecma_global_object_t *) ecma_builtin_get_global ();
-#else /* !JERRY_SNAPSHOT_EXEC */
-  return ECMA_GET_INTERNAL_VALUE_POINTER (ecma_global_object_t, realm_value);
 #endif /* JERRY_SNAPSHOT_EXEC */
+
+  ecma_value_t script_value = ((cbc_uint8_arguments_t *) bytecode_header_p)->script_value;
+  cbc_script_t *script_p = ECMA_GET_INTERNAL_VALUE_POINTER (cbc_script_t, script_value);
+
+  return (ecma_global_object_t *) script_p->realm_p;
 } /* ecma_op_function_get_realm */
 
 /**

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -360,6 +360,7 @@ bool jerry_backtrace_is_strict (jerry_backtrace_frame_t *frame_p);
  */
 void jerry_set_vm_exec_stop_callback (jerry_vm_exec_stop_callback_t stop_cb, void *user_p, uint32_t frequency);
 jerry_value_t jerry_get_resource_name (const jerry_value_t value);
+jerry_value_t jerry_get_user_value (const jerry_value_t value);
 
 /**
  * Array buffer components.

--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -41,14 +41,32 @@ typedef enum
 } jerry_generate_snapshot_opts_t;
 
 /**
- * Flags for jerry_exec_snapshot_at and jerry_load_function_snapshot_at.
+ * Flags for jerry_exec_snapshot.
  */
 typedef enum
 {
   JERRY_SNAPSHOT_EXEC_COPY_DATA = (1u << 0), /**< copy snashot data */
   JERRY_SNAPSHOT_EXEC_ALLOW_STATIC = (1u << 1), /**< static snapshots allowed */
   JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION = (1u << 2), /**< load snapshot as function instead of executing it */
+  JERRY_SNAPSHOT_EXEC_HAS_RESOURCE = (1u << 3), /**< resource_name_p and resource_name_length fields are valid
+                                                 *   in jerry_exec_snapshot_option_values_t */
+  JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE = (1u << 4), /**< user_value field is valid
+                                                   *   in jerry_exec_snapshot_option_values_t */
 } jerry_exec_snapshot_opts_t;
+
+/**
+ * Various configuration options for jerry_exec_snapshot.
+ */
+typedef struct
+{
+  const jerry_char_t *resource_name_p; /**< resource name (usually a file name)
+                                        *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
+  size_t resource_name_length; /**< length of resource name
+                                *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
+  jerry_value_t user_value; /**< user value assigned to all functions created by this script including
+                             *   eval calls executed by the script if JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE
+                             *   is set in exec_snapshot_opts */
+} jerry_exec_snapshot_option_values_t;
 
 /**
  * Snapshot functions.
@@ -63,7 +81,8 @@ jerry_value_t jerry_generate_function_snapshot (const jerry_char_t *source_p, si
                                                 uint32_t *buffer_p, size_t buffer_size);
 
 jerry_value_t jerry_exec_snapshot (const uint32_t *snapshot_p, size_t snapshot_size,
-                                   size_t func_index, uint32_t exec_snapshot_opts);
+                                   size_t func_index, uint32_t exec_snapshot_opts,
+                                   const jerry_exec_snapshot_option_values_t *options_values_p);
 
 size_t jerry_merge_snapshots (const uint32_t **inp_buffers_p, size_t *inp_buffer_sizes_p, size_t number_of_snapshots,
                               uint32_t *out_buffer_p, size_t out_buffer_size, const char **error_p);

--- a/jerry-core/include/jerryscript-types.h
+++ b/jerry-core/include/jerryscript-types.h
@@ -168,6 +168,7 @@ typedef enum
   JERRY_PARSE_MODULE = (1 << 1), /**< parse source as an ECMAScript module */
   JERRY_PARSE_HAS_RESOURCE = (1 << 2), /**< resource_name_p and resource_name_length fields are valid */
   JERRY_PARSE_HAS_START = (1 << 3), /**< start_line and start_column fields are valid */
+  JERRY_PARSE_HAS_USER_VALUE = (1 << 4), /**< user_value field is valid */
 } jerry_parse_option_enable_feature_t;
 
 /**
@@ -182,6 +183,8 @@ typedef struct
                                 *   if JERRY_PARSE_HAS_RESOURCE is set in options */
   uint32_t start_line; /**< start line of the source code if JERRY_PARSE_HAS_START is set in options */
   uint32_t start_column; /**< start column of the source code if JERRY_PARSE_HAS_START is set in options */
+  jerry_value_t user_value; /**< user value assigned to all functions created by this script including eval
+                             *   calls executed by the script if JERRY_PARSE_HAS_USER_VALUE is set in options */
 } jerry_parse_options_t;
 
 /**

--- a/jerry-core/parser/js/byte-code.c
+++ b/jerry-core/parser/js/byte-code.c
@@ -15,11 +15,15 @@
 
 #include "js-parser-internal.h"
 
-JERRY_STATIC_ASSERT ((sizeof (cbc_uint8_arguments_t) % sizeof (jmem_cpointer_t)) == 0,
-                     sizeof_cbc_uint8_arguments_t_must_be_divisible_by_sizeof_jmem_cpointer_t);
+/* These two checks only checks the compiler, they have no effect on the code. */
+JERRY_STATIC_ASSERT (sizeof (cbc_uint8_arguments_t) == 16,
+                     sizeof_cbc_uint8_arguments_t_must_be_16_byte_long);
 
-JERRY_STATIC_ASSERT ((sizeof (cbc_uint16_arguments_t) % sizeof (jmem_cpointer_t)) == 0,
-                     sizeof_cbc_uint16_arguments_t_must_be_divisible_by_sizeof_jmem_cpointer_t);
+JERRY_STATIC_ASSERT (sizeof (cbc_uint16_arguments_t) == 24,
+                     sizeof_cbc_uint16_arguments_t_must_be_24_byte_long);
+
+JERRY_STATIC_ASSERT (offsetof (cbc_uint8_arguments_t, script_value) == offsetof (cbc_uint16_arguments_t, script_value),
+                     script_value_in_cbc_uint8_arguments_and_cbc_uint16_arguments_must_be_in_the_same_offset);
 
 /**
  * The reason of these two static asserts to notify the developer to increase the JERRY_SNAPSHOT_VERSION

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -563,9 +563,12 @@ typedef struct
   uint32_t global_status_flags;               /**< global status flags */
   uint16_t stack_depth;                       /**< current stack depth */
   uint16_t stack_limit;                       /**< maximum stack depth */
-  const jerry_parse_options_t *options_p;      /**< parse options */
+  const jerry_parse_options_t *options_p;     /**< parse options */
   parser_saved_context_t *last_context_p;     /**< last saved context */
   parser_stack_iterator_t last_statement;     /**< last statement position */
+  cbc_script_t *script_p;                     /**< current script */
+  ecma_value_t script_value;                  /**< current script as value */
+  ecma_value_t user_value;                    /**< current user value */
 
 #if JERRY_MODULE_SYSTEM
   ecma_module_names_t *module_names_p;        /**< import / export names that is being processed */
@@ -629,10 +632,6 @@ typedef struct
   uint16_t breakpoint_info_count;             /**< current breakpoint index */
   parser_line_counter_t last_breakpoint_line; /**< last line where breakpoint has been inserted */
 #endif /* JERRY_DEBUGGER */
-
-#if JERRY_RESOURCE_NAME
-  ecma_value_t resource_name;                 /**< resource name */
-#endif /* JERRY_RESOURCE_NAME */
 
 #if JERRY_LINE_INFO
   parser_line_info_data_t line_info;          /**< line info data */

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -56,7 +56,7 @@ typedef enum
   PARSER_ERR_INVALID_NUMBER,                          /**< invalid number literal */
   PARSER_ERR_MISSING_EXPONENT,                        /**< missing exponent */
   PARSER_ERR_IDENTIFIER_AFTER_NUMBER,                 /**< identifier start after number */
-  PARSER_ERR_INVALID_UNDERSCORE_IN_NUMBER,        /**< invalid use of underscore in number */
+  PARSER_ERR_INVALID_UNDERSCORE_IN_NUMBER,            /**< invalid use of underscore in number */
 #if JERRY_BUILTIN_BIGINT
   PARSER_ERR_INVALID_BIGINT,                          /**< number is not a valid BigInt */
 #endif /* JERRY_BUILTIN_BIGINT */

--- a/jerry-main/main-jerry.c
+++ b/jerry-main/main-jerry.c
@@ -137,7 +137,8 @@ restart:
         ret_value = jerry_exec_snapshot ((uint32_t *) source_p,
                                          source_size,
                                          source_file_p->snapshot_index,
-                                         JERRY_SNAPSHOT_EXEC_COPY_DATA);
+                                         JERRY_SNAPSHOT_EXEC_COPY_DATA,
+                                         NULL);
 
         jerry_port_release_source (source_p);
         break;

--- a/tests/unit-core/CMakeLists.txt
+++ b/tests/unit-core/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SOURCE_UNIT_TEST_MAIN_MODULES
   test-regexp.c
   test-regression-3588.c
   test-resource-name.c
+  test-script-user-value.c
   test-snapshot.c
   test-special-proxy.c
   test-string-to-number.c

--- a/tests/unit-core/test-script-user-value.c
+++ b/tests/unit-core/test-script-user-value.c
@@ -1,0 +1,192 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include "jerryscript.h"
+
+#include "test-common.h"
+
+static jerry_value_t user_values[4];
+
+#define USER_VALUES_SIZE (sizeof (user_values) / sizeof (jerry_value_t))
+
+static void
+test_parse (const char *source_p, /**< source code */
+            jerry_parse_options_t *options_p, /**< options passed to jerry_parse */
+            bool run_code) /**< run the code after parsing */
+{
+  for (size_t i = 0; i < USER_VALUES_SIZE; i++)
+  {
+    options_p->user_value = user_values[i];
+
+    jerry_value_t result = jerry_parse ((const jerry_char_t *) source_p,
+                                        strlen (source_p),
+                                        options_p);
+    TEST_ASSERT (!jerry_value_is_error (result));
+
+    if (run_code)
+    {
+      jerry_value_t parse_result = result;
+      result = jerry_run (result);
+      jerry_release_value (parse_result);
+      TEST_ASSERT (!jerry_value_is_error (result));
+    }
+
+    jerry_value_t user_value = jerry_get_user_value (result);
+    jerry_value_t compare_value = jerry_binary_operation (JERRY_BIN_OP_STRICT_EQUAL,
+                                                          user_value,
+                                                          user_values[i]);
+
+    TEST_ASSERT (jerry_value_is_true (compare_value));
+
+    jerry_release_value (compare_value);
+    jerry_release_value (user_value);
+    jerry_release_value (result);
+  }
+} /* test_parse */
+
+static void
+test_parse_function (const char *source_p, /**< source code */
+                     jerry_parse_options_t *options_p, /**< options passed to jerry_parse */
+                     bool run_code) /**< run the code after parsing */
+{
+  for (size_t i = 0; i < USER_VALUES_SIZE; i++)
+  {
+    options_p->user_value = user_values[i];
+
+    jerry_value_t result = jerry_parse_function ((const jerry_char_t *) "",
+                                                 0,
+                                                 (const jerry_char_t *) source_p,
+                                                 strlen (source_p),
+                                                 options_p);
+    TEST_ASSERT (!jerry_value_is_error (result));
+
+    if (run_code)
+    {
+      jerry_value_t parse_result = result;
+      jerry_value_t this_value = jerry_create_undefined ();
+      result = jerry_call_function (result, this_value, NULL, 0);
+      jerry_release_value (parse_result);
+      jerry_release_value (this_value);
+      TEST_ASSERT (!jerry_value_is_error (result));
+    }
+
+    jerry_value_t user_value = jerry_get_user_value (result);
+    jerry_value_t compare_value = jerry_binary_operation (JERRY_BIN_OP_STRICT_EQUAL,
+                                                          user_value,
+                                                          user_values[i]);
+
+    TEST_ASSERT (jerry_value_is_true (compare_value));
+
+    jerry_release_value (compare_value);
+    jerry_release_value (user_value);
+    jerry_release_value (result);
+  }
+} /* test_parse_function */
+
+int
+main (void)
+{
+  TEST_INIT ();
+
+  jerry_init (JERRY_INIT_EMPTY);
+
+  user_values[0] = jerry_create_object ();
+  user_values[1] = jerry_create_null ();
+  user_values[2] = jerry_create_number (5.5);
+  user_values[3] = jerry_create_string ((const jerry_char_t *) "AnyString...");
+
+  jerry_parse_options_t parse_options;
+  const char *source_p = TEST_STRING_LITERAL ("");
+
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse (source_p, &parse_options, false);
+  test_parse_function (source_p, &parse_options, false);
+
+  if (jerry_is_feature_enabled (JERRY_FEATURE_MODULE))
+  {
+    parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_USER_VALUE;
+    test_parse (source_p, &parse_options, false);
+  }
+
+  source_p = TEST_STRING_LITERAL ("function f() { }\n"
+                                  "f");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("function f() { return function() {} }\n"
+                                  "f()");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("return function() {}");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse_function (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("eval('function f() {}')\n"
+                                  "f");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("eval('function f() { return eval(\\'(function () {})\\') }')\n"
+                                  "f()");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("eval('function f() {}')\n"
+                                  "return f");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse_function (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("eval('function f() { return eval(\\'(function () {})\\') }')\n"
+                                  "return f()");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse_function (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("function f() {}\n"
+                                  "f.bind(1)");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("function f() {}\n"
+                                  "f.bind(1).bind(2, 3)");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("function f() {}\n"
+                                  "return f.bind(1)");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse_function (source_p, &parse_options, true);
+
+  source_p = TEST_STRING_LITERAL ("function f() {}\n"
+                                  "return f.bind(1).bind(2, 3)");
+  parse_options.options = JERRY_PARSE_HAS_USER_VALUE;
+  test_parse_function (source_p, &parse_options, true);
+
+  for (size_t i = 0; i < USER_VALUES_SIZE; i++)
+  {
+    jerry_value_t result = jerry_get_user_value (user_values[i]);
+    TEST_ASSERT (jerry_value_is_undefined (result));
+    jerry_release_value (result);
+  }
+
+  for (size_t i = 0; i < USER_VALUES_SIZE; i++)
+  {
+    jerry_release_value (user_values[i]);
+  }
+
+  jerry_cleanup ();
+  return 0;
+} /* main */


### PR DESCRIPTION
The same data is returned for the script and all of its functions, including those which are created by an eval call.
