### PR TITLE
Fix Typedarray.slice fastpath when the content type is matching

### DIFF
--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1628,14 +1628,30 @@ ecma_builtin_typedarray_prototype_slice (ecma_value_t this_arg, /**< this argume
     return ECMA_VALUE_ERROR;
   }
 
-  JERRY_ASSERT (new_typedarray_info.offset == 0);
-
   src_buffer_p += relative_start << info_p->shift;
 
   if (info_p->id == new_typedarray_info.id)
   {
     // 22.2.3.23. Step 22. h-i.
-    memcpy (dst_buffer_p, src_buffer_p, count << info_p->shift);
+
+    if (JERRY_LIKELY (new_typedarray_info.offset == 0))
+    {
+      memcpy (dst_buffer_p, src_buffer_p, count << info_p->shift);
+    }
+    else if (count >= new_typedarray_info.offset)
+    {
+      uint32_t byte_shift = (uint32_t) (1 << info_p->shift);
+
+      while (count)
+      {
+        memmove (dst_buffer_p, src_buffer_p, byte_shift);
+
+        dst_buffer_p += byte_shift;
+        src_buffer_p += byte_shift;
+
+        count--;
+      }
+    }
   }
   else
   {

--- a/tests/jerry/es.next/regression-test-issue-4888.js
+++ b/tests/jerry/es.next/regression-test-issue-4888.js
@@ -1,0 +1,31 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var ab = new Int8Array(20).map((v, i) => i + 1).buffer;
+var ta = new Int8Array(ab, 0, 10);
+ta.constructor = {
+  [Symbol.species]: function (len) {
+    return new Int8Array(ab, 1, len);
+  }
+};
+
+var tb = ta.slice();
+
+for (let e of ta) {
+  assert(e === 1);
+}
+
+for (let e of tb) {
+  assert(e === 1);
+}


### PR DESCRIPTION
This patch fixes #4888.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu
