### PR TITLE
Date.prototype.setYear should invalidate cached tza

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-date-prototype.c
@@ -472,6 +472,9 @@ ecma_builtin_date_prototype_dispatch_set (uint16_t builtin_routine_id, /**< buil
         if (ecma_number_is_nan (converted_number[0]))
         {
           *date_value_p = converted_number[0];
+#if JERRY_ESNEXT
+          date_object_p->header.u.cls.u1.date_flags &= (uint8_t) ~ECMA_DATE_TZA_SET;
+#endif /* JERRY_ESNEXT */
           return ecma_make_number_value (converted_number[0]);
         }
 

--- a/tests/jerry/es.next/regression-test-issue-4939-4940.js
+++ b/tests/jerry/es.next/regression-test-issue-4939-4940.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var date = new Date(1970, 0);
+date.setYear(-0);
+assert(date.getFullYear() === 1900)


### PR DESCRIPTION
This patch fixes #4939 and fixes #4940.

JerryScript-DCO-1.0-Signed-off-by: Robert Fancsik robert.fancsik@h-lab.eu
