### PR TITLE
Fix jerry_value_is_{true,false} documentation

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -2424,7 +2424,7 @@ jerry_value_is_true (const jerry_value_t value);
     - true, if the given `jerry_value_t` is true value
     - false, otherwise
 
-*New in version [[NEXT_RELEASE]]*. Replaces the `jerry_value_is_boolean` method.
+*New in version [[NEXT_RELEASE]]*. Replaces the `jerry_get_boolean_value` method.
 
 **Example**
 
@@ -2464,7 +2464,7 @@ jerry_value_is_false (const jerry_value_t value);
     - true, if the given `jerry_value_t` is false value
     - false, otherwise
 
-*New in version [[NEXT_RELEASE]]*. Replaces the `jerry_value_is_boolean` method.
+*New in version [[NEXT_RELEASE]]*.
 
 **Example**
 


### PR DESCRIPTION
The API doc for jerry_value_is_{true,false} incorrectly stated
that it is a replacement for the `jerry_value_is_boolean` method.
The `jerry_value_is_true` is the direct replacement of the
`jerry_get_boolean_value` method and the "false" version is a new
method.