### PR TITLE
Fix JERRY_VLA macro on Windows

### DIFF
--- a/jerry-core/include/jerryscript-compiler.h
+++ b/jerry-core/include/jerryscript-compiler.h
@@ -70,7 +70,7 @@ JERRY_C_API_BEGIN
  * instead.
  */
 void *__cdecl _alloca (size_t _Size);
-#define JERRY_VLA(type, name, size) type *name = (type *) (_alloca (sizeof (type) * size))
+#define JERRY_VLA(type, name, size) type *name = (type *) (_alloca (sizeof (type) * (size)))
 
 #endif /* _MSC_VER */
 


### PR DESCRIPTION
Fixes #4824. The last macro argument should be inside parentheses.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu
