### PR TITLE
Fix class static block opening brace parsing

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -3273,14 +3273,17 @@ lexer_expect_object_literal_id (parser_context_t *context_p, /**< context */
 #endif /* JERRY_ESNEXT */
       case LIT_CHAR_LEFT_BRACE:
       {
-        if (ident_opts & (LEXER_OBJ_IDENT_CLASS_NO_STATIC | LEXER_OBJ_IDENT_CLASS_PRIVATE))
+        const uint32_t static_block_flags =
+          (LEXER_OBJ_IDENT_CLASS_NO_STATIC | LEXER_OBJ_IDENT_CLASS_PRIVATE | LEXER_OBJ_IDENT_CLASS_IDENTIFIER);
+
+        if ((ident_opts & static_block_flags) == LEXER_OBJ_IDENT_CLASS_IDENTIFIER)
         {
-          break;
+          context_p->token.type = LEXER_LEFT_BRACE;
+          lexer_consume_next_character (context_p);
+          return;
         }
 
-        context_p->token.type = LEXER_LEFT_BRACE;
-        lexer_consume_next_character (context_p);
-        return;
+        break;
       }
       case LIT_CHAR_RIGHT_BRACE:
       {

--- a/tests/jerry/es.next/regression-test-issue-4916.js
+++ b/tests/jerry/es.next/regression-test-issue-4916.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+    eval(`var a = { get {(param)} }`);
+    assert(false);
+}
+catch (e) {
+    assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
The next character should not be consumed after finding the static block opening brace.
This patch fixes #4916.

JerryScript-DCO-1.0-Signed-off-by: Martin Negyokru negyokru@inf.u-szeged.hu
