### PR TITLE
Accessors should be kept alive during their invocation

### DIFF
--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1390,6 +1390,55 @@ ecma_op_function_call_bound (ecma_object_t *func_obj_p, /**< Function object */
 } /* ecma_op_function_call_bound */
 
 /**
+ * Invoke accessor getter function
+ *
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
+ */
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+ecma_op_invoke_getter (ecma_getter_setter_pointers_t *get_set_pair_p, /**< accessor pair */
+                       ecma_value_t this_value) /**< 'this' argument's value */
+{
+  if (get_set_pair_p->getter_cp == JMEM_CP_NULL)
+  {
+    return ECMA_VALUE_UNDEFINED;
+  }
+
+  ecma_object_t *getter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, get_set_pair_p->getter_cp);
+  ecma_ref_object (getter_p);
+
+  ecma_value_t result = ecma_op_function_call (getter_p, this_value, NULL, 0);
+  ecma_deref_object (getter_p);
+
+  return result;
+} /* ecma_op_invoke_getter */
+
+/**
+ * Invoke accessor setter function
+ *
+ * @return ecma value
+ *         Returned value must be freed with ecma_free_value
+ */
+extern inline ecma_value_t JERRY_ATTR_ALWAYS_INLINE
+ecma_op_invoke_setter (ecma_getter_setter_pointers_t *get_set_pair_p, /**< accessor pair */
+                       ecma_value_t this_value, /**< 'this' argument's value */
+                       ecma_value_t value) /**< value to set */
+{
+  if (get_set_pair_p->setter_cp == JMEM_CP_NULL)
+  {
+    return ECMA_VALUE_UNDEFINED;
+  }
+
+  ecma_object_t *setter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, get_set_pair_p->setter_cp);
+  ecma_ref_object (setter_p);
+
+  ecma_value_t result = ecma_op_function_call (setter_p, this_value, &value, 1);
+  ecma_deref_object (setter_p);
+
+  return result;
+} /* ecma_op_invoke_setter */
+
+/**
  * General [[Call]] implementation
  *
  * @return ecma value

--- a/jerry-core/ecma/operations/ecma-function-object.h
+++ b/jerry-core/ecma/operations/ecma-function-object.h
@@ -84,6 +84,11 @@ ecma_object_t *ecma_op_get_prototype_from_constructor (ecma_object_t *ctor_obj_p
 
 ecma_value_t ecma_op_function_has_instance (ecma_object_t *func_obj_p, ecma_value_t value);
 
+ecma_value_t ecma_op_invoke_getter (ecma_getter_setter_pointers_t *get_set_pair_p, ecma_value_t this_value);
+
+ecma_value_t
+ecma_op_invoke_setter (ecma_getter_setter_pointers_t *get_set_pair_p, ecma_value_t this_value, ecma_value_t value);
+
 ecma_value_t ecma_op_function_validated_call (ecma_value_t callee,
                                               ecma_value_t this_arg_value,
                                               const ecma_value_t *arguments_list_p,

--- a/jerry-core/ecma/operations/ecma-reference.c
+++ b/jerry-core/ecma/operations/ecma-reference.c
@@ -371,17 +371,8 @@ ecma_op_resolve_reference_value (ecma_object_t *lex_env_p, /**< starting lexical
               return ecma_fast_copy_value (prop_value_p->value);
             }
 
-            ecma_getter_setter_pointers_t *get_set_pair_p = ecma_get_named_accessor_property (prop_value_p);
-
-            if (get_set_pair_p->getter_cp == JMEM_CP_NULL)
-            {
-              return ECMA_VALUE_UNDEFINED;
-            }
-
-            ecma_object_t *getter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, get_set_pair_p->getter_cp);
-
-            ecma_value_t base_value = ecma_make_object_value (binding_obj_p);
-            return ecma_op_function_call (getter_p, base_value, NULL, 0);
+            return ecma_op_invoke_getter (ecma_get_named_accessor_property (prop_value_p),
+                                          ecma_make_object_value (binding_obj_p));
           }
 #endif /* JERRY_LCACHE */
         }

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1429,9 +1429,7 @@ opfunc_private_set (ecma_value_t base, /**< this object */
     return ecma_raise_type_error (ECMA_ERR_PRIVATE_FIELD_WAS_DEFINED_WITHOUT_A_SETTER);
   }
 
-  ecma_object_t *setter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, get_set_pair_p->setter_cp);
-
-  return ecma_op_function_call (setter_p, base, &value, 1);
+  return ecma_op_invoke_setter (get_set_pair_p, base, value);
 } /* opfunc_private_set */
 
 /**
@@ -1479,8 +1477,7 @@ opfunc_private_get (ecma_value_t base, /**< this object */
     }
     else
     {
-      ecma_object_t *getter_p = ECMA_GET_NON_NULL_POINTER (ecma_object_t, get_set_pair_p->getter_cp);
-      result = ecma_op_function_call (getter_p, base, NULL, 0);
+      result = ecma_op_invoke_getter (get_set_pair_p, base);
     }
   }
 

--- a/tests/jerry/es.next/regression-test-issue-4900.js
+++ b/tests/jerry/es.next/regression-test-issue-4900.js
@@ -1,0 +1,41 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function assertArrayEqual(actual, expected) {
+  assert(actual.length === expected.length);
+
+  for (var i = 0; i < actual.length; i++) {
+    assert(actual[i] === expected[i]);
+  }
+}
+
+var i = 0;
+var a = [];
+var JSEtest = [];
+
+JSEtest.__defineGetter__(0, function NaN() {
+  if (i++ > 2) {
+    return;
+  }
+
+  JSEtest.shift();
+  gc();
+  a.push(0);
+  a.concat(JSEtest);
+});
+
+JSEtest[0];
+
+assertArrayEqual(a, [0, 0, 0]);
+assertArrayEqual(JSEtest, []);


### PR DESCRIPTION
This patch fixes #4900.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu
