### PR TITLE
Avoid buffer-overflow in Array.slice when using fast arrays

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -872,6 +872,13 @@ ecma_builtin_array_prototype_object_slice (ecma_value_t arg1, /**< start */
         return ecma_make_object_value (new_array_p);
       }
 
+      /* Source array's length could be changed during the start/end normalization.
+       * If the "end" value is greater than the current length, clamp the value to avoid buffer-overflow. */
+      if (ext_from_obj_p->u.array.length < end)
+      {
+        end = ext_from_obj_p->u.array.length;
+      }
+
       ecma_extended_object_t *ext_to_obj_p = (ecma_extended_object_t *) new_array_p;
 
 #if JERRY_ESNEXT

--- a/tests/jerry/regression-test-issue-4777.js
+++ b/tests/jerry/regression-test-issue-4777.js
@@ -1,0 +1,31 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+var fast_array = [];
+for (var i = 0; i < 1000; i++) {
+    fast_array.push(i);
+}
+
+var result_array = fast_array.slice(0, {valueOf: function() { fast_array.length = '3'; return 1000; }});
+
+assert(result_array.length === 1000);
+
+assert(result_array[0] === 0);
+assert(result_array[1] === 1);
+assert(result_array[2] === 2);
+
+for (var i = 3; i < 1000; i++) {
+  assert(typeof(result_array[i]) === "undefined");
+}


### PR DESCRIPTION
In the Array.slice method when the engine uses fast arrays the "end" value
was not updated if the input array's length changed. This can occur when the start/end
index normalization executes a method and the length is changed forcefully.
This leads to a buffer-overflow as the element copy reads too much data from the input
array.

Fixes: #4777