### PR TITLE
Fix invalid assertion CESU8-UTF8 buffer copy

### DIFF
--- a/jerry-core/lit/lit-strings.c
+++ b/jerry-core/lit/lit-strings.c
@@ -865,7 +865,7 @@ lit_convert_cesu8_string_to_utf8_string (const lit_utf8_byte_t *cesu8_string_p, 
     cesu8_cursor_p += read_size;
   }
 
-  JERRY_ASSERT (cesu8_cursor_p == cesu8_end_p);
+  JERRY_ASSERT (cesu8_cursor_p <= cesu8_end_p);
   JERRY_ASSERT (utf8_cursor_p <= utf8_end_p);
 
   return (lit_utf8_byte_t) (utf8_cursor_p - utf8_string_p);

--- a/tests/jerry/fail/regression-test-issue-4920.js
+++ b/tests/jerry/fail/regression-test-issue-4920.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const v2 = String.fromCodePoint(1337);
+const v4 = v2.padEnd(1337, v2);
+const v7 = undefined[v4];


### PR DESCRIPTION
The UTF8 buffer size can be smaller then the CESU8 string's size so the UTF8 output is may truncated. Therefore we cannot ensure that the CESU8 buffer is read until the end.
This patch fixes #4920.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu