### PR TITLE
Fixes running test262-esnext failed with installed python3.9 on win32 with space in path

### DIFF
--- a/tools/runners/util.py
+++ b/tools/runners/util.py
@@ -75,4 +75,4 @@ def get_platform_cmd_prefix():
 
 def get_python_cmd_prefix():
     # python script doesn't have execute permission on github actions windows runner
-    return get_platform_cmd_prefix() + [sys.executable or 'python']
+    return [sys.executable or 'python']


### PR DESCRIPTION
Fixes #4852


JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
