### PR TITLE
Remove redundant checks from builtin-dispatchers

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-iterator-prototype.c
@@ -209,8 +209,7 @@ ecma_builtin_array_iterator_prototype_dispatch_routine (uint8_t builtin_routine_
                                                                                                 *   passed to routine */
                                                         uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (arguments_list_p, arguments_number);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -2977,8 +2977,6 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
   }
 
   ecma_value_t ret_value;
-  ecma_value_t routine_arg_1 = arguments_list_p[0];
-  ecma_value_t routine_arg_2 = arguments_list_p[1];
 
   switch (builtin_routine_id)
   {
@@ -2989,7 +2987,7 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     }
     case ECMA_ARRAY_PROTOTYPE_JOIN:
     {
-      ret_value = ecma_builtin_array_prototype_join (routine_arg_1, obj_p, length);
+      ret_value = ecma_builtin_array_prototype_join (arguments_list_p[0], obj_p, length);
       break;
     }
     case ECMA_ARRAY_PROTOTYPE_POP:
@@ -3017,8 +3015,8 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     }
     case ECMA_ARRAY_PROTOTYPE_SLICE:
     {
-      ret_value = ecma_builtin_array_prototype_object_slice (routine_arg_1,
-                                                             routine_arg_2,
+      ret_value = ecma_builtin_array_prototype_object_slice (arguments_list_p[0],
+                                                             arguments_list_p[1],
                                                              obj_p,
                                                              length);
       break;
@@ -3041,7 +3039,7 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     }
     case ECMA_ARRAY_PROTOTYPE_AT:
     {
-      ret_value = ecma_builtin_array_prototype_object_at (routine_arg_1,
+      ret_value = ecma_builtin_array_prototype_object_at (arguments_list_p[0],
                                                           obj_p,
                                                           length);
       break;
@@ -3066,8 +3064,8 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     case ECMA_ARRAY_PROTOTYPE_SOME:
     case ECMA_ARRAY_PROTOTYPE_FOR_EACH:
     {
-      ret_value = ecma_builtin_array_apply (routine_arg_1,
-                                            routine_arg_2,
+      ret_value = ecma_builtin_array_apply (arguments_list_p[0],
+                                            arguments_list_p[1],
                                             (array_routine_mode) builtin_routine_id - ECMA_ARRAY_PROTOTYPE_EVERY,
                                             obj_p,
                                             length);
@@ -3075,8 +3073,8 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     }
     case ECMA_ARRAY_PROTOTYPE_MAP:
     {
-      ret_value = ecma_builtin_array_prototype_object_map (routine_arg_1,
-                                                           routine_arg_2,
+      ret_value = ecma_builtin_array_prototype_object_map (arguments_list_p[0],
+                                                           arguments_list_p[1],
                                                            obj_p,
                                                            length);
       break;
@@ -3103,8 +3101,8 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     case ECMA_ARRAY_PROTOTYPE_FIND:
     case ECMA_ARRAY_PROTOTYPE_FIND_INDEX:
     {
-      ret_value = ecma_builtin_array_prototype_object_find (routine_arg_1,
-                                                            routine_arg_2,
+      ret_value = ecma_builtin_array_prototype_object_find (arguments_list_p[0],
+                                                            arguments_list_p[1],
                                                             builtin_routine_id == ECMA_ARRAY_PROTOTYPE_FIND,
                                                             obj_p,
                                                             length);
@@ -3112,8 +3110,8 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     }
     case ECMA_ARRAY_PROTOTYPE_FILL:
     {
-      ret_value = ecma_builtin_array_prototype_fill (routine_arg_1,
-                                                     routine_arg_2,
+      ret_value = ecma_builtin_array_prototype_fill (arguments_list_p[0],
+                                                     arguments_list_p[1],
                                                      arguments_list_p[2],
                                                      obj_p,
                                                      length);
@@ -3137,8 +3135,8 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     }
     case ECMA_ARRAY_PROTOTYPE_FLATMAP:
     {
-      ret_value = ecma_builtin_array_prototype_object_flat_map (routine_arg_1,
-                                                                routine_arg_2,
+      ret_value = ecma_builtin_array_prototype_object_flat_map (arguments_list_p[0],
+                                                                arguments_list_p[1],
                                                                 obj_p,
                                                                 length);
       break;
@@ -3148,8 +3146,8 @@ ecma_builtin_array_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
     {
       JERRY_ASSERT (builtin_routine_id == ECMA_ARRAY_PROTOTYPE_FILTER);
 
-      ret_value = ecma_builtin_array_prototype_object_filter (routine_arg_1,
-                                                              routine_arg_2,
+      ret_value = ecma_builtin_array_prototype_object_filter (arguments_list_p[0],
+                                                              arguments_list_p[1],
                                                               obj_p,
                                                               length);
       break;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array.c
@@ -550,13 +550,15 @@ ecma_builtin_array_dispatch_routine (uint8_t builtin_routine_id, /**< built-in w
                                                                              *   passed to routine */
                                      uint32_t arguments_number) /**< length of arguments' list */
 {
+  JERRY_UNUSED (arguments_number);
+
   switch (builtin_routine_id)
   {
     case ECMA_ARRAY_ROUTINE_IS_ARRAY:
     {
       JERRY_UNUSED (this_arg);
 
-      return arguments_number > 0 ? ecma_is_value_array (arguments_list_p[0]) : ECMA_VALUE_FALSE;
+      return ecma_is_value_array (arguments_list_p[0]);
     }
 #if JERRY_ESNEXT
     case ECMA_ARRAY_ROUTINE_FROM:

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-async-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-async-iterator-prototype.c
@@ -83,8 +83,7 @@ ecma_builtin_async_iterator_prototype_dispatch_routine (uint8_t builtin_routine_
                                                                                                 * passed to routine */
                                                         uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (arguments_list_p, arguments_number);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-boolean-prototype.c
@@ -105,8 +105,7 @@ ecma_builtin_boolean_prototype_dispatch_routine (uint8_t builtin_routine_id, /**
                                                                                          *   passed to routine */
                                                  uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_number);
-  JERRY_UNUSED (arguments_list_p);
+  JERRY_UNUSED_2 (arguments_number, arguments_list_p);
 
   ecma_value_t value_of_ret = ecma_builtin_boolean_prototype_object_value_of (this_arg);
   if (builtin_routine_id == ECMA_BOOLEAN_PROTOTYPE_ROUTINE_VALUE_OF)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-dataview-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-dataview-prototype.c
@@ -152,8 +152,7 @@ ecma_builtin_dataview_prototype_dispatch_routine (uint8_t builtin_routine_id, /*
                                                                                           *   passed to routine */
                                                   uint32_t arguments_number) /**< length of arguments' list */
 {
-  ecma_value_t byte_offset = arguments_number > 0 ? arguments_list_p[0] : ECMA_VALUE_UNDEFINED;
-
+  JERRY_UNUSED (arguments_number);
   switch (builtin_routine_id)
   {
     case ECMA_DATAVIEW_PROTOTYPE_BUFFER_GETTER:
@@ -175,10 +174,12 @@ ecma_builtin_dataview_prototype_dispatch_routine (uint8_t builtin_routine_id, /*
     case ECMA_DATAVIEW_PROTOTYPE_GET_BIGUINT64:
 #endif /* JERRY_BUILTIN_BIGINT */
     {
-      ecma_value_t little_endian = arguments_number > 1 ? arguments_list_p[1] : ECMA_VALUE_FALSE;
       ecma_typedarray_type_t id = (ecma_typedarray_type_t) (builtin_routine_id - ECMA_DATAVIEW_PROTOTYPE_GET_INT8);
 
-      return ecma_op_dataview_get_set_view_value (this_arg, byte_offset, little_endian, ECMA_VALUE_EMPTY, id);
+      return ecma_op_dataview_get_set_view_value (this_arg,
+                                                  arguments_list_p[0],
+                                                  arguments_list_p[1],
+                                                  ECMA_VALUE_EMPTY, id);
     }
     case ECMA_DATAVIEW_PROTOTYPE_SET_FLOAT32:
 #if JERRY_NUMBER_TYPE_FLOAT64
@@ -193,27 +194,36 @@ ecma_builtin_dataview_prototype_dispatch_routine (uint8_t builtin_routine_id, /*
     case ECMA_DATAVIEW_PROTOTYPE_SET_BIGUINT64:
 #endif /* JERRY_BUILTIN_BIGINT */
     {
-      ecma_value_t value_to_set = arguments_number > 1 ? arguments_list_p[1] : ECMA_VALUE_UNDEFINED;
-      ecma_value_t little_endian = arguments_number > 2 ? arguments_list_p[2] : ECMA_VALUE_FALSE;
       ecma_typedarray_type_t id = (ecma_typedarray_type_t) (builtin_routine_id - ECMA_DATAVIEW_PROTOTYPE_SET_INT8);
 
-      return ecma_op_dataview_get_set_view_value (this_arg, byte_offset, little_endian, value_to_set, id);
+      return ecma_op_dataview_get_set_view_value (this_arg,
+                                                  arguments_list_p[0],
+                                                  arguments_list_p[2],
+                                                  arguments_list_p[1],
+                                                  id);
     }
     case ECMA_DATAVIEW_PROTOTYPE_GET_INT8:
     case ECMA_DATAVIEW_PROTOTYPE_GET_UINT8:
     {
       ecma_typedarray_type_t id = (ecma_typedarray_type_t) (builtin_routine_id - ECMA_DATAVIEW_PROTOTYPE_GET_INT8);
 
-      return ecma_op_dataview_get_set_view_value (this_arg, byte_offset, ECMA_VALUE_FALSE, ECMA_VALUE_EMPTY, id);
+      return ecma_op_dataview_get_set_view_value (this_arg,
+                                                  arguments_list_p[0],
+                                                  ECMA_VALUE_FALSE,
+                                                  ECMA_VALUE_EMPTY,
+                                                  id);
     }
     default:
     {
       JERRY_ASSERT (builtin_routine_id == ECMA_DATAVIEW_PROTOTYPE_SET_INT8
                     || builtin_routine_id == ECMA_DATAVIEW_PROTOTYPE_SET_UINT8);
-      ecma_value_t value_to_set = arguments_number > 1 ? arguments_list_p[1] : ECMA_VALUE_UNDEFINED;
       ecma_typedarray_type_t id = (ecma_typedarray_type_t) (builtin_routine_id - ECMA_DATAVIEW_PROTOTYPE_SET_INT8);
 
-      return ecma_op_dataview_get_set_view_value (this_arg, byte_offset, ECMA_VALUE_FALSE, value_to_set, id);
+      return ecma_op_dataview_get_set_view_value (this_arg,
+                                                  arguments_list_p[0],
+                                                  ECMA_VALUE_FALSE,
+                                                  arguments_list_p[1],
+                                                  id);
     }
   }
 } /* ecma_builtin_dataview_prototype_dispatch_routine */

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -631,8 +631,7 @@ ecma_builtin_date_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< b
 #if JERRY_ESNEXT
   if (JERRY_UNLIKELY (builtin_routine_id == ECMA_DATE_PROTOTYPE_TO_PRIMITIVE))
   {
-    ecma_value_t argument = arguments_number > 0 ? arguments_list[0] : ECMA_VALUE_UNDEFINED;
-    return ecma_builtin_date_prototype_to_primitive (this_arg, argument);
+    return ecma_builtin_date_prototype_to_primitive (this_arg, arguments_list[0]);
   }
 #endif /* JERRY_ESNEXT */
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-error-prototype.c
@@ -159,8 +159,7 @@ ecma_builtin_error_prototype_dispatch_routine (uint8_t builtin_routine_id, /**< 
                                                                                        *  routine */
                                                uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_number);
-  JERRY_UNUSED (arguments_list_p);
+  JERRY_UNUSED_2 (arguments_number, arguments_list_p);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -598,9 +598,7 @@ ecma_builtin_global_dispatch_routine (uint8_t builtin_routine_id, /**< built-in 
                                                                               *   passed to routine */
                                       uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (this_arg);
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (this_arg, arguments_number);
 
   ecma_value_t routine_arg_1 = arguments_list_p[0];
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-iterator-prototype.c
@@ -83,8 +83,7 @@ ecma_builtin_iterator_prototype_dispatch_routine (uint8_t builtin_routine_id, /*
                                                                                           * passed to routine */
                                                   uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (arguments_list_p, arguments_number);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1811,20 +1811,17 @@ ecma_builtin_json_dispatch_routine (uint8_t builtin_routine_id, /**< built-in wi
                                                                             *   passed to routine */
                                     uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (this_arg);
-  ecma_value_t arg1 = (arguments_number > 0) ? arguments_list_p[0] : ECMA_VALUE_UNDEFINED;
-  ecma_value_t arg2 = (arguments_number > 1) ? arguments_list_p[1] : ECMA_VALUE_UNDEFINED;
-  ecma_value_t arg3 = (arguments_number > 2) ? arguments_list_p[2] : ECMA_VALUE_UNDEFINED;
+  JERRY_UNUSED_2 (this_arg, arguments_number);
 
   switch (builtin_routine_id)
   {
     case ECMA_BUILTIN_JSON_PARSE:
     {
-      return ecma_builtin_json_parse (arg1, arg2);
+      return ecma_builtin_json_parse (arguments_list_p[0], arguments_list_p[1]);
     }
     case ECMA_BUILTIN_JSON_STRINGIFY:
     {
-      return ecma_builtin_json_stringify (arg1, arg2, arg3);
+      return ecma_builtin_json_stringify (arguments_list_p[0], arguments_list_p[1], arguments_list_p[2]);
     }
     default:
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-map-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-map-iterator-prototype.c
@@ -82,8 +82,7 @@ ecma_builtin_map_iterator_prototype_dispatch_routine (uint8_t builtin_routine_id
                                                                                               *   passed to routine */
                                                       uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (arguments_list_p, arguments_number);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number-prototype.c
@@ -768,8 +768,6 @@ ecma_builtin_number_prototype_dispatch_routine (uint8_t builtin_routine_id, /**<
 
   ecma_number_t this_arg_number = ecma_get_number_from_value (this_value);
 
-  ecma_value_t routine_arg_1 = arguments_list_p[0];
-
   switch (builtin_routine_id)
   {
     case ECMA_NUMBER_PROTOTYPE_TO_STRING:
@@ -786,7 +784,7 @@ ecma_builtin_number_prototype_dispatch_routine (uint8_t builtin_routine_id, /**<
     {
       const int option = NUMBER_ROUTINE_TO_FIXED + (builtin_routine_id - ECMA_NUMBER_PROTOTYPE_TO_FIXED);
       return ecma_builtin_number_prototype_object_to_number_convert (this_arg_number,
-                                                                     routine_arg_1,
+                                                                     arguments_list_p[0],
                                                                      (number_routine_mode_t) option);
     }
     default:

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-number.c
@@ -206,8 +206,7 @@ ecma_builtin_number_dispatch_routine (uint8_t builtin_routine_id, /**< built-in 
                                                                               *   passed to routine */
                                       uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (this_arg);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (this_arg, arguments_number);
 
   if (!ecma_is_value_number (arguments_list_p[0]))
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -1379,9 +1379,7 @@ ecma_builtin_object_dispatch_routine (uint8_t builtin_routine_id, /**< built-in 
                                                                               *   passed to routine */
                                       uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (this_arg);
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (this_arg, arguments_number);
 
   ecma_value_t arg1 = arguments_list_p[0];
   ecma_value_t arg2 = arguments_list_p[1];

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise-prototype.c
@@ -64,23 +64,22 @@ ecma_builtin_promise_prototype_dispatch_routine (uint8_t builtin_routine_id, /**
                                                                                          *   passed to routine */
                                                  uint32_t arguments_number) /**< length of arguments' list */
 {
-  ecma_value_t arg_1 = (arguments_number > 0) ? arguments_list_p[0] : ECMA_VALUE_UNDEFINED;
+  JERRY_UNUSED (arguments_number);
 
   switch (builtin_routine_id)
   {
     case ECMA_PROMISE_PROTOTYPE_ROUTINE_THEN:
     {
-      ecma_value_t arg_2 = (arguments_number > 1) ? arguments_list_p[1] : ECMA_VALUE_UNDEFINED;
-      return ecma_promise_then (this_arg, arg_1, arg_2);
+      return ecma_promise_then (this_arg, arguments_list_p[0], arguments_list_p[1]);
     }
     case ECMA_PROMISE_PROTOTYPE_ROUTINE_CATCH:
     {
-      ecma_value_t args[] = {ECMA_VALUE_UNDEFINED, arg_1};
+      ecma_value_t args[] = {ECMA_VALUE_UNDEFINED, arguments_list_p[0]};
       return ecma_op_invoke_by_magic_id (this_arg, LIT_MAGIC_STRING_THEN, args, 2);
     }
     case ECMA_PROMISE_PROTOTYPE_ROUTINE_FINALLY:
     {
-      return ecma_promise_finally (this_arg, arg_1);
+      return ecma_promise_finally (this_arg, arguments_list_p[0]);
     }
     default:
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-promise.c
@@ -529,7 +529,7 @@ ecma_builtin_promise_dispatch_routine (uint8_t builtin_routine_id, /**< built-in
                                                                                *   passed to routine */
                                        uint32_t arguments_number) /**< length of arguments' list */
 {
-  ecma_value_t argument = (arguments_number > 0) ? arguments_list_p[0] : ECMA_VALUE_UNDEFINED;
+  JERRY_UNUSED (arguments_number);
 
   switch (builtin_routine_id)
   {
@@ -537,14 +537,14 @@ ecma_builtin_promise_dispatch_routine (uint8_t builtin_routine_id, /**< built-in
     case ECMA_PROMISE_ROUTINE_RESOLVE:
     {
       bool is_resolve = (builtin_routine_id == ECMA_PROMISE_ROUTINE_RESOLVE);
-      return ecma_promise_reject_or_resolve (this_arg, argument, is_resolve);
+      return ecma_promise_reject_or_resolve (this_arg, arguments_list_p[0], is_resolve);
     }
     case ECMA_PROMISE_ROUTINE_RACE:
     case ECMA_PROMISE_ROUTINE_ALL:
     case ECMA_PROMISE_ROUTINE_ALLSETTLED:
     case ECMA_PROMISE_ROUTINE_ANY:
     {
-      return ecma_builtin_promise_helper (this_arg, argument, builtin_routine_id);
+      return ecma_builtin_promise_helper (this_arg, arguments_list_p[0], builtin_routine_id);
     }
     case ECMA_PROMISE_ROUTINE_SPECIES_GET:
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-proxy.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-proxy.c
@@ -136,16 +136,13 @@ ecma_builtin_proxy_dispatch_routine (uint8_t builtin_routine_id, /**< built-in w
                                                                              *   passed to routine */
                                      uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (this_arg);
-
-  ecma_value_t arg0 = (arguments_number > 0) ? arguments_list_p[0] : ECMA_VALUE_UNDEFINED;
-  ecma_value_t arg1 = (arguments_number > 1) ? arguments_list_p[1] : ECMA_VALUE_UNDEFINED;
+  JERRY_UNUSED_2 (this_arg, arguments_number);
 
   switch (builtin_routine_id)
   {
     case ECMA_BUILTIN_PROXY_OBJECT_REVOCABLE:
     {
-      return ecma_builtin_proxy_object_revocable (arg0, arg1);
+      return ecma_builtin_proxy_object_revocable (arguments_list_p[0], arguments_list_p[1]);
     }
     default:
     {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-reflect.c
@@ -84,7 +84,6 @@ ecma_builtin_reflect_dispatch_routine (uint8_t builtin_routine_id, /**< built-in
                                        uint32_t arguments_number) /**< length of arguments' list */
 {
   JERRY_UNUSED (this_arg);
-  JERRY_UNUSED (arguments_number);
 
   if (builtin_routine_id < ECMA_REFLECT_OBJECT_CONSTRUCT)
   {
@@ -95,8 +94,7 @@ ecma_builtin_reflect_dispatch_routine (uint8_t builtin_routine_id, /**< built-in
     }
 
     /* 2. */
-    ecma_string_t *name_str_p = ecma_op_to_property_key (((arguments_number > 1) ? arguments_list[1]
-                                                                                 : ECMA_VALUE_UNDEFINED));
+    ecma_string_t *name_str_p = ecma_op_to_property_key (arguments_list[1]);
 
     /* 3. */
     if (name_str_p == NULL)

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-set-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-set-iterator-prototype.c
@@ -82,8 +82,7 @@ ecma_builtin_set_iterator_prototype_dispatch_routine (uint8_t builtin_routine_id
                                                                                             *   passed to routine */
                                                       uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_list);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (arguments_list, arguments_number);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-string-iterator-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-string-iterator-prototype.c
@@ -187,8 +187,7 @@ ecma_builtin_string_iterator_prototype_dispatch_routine (uint8_t builtin_routine
                                                                                                  * passed to routine */
                                                          uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (arguments_list_p, arguments_number);
 
   switch (builtin_routine_id)
   {

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-weakref-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-weakref-prototype.c
@@ -90,8 +90,7 @@ ecma_builtin_weakref_prototype_dispatch_routine (uint8_t builtin_routine_id, /**
                                                                                          *   passed to routine */
                                                  uint32_t arguments_number) /**< length of arguments' list */
 {
-  JERRY_UNUSED (arguments_list_p);
-  JERRY_UNUSED (arguments_number);
+  JERRY_UNUSED_2 (arguments_list_p, arguments_number);
 
   switch (builtin_routine_id)
   {


### PR DESCRIPTION
We don't need to check arguments length inside the custom dispatchers,
because we have already checked within ecma_bultin_dispatch_routine.

JerryScript-DCO-1.0-Signed-off-by: Daniel Batiz batizjob@gmail.com