### PR TITLE
Fix class constructor as accessor check

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -726,7 +726,7 @@ parser_parse_class_body (parser_context_t *context_p, /**< context */
       }
       else if (parser_is_constructor_literal (context_p))
       {
-        JERRY_ASSERT (!is_static);
+        JERRY_ASSERT (!is_static || is_private);
         parser_raise_error (context_p, PARSER_ERR_CLASS_CONSTRUCTOR_AS_ACCESSOR);
       }
 

--- a/tests/jerry/es.next/regression-test-issue-4874.js
+++ b/tests/jerry/es.next/regression-test-issue-4874.js
@@ -1,0 +1,25 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Make sure that TypedArray filter correctly copies the data (avoid overflow).
+// Test creates a smaller region for "output" TypedArray.
+// Last number is intentionally a "big" float.
+
+for (let key of ['get', 'set']) {
+  try {
+    eval(`class { static ${key} #constructor() {} }`);
+  } catch (e) {
+    assert(e instanceof SyntaxError);
+  }
+}


### PR DESCRIPTION
This patch fixes #4874.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu
