### PR TITLE
Add missing toObject conversion for PrivateSet operation

### DIFF
--- a/tests/jerry/es.next/regression-test-issue-4936.js
+++ b/tests/jerry/es.next/regression-test-issue-4936.js
@@ -1,0 +1,33 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class JSEtest {
+  set #m(v) {
+    this._v = v;
+  }
+
+  method() {
+    let self = !this;
+    self.#m = 'Test262';
+  }
+}
+
+let c = new JSEtest();
+
+try {
+  c.method();
+  assert(false);
+} catch (e) {
+  assert(e instanceof TypeError);
+}

--- a/tests/test262-esnext-excludelist.xml
+++ b/tests/test262-esnext-excludelist.xml
@@ -478,7 +478,6 @@
   <test id="language/statements/class/elements/private-method-double-initialisation-get-and-set.js"><reason></reason></test>
   <test id="language/statements/class/elements/private-method-double-initialisation-get.js"><reason></reason></test>
   <test id="language/statements/class/elements/private-method-double-initialisation-set.js"><reason></reason></test>
-  <test id="language/statements/class/elements/privatefieldput-primitive-receiver.js"><reason></reason></test>
   <test id="language/statements/class/elements/privatefieldset-evaluation-order-1.js"><reason></reason></test>
   <test id="language/statements/class/elements/privatefieldset-evaluation-order-2.js"><reason></reason></test>
   <test id="language/statements/class/elements/privatefieldset-evaluation-order-3.js"><reason></reason></test>


### PR DESCRIPTION
This patch fixes #4936.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu