### PR TITLE
Fix object class check for builtin Atomics

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -2986,6 +2986,12 @@ ecma_object_get_class_name (ecma_object_t *obj_p) /**< object */
           return LIT_MAGIC_STRING_JSON_U;
         }
 #endif /* JERRY_BUILTIN_JSON */
+#if JERRY_BUILTIN_ATOMICS
+        case ECMA_BUILTIN_ID_ATOMICS:
+        {
+          return LIT_MAGIC_STRING_ATOMICS_U;
+        }
+#endif /* JERRY_BUILTIN_ATOMICS */
 #if !JERRY_ESNEXT
 #if JERRY_BUILTIN_ERRORS
         case ECMA_BUILTIN_ID_EVAL_ERROR_PROTOTYPE:

--- a/tests/jerry/es.next/regression-test-issue-4884.js
+++ b/tests/jerry/es.next/regression-test-issue-4884.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+assert(Object.prototype.toString.call(Atomics) === '[object Atomics]');


### PR DESCRIPTION
This patch fixes #4884.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu
