### PR TITLE
Remove IRC notification action to have a green master

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -293,7 +293,7 @@ jobs:
 
   Notification:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'jerryscript-project/jerryscript'
+    if: false && github.event_name == 'push' && github.repository == 'jerryscript-project/jerryscript'
     steps:
       - uses: rectalogic/notify-irc@v1
         with:


### PR DESCRIPTION
IRC notification GitHub action returns an error at the moment
and makes the master red (even if all builds passed).

Removing this action till we fix the notification.