### PR TITLE
Ban setting 'Object.prototype.__proto__' as Proxy to prevent circular…

### DIFF
--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -3332,6 +3332,15 @@ ecma_op_ordinary_object_set_prototype_of (ecma_object_t *obj_p, /**< base object
 #if JERRY_BUILTIN_PROXY
     if (ECMA_OBJECT_IS_PROXY (iter_p))
     {
+      /**
+       * Prevent setting 'Object.prototype.__proto__'
+       * to avoid circular referencing in the prototype chain.
+       */
+      if (obj_p == ecma_builtin_get (ECMA_BUILTIN_ID_OBJECT_PROTOTYPE))
+      {
+        return ECMA_VALUE_FALSE;
+      }
+
       break;
     }
 #endif /* JERRY_BUILTIN_PROXY */

--- a/tests/jerry/es.next/regression-test-issue-4941.js
+++ b/tests/jerry/es.next/regression-test-issue-4941.js
@@ -1,0 +1,27 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+    Object.prototype.__proto__ = new Proxy({}, {});
+    assert(false);
+} catch (e) {
+    assert(e instanceof TypeError);
+}
+
+try {
+    __proto__.__proto__ = new Proxy({}, {});
+    assert(false);
+} catch (e) {
+    assert(e instanceof TypeError);
+}


### PR DESCRIPTION
… referencing

in prototype chain.

This patch fixes #4941

JerryScript-DCO-1.0-Signed-off-by: Martin Negyokru negyokru@inf.u-szeged.hu
