### PR TITLE
Optimize typed array access

### DIFF
--- a/jerry-core/api/jerry.c
+++ b/jerry-core/api/jerry.c
@@ -3309,7 +3309,11 @@ jerry_has_own_property (const jerry_value_t obj_val, /**< object value */
   }
 #endif /* JERRY_BUILTIN_PROXY */
 
-  return ecma_make_boolean_value (ecma_op_ordinary_object_has_own_property (obj_p, prop_name_p));
+#if JERRY_BUILTIN_TYPEDARRAY
+  return jerry_return (ecma_op_ordinary_object_has_own_property (obj_p, prop_name_p));
+#else /* !JERRY_BUILTIN_TYPEDARRAY */
+  return ecma_op_ordinary_object_has_own_property (obj_p, prop_name_p);
+#endif /* JERRY_BUILTIN_TYPEDARRAY */
 } /* jerry_has_own_property */
 
 /**

--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -515,6 +515,19 @@ typedef enum
 #define ECMA_PROPERTY_TYPE_NOT_FOUND_AND_STOP ECMA_PROPERTY_TYPE_DELETED
 
 /**
+ * Type of property not found and an exception is thrown.
+ */
+#define ECMA_PROPERTY_TYPE_NOT_FOUND_AND_THROW \
+  (ECMA_PROPERTY_FLAG_LCACHED | (ECMA_DIRECT_STRING_SPECIAL << ECMA_PROPERTY_NAME_TYPE_SHIFT))
+
+/**
+ * Checks whether a property is not found.
+ */
+#define ECMA_PROPERTY_IS_FOUND(property) \
+  (((property) & (ECMA_PROPERTY_FLAG_DATA | (ECMA_DIRECT_STRING_SPECIAL << ECMA_PROPERTY_NAME_TYPE_SHIFT))) \
+   != (ECMA_DIRECT_STRING_SPECIAL << ECMA_PROPERTY_NAME_TYPE_SHIFT))
+
+/**
  * Abstract property representation.
  *
  * A property is a type_and_flags byte and an ecma_value_t value pair.

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object-prototype.c
@@ -147,7 +147,7 @@ ecma_builtin_object_prototype_object_has_own_property (ecma_object_t *obj_p, /**
   }
 #endif /* JERRY_BUILTIN_PROXY */
 
-  return ecma_make_boolean_value (ecma_op_ordinary_object_has_own_property (obj_p, prop_name_p));
+  return ecma_op_ordinary_object_has_own_property (obj_p, prop_name_p);
 } /* ecma_builtin_object_prototype_object_has_own_property */
 
 /**

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1352,7 +1352,7 @@ static ecma_value_t
 ecma_builtin_typedarray_prototype_at (ecma_typedarray_info_t *info_p, /**< object info */
                                       const ecma_value_t index) /**< index argument */
 {
-  ecma_length_t len = (ecma_length_t) info_p->length;
+  ecma_length_t len = info_p->length;
   ecma_length_t res_index;
   ecma_value_t return_value = ecma_builtin_helper_calculate_index (index, len, &res_index);
 
@@ -1361,7 +1361,12 @@ ecma_builtin_typedarray_prototype_at (ecma_typedarray_info_t *info_p, /**< objec
     return return_value;
   }
 
-  return ecma_get_typedarray_element (info_p, (ecma_number_t) res_index);
+  if (res_index >= UINT32_MAX)
+  {
+    return ECMA_VALUE_UNDEFINED;
+  }
+
+  return ecma_get_typedarray_element (info_p, (uint32_t) res_index);
 } /* ecma_builtin_typedarray_prototype_at */
 
 /**

--- a/jerry-core/ecma/operations/ecma-objects-general.c
+++ b/jerry-core/ecma/operations/ecma-objects-general.c
@@ -102,8 +102,10 @@ ecma_op_general_object_delete (ecma_object_t *obj_p, /**< the object */
                                                               ECMA_PROPERTY_GET_NO_OPTIONS);
 
   /* 2. */
-  if (property == ECMA_PROPERTY_TYPE_NOT_FOUND || property == ECMA_PROPERTY_TYPE_NOT_FOUND_AND_STOP)
+  if (!ECMA_PROPERTY_IS_FOUND (property))
   {
+    JERRY_ASSERT (property == ECMA_PROPERTY_TYPE_NOT_FOUND
+                  || property == ECMA_PROPERTY_TYPE_NOT_FOUND_AND_STOP);
     return ECMA_VALUE_TRUE;
   }
 
@@ -419,8 +421,11 @@ ecma_op_general_object_define_own_property (ecma_object_t *object_p, /**< the ob
                                                   &ext_property_ref.property_ref,
                                                   ECMA_PROPERTY_GET_VALUE | ECMA_PROPERTY_GET_EXT_REFERENCE);
 
-  if (current_prop == ECMA_PROPERTY_TYPE_NOT_FOUND || current_prop == ECMA_PROPERTY_TYPE_NOT_FOUND_AND_STOP)
+  if (!ECMA_PROPERTY_IS_FOUND (current_prop))
   {
+    JERRY_ASSERT (current_prop == ECMA_PROPERTY_TYPE_NOT_FOUND
+                  || current_prop == ECMA_PROPERTY_TYPE_NOT_FOUND_AND_STOP);
+
     /* 3. */
     if (!ecma_op_ordinary_object_is_extensible (object_p))
     {

--- a/jerry-core/ecma/operations/ecma-objects.h
+++ b/jerry-core/ecma/operations/ecma-objects.h
@@ -58,7 +58,7 @@ ecma_value_t ecma_raise_readonly_assignment (ecma_string_t *property_name_p, boo
 
 ecma_property_t ecma_op_object_get_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p,
                                                  ecma_property_ref_t *property_ref_p, uint32_t options);
-bool ecma_op_ordinary_object_has_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
+ecma_value_t ecma_op_ordinary_object_has_own_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
 ecma_value_t ecma_op_object_has_property (ecma_object_t *object_p, ecma_string_t *property_name_p);
 ecma_value_t ecma_op_object_find_own (ecma_value_t base_value, ecma_object_t *object_p, ecma_string_t *property_name_p);
 ecma_value_t ecma_op_object_find (ecma_object_t *object_p, ecma_string_t *property_name_p);

--- a/jerry-core/ecma/operations/ecma-typedarray-object.h
+++ b/jerry-core/ecma/operations/ecma-typedarray-object.h
@@ -33,10 +33,10 @@ lit_magic_string_id_t ecma_get_typedarray_magic_string_id (ecma_typedarray_type_
 ecma_typedarray_getter_fn_t ecma_get_typedarray_getter_fn (ecma_typedarray_type_t typedarray_id);
 ecma_typedarray_setter_fn_t ecma_get_typedarray_setter_fn (ecma_typedarray_type_t typedarray_id);
 ecma_value_t ecma_get_typedarray_element (ecma_typedarray_info_t *info_p,
-                                          ecma_number_t num);
+                                          uint32_t index);
 ecma_value_t ecma_set_typedarray_element (ecma_typedarray_info_t *info_p,
                                           ecma_value_t value,
-                                          ecma_number_t num);
+                                          uint32_t index);
 bool ecma_typedarray_helper_is_typedarray (ecma_builtin_id_t builtin_id);
 ecma_typedarray_type_t ecma_get_typedarray_id (ecma_object_t *obj_p);
 ecma_builtin_id_t ecma_typedarray_helper_get_prototype_id (ecma_typedarray_type_t typedarray_id);
@@ -62,11 +62,12 @@ ecma_typedarray_iterators_helper (ecma_value_t this_arg, ecma_iterator_kind_t ki
 
 bool ecma_object_is_typedarray (ecma_object_t *obj_p);
 bool ecma_is_typedarray (ecma_value_t target);
+bool ecma_typedarray_is_element_index (ecma_string_t *property_name_p);
 void ecma_op_typedarray_list_lazy_property_names (ecma_object_t *obj_p, ecma_collection_t *prop_names_p,
                                                   ecma_property_counter_t *prop_counter_p,
                                                   jerry_property_filter_t filter);
 ecma_value_t ecma_op_typedarray_define_own_property (ecma_object_t *obj_p,
-                                                     ecma_string_t *prop_name_p,
+                                                     ecma_string_t *property_name_p,
                                                      const ecma_property_descriptor_t *property_desc_p);
 ecma_value_t ecma_op_create_typedarray_with_type_and_length (ecma_typedarray_type_t typedarray_id,
                                                              uint32_t array_length);

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1726,8 +1726,11 @@ opfunc_lexical_scope_has_restricted_binding (vm_frame_ctx_t *frame_ctx_p, /**< f
                                                               NULL,
                                                               ECMA_PROPERTY_GET_NO_OPTIONS);
 
-  return ecma_make_boolean_value ((property != ECMA_PROPERTY_TYPE_NOT_FOUND
-                                   && !ecma_is_property_configurable (property)));
+  JERRY_ASSERT (property == ECMA_PROPERTY_TYPE_NOT_FOUND
+                || ECMA_PROPERTY_IS_FOUND (property));
+
+  return ecma_make_boolean_value (property != ECMA_PROPERTY_TYPE_NOT_FOUND
+                                  && !ecma_is_property_configurable (property));
 } /* opfunc_lexical_scope_has_restricted_binding */
 
 #endif /* JERRY_ESNEXT */


### PR DESCRIPTION
Use uint32 indexes instead of double indexes.
#4801 must land first