### PR TITLE
Fix leaking lastIndex values in RegExp built-ins

### DIFF
--- a/jerry-core/ecma/operations/ecma-regexp-object.c
+++ b/jerry-core/ecma/operations/ecma-regexp-object.c
@@ -3496,7 +3496,7 @@ ecma_regexp_match_helper (ecma_value_t this_arg, /**< this argument */
       last_index = ecma_make_length_value (index);
       ecma_value_t next_set_status = ecma_op_object_put (obj_p,
                                                          ecma_get_magic_string (LIT_MAGIC_STRING_LASTINDEX_UL),
-                                                         ecma_make_length_value (index),
+                                                         last_index,
                                                          true);
 #else /* !JERRY_ESNEXT */
       ecma_number_t index = ecma_get_number_from_value (last_index);

--- a/tests/jerry/es.next/regression-test-issue-4781.js
+++ b/tests/jerry/es.next/regression-test-issue-4781.js
@@ -1,0 +1,38 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function testAdvanceStringIndex(lastIndex) {
+  let exec_count = 0;
+  let last_last_index = -1;
+  let fake_re = {
+    exec: () => {
+      return exec_count++ == 0 ? [""] : null;
+    },
+
+    get lastIndex() {
+      return lastIndex;
+    },
+
+    set lastIndex(value) {
+    },
+
+    get global() {
+      return true;
+    }
+  };
+
+  RegExp.prototype[Symbol.match].call(fake_re, "abc");
+}
+
+testAdvanceStringIndex(0x7ffffff);


### PR DESCRIPTION
Fixes #4781. This is a followup fix after #4166.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
