### PR TITLE
Fixes test262-harness.py complain cannot use a string pattern on a bytes-like object with running test262 with python3

### DIFF
--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -288,7 +288,8 @@ def create_binary(job, options):
         subprocess.check_output(build_cmd)
         ret = 0
     except subprocess.CalledProcessError as err:
-        print(err.output.decode("utf8"))
+        # For python <-> native program, we use default encoding with error='ignore' to not lost data
+        print(err.output.decode(errors="ignore"))
         ret = err.returncode
 
     BINARY_CACHE[binary_key] = (ret, build_dir_path)

--- a/tools/runners/run-test-suite.py
+++ b/tools/runners/run-test-suite.py
@@ -79,6 +79,7 @@ def execute_test_command(test_cmd):
     kwargs = {}
     if sys.version_info.major >= 3:
         kwargs['encoding'] = 'unicode_escape'
+        kwargs['errors'] = 'ignore'
     process = subprocess.Popen(test_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                universal_newlines=True, **kwargs)
     stdout = process.communicate()[0]

--- a/tools/runners/test262-harness.py
+++ b/tools/runners/test262-harness.py
@@ -42,6 +42,7 @@
 
 from __future__ import print_function
 
+import codecs
 import logging
 import optparse
 import os
@@ -402,13 +403,13 @@ class TempFile(object):
             text=self.text)
 
     def write(self, string):
-        os.write(self.file_desc, string)
+        os.write(self.file_desc, string.encode("utf8", "ignore"))
 
     def read(self):
-        file_desc = file(self.name)
+        file_desc = open(self.name, "rb")
         result = file_desc.read()
         file_desc.close()
-        return result
+        return result.decode("utf8", "ignore")
 
     def close(self):
         if not self.is_closed:
@@ -460,12 +461,12 @@ class TestResult(object):
     def write_output(self, target):
         out = self.stdout.strip()
         if out:
-            target.write("--- output --- \n %s" % out)
+            target.write(u"--- output --- \n %s" % out)
         error = self.stderr.strip()
         if error:
-            target.write("--- errors ---  \n %s" % error)
+            target.write(u"--- errors ---  \n %s" % error)
 
-        target.write("\n--- exit code: %d ---\n" % self.exit_code)
+        target.write(u"\n--- exit code: %d ---\n" % self.exit_code)
 
     def has_failed(self):
         return self.exit_code != 0
@@ -496,7 +497,7 @@ class TestCase(object):
         self.full_path = full_path
         self.strict_mode = strict_mode
         with open(self.full_path, "rb") as file_desc:
-            self.contents = file_desc.read()
+            self.contents = file_desc.read().decode("utf8", "ignore")
         test_record = parse_test_record(self.contents, name)
         self.test = test_record["test"]
         del test_record["test"]
@@ -762,8 +763,8 @@ class TestSuite(object):
         if not name in self.include_cache:
             static = path.join(self.lib_root, name)
             if path.exists(static):
-                with open(static) as file_desc:
-                    contents = file_desc.read()
+                with open(static, "rb") as file_desc:
+                    contents = file_desc.read().decode("utf8", "ignore")
                     contents = re.sub(r'\r\n', '\n', contents)
                     self.include_cache[name] = contents + "\n"
             else:
@@ -851,7 +852,7 @@ class TestSuite(object):
             report_error("No tests to run")
         progress = ProgressIndicator(len(cases))
         if logname:
-            self.logf = open(logname, "w")
+            self.logf = codecs.open(logname, "w", encoding="utf8", errors="ignore")
 
         if job_count == 1:
             for case in cases:


### PR DESCRIPTION
For reading/writing to file, we use 'utf8' /'ignore' encoding for not lost characters.
For decoding from process stdout, using native encoding with decoding error ignored for not lost data.
Execute commands also ignore errors
Fixes #4853

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
