### PR TITLE
Fix for-in collection cleanup on abrupt 'has' result

### DIFF
--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -4144,6 +4144,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
             if (ECMA_IS_VALUE_ERROR (result))
             {
+              stack_top_p[-3] = index;
               goto error;
             }
 

--- a/tests/jerry/es.next/regression-test-issue-4747.js
+++ b/tests/jerry/es.next/regression-test-issue-4747.js
@@ -1,0 +1,32 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = new Int32Array(256);
+try {
+    a.sort(function () {
+        var o = new Proxy(this, {
+            has: function () {},
+            get: function () {
+                a = true;
+                return 30;
+            }
+        });
+        var result = "";
+        for (var p in o)
+            result += o[p];
+    });
+    assert(false);
+} catch (e) {
+    assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #4747

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu