### PR TITLE
Fix arguments object detection in non-complex param list

### DIFF
--- a/tests/jerry/es.next/arguments.js
+++ b/tests/jerry/es.next/arguments.js
@@ -217,3 +217,8 @@ function f22 (arguments, [a = arguments]) {
   assert(arguments === 3.1);
 }
 f22(3.1, []);
+
+function f23(arguments, eval = () => eval()) {
+  assert(arguments === undefined);
+}
+f23(undefined);


### PR DESCRIPTION
This patch is the followup of #4849.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu