### PR TITLE
Support parsing of scripts / functions stored in string values

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -243,6 +243,7 @@ Option bits for [jerry_parse_options_t](#jerry_parse_options_t).
  - JERRY_PARSE_NO_OPTS - No options passed
  - JERRY_PARSE_STRICT_MODE - Enable strict mode
  - JERRY_PARSE_MODULE - Parse source as an ECMAScript module
+ - JERRY_PARSE_HAS_ARGUMENT_LIST - `argument_list` field is valid
  - JERRY_PARSE_HAS_RESOURCE - `resource_name` field is valid
  - JERRY_PARSE_HAS_START - `start_line` and `start_column` fields are valid
  - JERRY_PARSE_HAS_USER_VALUE - `user_value` field is valid
@@ -278,8 +279,7 @@ List of backtrace frame types returned by
 
 ## jerry_generate_snapshot_opts_t
 
-Flags for [jerry_generate_snapshot](#jerry_generate_snapshot) and
-[jerry_generate_function_snapshot](#jerry_generate_function_snapshot) functions:
+Flags for [jerry_generate_snapshot](#jerry_generate_snapshot):
 
  - JERRY_SNAPSHOT_SAVE_STATIC - generate static snapshot (see below)
 
@@ -540,8 +540,7 @@ Enum that contains the flags of property descriptors.
 
 **Summary**
 
-Various configuration options for parsing functions such as [jerry_parse](#jerry_parse)
-or [jerry_parse_function](#jerry_parse_function)
+Various configuration options for parsing functions such as [jerry_parse](#jerry_parse).
 
 **Prototype**
 
@@ -549,9 +548,11 @@ or [jerry_parse_function](#jerry_parse_function)
 typedef struct
 {
   uint32_t options; /**< combination of jerry_parse_option_enable_feature_t values */
+  jerry_value_t argument_list; /**< function argument list if JERRY_PARSE_HAS_ARGUMENT_LIST is set in options
+                                *   Note: must be string value */
   jerry_value_t resource_name; /**< resource name string (usually a file name)
                                 *   if JERRY_PARSE_HAS_RESOURCE is set in options
-                                *   Note: non-string values are ignored */
+                                *   Note: must be string value */
   uint32_t start_line; /**< start line of the source code if JERRY_PARSE_HAS_START is set in options */
   uint32_t start_column; /**< start column of the source code if JERRY_PARSE_HAS_START is set in options */
   jerry_value_t user_value; /**< user value assigned to all functions created by this script including eval
@@ -564,9 +565,7 @@ typedef struct
 **See also**
 
 - [jerry_parse](#jerry_parse)
-- [jerry_parse_function](#jerry_parse_function)
 - [jerry_generate_snapshot](#jerry_generate_snapshot)
-- [jerry_generate_function_snapshot](#jerry_generate_function_snapshot)
 - [jerry_exec_snapshot](#jerry_exec_snapshot)
 - [jerry_parse_option_enable_feature_t](#jerry_parse_option_enable_feature_t)
 
@@ -1696,9 +1695,7 @@ main (void)
 
 **Summary**
 
-Parse script and construct an EcmaScript function. The lexical environment is
-set to the global lexical environment. The resource name can be used by
-debugging systems to provide line / backtrace info.
+Parse a script, module, or function and create a compiled code using a character string.
 
 *Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
 is no longer needed.
@@ -1734,6 +1731,7 @@ main (void)
 {
   jerry_init (JERRY_INIT_EMPTY);
 
+  /* Parsing a script. */
   const jerry_char_t script[] = "print ('Hello, World!');";
 
   jerry_parse_options_t parse_options;
@@ -1745,6 +1743,89 @@ main (void)
 
   jerry_value_t parsed_code = jerry_parse (script, sizeof (script) - 1, &parse_options);
   jerry_release_value (parse_options.resource_name);
+
+  jerry_release_value (jerry_run (parsed_code));
+  jerry_release_value (parsed_code);
+
+  /* Parsing a function. */
+  parse_options.options = JERRY_PARSE_HAS_ARGUMENT_LIST;
+  parse_options.argument_list = jerry_create_string ((const jerry_char_t *) "a, b");
+
+  const jerry_char_t function_code[] = "return a + b;";
+  jerry_value_t parsed_function = jerry_parse (function_code, sizeof (function_code) - 1, &parse_options);
+  jerry_release_value (parse_options.argument_list);
+
+  jerry_value_t args[] = {
+    jerry_create_number (3),
+    jerry_create_number (4),
+  };
+  jerry_size_t argc = sizeof (args) / sizeof (args[0]);
+  jerry_release_value (jerry_call_function (parsed_function,
+                                            jerry_create_undefined(),
+                                            args,
+                                            argc));
+  jerry_release_value (parsed_function);
+
+  jerry_cleanup ();
+  return 0;
+}
+```
+
+**See also**
+
+- [jerry_parse_value](#jerry_parse_value)
+- [jerry_run](#jerry_run)
+- [jerry_parse_options_t](#jerry_parse_options_t)
+
+## jerry_parse_value
+
+**Summary**
+
+Parse a script, module, or function and create a compiled code using a string value.
+
+*Note*: Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
+is no longer needed.
+
+**Prototype**
+
+```c
+jerry_value_t
+jerry_parse_value (const jerry_value_t source_value,
+                   const jerry_parse_options_t *options_p);
+```
+
+- `source_value` - string value, containing source code to parse (only string values are accepted).
+- `options_p` - additional parsing options, can be NULL if not used
+- return value
+  - function object value, if script was parsed successfully,
+  - thrown error, otherwise
+
+*New in version [[NEXT_RELEASE]]*.
+
+**Example**
+
+[doctest]: # ()
+
+```c
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t script_value = jerry_create_string ((const jerry_char_t *) "print ('Hello, World!');");
+
+  jerry_parse_options_t parse_options;
+  parse_options.options = JERRY_PARSE_STRICT_MODE | JERRY_PARSE_HAS_RESOURCE | JERRY_PARSE_HAS_START;
+  parse_options.resource_name = jerry_create_string ((const jerry_char_t *) "hello.js");
+  /* This example script is extracted from the middle of a file. */
+  parse_options.start_line = 10;
+  parse_options.start_column = 1;
+
+  jerry_value_t parsed_code = jerry_parse_value (script_value, &parse_options);
+  jerry_release_value (parse_options.resource_name);
+  jerry_release_value (script_value);
   jerry_release_value (parsed_code);
 
   jerry_cleanup ();
@@ -1754,119 +1835,9 @@ main (void)
 
 **See also**
 
+- [jerry_parse](#jerry_parse)
 - [jerry_run](#jerry_run)
-- [jerry_parse_function](#jerry_parse_function)
 - [jerry_parse_options_t](#jerry_parse_options_t)
-
-## jerry_parse_function
-
-**Summary**
-
-Parse function source code and construct an ECMAScript
-function. The function arguments and function body are
-passed as separated arguments. The lexical environment
-is set to the global lexical environment. The resource
-name (usually a file name) is also passed to this function
-which is used by the debugger to find the source code.
-
-*Note*: The returned value must be freed with [jerry_release_value](#jerry_release_value) when it
-is no longer needed.
-
-**Prototype**
-
-```c
-jerry_value_t
-jerry_parse_function (const jerry_char_t *arg_list_p,
-                      size_t arg_list_size,
-                      const jerry_char_t *source_p,
-                      size_t source_size,
-                      const jerry_parse_options_t *options_p);
-```
-
-- `arg_list_p` - argument list of the function (must be a valid UTF8 string).
-- `arg_list_size` - size of the argument list, in bytes.
-- `source_p` - string, containing source code to parse (must be a valid UTF8 string).
-- `source_size` - size of the string, in bytes.
-- `options_p` - additional parsing options, can be NULL if not used
-- return value
-  - function object value, if script was parsed successfully,
-  - thrown error, otherwise
-
-*New in version 2.0*.
-*Changed in version [[NEXT_RELEASE]]*: The `resource_name_p`, `resource_name_length`, and `parse_opts` arguments are replaced by `options_p`.
-
-**Example**
-
-[doctest]: # (name="02.API-REFERENCE-parse-func.c")
-
-```c
-#include <stdio.h>
-#include <string.h>
-#include "jerryscript.h"
-
-int
-main (void)
-{
-  int return_value = 1;
-
-  /* Initialize engine */
-  jerry_init (JERRY_INIT_EMPTY);
-
-  /* Parse the 'function (a,b) { return a + b; }' function */
-  const char function_args[] = "a, b";
-  const char function_source[] = "return a + b";
-
-  jerry_value_t parsed_function = jerry_parse_function ((const jerry_char_t *) function_args,
-                                                        strlen (function_args),
-                                                        (const jerry_char_t *) function_source,
-                                                        strlen (function_source),
-                                                        NULL);
-
-  if (!jerry_value_is_error (parsed_function))
-  {
-    /* Run the parsed function */
-    jerry_value_t args[] = {
-        jerry_create_number (3),
-        jerry_create_number (55),
-    };
-    jerry_size_t argc = sizeof (args) / sizeof (args[0]);
-    jerry_value_t ret_value = jerry_call_function (parsed_function,
-                                                   jerry_create_undefined(),
-                                                   args,
-                                                   argc);
-
-    /* Process result value */
-    if (jerry_value_is_number (ret_value)) {
-        double value = jerry_get_number_value (ret_value);
-        printf ("Function result: %lf\n", value);
-
-        return_value = !(value == (3 + 55));
-    }
-
-    /* Release the function arguments */
-    for (jerry_size_t idx = 0; idx < argc; idx++) {
-        jerry_release_value (args[idx]);
-    }
-
-    /* Returned value must be freed */
-    jerry_release_value (ret_value);
-  }
-
-  /* Parsed function must be freed */
-  jerry_release_value (parsed_function);
-
-  /* Cleanup engine */
-  jerry_cleanup ();
-
-  return return_value;
-}
-```
-
-**See also**
-
-- [jerry_call_function](#jerry_call_function)
-- [jerry_parse_options_t](#jerry_parse_options_t)
-
 
 ## jerry_run
 
@@ -10429,17 +10400,13 @@ Generate snapshot from the specified source code.
 
 ```c
 jerry_value_t
-jerry_generate_snapshot (const jerry_char_t *source_p,
-                         size_t source_size,
-                         const jerry_parse_options_t *options_p,
+jerry_generate_snapshot (jerry_value_t compiled_code,
                          uint32_t generate_snapshot_opts,
                          uint32_t *buffer_p,
                          size_t buffer_size);
 ```
 
-- `source_p` - script source, it must be a valid utf8 string.
-- `source_size` - script source size, in bytes.
-- `options_p` - additional parsing options, can be NULL if not used
+- `compiled_code` - compiled script or function (see: [jerry_parse](#jerry_parse)).
 - `generate_snapshot_opts` - any combination of [jerry_generate_snapshot_opts_t](#jerry_generate_snapshot_opts_t) flags.
 - `buffer_p` - output buffer (aligned to 4 bytes) to save snapshot to.
 - `buffer_size` - the output buffer's size in bytes.
@@ -10450,7 +10417,10 @@ jerry_generate_snapshot (const jerry_char_t *source_p,
   - thrown error, otherwise.
 
 *New in version 2.0*.
-*Changed in version [[NEXT_RELEASE]]*: The `resource_name_p`, and `resource_name_length` arguments are replaced by `options_p`.
+
+*Changed in version [[NEXT_RELEASE]]*: The `source_p`, `source_size`, `resource_name_p`,
+                                       and `resource_name_length` arguments are replaced by `compiled_code`
+                                       which should contain a compiled ECMAScript script / function.
 
 **Example**
 
@@ -10467,13 +10437,16 @@ main (void)
   static uint32_t global_mode_snapshot_buffer[256];
   const jerry_char_t script_to_snapshot[] = "(function () { return 'string from snapshot'; }) ();";
 
-  jerry_value_t generate_result;
-  generate_result = jerry_generate_snapshot (script_to_snapshot,
-                                             sizeof (script_to_snapshot) - 1,
-                                             NULL,
-                                             0,
-                                             global_mode_snapshot_buffer,
-                                             sizeof (global_mode_snapshot_buffer) / sizeof (uint32_t));
+  jerry_value_t parse_result = jerry_parse (script_to_snapshot,
+                                            sizeof (script_to_snapshot) - 1,
+                                            NULL);
+
+  size_t buffer_size = sizeof (global_mode_snapshot_buffer) / sizeof (uint32_t);
+  jerry_value_t generate_result = jerry_generate_snapshot (parse_result,
+                                                           0,
+                                                           global_mode_snapshot_buffer,
+                                                           buffer_size);
+  jerry_release_value (parse_result);
 
   if (!jerry_value_is_error (generate_result))
   {
@@ -10489,104 +10462,9 @@ main (void)
 
 **See also**
 
-- [jerry_init](#jerry_init)
-- [jerry_cleanup](#jerry_cleanup)
-- [jerry_generate_function_snapshot](#jerry_generate_function_snapshot)
+- [jerry_parse](#jerry_parse)
+- [jerry_parse_value](#jerry_parse_value)
 - [jerry_exec_snapshot](#jerry_exec_snapshot)
-- [jerry_parse_options_t](#jerry_parse_options_t)
-
-
-## jerry_generate_function_snapshot
-
-**Summary**
-
-Generate function snapshot from the specified source code
-with the given arguments.
-
-The function arguments and function body are
-passed as separated arguments.
-
-*Notes*:
-- Returned value must be freed with [jerry_release_value](#jerry_release_value) when it
-  is no longer needed.
-- This API depends on a build option (`JERRY_SNAPSHOT_SAVE`) and can be checked in runtime with
-  the `JERRY_FEATURE_SNAPSHOT_SAVE` feature enum value, see [jerry_is_feature_enabled](#jerry_is_feature_enabled).
-  If the feature is not enabled the function will return an error.
-
-**Prototype**
-
-```c
-jerry_value_t
-jerry_generate_function_snapshot (const jerry_char_t *source_p,
-                                  size_t source_size,
-                                  const jerry_char_t *args_p,
-                                  size_t args_size,
-                                  const jerry_parse_options_t *options_p,
-                                  uint32_t generate_snapshot_opts,
-                                  uint32_t *buffer_p,
-                                  size_t buffer_size)
-```
-
-- `source_p` - script source, it must be a valid utf8 string.
-- `source_size` - script source size, in bytes.
-- `args_p` - function arguments, it must be a valid utf8 string.
-- `args_size` - function argument size, in bytes.
-- `options_p` - additional parsing options, can be NULL if not used
-- `generate_snapshot_opts` - any combination of [jerry_generate_snapshot_opts_t](#jerry_generate_snapshot_opts_t) flags.
-- `buffer_p` - buffer (aligned to 4 bytes) to save snapshot to.
-- `buffer_size` - the buffer's size in bytes.
-- return value
-  - the size of the generated snapshot in bytes as number value, if it was generated succesfully (i.e. there
-    are no syntax errors in source code, buffer size is sufficient, and snapshot support is enabled in
-    current configuration through JERRY_SNAPSHOT_SAVE)
-  - thrown error, otherwise.
-
-*New in version 2.0*.
-*Changed in version [[NEXT_RELEASE]]*: The `resource_name_p`, and `resource_name_length` arguments are replaced by `options_p`.
-
-**Example**
-
-[doctest]: # ()
-
-```c
-#include "jerryscript.h"
-
-int
-main (void)
-{
-  jerry_init (JERRY_INIT_EMPTY);
-
-  static uint32_t func_snapshot_buffer[256];
-  const jerry_char_t args[] = "a, b";
-  const jerry_char_t src[] = "return a + b;";
-
-  jerry_value_t generate_result;
-  generate_result = jerry_generate_function_snapshot (src,
-                                                      sizeof (src) - 1,
-                                                      args,
-                                                      sizeof (args) - 1,
-                                                      NULL,
-                                                      0,
-                                                      func_snapshot_buffer,
-                                                      sizeof (func_snapshot_buffer) / sizeof (uint32_t));
-
-  if (!jerry_value_is_error (generate_result))
-  {
-    size_t snapshot_size = (size_t) jerry_get_number_value (generate_result);
-  }
-
-  jerry_release_value (generate_result);
-
-  jerry_cleanup ();
-  return 0;
-}
-```
-
-**See also**
-
-- [jerry_init](#jerry_init)
-- [jerry_cleanup](#jerry_cleanup)
-- [jerry_generate_snapshot](#jerry_generate_snapshot)
 - [jerry_parse_options_t](#jerry_parse_options_t)
 
 
@@ -10645,13 +10523,17 @@ main (void)
 
   const jerry_char_t script_to_snapshot[] = "(function () { return 'string from snapshot'; }) ();";
 
-  jerry_value_t generate_result;
-  generate_result = jerry_generate_snapshot (script_to_snapshot,
-                                             sizeof (script_to_snapshot) - 1,
-                                             NULL,
-                                             0,
-                                             snapshot_buffer,
-                                             sizeof (snapshot_buffer) / sizeof (uint32_t));
+  jerry_value_t parse_result = jerry_parse (script_to_snapshot,
+                                            sizeof (script_to_snapshot) - 1,
+                                            NULL);
+
+  size_t buffer_size = sizeof (snapshot_buffer) / sizeof (uint32_t);
+  jerry_value_t generate_result = jerry_generate_snapshot (parse_result,
+                                                           0,
+                                                           snapshot_buffer,
+                                                           buffer_size);
+  jerry_release_value (parse_result);
+
   /* 'generate_result' variable should be checked whether it contains an error. */
 
   size_t snapshot_size = (size_t) jerry_get_number_value (generate_result);
@@ -10689,18 +10571,24 @@ main (void)
   /* 2nd example: function snapshot. */
   jerry_init (JERRY_INIT_EMPTY);
 
-  const jerry_char_t function_to_snapshot_args[] = "a, b";
   const jerry_char_t function_to_snapshot[] = "return a + b;";
 
-  jerry_value_t generate_result;
-  generate_result = jerry_generate_function_snapshot (function_to_snapshot,
-                                                      sizeof (function_to_snapshot) - 1,
-                                                      function_to_snapshot_args,
-                                                      sizeof (function_to_snapshot_args) - 1,
-                                                      NULL,
-                                                      0,
-                                                      snapshot_buffer,
-                                                      sizeof (snapshot_buffer) / sizeof (uint32_t));
+  jerry_parse_options_t parse_options;
+  parse_options.options = JERRY_PARSE_HAS_ARGUMENT_LIST;
+  parse_options.argument_list = jerry_create_string ((const jerry_char_t *) "a, b");
+
+  jerry_value_t parse_result = jerry_parse (function_to_snapshot,
+                                            sizeof (function_to_snapshot) - 1,
+                                            &parse_options);
+
+  size_t buffer_size = sizeof (snapshot_buffer) / sizeof (uint32_t);
+  jerry_value_t generate_result = jerry_generate_snapshot (parse_result,
+                                                           0,
+                                                           snapshot_buffer,
+                                                           buffer_size);
+  jerry_release_value (parse_result);
+  jerry_release_value (parse_options.argument_list);
+
   /* 'generate_result' variable should be checked whether it contains an error. */
 
   size_t snapshot_size = (size_t) jerry_get_number_value (generate_result);
@@ -10740,7 +10628,6 @@ main (void)
 - [jerry_init](#jerry_init)
 - [jerry_cleanup](#jerry_cleanup)
 - [jerry_generate_snapshot](#jerry_generate_snapshot)
-- [jerry_generate_function_snapshot](#jerry_generate_function_snapshot)
 
 
 ## jerry_get_literals_from_snapshot
@@ -10795,12 +10682,17 @@ main (void)
   static uint32_t snapshot_buffer[256];
   const jerry_char_t script_for_literal_save[] = "var obj = { a:'aa', bb:'Bb' }";
 
-  jerry_value_t generate_result = jerry_generate_snapshot (script_for_literal_save,
-                                                           sizeof (script_for_literal_save) - 1,
-                                                           NULL,
+  jerry_value_t parse_result = jerry_parse (script_for_literal_save,
+                                            sizeof (script_for_literal_save) - 1,
+                                            NULL);
+
+  size_t buffer_size = sizeof (snapshot_buffer) / sizeof (uint32_t);
+  jerry_value_t generate_result = jerry_generate_snapshot (parse_result,
                                                            0,
                                                            snapshot_buffer,
-                                                           256);
+                                                           buffer_size);
+  jerry_release_value (parse_result);
+
   size_t snapshot_size = (size_t) jerry_get_number_value (generate_result);
   jerry_release_value (generate_result);
 
@@ -11667,9 +11559,7 @@ main (void)
 **See also**
 
 - [jerry_parse](#jerry_parse)
-- [jerry_parse_function](#jerry_parse_function)
 - [jerry_generate_snapshot](#jerry_generate_snapshot)
-- [jerry_generate_function_snapshot](#jerry_generate_function_snapshot)
 - [jerry_exec_snapshot](#jerry_exec_snapshot)
 
 

--- a/jerry-core/debugger/debugger.c
+++ b/jerry-core/debugger/debugger.c
@@ -548,7 +548,11 @@ jerry_debugger_send_eval (const lit_utf8_byte_t *eval_string_p, /**< evaluated s
   memcpy (&chain_index, eval_string_p, sizeof (uint32_t));
   uint32_t parse_opts = ECMA_PARSE_DIRECT_EVAL | (chain_index << ECMA_PARSE_CHAIN_INDEX_SHIFT);
 
-  ecma_value_t result = ecma_op_eval_chars_buffer (eval_string_p + 5, eval_string_size - 5, parse_opts);
+  parser_source_char_t source_char;
+  source_char.source_p = eval_string_p + 5;
+  source_char.source_size = eval_string_size - 5;
+
+  ecma_value_t result = ecma_op_eval_chars_buffer ((void *) &source_char, parse_opts);
   JERRY_DEBUGGER_CLEAR_FLAGS (JERRY_DEBUGGER_VM_IGNORE);
 
   if (!ECMA_IS_VALUE_ERROR (result))

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -115,12 +115,20 @@ typedef enum
   ECMA_PARSE_ALLOW_NEW_TARGET = (1u << 8), /**< allow new.target access */
   ECMA_PARSE_FUNCTION_CONTEXT = (1u << 9), /**< function context is present (ECMA_PARSE_DIRECT_EVAL must be set) */
 
-  ECMA_PARSE_GENERATOR_FUNCTION = (1u << 10), /**< generator function is parsed */
-  ECMA_PARSE_ASYNC_FUNCTION = (1u << 11), /**< async function is parsed */
+  ECMA_PARSE_HAS_SOURCE_VALUE = (1u << 10), /**< source_p points to a value list
+                                             *   and the first value is the source code */
+  ECMA_PARSE_HAS_ARGUMENT_LIST_VALUE = (1u << 11), /**< source_p points to a value list
+                                                    *   and the second value is the argument list */
+#if JERRY_ESNEXT
+  ECMA_PARSE_GENERATOR_FUNCTION = (1u << 12), /**< generator function is parsed */
+  ECMA_PARSE_ASYNC_FUNCTION = (1u << 13), /**< async function is parsed */
+#endif /* JERRY_ESNEXT */
 
   /* These flags are internally used by the parser. */
+  ECMA_PARSE_INTERNAL_FREE_SOURCE = (1u << 14), /**< free source_p data */
+  ECMA_PARSE_INTERNAL_FREE_ARG_LIST = (1u << 15), /**< free arg_list_p data */
 #if JERRY_ESNEXT
-  ECMA_PARSE_INTERNAL_PRE_SCANNING = (1u << 12),
+  ECMA_PARSE_INTERNAL_PRE_SCANNING = (1u << 16), /**< the parser is in pre-scanning mode */
 #endif /* JERRY_ESNEXT */
 #ifndef JERRY_NDEBUG
   /**

--- a/jerry-core/ecma/base/ecma-literal-storage.c
+++ b/jerry-core/ecma/base/ecma-literal-storage.c
@@ -714,7 +714,7 @@ ecma_snapshot_get_literal (const uint8_t *literal_base_p, /**< literal start */
  * @return pointer to the beginning of the serializable ecma-values
  */
 ecma_value_t *
-ecma_snapshot_resolve_serializable_values (ecma_compiled_code_t *compiled_code_p, /**< compiled code */
+ecma_snapshot_resolve_serializable_values (const ecma_compiled_code_t *compiled_code_p, /**< compiled code */
                                            uint8_t *bytecode_end_p) /**< end of the bytecode */
 {
   ecma_value_t *base_p = (ecma_value_t *) bytecode_end_p;

--- a/jerry-core/ecma/base/ecma-literal-storage.h
+++ b/jerry-core/ecma/base/ecma-literal-storage.h
@@ -59,7 +59,7 @@ bool ecma_save_literals_for_snapshot (ecma_collection_t *lit_pool_p, uint32_t *b
 ecma_value_t
 ecma_snapshot_get_literal (const uint8_t *literal_base_p, ecma_value_t literal_value);
 ecma_value_t *
-ecma_snapshot_resolve_serializable_values (ecma_compiled_code_t *compiled_code_p, uint8_t *byte_code_end_p);
+ecma_snapshot_resolve_serializable_values (const ecma_compiled_code_t *compiled_code_p, uint8_t *byte_code_end_p);
 #endif /* JERRY_SNAPSHOT_EXEC || JERRY_SNAPSHOT_SAVE */
 
 /**

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -107,7 +107,7 @@ ecma_builtin_global_object_eval (ecma_value_t x) /**< routine's first argument *
 #endif /* JERRY_ESNEXT */
 
   /* steps 2 to 8 */
-  return ecma_op_eval (ecma_get_string_from_value (x), parse_opts);
+  return ecma_op_eval (x, parse_opts);
 } /* ecma_builtin_global_object_eval */
 
 /**

--- a/jerry-core/ecma/operations/ecma-eval.h
+++ b/jerry-core/ecma/operations/ecma-eval.h
@@ -26,10 +26,10 @@
  */
 
 ecma_value_t
-ecma_op_eval (ecma_string_t *code_p, uint32_t parse_opts);
+ecma_op_eval (ecma_value_t source_code, uint32_t parse_opts);
 
 ecma_value_t
-ecma_op_eval_chars_buffer (const lit_utf8_byte_t *code_p, size_t code_buffer_size, uint32_t parse_opts);
+ecma_op_eval_chars_buffer (void *source_p, uint32_t parse_opts);
 
 /**
  * @}

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -454,18 +454,14 @@ ecma_op_create_dynamic_function (const ecma_value_t *arguments_list_p, /**< argu
     function_body_str_p = ecma_get_magic_string (LIT_MAGIC_STRING__EMPTY);
   }
 
-  ECMA_STRING_TO_UTF8_STRING (arguments_str_p, arguments_buffer_p, arguments_buffer_size);
-  ECMA_STRING_TO_UTF8_STRING (function_body_str_p, function_body_buffer_p, function_body_buffer_size);
+  ecma_value_t source[2];
+  source[0] = ecma_make_string_value (function_body_str_p);
+  source[1] = ecma_make_string_value (arguments_str_p);
 
-  ecma_compiled_code_t *bytecode_p = parser_parse_script (arguments_buffer_p,
-                                                          arguments_buffer_size,
-                                                          function_body_buffer_p,
-                                                          function_body_buffer_size,
-                                                          parse_opts,
-                                                          NULL);
+  parse_opts |= ECMA_PARSE_HAS_SOURCE_VALUE | ECMA_PARSE_HAS_ARGUMENT_LIST_VALUE;
 
-  ECMA_FINALIZE_UTF8_STRING (function_body_buffer_p, function_body_buffer_size);
-  ECMA_FINALIZE_UTF8_STRING (arguments_buffer_p, arguments_buffer_size);
+  ecma_compiled_code_t *bytecode_p = parser_parse_script ((void *) source, parse_opts, NULL);
+
   ecma_deref_ecma_string (arguments_str_p);
   ecma_deref_ecma_string (function_body_str_p);
 

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -46,9 +46,7 @@ bool jerry_get_memory_stats (jerry_heap_stats_t *out_stats_p);
 bool jerry_run_simple (const jerry_char_t *script_source_p, size_t script_source_size, jerry_init_flag_t flags);
 jerry_value_t jerry_parse (const jerry_char_t *source_p, size_t source_size,
                            const jerry_parse_options_t *options_p);
-jerry_value_t jerry_parse_function (const jerry_char_t *arg_list_p, size_t arg_list_size,
-                                    const jerry_char_t *source_p, size_t source_size,
-                                    const jerry_parse_options_t *options_p);
+jerry_value_t jerry_parse_value (const jerry_value_t source_value, const jerry_parse_options_t *options_p);
 jerry_value_t jerry_run (const jerry_value_t func_val);
 jerry_value_t jerry_eval (const jerry_char_t *source_p, size_t source_size, uint32_t parse_opts);
 

--- a/jerry-core/include/jerryscript-snapshot.h
+++ b/jerry-core/include/jerryscript-snapshot.h
@@ -70,14 +70,8 @@ typedef struct
 /**
  * Snapshot functions.
  */
-jerry_value_t jerry_generate_snapshot (const jerry_char_t *source_p, size_t source_size,
-                                       const jerry_parse_options_t *options_p, uint32_t generate_snapshot_opts,
+jerry_value_t jerry_generate_snapshot (jerry_value_t compiled_code, uint32_t generate_snapshot_opts,
                                        uint32_t *buffer_p, size_t buffer_size);
-jerry_value_t jerry_generate_function_snapshot (const jerry_char_t *source_p, size_t source_size,
-                                                const jerry_char_t *args_p, size_t args_size,
-                                                const jerry_parse_options_t *options_p,
-                                                uint32_t generate_snapshot_opts,
-                                                uint32_t *buffer_p, size_t buffer_size);
 
 jerry_value_t jerry_exec_snapshot (const uint32_t *snapshot_p, size_t snapshot_size,
                                    size_t func_index, uint32_t exec_snapshot_opts,

--- a/jerry-core/include/jerryscript-types.h
+++ b/jerry-core/include/jerryscript-types.h
@@ -167,9 +167,10 @@ typedef enum
   JERRY_PARSE_NO_OPTS = 0, /**< no options passed */
   JERRY_PARSE_STRICT_MODE = (1 << 0), /**< enable strict mode */
   JERRY_PARSE_MODULE = (1 << 1), /**< parse source as an ECMAScript module */
-  JERRY_PARSE_HAS_RESOURCE = (1 << 2), /**< resource_name field is valid */
-  JERRY_PARSE_HAS_START = (1 << 3), /**< start_line and start_column fields are valid */
-  JERRY_PARSE_HAS_USER_VALUE = (1 << 4), /**< user_value field is valid */
+  JERRY_PARSE_HAS_ARGUMENT_LIST = (1 << 2), /**< argument_list field is valid */
+  JERRY_PARSE_HAS_RESOURCE = (1 << 3), /**< resource_name field is valid */
+  JERRY_PARSE_HAS_START = (1 << 4), /**< start_line and start_column fields are valid */
+  JERRY_PARSE_HAS_USER_VALUE = (1 << 5), /**< user_value field is valid */
 } jerry_parse_option_enable_feature_t;
 
 /**
@@ -178,9 +179,11 @@ typedef enum
 typedef struct
 {
   uint32_t options; /**< combination of jerry_parse_option_enable_feature_t values */
+  jerry_value_t argument_list; /**< function argument list if JERRY_PARSE_HAS_ARGUMENT_LIST is set in options
+                                *   Note: must be string value */
   jerry_value_t resource_name; /**< resource name string (usually a file name)
                                 *   if JERRY_PARSE_HAS_RESOURCE is set in options
-                                *   Note: non-string values are ignored */
+                                *   Note: must be string value */
   uint32_t start_line; /**< start line of the source code if JERRY_PARSE_HAS_START is set in options */
   uint32_t start_column; /**< start column of the source code if JERRY_PARSE_HAS_START is set in options */
   jerry_value_t user_value; /**< user value assigned to all functions created by this script including eval

--- a/jerry-core/parser/js/js-parser-internal.h
+++ b/jerry-core/parser/js/js-parser-internal.h
@@ -567,6 +567,10 @@ typedef struct
   parser_saved_context_t *last_context_p;     /**< last saved context */
   parser_stack_iterator_t last_statement;     /**< last statement position */
   cbc_script_t *script_p;                     /**< current script */
+  const uint8_t *source_start_p;              /**< source start */
+  lit_utf8_size_t source_size;                /**< source size */
+  const uint8_t *arguments_start_p;           /**< function argument list start */
+  lit_utf8_size_t arguments_size;             /**< function argument list size */
   ecma_value_t script_value;                  /**< current script as value */
   ecma_value_t user_value;                    /**< current user value */
 
@@ -853,8 +857,7 @@ bool scanner_literal_is_created (parser_context_t *context_p, uint16_t literal_i
 bool scanner_literal_exists (parser_context_t *context_p, uint16_t literal_index);
 #endif /* JERRY_ESNEXT */
 
-void scanner_scan_all (parser_context_t *context_p, const uint8_t *arg_list_p, const uint8_t *arg_list_end_p,
-                       const uint8_t *source_p, const uint8_t *source_end_p);
+void scanner_scan_all (parser_context_t *context_p);
 
 /**
  * @}

--- a/jerry-core/parser/js/js-parser.h
+++ b/jerry-core/parser/js/js-parser.h
@@ -192,11 +192,18 @@ typedef enum
  */
 typedef uint32_t parser_line_counter_t;
 
+/**
+ * Source code as character data.
+ */
+typedef struct
+{
+  const uint8_t *source_p; /**< valid UTF-8 source code */
+  size_t source_size; /**< size of the source code */
+} parser_source_char_t;
+
 /* Note: source must be a valid UTF-8 string */
 ecma_compiled_code_t *
-parser_parse_script (const uint8_t *arg_list_p, size_t arg_list_size,
-                     const uint8_t *source_p, size_t source_size,
-                     uint32_t parse_opts, const jerry_parse_options_t *options_p);
+parser_parse_script (void *source_p, uint32_t parse_opts, const jerry_parse_options_t *options_p);
 
 #if JERRY_ERROR_MESSAGES
 const char *parser_error_to_string (parser_error_t);

--- a/tests/unit-core/test-regexp-dotall-unicode.c
+++ b/tests/unit-core/test-regexp-dotall-unicode.c
@@ -36,13 +36,14 @@ main (void)
   jerry_value_t regex_obj = jerry_create_regexp (pattern2, flags);
   TEST_ASSERT (jerry_value_is_object (regex_obj));
 
-  const jerry_char_t func_arg_list[] = "regex";
   const jerry_char_t func_src2[] = "return [regex.exec('a\\nb'), regex.dotAll, regex.sticky, regex.unicode ];";
-  jerry_value_t func_val = jerry_parse_function (func_arg_list,
-                                                 sizeof (func_arg_list) - 1,
-                                                 func_src2,
-                                                 sizeof (func_src2) - 1,
-                                                 NULL);
+
+  jerry_parse_options_t parse_options;
+  parse_options.options = JERRY_PARSE_HAS_ARGUMENT_LIST;
+  parse_options.argument_list = jerry_create_string ((const jerry_char_t *) "regex");
+
+  jerry_value_t func_val = jerry_parse (func_src2, sizeof (func_src2) - 1, &parse_options);
+  jerry_release_value (parse_options.argument_list);
 
   jerry_value_t res = jerry_call_function (func_val, undefined_this_arg, &regex_obj, 1);
   jerry_value_t regex_res = jerry_get_property_by_index (res, 0);

--- a/tests/unit-core/test-regexp.c
+++ b/tests/unit-core/test-regexp.c
@@ -30,13 +30,14 @@ main (void)
   jerry_value_t regex_obj = jerry_create_regexp (pattern, flags);
   TEST_ASSERT (jerry_value_is_object (regex_obj));
 
-  const jerry_char_t func_arg_list[] = "regex";
   const jerry_char_t func_src[] = "return [regex.exec('something.domain.com'), regex.multiline, regex.global];";
-  jerry_value_t func_val = jerry_parse_function (func_arg_list,
-                                                 sizeof (func_arg_list) - 1,
-                                                 func_src,
-                                                 sizeof (func_src) - 1,
-                                                 NULL);
+
+  jerry_parse_options_t parse_options;
+  parse_options.options = JERRY_PARSE_HAS_ARGUMENT_LIST;
+  parse_options.argument_list = jerry_create_string ((const jerry_char_t *) "regex");
+
+  jerry_value_t func_val = jerry_parse (func_src, sizeof (func_src) - 1, &parse_options);
+  jerry_release_value (parse_options.argument_list);
 
   jerry_value_t res = jerry_call_function (func_val, global_obj_val, &regex_obj, 1);
   jerry_value_t regex_res = jerry_get_property_by_index (res, 0);

--- a/tests/unit-core/test-script-user-value.c
+++ b/tests/unit-core/test-script-user-value.c
@@ -62,15 +62,16 @@ test_parse_function (const char *source_p, /**< source code */
                      jerry_parse_options_t *options_p, /**< options passed to jerry_parse */
                      bool run_code) /**< run the code after parsing */
 {
+  options_p->options |= JERRY_PARSE_HAS_ARGUMENT_LIST;
+  options_p->argument_list = jerry_create_string ((const jerry_char_t *) "");
+
   for (size_t i = 0; i < USER_VALUES_SIZE; i++)
   {
     options_p->user_value = user_values[i];
 
-    jerry_value_t result = jerry_parse_function ((const jerry_char_t *) "",
-                                                 0,
-                                                 (const jerry_char_t *) source_p,
-                                                 strlen (source_p),
-                                                 options_p);
+    jerry_value_t result = jerry_parse ((const jerry_char_t *) source_p,
+                                        strlen (source_p),
+                                        options_p);
     TEST_ASSERT (!jerry_value_is_error (result));
 
     if (run_code)
@@ -94,6 +95,8 @@ test_parse_function (const char *source_p, /**< source code */
     jerry_release_value (user_value);
     jerry_release_value (result);
   }
+
+  jerry_release_value (options_p->argument_list);
 } /* test_parse_function */
 
 int


### PR DESCRIPTION
Function arguments must be passed as string values.

This patch is mostly a preparation for a future `toString` support. Passing scripts as strings is optional, but it can reduce memory consumption if used well.

Function arguments must be string values after this patch is landed. I think these are used in special cases, and most applications use only a few argument list variations. This way we encourage to store them as global values. The worst case is some extra memory consumption during parsing, since function arguments are rarely large strings. External strings is also a way to control them.