### PR TITLE
Fix async identifier parsing in class field position

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -2861,7 +2861,7 @@ scanner_scan_all (parser_context_t *context_p) /**< context */
             continue;
           }
 
-          if (literal_pool_flags != SCANNER_LITERAL_POOL_FUNCTION)
+          if (literal_pool_flags & SCANNER_LITERAL_POOL_GENERATOR)
           {
             scanner_raise_error (context_p);
           }

--- a/tests/jerry/es.next/regression-test-issue-4927.js
+++ b/tests/jerry/es.next/regression-test-issue-4927.js
@@ -1,0 +1,29 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class C1 { async }
+class C2 { async; constructor() {} }
+class C3 { async = 5.1; constructor() {} }
+
+assert((new C1).async === undefined);
+assert((new C2).async === undefined);
+assert((new C3).async === 5.1);
+
+try {
+  eval('class C1 { async* }');
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}
+


### PR DESCRIPTION
This patch fixes #4927

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu