### PR TITLE
Drop legacy test262-ES2015 testing support

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -82,20 +82,6 @@ jobs:
       - run: $RUNNER --test262
       - run: $RUNNER --test262 --build-debug
 
-  Conformance_Tests_ES2015:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: $RUNNER --test262-es2015=update
-      - run: $RUNNER --test262-es2015=update --build-debug
-      - uses: actions/upload-artifact@v2
-        if: success() || failure()
-        with:
-          name: Test262-ES2015-results
-          path: |
-            build/tests/test262_tests_es2015/local/bin/test262.report
-            build/tests/test262_tests_es2015-debug/local/bin/test262.report
-
   Conformance_Tests_ESNext:
     runs-on: ubuntu-latest
     steps:

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -97,11 +97,6 @@ TEST262_TEST_SUITE_OPTIONS = [
     Options('test262_tests', OPTIONS_PROFILE_ES51),
 ]
 
-# Test options for test262-es2015
-TEST262_ES2015_TEST_SUITE_OPTIONS = [
-    Options('test262_tests_es2015', OPTIONS_PROFILE_ESNEXT + ['--line-info=on', '--error-messages=on']),
-]
-
 # Test options for test262-esnext
 TEST262_ESNEXT_TEST_SUITE_OPTIONS = [
     Options('test262_tests_esnext', OPTIONS_PROFILE_ESNEXT
@@ -199,10 +194,6 @@ def get_arguments():
                         help='Run jerry-tests')
     parser.add_argument('--test262', action='store_true',
                         help='Run test262 - ES5.1')
-    parser.add_argument('--test262-es2015', default=False, const='default',
-                        nargs='?', choices=['default', 'all', 'update'],
-                        help='Run test262 - ES2015. default: all tests except excludelist, ' +
-                        'all: all tests, update: all tests and update excludelist')
     parser.add_argument('--test262-esnext', default=False, const='default',
                         nargs='?', choices=['default', 'all', 'update'],
                         help='Run test262 - ESnext. default: all tests except excludelist, ' +
@@ -223,8 +214,8 @@ def get_arguments():
     script_args = parser.parse_args()
 
     if script_args.test262_test_list and not \
-       (script_args.test262 or script_args.test262_es2015 or script_args.test262_esnext):
-        print("--test262-test-list is only allowed with --test262 or --test262-es2015 or --test262-esnext\n")
+       (script_args.test262 or script_args.test262_esnext):
+        print("--test262-test-list is only allowed with --test262 or --test262-esnext\n")
         parser.print_help()
         sys.exit(1)
 
@@ -412,8 +403,6 @@ def run_test262_test_suite(options):
     jobs = []
     if options.test262:
         jobs.extend(TEST262_TEST_SUITE_OPTIONS)
-    if options.test262_es2015:
-        jobs.extend(TEST262_ES2015_TEST_SUITE_OPTIONS)
     if options.test262_esnext:
         jobs.extend(TEST262_ESNEXT_TEST_SUITE_OPTIONS)
 
@@ -430,10 +419,7 @@ def run_test262_test_suite(options):
             '--test-dir', settings.TEST262_TEST_SUITE_DIR
         ]
 
-        if job.name.endswith('es2015'):
-            test_cmd.append('--es2015')
-            test_cmd.append(options.test262_es2015)
-        elif job.name.endswith('esnext'):
+        if job.name.endswith('esnext'):
             test_cmd.append('--esnext')
             test_cmd.append(options.test262_esnext)
         else:
@@ -506,7 +492,7 @@ def main(options):
         Check(options.check_strings, run_check, [settings.STRINGS_SCRIPT]),
         Check(options.jerry_debugger, run_jerry_debugger_tests, options),
         Check(options.jerry_tests, run_jerry_tests, options),
-        Check(options.test262 or options.test262_es2015 or options.test262_esnext, run_test262_test_suite, options),
+        Check(options.test262 or options.test262_esnext, run_test262_test_suite, options),
         Check(options.unittests, run_unittests, options),
         Check(options.buildoption_test, run_buildoption_test, options),
     ]

--- a/tools/runners/run-test-suite-test262.py
+++ b/tools/runners/run-test-suite-test262.py
@@ -44,10 +44,6 @@ def get_arguments():
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--es51', action='store_true',
                        help='Run test262 ES5.1 version')
-    group.add_argument('--es2015', default=False, const='default',
-                       nargs='?', choices=['default', 'all', 'update'],
-                       help='Run test262 - ES2015. default: all tests except excludelist, ' +
-                       'all: all tests, update: all tests and update excludelist')
     group.add_argument('--esnext', default=False, const='default',
                        nargs='?', choices=['default', 'all', 'update'],
                        help='Run test262 - ES.next. default: all tests except excludelist, ' +
@@ -57,12 +53,7 @@ def get_arguments():
 
     args = parser.parse_args()
 
-    if args.es2015:
-        args.test_dir = os.path.join(args.test_dir, 'es2015')
-        args.test262_harness_dir = os.path.abspath(os.path.dirname(__file__))
-        args.test262_git_hash = 'fd44cd73dfbce0b515a2474b7cd505d6176a9eb5'
-        args.excludelist_path = os.path.join('tests', 'test262-es6-excludelist.xml')
-    elif args.esnext:
+    if args.esnext:
         args.test_dir = os.path.join(args.test_dir, 'esnext')
         args.test262_harness_dir = os.path.abspath(os.path.dirname(__file__))
         args.test262_git_hash = '9f2814f00ff7612f74024c15c165853b6765c7ab'
@@ -72,7 +63,7 @@ def get_arguments():
         args.test262_harness_dir = args.test_dir
         args.test262_git_hash = 'es5-tests'
 
-    args.mode = args.es2015 or args.esnext
+    args.mode = args.esnext
 
     return args
 
@@ -98,15 +89,6 @@ def prepare_test262_test_suite(args):
         path_to_remove = os.path.join(args.test_dir, 'test', 'suite', 'intl402')
         if os.path.isdir(path_to_remove):
             shutil.rmtree(path_to_remove)
-
-    # Since ES2018 iterator's next method is called once during the prologue of iteration,
-    # rather than during each step. The test is incorrect and stuck in an infinite loop.
-    # https://github.com/tc39/test262/pull/1248 fixed the test and it passes on test262-esnext.
-    if args.es2015:
-        test_to_remove = 'test/language/statements/for-of/iterator-next-reference.js'
-        path_to_remove = os.path.join(args.test_dir, os.path.normpath(test_to_remove))
-        if os.path.isfile(path_to_remove):
-            os.remove(path_to_remove)
 
     return 0
 


### PR DESCRIPTION
ES2015 features are already covered by ES.Next tests,
there is no need to run duplicated and outdated tests.

JerryScript-DCO-1.0-Signed-off-by: Csaba Osztrogonác csaba.osztrogonac@h-lab.eu