### PR TITLE
Fixes msvc warnings

### DIFF
--- a/jerry-core/lit/lit-char-helpers.c
+++ b/jerry-core/lit/lit-char-helpers.c
@@ -150,8 +150,7 @@ lit_char_is_white_space (lit_code_point_t c) /**< code point */
   }
 
   return (c <= LIT_UTF16_CODE_UNIT_MAX
-          && ((c >= lit_unicode_white_space_interval_starts[0]
-               && c <= lit_unicode_white_space_interval_starts[0] + lit_unicode_white_space_interval_lengths[0])
+          && ((c >= lit_unicode_white_space_interval_starts[0] && c <= lit_unicode_white_space_interval_ends[0])
               || lit_search_char_in_array ((ecma_char_t) c,
                                            lit_unicode_white_space_chars,
                                            NUM_OF_ELEMENTS (lit_unicode_white_space_chars))));

--- a/jerry-core/lit/lit-unicode-ranges.inc.h
+++ b/jerry-core/lit/lit-unicode-ranges.inc.h
@@ -162,9 +162,9 @@ static const uint16_t lit_unicode_id_continue_chars[] JERRY_ATTR_CONST_DATA = {
 static const uint16_t lit_unicode_white_space_interval_starts[] JERRY_ATTR_CONST_DATA = { 0x2000 };
 
 /**
- * Character interval lengths for White_Space.
+ * Character interval ending points for White_Space.
  */
-static const uint8_t lit_unicode_white_space_interval_lengths[] JERRY_ATTR_CONST_DATA = { 0x000a };
+static const uint16_t lit_unicode_white_space_interval_ends[] JERRY_ATTR_CONST_DATA = { 0x2000 + 0x000a };
 
 /**
  * Non-interval characters for White_Space.


### PR DESCRIPTION
Simplify the code a bit by rename lit_unicode_white_space_interval_lengths to lit_unicode_white_space_interval_ends

[build] [1/3  33% :: 0.150] Building C object jerry-core\CMakeFiles\jerry-core.dir\lit\lit-char-helpers.c.obj
[build] C:\work\study\languages\typescript\jerryscript\jerry-core\lit\lit-char-helpers.c(154): warning C4018: '<=': signed/unsigned mismatch

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com