### PR TITLE
Change resource name to a string

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -242,7 +242,7 @@ Option bits for [jerry_parse_options_t](#jerry_parse_options_t).
  - JERRY_PARSE_NO_OPTS - No options passed
  - JERRY_PARSE_STRICT_MODE - Enable strict mode
  - JERRY_PARSE_MODULE - Parse source as an ECMAScript module
- - JERRY_PARSE_HAS_RESOURCE - `resource_name_p` and `resource_name_length` fields are valid
+ - JERRY_PARSE_HAS_RESOURCE - `resource_name` field is valid
  - JERRY_PARSE_HAS_START - `start_line` and `start_column` fields are valid
  - JERRY_PARSE_HAS_USER_VALUE - `user_value` field is valid
 
@@ -312,9 +312,9 @@ Flags for [jerry_exec_snapshot](#jerry_exec_snapshot) functions:
  - JERRY_SNAPSHOT_EXEC_COPY_DATA - copy snapshot data into memory (see below)
  - JERRY_SNAPSHOT_EXEC_ALLOW_STATIC - allow executing static snapshots
  - JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION - load snapshot as function instead of executing it
- - JERRY_SNAPSHOT_EXEC_HAS_RESOURCE - resource_name_p and resource_name_length fields are valid
+ - JERRY_SNAPSHOT_EXEC_HAS_RESOURCE - `resource_name` field is valid
                                       in [jerry_exec_snapshot_option_values_t](#jerry_exec_snapshot_option_values_t)
- - JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE - user_value field is valid
+ - JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE - `user_value` field is valid
                                         in [jerry_exec_snapshot_option_values_t](#jerry_exec_snapshot_option_values_t)
 
 *Changed in version [[NEXT_RELEASE]]*: The `JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION` value is added,
@@ -536,10 +536,9 @@ or [jerry_parse_function](#jerry_parse_function)
 typedef struct
 {
   uint32_t options; /**< combination of jerry_parse_option_enable_feature_t values */
-  const jerry_char_t *resource_name_p; /**< resource name (usually a file name)
-                                        *   if JERRY_PARSE_HAS_RESOURCE is set in options */
-  size_t resource_name_length; /**< length of resource name
-                                *   if JERRY_PARSE_HAS_RESOURCE is set in options */
+  jerry_value_t resource_name; /**< resource name string (usually a file name)
+                                *   if JERRY_PARSE_HAS_RESOURCE is set in options
+                                *   Note: non-string values are ignored */
   uint32_t start_line; /**< start line of the source code if JERRY_PARSE_HAS_START is set in options */
   uint32_t start_column; /**< start column of the source code if JERRY_PARSE_HAS_START is set in options */
   jerry_value_t user_value; /**< user value assigned to all functions created by this script including eval
@@ -1293,10 +1292,9 @@ Various configuration options for [jerry_exec_snapshot](#jerry_exec_snapshot)
 ```c
 typedef struct
 {
-  const jerry_char_t *resource_name_p; /**< resource name (usually a file name)
-                                        *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
-  size_t resource_name_length; /**< length of resource name
-                                *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
+  jerry_value_t resource_name; /**< resource name string (usually a file name)
+                                *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts
+                                *   Note: non-string values are ignored */
   jerry_value_t user_value; /**< user value assigned to all functions created by this script including
                              *   eval calls executed by the script if JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE
                              *   is set in exec_snapshot_opts */
@@ -1698,17 +1696,16 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "print ('Hello, World!');";
-  const jerry_char_t file[] = "hello.js";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_STRICT_MODE | JERRY_PARSE_HAS_RESOURCE | JERRY_PARSE_HAS_START;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof(file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "hello.js");
   /* This example script is extracted from the middle of a file. */
   parse_options.start_line = 10;
   parse_options.start_column = 1;
 
   jerry_value_t parsed_code = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
   jerry_release_value (parsed_code);
 
   jerry_cleanup ();
@@ -4609,14 +4606,14 @@ module_resolve_callback (const jerry_value_t specifier,
    * returns with a new module. */
 
   const jerry_char_t script[] = "export var a = 5";
-  const jerry_char_t file[] = "b.mjs";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "b.mjs");
 
-  return jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_value_t result = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
+  return result;
 } /* module_resolve_callback */
 
 int
@@ -4625,14 +4622,13 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "import a from 'b.mjs'";
-  const jerry_char_t file[] = "a.mjs";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "a.mjs");
 
   jerry_value_t ret_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_module_link (ret_value, module_resolve_callback, NULL);
 
@@ -4684,14 +4680,13 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "export var a = 6";
-  const jerry_char_t file[] = "a.mjs";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "a.mjs");
 
   jerry_value_t module_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_release_value (jerry_module_link (module_value, NULL, NULL));
   jerry_release_value (jerry_module_evaluate (module_value));
@@ -4746,14 +4741,13 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "import a from 'b.mjs'";
-  const jerry_char_t file[] = "a.mjs";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "a.mjs");
 
   jerry_value_t module_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   if (jerry_module_get_state (module_value) == JERRY_MODULE_STATE_UNLINKED)
   {
@@ -4825,16 +4819,15 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "12";
-  const jerry_char_t file[] = "a.mjs";
 
   jerry_module_set_state_changed_callback (module_state_changed, NULL);
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "a.mjs");
 
   jerry_value_t module_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_release_value (jerry_module_link (module_value, NULL, NULL));
 
@@ -4891,14 +4884,13 @@ main (void)
 
   const jerry_char_t script[] = "export * from 'b.mjs'"
                                 "import a from 'c.mjs'";
-  const jerry_char_t file[] = "a.mjs";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "a.mjs");
 
   jerry_value_t module_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   /* Prints 2. */
   printf ("Number of requests: %d\n", (int) jerry_module_get_number_of_requests (module_value));
@@ -4967,10 +4959,10 @@ main (void)
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "a.mjs");
 
   jerry_value_t module_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_value_t request_value = jerry_module_get_request (module_value, 0);
   /* Returns with b.mjs */
@@ -5031,14 +5023,13 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
 
   const jerry_char_t script[] = "export var a = 6";
-  const jerry_char_t file[] = "a.mjs";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = file;
-  parse_options.resource_name_length = sizeof (file) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "a.mjs");
 
   jerry_value_t module_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_release_value (jerry_module_link (module_value, NULL, NULL));
   jerry_release_value (jerry_module_evaluate (module_value));
@@ -5132,20 +5123,19 @@ main (void)
                                 "  function (namespace) { /* use namespace */},\n"
                                 "  function (error) { /* handle error */}\n"
                                 ")";
-  const jerry_char_t resource[] = "dir/my_script.js";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE | JERRY_PARSE_HAS_USER_VALUE;
 
   /* Resource is usually used for debugging purposes, e.g. for generating backtrace. */
-  parse_options.resource_name_p = resource;
-  parse_options.resource_name_length = sizeof (resource) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "dir/my_script.js");
 
   /* User value should provide information for resolving dynamic imports.
    * In this case it contains the full path excluding the filename. */
   parse_options.user_value = jerry_create_string ((const jerry_char_t *) "/home/user/dir");
 
   jerry_value_t script_value = jerry_parse (script, sizeof (script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
   jerry_release_value (parse_options.user_value);
   jerry_release_value (jerry_run (script_value));
   jerry_release_value (script_value);
@@ -5153,14 +5143,13 @@ main (void)
   /* The application resolves both the module and the promise using the specifier
    * and the user_value. In this example the specifier is modules/my_module.mjs. */
   const jerry_char_t module_script[] = "export var a = 5";
-  const jerry_char_t module_resource[] = "modules/my_module.mjs";
 
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE | JERRY_PARSE_HAS_USER_VALUE;
-  parse_options.resource_name_p = module_resource;
-  parse_options.resource_name_length = sizeof (module_resource) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "modules/my_module.mjs");
   parse_options.user_value = jerry_create_string ((const jerry_char_t *) "/home/user/dir/modules");
 
   jerry_value_t module_value = jerry_parse (module_script, sizeof (module_script) - 1, &parse_options);
+  jerry_release_value (parse_options.resource_name);
   jerry_release_value (parse_options.user_value);
   jerry_release_value (jerry_module_link (module_value, NULL, NULL));
   jerry_release_value (jerry_module_evaluate (module_value));
@@ -10893,16 +10882,16 @@ main (void)
                         "function g() { h (); }\n"
                         "function h() { backtrace (); }\n"
                         "f ();\n");
-  const char *resource = "demo_memoryjs";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = (jerry_char_t *) resource;
-  parse_options.resource_name_length = (size_t) strlen (resource);
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "demo_memory.js");
 
   jerry_value_t program = jerry_parse ((const jerry_char_t *) source,
                                        strlen (source),
                                        &parse_options);
+  jerry_release_value (parse_options.resource_name);
+
   if (!jerry_value_is_error (program))
   {
     jerry_value_t run_result = jerry_run (program);
@@ -10999,16 +10988,16 @@ main (void)
                         "function g() { h (); }\n"
                         "function h() { backtrace (g); }\n"
                         "f ();\n");
-  const char *resource = "demo_backtrace.js";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = (jerry_char_t *) resource;
-  parse_options.resource_name_length = (size_t) strlen (resource);
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "demo_backtrace.js");
 
   jerry_value_t program = jerry_parse ((const jerry_char_t *) source,
                                        strlen (source),
                                        &parse_options);
+  jerry_release_value (parse_options.resource_name);
+
   if (!jerry_value_is_error (program))
   {
     jerry_value_t run_result = jerry_run (program);
@@ -11469,16 +11458,15 @@ main (void)
   jerry_release_value (global);
 
   const jerry_char_t source[] = "function myFunction() { return resourceName() }; myFunction()";
-  const jerry_char_t resource[] = "demo.js";
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = resource;
-  parse_options.resource_name_length = sizeof (resource) - 1;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "demo.js");
 
   jerry_value_t program = jerry_parse (source,
                                        sizeof (source) - 1,
                                        &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   if (!jerry_value_is_error (program))
   {

--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -316,12 +316,12 @@ wait_for_source_callback (const jerry_char_t *resource_name_p, /**< resource nam
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = resource_name_p;
-  parse_options.resource_name_length = resource_name_size;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) resource_name_p);
 
   jerry_value_t ret_val = jerry_parse (source_p,
                                        source_size,
                                        &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   if (!jerry_value_is_error (ret_val))
   {

--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -1021,10 +1021,10 @@ jerry_exec_snapshot (const uint32_t *snapshot_p, /**< snapshot */
 
     if ((exec_snapshot_opts & JERRY_SNAPSHOT_EXEC_HAS_RESOURCE)
         && option_values_p != NULL
-        && option_values_p->resource_name_length > 0)
+        && ecma_is_value_string (option_values_p->resource_name) > 0)
     {
-      resource_name = ecma_find_or_create_literal_string (option_values_p->resource_name_p,
-                                                          (lit_utf8_size_t) option_values_p->resource_name_length);
+      ecma_ref_ecma_string (ecma_get_string_from_value (option_values_p->resource_name));
+      resource_name = option_values_p->resource_name;
     }
 
     script_p->resource_name = resource_name;

--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -407,12 +407,16 @@ jerry_parse (const jerry_char_t *source_p, /**< script source */
   if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
       && options_p != NULL
       && (options_p->options & JERRY_PARSE_HAS_RESOURCE)
-      && options_p->resource_name_length > 0)
+      && ecma_is_value_string (options_p->resource_name))
   {
+    ECMA_STRING_TO_UTF8_STRING (ecma_get_string_from_value (options_p->resource_name),
+                                resource_name_start_p,
+                                resource_name_size);
     jerry_debugger_send_string (JERRY_DEBUGGER_SOURCE_CODE_NAME,
                                 JERRY_DEBUGGER_NO_SUBTYPE,
-                                options_p->resource_name_p,
-                                options_p->resource_name_length);
+                                resource_name_start_p,
+                                resource_name_size);
+    ECMA_FINALIZE_UTF8_STRING (resource_name_start_p, resource_name_size);
   }
 #endif /* JERRY_DEBUGGER && JERRY_PARSER */
 
@@ -508,12 +512,16 @@ jerry_parse_function (const jerry_char_t *arg_list_p, /**< script source */
   if ((JERRY_CONTEXT (debugger_flags) & JERRY_DEBUGGER_CONNECTED)
       && options_p != NULL
       && (options_p->options & JERRY_PARSE_HAS_RESOURCE)
-      && options_p->resource_name_length > 0)
+      && ecma_is_value_string (options_p->resource_name))
   {
+    ECMA_STRING_TO_UTF8_STRING (ecma_get_string_from_value (options_p->resource_name),
+                                resource_name_start_p,
+                                resource_name_size);
     jerry_debugger_send_string (JERRY_DEBUGGER_SOURCE_CODE_NAME,
                                 JERRY_DEBUGGER_NO_SUBTYPE,
-                                options_p->resource_name_p,
-                                options_p->resource_name_length);
+                                resource_name_start_p,
+                                resource_name_size);
+    ECMA_FINALIZE_UTF8_STRING (resource_name_start_p, resource_name_size);
   }
 #endif /* JERRY_DEBUGGER && JERRY_PARSER */
 

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -1538,6 +1538,10 @@ ecma_bytecode_deref (ecma_compiled_code_t *bytecode_p) /**< byte code pointer */
         }
       }
 
+#if JERRY_RESOURCE_NAME
+      ecma_deref_ecma_string (ecma_get_string_from_value (script_p->resource_name));
+#endif /* JERRY_RESOURCE_NAME */
+
       jmem_heap_free_block (script_p, script_size);
     }
 

--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -48,7 +48,7 @@ typedef enum
   JERRY_SNAPSHOT_EXEC_COPY_DATA = (1u << 0), /**< copy snashot data */
   JERRY_SNAPSHOT_EXEC_ALLOW_STATIC = (1u << 1), /**< static snapshots allowed */
   JERRY_SNAPSHOT_EXEC_LOAD_AS_FUNCTION = (1u << 2), /**< load snapshot as function instead of executing it */
-  JERRY_SNAPSHOT_EXEC_HAS_RESOURCE = (1u << 3), /**< resource_name_p and resource_name_length fields are valid
+  JERRY_SNAPSHOT_EXEC_HAS_RESOURCE = (1u << 3), /**< resource_name field is valid
                                                  *   in jerry_exec_snapshot_option_values_t */
   JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE = (1u << 4), /**< user_value field is valid
                                                    *   in jerry_exec_snapshot_option_values_t */
@@ -59,10 +59,9 @@ typedef enum
  */
 typedef struct
 {
-  const jerry_char_t *resource_name_p; /**< resource name (usually a file name)
-                                        *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
-  size_t resource_name_length; /**< length of resource name
-                                *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts */
+  jerry_value_t resource_name; /**< resource name string (usually a file name)
+                                *   if JERRY_SNAPSHOT_EXEC_HAS_RESOURCE is set in exec_snapshot_opts
+                                *   Note: non-string values are ignored */
   jerry_value_t user_value; /**< user value assigned to all functions created by this script including
                              *   eval calls executed by the script if JERRY_SNAPSHOT_EXEC_HAS_USER_VALUE
                              *   is set in exec_snapshot_opts */

--- a/jerry-core/include/jerryscript-types.h
+++ b/jerry-core/include/jerryscript-types.h
@@ -166,7 +166,7 @@ typedef enum
   JERRY_PARSE_NO_OPTS = 0, /**< no options passed */
   JERRY_PARSE_STRICT_MODE = (1 << 0), /**< enable strict mode */
   JERRY_PARSE_MODULE = (1 << 1), /**< parse source as an ECMAScript module */
-  JERRY_PARSE_HAS_RESOURCE = (1 << 2), /**< resource_name_p and resource_name_length fields are valid */
+  JERRY_PARSE_HAS_RESOURCE = (1 << 2), /**< resource_name field is valid */
   JERRY_PARSE_HAS_START = (1 << 3), /**< start_line and start_column fields are valid */
   JERRY_PARSE_HAS_USER_VALUE = (1 << 4), /**< user_value field is valid */
 } jerry_parse_option_enable_feature_t;
@@ -177,10 +177,9 @@ typedef enum
 typedef struct
 {
   uint32_t options; /**< combination of jerry_parse_option_enable_feature_t values */
-  const jerry_char_t *resource_name_p; /**< resource name (usually a file name)
-                                        *   if JERRY_PARSE_HAS_RESOURCE is set in options */
-  size_t resource_name_length; /**< length of resource name
-                                *   if JERRY_PARSE_HAS_RESOURCE is set in options */
+  jerry_value_t resource_name; /**< resource name string (usually a file name)
+                                *   if JERRY_PARSE_HAS_RESOURCE is set in options
+                                *   Note: non-string values are ignored */
   uint32_t start_line; /**< start line of the source code if JERRY_PARSE_HAS_START is set in options */
   uint32_t start_column; /**< start column of the source code if JERRY_PARSE_HAS_START is set in options */
   jerry_value_t user_value; /**< user value assigned to all functions created by this script including eval

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1863,10 +1863,10 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
 
   if (context.options_p != NULL
       && (context.options_p->options & JERRY_PARSE_HAS_RESOURCE)
-      && context.options_p->resource_name_length > 0)
+      && ecma_is_value_string (context.options_p->resource_name))
   {
-    resource_name = ecma_find_or_create_literal_string (context.options_p->resource_name_p,
-                                                        (lit_utf8_size_t) context.options_p->resource_name_length);
+    ecma_ref_ecma_string (ecma_get_string_from_value (context.options_p->resource_name));
+    resource_name = context.options_p->resource_name;
   }
   else if (context.global_status_flags & ECMA_PARSE_EVAL)
   {
@@ -2099,6 +2099,10 @@ parser_parse_source (const uint8_t *arg_list_p, /**< function argument list */
     compiled_code_p = NULL;
     parser_free_literals (&context.literal_pool);
     parser_cbc_stream_free (&context.byte_code);
+
+#if JERRY_RESOURCE_NAME
+    ecma_deref_ecma_string (ecma_get_string_from_value (context.script_p->resource_name));
+#endif /* JERRY_RESOURCE_NAME */
 
     JERRY_ASSERT (context.script_p->refs_and_type >= CBC_SCRIPT_REF_ONE);
     jmem_heap_free_block (context.script_p, script_size);

--- a/jerry-main/main-jerry-snapshot.c
+++ b/jerry-main/main-jerry-snapshot.c
@@ -378,8 +378,8 @@ process_generate (cli_state_t *cli_state_p, /**< cli state */
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = (jerry_char_t *) file_name_p;
-  parse_options.resource_name_length = (size_t) strlen (file_name_p);
+  parse_options.resource_name = jerry_create_string_sz ((const jerry_char_t *) file_name_p,
+                                                        (jerry_size_t) strlen (file_name_p));
 
   if (function_args_p != NULL)
   {
@@ -401,6 +401,8 @@ process_generate (cli_state_t *cli_state_p, /**< cli state */
                                                output_buffer,
                                                sizeof (output_buffer) / sizeof (uint32_t));
   }
+
+  jerry_release_value (parse_options.resource_name);
 
   if (jerry_value_is_error (snapshot_result))
   {

--- a/jerry-main/main-jerry.c
+++ b/jerry-main/main-jerry.c
@@ -157,13 +157,14 @@ restart:
 
         jerry_parse_options_t parse_options;
         parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-        parse_options.resource_name_p = (jerry_char_t *) file_path_p;
-        parse_options.resource_name_length = (size_t) strlen (file_path_p);
+        parse_options.resource_name = jerry_create_string_sz ((const jerry_char_t *) file_path_p,
+                                                              (jerry_size_t) strlen (file_path_p));
 
         ret_value = jerry_parse (source_p,
                                  source_size,
                                  &parse_options);
 
+        jerry_release_value (parse_options.resource_name);
         jerry_port_release_source (source_p);
 
         if (!jerry_value_is_error (ret_value) && !(arguments.option_flags & OPT_FLAG_PARSE_ONLY))

--- a/jerry-main/main-utils.c
+++ b/jerry-main/main-utils.c
@@ -477,12 +477,13 @@ main_wait_for_source_callback (const jerry_char_t *resource_name_p, /**< resourc
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = resource_name_p;
-  parse_options.resource_name_length = resource_name_size;
+  parse_options.resource_name = jerry_create_string_sz (resource_name_p, (jerry_size_t) resource_name_size);
 
   jerry_value_t ret_val = jerry_parse (source_p,
                                        source_size,
                                        &parse_options);
+
+  jerry_release_value (parse_options.resource_name);
 
   if (!jerry_value_is_error (ret_val))
   {

--- a/jerry-port/default/default-module.c
+++ b/jerry-port/default/default-module.c
@@ -373,12 +373,12 @@ jerry_port_module_resolve (const jerry_value_t specifier, /**< module specifier 
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = (jerry_char_t *) in_path_p;
-  parse_options.resource_name_length = (size_t) in_path_length;
+  parse_options.resource_name = jerry_create_string_sz ((const jerry_char_t *) in_path_p, in_path_length);
 
   jerry_value_t ret_value = jerry_parse (source_p,
                                          source_size,
                                          &parse_options);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_port_release_source (source_p);
   free (in_path_p);

--- a/targets/nuttx-stm32f4/jerry_main.c
+++ b/targets/nuttx-stm32f4/jerry_main.c
@@ -419,12 +419,12 @@ int jerry_main (int argc, char *argv[])
 
       jerry_parse_options_t parse_options;
       parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-      parse_options.resource_name_p = (const jerry_char_t *) file_names[i];
-      parse_options.resource_name_length = strlen (file_names[i]);
+      parse_options.resource_name = jerry_create_string ((const jerry_char_t *) file_names[i]);
 
       ret_value = jerry_parse (source_p,
                                source_size,
                                &parse_options);
+      jerry_release_value (parse_options.resource_name);
       free ((void*) source_p);
 
       if (!jerry_value_is_error (ret_value))

--- a/targets/nuttx-stm32f4/jerry_module.c
+++ b/targets/nuttx-stm32f4/jerry_module.c
@@ -259,13 +259,13 @@ jerry_port_module_resolve (const jerry_value_t specifier, /**< module specifier 
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_MODULE | JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = (jerry_char_t *) in_path_p;
-  parse_options.resource_name_length = (size_t) in_path_length;
+  parse_options.resource_name = jerry_create_string_sz ((const jerry_char_t *) in_path_p, in_path_length);
 
   jerry_value_t ret_value = jerry_parse (source_p,
                                          source_size,
                                          &parse_options);
 
+  jerry_release_value (parse_options.resource_name);
   jerry_port_release_source (source_p);
   free (in_path_p);
 

--- a/tests/unit-core/test-api.c
+++ b/tests/unit-core/test-api.c
@@ -1048,11 +1048,9 @@ main (void)
                        "SyntaxError: Primary expression expected [<anonymous>:2:10]",
                        false);
 
-    const jerry_char_t file_str[] = "filename.js";
     jerry_parse_options_t parse_options;
     parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-    parse_options.resource_name_p = file_str;
-    parse_options.resource_name_length = sizeof (file_str) - 1;
+    parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "filename.js");
 
     test_syntax_error ("b = 'hello';\nvar a = (;",
                        &parse_options,
@@ -1073,6 +1071,7 @@ main (void)
                        "SyntaxError: Expected ')' token [filename.js:10:36]",
                        false);
 
+    jerry_release_value (parse_options.resource_name);
     jerry_cleanup ();
   }
 

--- a/tests/unit-core/test-backtrace.c
+++ b/tests/unit-core/test-backtrace.c
@@ -225,12 +225,12 @@ run (const char *resource_name_p, /**< resource name */
 {
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_RESOURCE;
-  parse_options.resource_name_p = (const jerry_char_t *) resource_name_p;
-  parse_options.resource_name_length = strlen (resource_name_p);
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) resource_name_p);
 
   jerry_value_t code = jerry_parse ((const jerry_char_t *) source_p,
                                     strlen (source_p),
                                     &parse_options);
+  jerry_release_value (parse_options.resource_name);
   TEST_ASSERT (!jerry_value_is_error (code));
 
   jerry_value_t result = jerry_run (code);

--- a/tests/unit-core/test-resource-name.c
+++ b/tests/unit-core/test-resource-name.c
@@ -68,10 +68,8 @@ main (void)
                           "  return f1; \n"
                           "} \n"
                           "f1();");
-  const char *resource_1 = "demo1.js";
 
-  parse_options.resource_name_p = (const jerry_char_t *) resource_1;
-  parse_options.resource_name_length = strlen (resource_1);
+  parse_options.resource_name = jerry_create_string ((jerry_char_t *) "demo1.js");
 
   jerry_value_t program = jerry_parse ((const jerry_char_t *) source_1,
                                        strlen (source_1),
@@ -83,10 +81,9 @@ main (void)
   TEST_ASSERT (jerry_value_is_object (run_result));
 
   jerry_value_t resource_value = jerry_get_resource_name (run_result);
-  jerry_value_t resource1_name_value = jerry_create_string ((const jerry_char_t *) resource_1);
-  TEST_ASSERT (jerry_binary_operation (JERRY_BIN_OP_STRICT_EQUAL, resource_value, resource1_name_value));
-  jerry_release_value (resource1_name_value);
+  TEST_ASSERT (jerry_binary_operation (JERRY_BIN_OP_STRICT_EQUAL, resource_value, parse_options.resource_name));
   jerry_release_value (resource_value);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_release_value (run_result);
   jerry_release_value (program);
@@ -100,10 +97,8 @@ main (void)
                           "  return f2; \n"
                           "} \n"
                           "f2(); \n");
-  const char *resource_2 = "demo2.js";
 
-  parse_options.resource_name_p = (const jerry_char_t *) resource_2;
-  parse_options.resource_name_length = strlen (resource_2);
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "demo2.js");
 
   program = jerry_parse ((const jerry_char_t *) source_2,
                          strlen (source_2),
@@ -115,10 +110,9 @@ main (void)
   TEST_ASSERT (jerry_value_is_object (run_result));
 
   resource_value = jerry_get_resource_name (run_result);
-  jerry_value_t resource2_name_value = jerry_create_string ((const jerry_char_t *) resource_2);
-  TEST_ASSERT (jerry_binary_operation (JERRY_BIN_OP_STRICT_EQUAL, resource_value, resource2_name_value));
-  jerry_release_value (resource2_name_value);
+  TEST_ASSERT (jerry_binary_operation (JERRY_BIN_OP_STRICT_EQUAL, resource_value, parse_options.resource_name));
   jerry_release_value (resource_value);
+  jerry_release_value (parse_options.resource_name);
 
   jerry_release_value (run_result);
   jerry_release_value (program);


### PR DESCRIPTION
This patch has various small advantages:
- resource name can be utf8 string
- resource name is not kept forever in literal storage
- plays better with user vale

The API is not released, so this is not a breaking change.