### PR TITLE
Test262 runner shouldn't change newline characters

### DIFF
--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -81,7 +81,7 @@ def prepare_test262_test_suite(args):
     if os.path.isdir(os.path.join(args.test_dir, '.git')):
         return 0
 
-    return_code = subprocess.call(['git', 'clone', '--no-checkout',
+    return_code = subprocess.call(['git', 'clone', '--no-checkout', '--config', 'core.autocrlf=false',
                                    'https://github.com/tc39/test262.git', args.test_dir])
     if return_code:
         print('Cloning test262 repository failed.')

--- a/tools/runners/test262-harness.py
+++ b/tools/runners/test262-harness.py
@@ -495,7 +495,7 @@ class TestCase(object):
         self.name = name
         self.full_path = full_path
         self.strict_mode = strict_mode
-        with open(self.full_path) as file_desc:
+        with open(self.full_path, "rb") as file_desc:
             self.contents = file_desc.read()
         test_record = parse_test_record(self.contents, name)
         self.test = test_record["test"]
@@ -645,7 +645,7 @@ class TestCase(object):
         return TestResult(code, out, err, self)
 
     def run(self):
-        tmp = TempFile(suffix=".js", prefix="test262-", text=True)
+        tmp = TempFile(suffix=".js", prefix="test262-")
         try:
             result = self.run_test_in(tmp)
         finally:


### PR DESCRIPTION
It fixes the following test on Windows:
built-ins/Function/prototype/toString/line-terminator-normalisation-LF.js

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
