### PR TITLE
Add allocate/free callbacks to ArrayBuffers

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -1457,6 +1457,86 @@ typedef struct
 - [jerry_source_info_enabled_fields_t](#jerry_source_info_enabled_fields_t)
 - [jerry_get_source_info](#jerry_get_source_info)
 
+## jerry_arraybuffer_type_t
+
+**Summary**
+
+Enum that contains the JerryScript type of an array buffer:
+
+ - JERRY_ARRAYBUFFER_TYPE_ARRAYBUFFER - the object is an array buffer object
+ - JERRY_ARRAYBUFFER_TYPE_SHARED_ARRAYBUFFER - the object is a shared array buffer object
+
+*New in version [[NEXT_RELEASE]]*.
+
+**See also**
+
+- [jerry_arraybuffer_allocate_t](#jerry_arraybuffer_allocate_t)
+- [jerry_arraybuffer_free_t](#jerry_arraybuffer_free_t)
+
+## jerry_arraybuffer_allocate_t
+
+**Summary**
+
+Callback for allocating the backing store of array buffer or shared array buffer objects.
+
+*Note*:
+- The value referenced by `arraybuffer_user_p` is always NULL unless the buffer is created by
+  [jerry_create_arraybuffer_external](#jerry_create_arraybuffer_external) or
+  [jerry_create_shared_arraybuffer_external](#jerry_create_shared_arraybuffer_external).
+  The value referenced by `arraybuffer_user_p` can be changed, and the new value is passed to
+  [jerry_arraybuffer_free_t](#jerry_arraybuffer_free_t).
+
+**Prototype**
+
+```c
+typedef uint8_t *(*jerry_arraybuffer_allocate_t) (jerry_arraybuffer_type_t buffer_type, uint32_t buffer_size,
+                                                  void **arraybuffer_user_p, void *user_p);
+```
+
+- `buffer_type` - type of the array buffer object, see: [jerry_arraybuffer_type_t](#jerry_arraybuffer_type_t).
+- `buffer_size` - size of the requested buffer.
+- `arraybuffer_user_p` - [in/out] user pointer assigned to the array buffer or shared array buffer object.
+- `user_p` - user pointer passed to [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
+- return value
+  - Pointer to the buffer, if the allocation is successful, NULL otherwise.
+
+*New in version [[NEXT_RELEASE]]*.
+
+**See also**
+
+- [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
+
+## jerry_arraybuffer_free_t
+
+**Summary**
+
+Callback for freeing the backing store of array buffer or shared array buffer objects.
+
+*Note*:
+- The value passed to `arraybuffer_user_p` is always NULL unless the buffer is created by
+  [jerry_create_arraybuffer_external](#jerry_create_arraybuffer_external) or
+  [jerry_create_shared_arraybuffer_external](#jerry_create_shared_arraybuffer_external),
+  or the value is modified by [jerry_arraybuffer_allocate_t](#jerry_arraybuffer_allocate_t).
+
+**Prototype**
+
+```c
+typedef void (*jerry_arraybuffer_free_t) (jerry_arraybuffer_type_t buffer_type, uint8_t *buffer_p,
+                                          uint32_t buffer_size, void *arraybuffer_user_p, void *user_p);
+```
+
+- `buffer_type` - type of the array buffer object, see: [jerry_arraybuffer_type_t](#jerry_arraybuffer_type_t).
+- `buffer_p` - pointer to the allocated buffer.
+- `buffer_size` - size of the allocated buffer.
+- `arraybuffer_user_p` - [in/out] user pointer assigned to the array buffer or shared array buffer object.
+- `user_p` - user pointer passed to [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
+
+*New in version [[NEXT_RELEASE]]*.
+
+**See also**
+
+- [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
+
 
 # General engine functions
 
@@ -6893,9 +6973,11 @@ jerry_create_array (uint32_t size);
 Create a jerry_value_t representing an ArrayBuffer object.
 
 *Note*:
-  - This API depends on the es.next profile.
-  - Returned value must be freed with [jerry_release_value](#jerry_release_value)
-    when it is no longer needed.
+- This API depends on a build option (`JERRY_BUILTIN_TYPEDARRAY`) and can be checked
+  in runtime with the `JERRY_FEATURE_TYPEDARRAY` feature enum value,
+  see: [jerry_is_feature_enabled](#jerry_is_feature_enabled).
+- Returned value must be freed with [jerry_release_value](#jerry_release_value)
+  when it is no longer needed.
 
 **Prototype**
 
@@ -6904,7 +6986,7 @@ jerry_value_t
 jerry_create_arraybuffer (jerry_length_t size);
 ```
 
- - `size` - size of the ArrayBuffer to create **in bytes**
+ - `size` - size of the backing store allocated for the array buffer **in bytes**.
  - return value - the new ArrayBuffer as a `jerry_value_t`
 
 *New in version 2.0*.
@@ -6941,29 +7023,31 @@ After the object is not needed the GC will call the `free_cb`
 so the user can release the buffer which was provided.
 
 *Note*:
-  - This API depends on the es.next profile.
-  - Returned value must be freed with [jerry_release_value](#jerry_release_value)
-    when it is no longer needed.
+- This API depends on a build option (`JERRY_BUILTIN_TYPEDARRAY`) and can be checked
+  in runtime with the `JERRY_FEATURE_TYPEDARRAY` feature enum value,
+  see: [jerry_is_feature_enabled](#jerry_is_feature_enabled).
+- If `buffer_p` is NULL, the buffer is allocated by the allocator callback passed to
+  [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
+- Returned value must be freed with [jerry_release_value](#jerry_release_value)
+  when it is no longer needed.
 
 **Prototype**
 
 ```c
 jerry_value_t
 jerry_create_arraybuffer_external (const jerry_length_t size
-                                   uint8_t *buffer_p,
-                                   jerry_value_free_callback_t free_cb);
+                                   uint8_t *buffer_p, void *arraybuffer_user_p);
 ```
 
-- `size` - size of the buffer to use **in bytes** (should not be 0)
-- `buffer_p` - the buffer used for the Array Buffer object (should not be a null pointer)
-- `free_cb` - the callback function called when the object is released
+- `size` - size of the buffer **in bytes**.
+- `buffer_p` - the backing store used by the array buffer object.
+- `arraybuffer_user_p` - user pointer assigned to the array buffer object.
 - return value
-  - the new ArrayBuffer as a `jerry_value_t`
-  - if the `size` is zero or `buffer_p` is a null pointer this will return an empty ArrayBuffer.
+  - value of the newly construced array buffer object.
 
 *New in version 2.0*.
 
-*Changed in version [[NEXT_RELEASE]]*: type of `free_cb` has been changed.
+*Changed in version [[NEXT_RELEASE]]*: `free_cb` has been replaced by `arraybuffer_user_p`.
 
 **Example**
 
@@ -6995,7 +7079,7 @@ jerry_create_arraybuffer_external (const jerry_length_t size
 Create a jerry_value_t representing a SharedArrayBuffer object.
 
 *Note*:
-- This API depends on the es.next profile.
+- This API depends on a build option (`JERRY_BUILTIN_SHAREDARRAYBUFFER`).
 - Returned value must be freed with [jerry_release_value](#jerry_release_value)
   when it is no longer needed.
 
@@ -7006,7 +7090,7 @@ jerry_value_t
 jerry_create_shared_arraybuffer (jerry_length_t size);
 ```
 
-- `size` - size of the SharedArrayBuffer to create **in bytes**
+- `size` - size of the backing store allocated for the shared array buffer **in bytes**.
 - return value - the new SharedArrayBuffer as a `jerry_value_t`
 
 *New in version [[NEXT_RELEASE]]*.
@@ -7043,7 +7127,9 @@ After the object is not needed the GC will call the `free_cb`
 so the user can release the buffer which was provided.
 
 *Note*:
-- This API depends on the es.next profile.
+- This API depends on a build option (`JERRY_BUILTIN_SHAREDARRAYBUFFER`).
+- If `buffer_p` is NULL, the buffer is allocated by the allocator callback passed to
+  [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
 - Returned value must be freed with [jerry_release_value](#jerry_release_value)
   when it is no longer needed.
 
@@ -7056,12 +7142,11 @@ jerry_create_shared_arraybuffer_external (const jerry_length_t size
                                           jerry_value_free_callback_t free_cb);
 ```
 
-- `size` - size of the buffer to use **in bytes** (should not be 0)
-- `buffer_p` - the buffer used for the Shared Array Buffer object (should not be a null pointer)
-- `free_cb` - the callback function called when the object is released
+- `size` - size of the buffer **in bytes**.
+- `buffer_p` - the backing store used by the shared array buffer object.
+- `arraybuffer_user_p` - user pointer assigned to the shared array buffer object.
 - return value
-    - the new SharedArrayBuffer as a `jerry_value_t`
-    - if the `size` is zero or `buffer_p` is a null pointer this will return an empty SharedArrayBuffer.
+    - value of the newly construced shared array buffer object.
 
 *New in version [[NEXT_RELEASE]]*.
 
@@ -12701,6 +12786,231 @@ jerry_detach_arraybuffer (const jerry_value_t value);
 **See also**
 
 - [jerry_is_arraybuffer_detachable](#jerry_is_arraybuffer_detachable)
+
+## jerry_arraybuffer_has_buffer
+
+**Summary**
+
+Checks whether a buffer is currently allocated for an array buffer or typed array.
+
+*Notes*:
+- This API depends on a build option (`JERRY_BUILTIN_TYPEDARRAY`) and can be checked
+  in runtime with the `JERRY_FEATURE_TYPEDARRAY` feature enum value,
+  see: [jerry_is_feature_enabled](#jerry_is_feature_enabled).
+
+**Prototype**
+
+```c
+bool
+jerry_arraybuffer_has_buffer (const jerry_value_t value);
+```
+
+- `value` - array buffer or typed array value.
+- return
+  - true, if a buffer is allocated for an array buffer or typed array
+  - false, otherwise
+
+*New in version [[NEXT_RELEASE]]*.
+
+**Example**
+
+[doctest]: # (test="compile")
+
+```c
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_value_t array_buffer_value = jerry_create_arraybuffer (1024 * 1024);
+
+  /* By default, the backing store of large array buffers
+   * is allocated when it is used the first time. */
+
+  if (!jerry_arraybuffer_has_buffer (array_buffer_value))
+  {
+    /* Code enters here in this case. */
+  }
+
+  jerry_release_value (array_buffer_value);
+
+  jerry_cleanup ();
+  return 0;
+}
+```
+
+**See also**
+
+- [jerry_create_arraybuffer_external](#jerry_create_arraybuffer_external)
+- [jerry_create_shared_arraybuffer_external](#jerry_create_shared_arraybuffer_external)
+- [jerry_arraybuffer_set_compact_allocation_limit](#jerry_arraybuffer_set_compact_allocation_limit)
+- [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
+
+## jerry_arraybuffer_set_compact_allocation_limit
+
+**Summary**
+
+Array buffers which size is less or equal than the limit passed to this
+function are allocated in a single memory block. The allocator callbacks set by
+[jerry_arraybuffer_set_allocation_callbacks](#jerry_arraybuffer_set_allocation_callbacks)
+are not called for these array buffers.
+
+*Notes*:
+- This API depends on a build option (`JERRY_BUILTIN_TYPEDARRAY`) and can be checked
+  in runtime with the `JERRY_FEATURE_TYPEDARRAY` feature enum value,
+  see: [jerry_is_feature_enabled](#jerry_is_feature_enabled).
+- The default limit is 256 bytes.
+- When an array buffer is allocated in a single memory block, its
+  backing store is not freed when the array buffer is detached.
+- This limit does not affect shared array buffers, their backing store is always
+  allocated by the allocator callback.
+
+**Prototype**
+
+```c
+void
+jerry_arraybuffer_set_compact_allocation_limit (const jerry_length_t allocation_limit);
+```
+
+- `allocation_limit` - maximum size of compact allocation.
+
+*New in version [[NEXT_RELEASE]]*.
+
+**Example**
+
+[doctest]: # (test="compile")
+
+```c
+#include "jerryscript.h"
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_arraybuffer_set_compact_allocation_limit (1);
+
+  jerry_value_t array_buffer_value = jerry_create_arraybuffer (1);
+
+  if (jerry_arraybuffer_has_buffer (array_buffer_value))
+  {
+    /* Code enters here because the backing store
+     * is allocated during buffer creation. */
+  }
+
+  jerry_release_value (array_buffer_value);
+
+  array_buffer_value = jerry_create_arraybuffer (2);
+
+  if (jerry_arraybuffer_has_buffer (array_buffer_value))
+  {
+    /* Code does not enter here because the backing store
+     * is allocated when it is used the first time. */
+  }
+
+  jerry_release_value (array_buffer_value);
+
+  jerry_cleanup ();
+  return 0;
+}
+```
+
+**See also**
+
+- [jerry_arraybuffer_has_buffer](#jerry_arraybuffer_has_buffer)
+- [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
+
+## jerry_arraybuffer_set_allocator_callbacks
+
+**Summary**
+
+Set callbacks for allocating and freeing backing stores for array buffer objects.
+
+*Notes*:
+- This API depends on a build option (`JERRY_BUILTIN_TYPEDARRAY`) and can be checked
+  in runtime with the `JERRY_FEATURE_TYPEDARRAY` feature enum value,
+  see: [jerry_is_feature_enabled](#jerry_is_feature_enabled).
+- This function is recommended to be called after [jerry_init](#jerry_init) before
+  any array buffer is allocated.
+- The callbacks can be NULL to use the default callbacks. The default `allocate_callback`
+  allocates memory using [jerry_heap_alloc](#jerry_heap_alloc) and the default
+  `free_callback` frees memory using [jerry_heap_free](#jerry_heap_free).
+
+
+**Prototype**
+
+```c
+void
+jerry_arraybuffer_set_allocator_callbacks (jerry_arraybuffer_allocate_t allocate_callback,
+                                           jerry_arraybuffer_free_t free_callback,
+                                           void *user_p)
+```
+
+- `allocate_callback` - callback for allocating array buffer memory.
+- `free_callback` - callback for freeing array buffer memory.
+- `user_p` - user pointer passed to the callbacks.
+
+*New in version [[NEXT_RELEASE]]*.
+
+**Example**
+
+[doctest]: # (test="compile")
+
+```c
+#include "jerryscript.h"
+
+static uint8_t global_buffer[64];
+
+static void
+array_buffer_free_cb (jerry_arraybuffer_type_t buffer_type, /**< type of the array buffer object */
+                      uint8_t *buffer_p, /**< pointer to the allocated buffer */
+                      uint32_t buffer_size, /**< size of the allocated buffer */
+                      void *arraybuffer_user_p, /**< user pointer assigned to the array buffer object */
+                      void *user_p) /**< user pointer passed to jerry_arraybuffer_set_allocation_callbacks */
+{
+  (void) buffer_type;
+  (void) user_p;
+
+  /* As for this example, only the free callback is redirected. This callback
+   * function does not free the memory if the arraybuffer_user_p is non-NULL. */
+
+  if (arraybuffer_user_p == NULL)
+  {
+    jerry_heap_free (buffer_p, buffer_size);
+  }
+} /* array_buffer_free_cb */
+
+int
+main (void)
+{
+  jerry_init (JERRY_INIT_EMPTY);
+
+  jerry_arraybuffer_set_allocator_callbacks (NULL, array_buffer_free_cb, NULL);
+
+  /* The buffer of the array buffer object is allocated by the default
+   * allocator using jerry_heap_alloc and freed by array_buffer_free_cb. */
+
+  const jerry_char_t script[] = "var result = new uint32Array(1024); result[0] = 1; result";
+  jerry_value_t array_buffer_value = jerry_eval (script, sizeof (script) - 1, JERRY_PARSE_NO_OPTS);
+  jerry_release_value (array_buffer_value);
+
+  /* The buffer of the array buffer object has a non-NULL
+   * arraybuffer_user_p value, so it is not freed by array_buffer_free_cb. */
+
+  array_buffer_value = jerry_create_arraybuffer_external (sizeof (global_buffer), global_buffer, global_buffer);
+  jerry_release_value (array_buffer_value);
+
+  jerry_cleanup ();
+  return 0;
+}
+```
+
+**See also**
+
+- [jerry_arraybuffer_has_buffer](#jerry_arraybuffer_has_buffer)
+- [jerry_arraybuffer_set_allocator_callbacks](#jerry_arraybuffer_set_allocator_callbacks)
 
 ## jerry_get_dataview_buffer
 

--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -19,6 +19,7 @@
 
 #include "ecma-alloc.h"
 #include "ecma-array-object.h"
+#include "ecma-arraybuffer-object.h"
 #include "ecma-builtin-handlers.h"
 #include "ecma-container-object.h"
 #include "ecma-function-object.h"
@@ -1837,25 +1838,18 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
         case ECMA_OBJECT_CLASS_SHARED_ARRAY_BUFFER:
 #endif /* JERRY_BUILTIN_SHAREDARRAYBUFFER */
         {
-          uint32_t arraybuffer_length = ext_object_p->u.cls.u3.length;
-
-          if (ECMA_ARRAYBUFFER_HAS_EXTERNAL_MEMORY (ext_object_p))
+          if (!(ECMA_ARRAYBUFFER_GET_FLAGS (ext_object_p) & ECMA_ARRAYBUFFER_HAS_POINTER))
           {
-            ext_object_size = sizeof (ecma_arraybuffer_external_info);
-
-            /* Call external free callback if any. */
-            ecma_arraybuffer_external_info *array_p = (ecma_arraybuffer_external_info *) ext_object_p;
-
-            if (array_p->free_cb != NULL)
-            {
-              array_p->free_cb (array_p->buffer_p);
-            }
-          }
-          else
-          {
-            ext_object_size += arraybuffer_length;
+            ext_object_size += ext_object_p->u.cls.u3.length;
+            break;
           }
 
+          ext_object_size = sizeof (ecma_arraybuffer_pointer_t);
+
+          if (ECMA_ARRAYBUFFER_GET_FLAGS (ext_object_p) & ECMA_ARRAYBUFFER_ALLOCATED)
+          {
+            ecma_arraybuffer_release_buffer (object_p);
+          }
           break;
         }
 #endif /* JERRY_BUILTIN_TYPEDARRAY */

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -2082,35 +2082,24 @@ typedef enum
 } ecma_typedarray_flag_t;
 
 /**
- * ArrayBuffers flags.
+ * Array buffer flags.
  */
 typedef enum
 {
-  ECMA_ARRAYBUFFER_INTERNAL_MEMORY = 0u, /* ArrayBuffer memory is handled internally. */
-  ECMA_ARRAYBUFFER_EXTERNAL_MEMORY = (1u << 0), /* ArrayBuffer created via jerry_create_arraybuffer_external. */
-  ECMA_ARRAYBUFFER_DETACHED = (1u << 1), /* ArrayBuffer has been detached */
+  ECMA_ARRAYBUFFER_HAS_POINTER = (1u << 0), /* ArrayBuffer has a buffer pointer. */
+  ECMA_ARRAYBUFFER_ALLOCATED = (1u << 1), /* ArrayBuffer memory is allocated */
+  ECMA_ARRAYBUFFER_DETACHED = (1u << 2), /* ArrayBuffer has been detached */
 } ecma_arraybuffer_flag_t;
 
 /**
- * Check whether the ArrayBuffer has external underlying buffer
- */
-#define ECMA_ARRAYBUFFER_HAS_EXTERNAL_MEMORY(object_p) \
-    ((((ecma_extended_object_t *) object_p)->u.cls.u1.array_buffer_flags & ECMA_ARRAYBUFFER_EXTERNAL_MEMORY) != 0)
-
-/**
- * Struct to store information for ArrayBuffers with external memory.
- *
- * The following elements are stored in Jerry memory.
- *
- *  buffer_p - pointer to the external memory.
- *  free_cb - pointer to a callback function which is called when the ArrayBuffer is freed.
+ * Structure for array buffers with a backing store pointer.
  */
 typedef struct
 {
   ecma_extended_object_t extended_object; /**< extended object part */
-  void *buffer_p; /**< external buffer pointer */
-  jerry_value_free_callback_t free_cb; /**<  the free callback for the above buffer pointer */
-} ecma_arraybuffer_external_info;
+  void *buffer_p; /**< pointer to the backing store of the array buffer object */
+  void *arraybuffer_user_p; /**< user pointer passed to the free callback */
+} ecma_arraybuffer_pointer_t;
 
 /**
  * Some internal properties of TypedArray object.
@@ -2130,10 +2119,6 @@ typedef struct
 typedef struct
 {
   ecma_object_t *array_buffer_p; /**< pointer to the typedArray's [[ViewedArrayBuffer]] internal slot */
-  lit_utf8_byte_t *buffer_p; /**< pointer to the underlying raw data buffer.
-                              *   Note:
-                              *    - This address is increased by the [ByteOffset]] internal property.
-                              *    - This address must be used during indexed read/write operation. */
   ecma_typedarray_type_t id; /**< [[TypedArrayName]] internal slot */
   uint32_t length; /**< [[ByteLength]] internal slot */
   uint32_t offset; /**< [[ByteOffset]] internal slot. */

--- a/jerry-core/ecma/base/ecma-init-finalize.c
+++ b/jerry-core/ecma/base/ecma-init-finalize.c
@@ -63,6 +63,10 @@ ecma_init (void)
 #if JERRY_ESNEXT
   JERRY_CONTEXT (current_new_target_p) = NULL;
 #endif /* JERRY_ESNEXT */
+
+#if JERRY_BUILTIN_TYPEDARRAY
+  JERRY_CONTEXT (arraybuffer_compact_allocation_limit) = 256;
+#endif /* JERRY_BUILTIN_TYPEDARRAY */
 } /* ecma_init */
 
 /**

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray.c
@@ -131,10 +131,17 @@ ecma_builtin_typedarray_of (ecma_value_t this_arg, /**< 'this' argument */
   ecma_object_t *ret_obj_p = ecma_get_object_from_value (ret_val);
   ecma_typedarray_info_t info = ecma_typedarray_get_info (ret_obj_p);
   ecma_typedarray_setter_fn_t setter_cb = ecma_get_typedarray_setter_fn (info.id);
+  lit_utf8_byte_t *buffer_p = ecma_typedarray_get_buffer (&info);
+
+  if (JERRY_UNLIKELY (buffer_p == NULL))
+  {
+    ecma_deref_object (ret_obj_p);
+    return ECMA_VALUE_ERROR;
+  }
 
   while (k < arguments_list_len)
   {
-    ecma_value_t set_element = setter_cb (info.buffer_p, arguments_list_p[k]);
+    ecma_value_t set_element = setter_cb (buffer_p, arguments_list_p[k]);
 
     if (ECMA_IS_VALUE_ERROR (set_element))
     {
@@ -143,7 +150,7 @@ ecma_builtin_typedarray_of (ecma_value_t this_arg, /**< 'this' argument */
     }
 
     k++;
-    info.buffer_p += info.element_size;
+    buffer_p += info.element_size;
   }
 
   return ret_val;

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -27,6 +27,19 @@
  * @{
  */
 
+/**
+ * Get array buffer flags.
+ */
+#define ECMA_ARRAYBUFFER_GET_FLAGS(arraybuffer_p) \
+  (((ecma_extended_object_t *) (arraybuffer_p))->u.cls.u1.array_buffer_flags)
+
+/**
+ * Check whether the backing store is allocated for an array buffer.
+ */
+#define ECMA_ARRAYBUFFER_CHECK_BUFFER_ERROR(arraybuffer_p) \
+  (JERRY_UNLIKELY (!(ECMA_ARRAYBUFFER_GET_FLAGS (arraybuffer_p) & ECMA_ARRAYBUFFER_ALLOCATED)) \
+   && ecma_arraybuffer_allocate_buffer (arraybuffer_p) == ECMA_VALUE_ERROR)
+
 ecma_value_t
 ecma_op_create_arraybuffer_object (const ecma_value_t *, uint32_t);
 
@@ -34,12 +47,16 @@ ecma_op_create_arraybuffer_object (const ecma_value_t *, uint32_t);
  * Helper functions for arraybuffer.
  */
 ecma_object_t *
-ecma_arraybuffer_new_object (uint32_t lengh);
+ecma_arraybuffer_create_object (uint8_t type, uint32_t length);
 ecma_object_t *
-ecma_arraybuffer_new_object_external (uint32_t length,
-                                      void *buffer_p,
-                                      jerry_value_free_callback_t free_cb);
-lit_utf8_byte_t * JERRY_ATTR_PURE
+ecma_arraybuffer_create_object_with_buffer (uint8_t type, uint32_t length);
+ecma_object_t *
+ecma_arraybuffer_new_object (uint32_t length);
+ecma_value_t
+ecma_arraybuffer_allocate_buffer (ecma_object_t *object_p);
+void
+ecma_arraybuffer_release_buffer (ecma_object_t *object_p);
+uint8_t * JERRY_ATTR_PURE
 ecma_arraybuffer_get_buffer (ecma_object_t *obj_p);
 uint32_t JERRY_ATTR_PURE
 ecma_arraybuffer_get_length (ecma_object_t *obj_p);

--- a/jerry-core/ecma/operations/ecma-shared-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-shared-arraybuffer-object.h
@@ -35,10 +35,6 @@ ecma_op_create_shared_arraybuffer_object (const ecma_value_t *, uint32_t);
  */
 ecma_object_t *
 ecma_shared_arraybuffer_new_object (uint32_t lengh);
-ecma_object_t *
-ecma_shared_arraybuffer_new_object_external (uint32_t length,
-                                             void *buffer_p,
-                                             jerry_value_free_callback_t free_cb);
 #endif /* JERRY_BUILTIN_SHAREDARRAYBUFFER */
 bool
 ecma_is_shared_arraybuffer (ecma_value_t val);

--- a/jerry-core/ecma/operations/ecma-typedarray-object.h
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.h
@@ -49,7 +49,7 @@ ecma_value_t ecma_op_typedarray_from (ecma_value_t this_val,
                                       ecma_value_t this_arg);
 uint32_t ecma_typedarray_get_length (ecma_object_t *typedarray_p);
 uint32_t ecma_typedarray_get_offset (ecma_object_t *typedarray_p);
-lit_utf8_byte_t *ecma_typedarray_get_buffer (ecma_object_t *typedarray_p);
+uint8_t *ecma_typedarray_get_buffer (ecma_typedarray_info_t *info_p);
 uint8_t ecma_typedarray_get_element_size_shift (ecma_object_t *typedarray_p);
 ecma_object_t *ecma_typedarray_get_arraybuffer (ecma_object_t *typedarray_p);
 ecma_value_t ecma_op_create_typedarray (const ecma_value_t *arguments_list_p,

--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -374,8 +374,7 @@ void jerry_free_source_info (jerry_source_info_t *source_info_p);
 bool jerry_value_is_arraybuffer (const jerry_value_t value);
 jerry_value_t jerry_create_arraybuffer (const jerry_length_t size);
 jerry_value_t jerry_create_arraybuffer_external (const jerry_length_t size,
-                                                 uint8_t *buffer_p,
-                                                 jerry_value_free_callback_t free_cb);
+                                                 uint8_t *buffer_p, void *buffer_user_p);
 jerry_length_t jerry_arraybuffer_write (const jerry_value_t value,
                                         jerry_length_t offset,
                                         const uint8_t *buf_p,
@@ -388,6 +387,11 @@ jerry_length_t jerry_get_arraybuffer_byte_length (const jerry_value_t value);
 uint8_t *jerry_get_arraybuffer_pointer (const jerry_value_t value);
 jerry_value_t jerry_is_arraybuffer_detachable (const jerry_value_t value);
 jerry_value_t jerry_detach_arraybuffer (const jerry_value_t value);
+bool jerry_arraybuffer_has_buffer (const jerry_value_t value);
+void jerry_arraybuffer_set_compact_allocation_limit (const jerry_length_t allocation_limit);
+void jerry_arraybuffer_set_allocator_callbacks (jerry_arraybuffer_allocate_t allocate_callback,
+                                                jerry_arraybuffer_free_t free_callback,
+                                                void *user_p);
 
 /**
  * SharedArrayBuffer components.
@@ -396,8 +400,7 @@ jerry_value_t jerry_detach_arraybuffer (const jerry_value_t value);
 bool jerry_value_is_shared_arraybuffer (const jerry_value_t value);
 jerry_value_t jerry_create_shared_arraybuffer (const jerry_length_t size);
 jerry_value_t jerry_create_shared_arraybuffer_external (const jerry_length_t size,
-                                                        uint8_t *buffer_p,
-                                                        jerry_value_free_callback_t free_cb);
+                                                        uint8_t *buffer_p, void *buffer_user_p);
 
 /**
  * DataView functions.

--- a/jerry-core/include/jerryscript-types.h
+++ b/jerry-core/include/jerryscript-types.h
@@ -819,6 +819,31 @@ typedef struct
 } jerry_source_info_t;
 
 /**
+ * Array buffer types.
+ */
+
+/**
+ * Type of an array buffer.
+ */
+typedef enum
+{
+  JERRY_ARRAYBUFFER_TYPE_ARRAYBUFFER, /**< the object is an array buffer object */
+  JERRY_ARRAYBUFFER_TYPE_SHARED_ARRAYBUFFER, /**< the object is a shared array buffer object */
+} jerry_arraybuffer_type_t;
+
+/**
+ * Callback for allocating the backing store of array buffer or shared array buffer objects.
+ */
+typedef uint8_t *(*jerry_arraybuffer_allocate_t) (jerry_arraybuffer_type_t buffer_type, uint32_t buffer_size,
+                                                  void **arraybuffer_user_p, void *user_p);
+
+/**
+ * Callback for freeing the backing store of array buffer or shared array buffer objects.
+ */
+typedef void (*jerry_arraybuffer_free_t) (jerry_arraybuffer_type_t buffer_type, uint8_t *buffer_p,
+                                          uint32_t buffer_size, void *arraybuffer_user_p, void *user_p);
+
+/**
  * @}
  */
 

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -197,6 +197,15 @@ struct jerry_context_t
 #endif /* JERRY_PROMISE_CALLBACK */
 #endif /* JERRY_ESNEXT */
 
+#if JERRY_BUILTIN_TYPEDARRAY
+  uint32_t arraybuffer_compact_allocation_limit; /**< maximum size of compact allocation */
+  jerry_arraybuffer_allocate_t arraybuffer_allocate_callback;  /**< callback for allocating
+                                                                *   arraybuffer memory */
+  jerry_arraybuffer_free_t arraybuffer_free_callback; /**< callback for freeing arraybuffer memory */
+  void *arraybuffer_allocate_callback_user_p;  /**< user pointer passed to arraybuffer_allocate_callback
+                                                *   and arraybuffer_free_callback functions */
+#endif /* JERRY_BUILTIN_TYPEDARRAY */
+
 #if JERRY_VM_EXEC_STOP
   uint32_t vm_exec_stop_frequency; /**< reset value for vm_exec_stop_counter */
   uint32_t vm_exec_stop_counter; /**< down counter for reducing the calls of vm_exec_stop_cb */


### PR DESCRIPTION
Larger buffer allocations will throw error instead of calling jerry_fatal.