### PR TITLE
Prevent arguments object creation if 'arguments' function argument is present

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -1246,6 +1246,7 @@ scanner_filter_arguments (parser_context_t *context_p, /**< context */
 
     if (has_arguments)
     {
+      /* Force the lexically stored arguments object creation */
       literal_pool_p->status_flags |= (SCANNER_LITERAL_POOL_ARGUMENTS_IN_ARGS | SCANNER_LITERAL_POOL_NO_ARGUMENTS);
     }
   }
@@ -1306,6 +1307,14 @@ scanner_filter_arguments (parser_context_t *context_p, /**< context */
         literal_p->type = type;
       }
 
+      if (has_arguments && scanner_literal_is_arguments (literal_p))
+      {
+        /* 'arguments' function argument existence should prevent the arguments object construction */
+        new_literal_pool_p->status_flags =
+          (uint16_t) (new_literal_pool_p->status_flags
+                      & ~(SCANNER_LITERAL_POOL_ARGUMENTS_IN_ARGS | SCANNER_LITERAL_POOL_NO_ARGUMENTS));
+      }
+
       if (type & (SCANNER_LITERAL_IS_DESTRUCTURED_ARG | SCANNER_LITERAL_IS_ARROW_DESTRUCTURED_ARG))
       {
         has_destructured_arg = true;
@@ -1328,6 +1337,7 @@ scanner_filter_arguments (parser_context_t *context_p, /**< context */
     }
     else if (has_arguments && scanner_literal_is_arguments (literal_p))
     {
+      /* Arguments object is directly referenced from the function arguments */
       new_literal_pool_p->status_flags |= SCANNER_LITERAL_POOL_ARGUMENTS_IN_ARGS;
 
       if (type & SCANNER_LITERAL_NO_REG)

--- a/tests/jerry/es.next/arguments.js
+++ b/tests/jerry/es.next/arguments.js
@@ -199,3 +199,21 @@ function f19(e = (v) => eval(v))
   assert(arguments === -12.5)
 }
 f19(undefined, "A");
+
+function f20 (arguments, a = eval('arguments')) {
+  assert(a === 3.1);
+  assert(arguments === 3.1);
+}
+f20(3.1);
+
+function f21 (arguments, a = arguments) {
+  assert(a === 3.1);
+  assert(arguments === 3.1);
+}
+f21(3.1);
+
+function f22 (arguments, [a = arguments]) {
+  assert(a === 3.1);
+  assert(arguments === 3.1);
+}
+f22(3.1, []);


### PR DESCRIPTION
This patch fixes #4847.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu