### PR TITLE
Check rest initializer existence after pattern finalization

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -4072,6 +4072,10 @@ parser_parse_object_initializer (parser_context_t *context_p, /**< context */
     return;
   }
 
+#ifndef JERRY_NDEBUG
+  bool rest_found = false;
+#endif /* !defined(JERRY_NDEBUG) */
+
   cbc_ext_opcode_t context_opcode = CBC_EXT_OBJ_INIT_CONTEXT_CREATE;
 
   if (flags & PARSER_PATTERN_HAS_REST_ELEMENT)
@@ -4115,8 +4119,9 @@ parser_parse_object_initializer (parser_context_t *context_p, /**< context */
         parser_raise_error (context_p, PARSER_ERR_RIGHT_BRACE_EXPECTED);
       }
 
-      /* Checked at the end because there might be syntax errors before. */
-      JERRY_ASSERT (flags & PARSER_PATTERN_HAS_REST_ELEMENT);
+#ifndef JERRY_NDEBUG
+      rest_found = true;
+#endif /* !defined(JERRY_NDEBUG) */
       break;
     }
 
@@ -4203,6 +4208,11 @@ parser_parse_object_initializer (parser_context_t *context_p, /**< context */
   parser_emit_cbc_ext (context_p, CBC_EXT_OBJ_INIT_CONTEXT_END);
 
   parser_pattern_finalize (context_p, flags, &end_pos);
+
+#ifndef JERRY_NDEBUG
+  /* Checked at the end because there might be syntax errors before. */
+  JERRY_ASSERT (!!(flags & PARSER_PATTERN_HAS_REST_ELEMENT) == rest_found);
+#endif /* !defined(JERRY_NDEBUG) */
 } /* parser_parse_object_initializer */
 
 /**

--- a/tests/jerry/es.next/regression-test-issue-4928.js
+++ b/tests/jerry/es.next/regression-test-issue-4928.js
@@ -1,0 +1,20 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval('var { a, b, ...rest }"');
+  assert(false);
+} catch(e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
Since the scanner info is not present for invalid destructuring patterns we can only ensure the existence of the rest element after the pattern is finalized.
This patch fixes #4928.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu