### PR TITLE
Const literal marker should be processed before group assignment marker

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -3486,16 +3486,16 @@ parser_process_binary_assignment_token (parser_context_t *context_p, /**< contex
 
   bool group_expr_assingment = false;
 
-  if (JERRY_UNLIKELY (context_p->stack_top_uint8 == LEXER_ASSIGN_GROUP_EXPR))
-  {
-    group_expr_assingment = true;
-    parser_stack_pop_uint8 (context_p);
-  }
-
   if (JERRY_UNLIKELY (context_p->stack_top_uint8 == LEXER_ASSIGN_CONST))
   {
     parser_stack_pop_uint8 (context_p);
     parser_emit_cbc_ext (context_p, CBC_EXT_THROW_ASSIGN_CONST_ERROR);
+  }
+
+  if (JERRY_UNLIKELY (context_p->stack_top_uint8 == LEXER_ASSIGN_GROUP_EXPR))
+  {
+    group_expr_assingment = true;
+    parser_stack_pop_uint8 (context_p);
   }
 
   if (index == PARSER_INVALID_LITERAL_INDEX)

--- a/tests/jerry/es.next/regression-test-issue-4925.js
+++ b/tests/jerry/es.next/regression-test-issue-4925.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  for (const i = 0;;)
+    (i) = 5;
+  assert(false);
+} catch (e) {
+    assert(e instanceof TypeError);
+}


### PR DESCRIPTION
This patch fixes #4925.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu
