### PR TITLE
Fix fast array objects cannot hold private properties

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -1235,6 +1235,11 @@ opfunc_find_private_key (ecma_object_t *class_object_p, /**< class environment *
                          ecma_string_t *search_key_p, /**< key */
                          ecma_string_t **out_private_key_p) /**< [out] private key */
 {
+  if (ecma_op_object_is_fast_array (obj_p))
+  {
+    return NULL;
+  }
+
   ecma_string_t *internal_string_p = ecma_get_internal_string (LIT_INTERNAL_MAGIC_STRING_CLASS_PRIVATE_ELEMENTS);
   ecma_property_t *prop_p = ecma_find_named_property (class_object_p, internal_string_p);
 

--- a/tests/jerry/es.next/regression-test-issue-4934.js
+++ b/tests/jerry/es.next/regression-test-issue-4934.js
@@ -1,0 +1,39 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function expectTypeError(cb) {
+  try {
+    cb();
+    assert(false);
+  } catch (e) {
+    assert(e instanceof TypeError);
+  }
+}
+
+class JSEtest {
+  static set #m(v) {
+    this._v = v;
+  }
+
+  static b() {
+    new Proxy([1], {}).#m = "Test262";
+  }
+
+  static c() {
+    [1].#m = "Test262";
+  }
+}
+
+expectTypeError(_ => JSEtest.b());
+expectTypeError(_ => JSEtest.c());


### PR DESCRIPTION
This patch fixes #4934.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu