### PR TITLE
Private identifier resolving should always construct new literal object

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -1517,6 +1517,7 @@ parser_resolve_private_identifier (parser_context_t *context_p) /**< context */
 
     if (!(context_iter_p->opts & SCANNER_SUCCESSFUL_CLASS_SCAN))
     {
+      lexer_construct_literal_object (context_p, &context_p->token.lit_location, LEXER_STRING_LITERAL);
       return;
     }
 

--- a/tests/jerry/es.next/regression-test-issue-4930.js
+++ b/tests/jerry/es.next/regression-test-issue-4930.js
@@ -1,0 +1,30 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+  eval(`class JSEtest {
+      #test262;
+
+      getPrivateReference() {
+          return this.#test262;
+      }
+
+      setPrivateReference(value) {function    this.#test262 = value;
+      }
+      };
+  `);
+  assert(false);
+} catch (e) {
+  assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
This patch fixes #4930.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu