### PR TITLE
Force value conversion in case of TypedArray filter method

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -412,9 +412,7 @@ ecma_builtin_typedarray_prototype_filter (ecma_value_t this_arg, /**< this objec
     return ecma_op_create_typedarray_with_type_and_length (info_p->id, 0);
   }
 
-  JMEM_DEFINE_LOCAL_ARRAY (pass_value_list_p, info_p->length * info_p->element_size, lit_utf8_byte_t);
-
-  lit_utf8_byte_t *pass_value_p = pass_value_list_p;
+  ecma_collection_t *collected_p = ecma_new_collection ();
   uint32_t byte_pos = 0;
 
   for (uint32_t index = 0; index < info_p->length; index++)
@@ -429,50 +427,63 @@ ecma_builtin_typedarray_prototype_filter (ecma_value_t this_arg, /**< this objec
     ecma_value_t call_value = ecma_op_function_call (func_object_p, cb_this_arg, call_args, 3);
 
     ecma_fast_free_value (current_index);
-    ecma_fast_free_value (get_value);
 
     if (ECMA_IS_VALUE_ERROR (call_value))
     {
+      ecma_fast_free_value (get_value);
       goto cleanup;
     }
 
     if (ecma_arraybuffer_is_detached (info_p->array_buffer_p))
     {
       ecma_free_value (call_value);
+      ecma_fast_free_value (get_value);
       ecma_raise_type_error (ECMA_ERR_MSG (ecma_error_arraybuffer_is_detached));
       goto cleanup;
     }
 
     if (ecma_op_to_boolean (call_value))
     {
-      memcpy (pass_value_p, info_p->buffer_p + byte_pos, info_p->element_size);
-      pass_value_p += info_p->element_size;
+      ecma_collection_push_back (collected_p, get_value);
+    }
+    else
+    {
+      ecma_fast_free_value (get_value);
     }
 
     byte_pos += info_p->element_size;
-
-    ecma_free_value (call_value);
+    ecma_fast_free_value (call_value);
   }
 
-  uint32_t pass_num = (uint32_t) ((pass_value_p - pass_value_list_p) >> info_p->shift);
-
-  ecma_value_t collected = ecma_make_number_value (pass_num);
+  ecma_value_t collected = ecma_make_number_value (collected_p->item_count);
   ret_value = ecma_typedarray_species_create (this_arg, &collected, 1);
   ecma_free_value (collected);
 
   if (!ECMA_IS_VALUE_ERROR (ret_value))
   {
     ecma_object_t *obj_p = ecma_get_object_from_value (ret_value);
+    ecma_typedarray_info_t target_info = ecma_typedarray_get_info (obj_p);
 
-    JERRY_ASSERT (ecma_typedarray_get_offset (obj_p) == 0);
+    JERRY_ASSERT (target_info.offset == 0);
 
-    memcpy (ecma_typedarray_get_buffer (obj_p),
-            pass_value_list_p,
-            (size_t) (pass_value_p - pass_value_list_p));
+    ecma_typedarray_setter_fn_t target_typedarray_setter_cb = ecma_get_typedarray_setter_fn (target_info.id);
+    uint32_t target_byte_index = 0;
+    for (uint32_t idx = 0; idx < collected_p->item_count; idx++)
+    {
+      ecma_value_t set_element = target_typedarray_setter_cb (target_info.buffer_p + target_byte_index,
+                                                              collected_p->buffer_p[idx]);
+
+      if (ECMA_IS_VALUE_ERROR (set_element))
+      {
+        goto cleanup;
+      }
+
+      target_byte_index += target_info.element_size;
+    }
   }
 
 cleanup:
-  JMEM_FINALIZE_LOCAL_ARRAY (pass_value_list_p);
+  ecma_collection_free (collected_p);
 
   return ret_value;
 } /* ecma_builtin_typedarray_prototype_filter */

--- a/tests/jerry/es.next/regression-test-issue-4793.js
+++ b/tests/jerry/es.next/regression-test-issue-4793.js
@@ -1,0 +1,42 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Make sure that TypedArray filter correctly copies the data (avoid overflow).
+// Test creates a smaller region for "output" TypedArray.
+// Last number is intentionally a "big" float.
+var big_array = new Float64Array([0.523565555, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 333333232134.1]);
+big_array.constructor = Float32Array;
+
+var result_float32_array = big_array.filter(x => x % 2 == 0);
+assert(result_float32_array instanceof Float32Array);
+assert(result_float32_array.length === 5);
+
+// Create an even smaller result TypedArray.
+big_array.constructor = Uint8Array;
+var result_uint8_array = big_array.filter(x => x % 3 == 0);
+assert(result_uint8_array instanceof Uint8Array);
+assert(result_uint8_array.length === 3);
+
+// Trigger a filter error when at the last element
+try {
+  big_array.filter(function(x, idx) {
+    if (idx > 10) {
+        throw new Error("Error test magic");
+    }
+    return x % 4 == 0;
+  });
+} catch (ex) {
+  assert(ex instanceof Error);
+  assert(ex.message === "Error test magic");
+}


### PR DESCRIPTION
During the execution of the TypedArray filter method it is possible
to have a different sized output TypedArray than the input one.
When copying the data to the output array the values must be
correctly converted to the output TypedArray's value range.

Fixes: #4793