### PR TITLE
Prevent stack-overflow in json internalize property

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -162,7 +162,7 @@ jobs:
       - run: >-
           $RUNNER -q --jerry-tests
           --buildoptions=--stack-limit=0,--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--system-allocator=on,--linker-flag=-fuse-ld=gold
-          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js
+          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js
 
   ASAN_Tests_Debug:
     runs-on: ubuntu-latest
@@ -175,7 +175,7 @@ jobs:
       - run: >-
           $RUNNER -q --jerry-tests --build-debug
           --buildoptions=--stack-limit=0,--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--system-allocator=on,--linker-flag=-fuse-ld=gold
-          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js
+          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js
 
   UBSAN_Tests:
     runs-on: ubuntu-latest

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -26,6 +26,7 @@
 #include "ecma-objects-general.h"
 #include "ecma-objects.h"
 
+#include "jcontext.h"
 #include "jrt-libc-includes.h"
 #include "jrt.h"
 #include "lit-char-helpers.h"
@@ -634,6 +635,8 @@ ecma_builtin_json_internalize_property (ecma_object_t *reviver_p, /**< reviver f
   JERRY_ASSERT (reviver_p);
   JERRY_ASSERT (holder_p);
   JERRY_ASSERT (name_p);
+
+  ECMA_CHECK_STACK_USAGE ();
 
   /* 1. */
   ecma_value_t value = ecma_op_object_get (holder_p, name_p);

--- a/tests/jerry/regression-test-issue-4848.js
+++ b/tests/jerry/regression-test-issue-4848.js
@@ -1,0 +1,32 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var once = false;
+var m = 1;
+
+function JSEtest(){
+  if(!once){
+    m = new Array(1, 2, 3);
+    this[2] = m;
+  }
+  once = true;
+  return this[2] = m;
+}
+
+try {
+  JSON.parse("[1, 2, [4, 5]]", JSEtest);
+  assert(false);
+} catch (e){
+  assert(e instanceof RangeError);
+}


### PR DESCRIPTION
This patch fixes #4848.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu
