### PR TITLE
Fixes the code before update test262 git hash, and update exclude list

### DIFF
--- a/jerry-core/api/jerryscript.c
+++ b/jerry-core/api/jerryscript.c
@@ -35,6 +35,7 @@
 #include "ecma-extended-info.h"
 #include "ecma-function-object.h"
 #include "ecma-gc.h"
+#include "ecma-globals.h"
 #include "ecma-helpers.h"
 #include "ecma-init-finalize.h"
 #include "ecma-iterator-object.h"
@@ -5950,7 +5951,7 @@ jerry_arraybuffer_allocate_buffer_no_throw (ecma_object_t *arraybuffer_p) /**< A
     return false;
   }
 
-  return ecma_arraybuffer_allocate_buffer (arraybuffer_p) != NULL;
+  return ecma_arraybuffer_allocate_buffer (arraybuffer_p) != ECMA_VALUE_ERROR;
 } /* jerry_arraybuffer_allocate_buffer_no_throw */
 
 #endif /* JERRY_BUILTIN_TYPEDARRAY */

--- a/jerry-core/ecma/operations/ecma-arraybuffer-object.h
+++ b/jerry-core/ecma/operations/ecma-arraybuffer-object.h
@@ -36,7 +36,7 @@
 /**
  * Check whether the backing store is allocated for an array buffer.
  */
-#define ECMA_ARRAYBUFFER_CHECK_BUFFER_ERROR(arraybuffer_p)                                     \
+#define ECMA_ARRAYBUFFER_LAZY_ALLOC(arraybuffer_p)                                             \
   (JERRY_UNLIKELY (!(ECMA_ARRAYBUFFER_GET_FLAGS (arraybuffer_p) & ECMA_ARRAYBUFFER_ALLOCATED)) \
    && ecma_arraybuffer_allocate_buffer_throw (arraybuffer_p) == ECMA_VALUE_ERROR)
 
@@ -48,7 +48,7 @@ ecma_value_t ecma_op_create_arraybuffer_object (const ecma_value_t *, uint32_t);
 ecma_object_t *ecma_arraybuffer_create_object (uint8_t type, uint32_t length);
 ecma_object_t *ecma_arraybuffer_create_object_with_buffer (uint8_t type, uint32_t length);
 ecma_object_t *ecma_arraybuffer_new_object (uint32_t length);
-uint8_t *ecma_arraybuffer_allocate_buffer (ecma_object_t *arraybuffer_p);
+ecma_value_t ecma_arraybuffer_allocate_buffer (ecma_object_t *arraybuffer_p);
 ecma_value_t ecma_arraybuffer_allocate_buffer_throw (ecma_object_t *arraybuffer_p);
 void ecma_arraybuffer_release_buffer (ecma_object_t *arraybuffer_p);
 uint8_t *JERRY_ATTR_PURE ecma_arraybuffer_get_buffer (ecma_object_t *obj_p);

--- a/jerry-core/ecma/operations/ecma-dataview-object.c
+++ b/jerry-core/ecma/operations/ecma-dataview-object.c
@@ -299,9 +299,16 @@ ecma_op_dataview_get_set_view_value (ecma_value_t view, /**< the operation's 'vi
   /* GetViewValue 4., SetViewValue 6. */
   bool is_little_endian = ecma_op_to_boolean (is_little_endian_value);
 
-  if (ECMA_ARRAYBUFFER_CHECK_BUFFER_ERROR (buffer_p))
+  if (ECMA_ARRAYBUFFER_LAZY_ALLOC (buffer_p))
   {
+    ecma_free_value (value_to_set);
     return ECMA_VALUE_ERROR;
+  }
+
+  if (ecma_arraybuffer_is_detached (buffer_p))
+  {
+    ecma_free_value (value_to_set);
+    return ecma_raise_type_error (ECMA_ERR_ARRAYBUFFER_IS_DETACHED);
   }
 
   /* GetViewValue 7., SetViewValue 9. */
@@ -320,9 +327,16 @@ ecma_op_dataview_get_set_view_value (ecma_value_t view, /**< the operation's 'vi
     return ecma_raise_range_error (ECMA_ERR_START_OFFSET_IS_OUTSIDE_THE_BOUNDS_OF_THE_BUFFER);
   }
 
-  if (ECMA_ARRAYBUFFER_CHECK_BUFFER_ERROR (buffer_p))
+  if (ECMA_ARRAYBUFFER_LAZY_ALLOC (buffer_p))
   {
+    ecma_free_value (value_to_set);
     return ECMA_VALUE_ERROR;
+  }
+
+  if (ecma_arraybuffer_is_detached (buffer_p))
+  {
+    ecma_free_value (value_to_set);
+    return ecma_raise_type_error (ECMA_ERR_ARRAYBUFFER_IS_DETACHED);
   }
 
   /* GetViewValue 11., SetViewValue 13. */

--- a/jerry-core/vm/vm.c
+++ b/jerry-core/vm/vm.c
@@ -2185,7 +2185,7 @@ vm_loop (vm_frame_ctx_t *frame_ctx_p) /**< frame context */
 
           if (opcode == CBC_EXT_SET_NEXT_COMPUTED_FIELD_ANONYMOUS_FUNC)
           {
-            ecma_object_t *func_obj_p = ecma_get_object_from_value (result);
+            ecma_object_t *func_obj_p = ecma_get_object_from_value (stack_top_p[-1]);
 
             JERRY_ASSERT (ecma_find_named_property (func_obj_p, ecma_get_magic_string (LIT_MAGIC_STRING_NAME)) == NULL);
             ecma_property_value_t *value_p;

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -2294,8 +2294,33 @@
   <test id="built-ins/Atomics/xor/expected-return-value.js"><reason></reason></test>
   <test id="built-ins/Atomics/xor/good-views.js"><reason></reason></test>
   <test id="built-ins/Atomics/xor/non-views.js"><reason></reason></test>
+  <test id="built-ins/TypedArray/prototype/includes/detached-buffer-tointeger.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors-bigint/buffer-arg/typedarray-backed-by-sharedarraybuffer.js"><reason></reason></test>
   <test id="built-ins/TypedArrayConstructors/ctors/buffer-arg/typedarray-backed-by-sharedarraybuffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/DefineOwnProperty/BigInt/tonumber-value-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/DefineOwnProperty/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/DefineOwnProperty/tonumber-value-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Get/BigInt/detached-buffer-realm.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Get/BigInt/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Get/BigInt/infinity-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Get/detached-buffer-realm.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Get/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Get/infinity-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/detached-buffer-realm.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/GetOwnProperty/BigInt/enumerate-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/GetOwnProperty/detached-buffer-realm.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/GetOwnProperty/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/GetOwnProperty/enumerate-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/detached-buffer-realm.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/HasProperty/BigInt/infinity-with-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/HasProperty/detached-buffer-realm.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/HasProperty/detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/HasProperty/infinity-with-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Set/BigInt/tonumber-value-detached-buffer.js"><reason></reason></test>
+  <test id="built-ins/TypedArrayConstructors/internals/Set/tonumber-value-detached-buffer.js"><reason></reason></test>
   <!-- END - ES2017: Shared Memory and Atomics -->
 
   <!-- ES2018: RegExp Lookbehind Assertions


### PR DESCRIPTION
Added minor fixes to be able to update the test262 revision without failing on the CI
- Fixed TypedArray related functions where the ECMA_ARRAYBUFFER_CHECK_BUFFER_ERROR macro was used, because it was incorrect.
  According to the ECMAScript standard it is not always a TypeError is the underlying arraybuffer is detached
  (see also ECMAScript 2022: 10.4.5.6 [[Delete]] 1.b.i IsValidIntegerIndex)

JerryScript-DCO-1.0-Signed-off-by: Adam Szilagyi aszilagy@inf.u-szeged.hu
