### PR TITLE
Fix scanning bracketed expressions

### DIFF
--- a/jerry-core/parser/js/js-scanner-ops.c
+++ b/jerry-core/parser/js/js-scanner-ops.c
@@ -480,18 +480,16 @@ scanner_scan_bracket (parser_context_t *context_p, /**< context */
           async_source_p = source_p;
         }
       }
-      else if (depth == total_depth - 1)
-      {
-        if (lexer_check_arrow (context_p))
-        {
-          arrow_type = SCANNER_SCAN_BRACKET_ARROW_WITH_ONE_ARG;
-          break;
-        }
 
-        if (context_p->stack_top_uint8 == SCAN_STACK_USE_ASYNC)
-        {
-          scanner_add_async_literal (context_p, scanner_context_p);
-        }
+      if (depth == total_depth - 1 && lexer_check_arrow (context_p))
+      {
+        arrow_type = SCANNER_SCAN_BRACKET_ARROW_WITH_ONE_ARG;
+        break;
+      }
+
+      if (context_p->stack_top_uint8 == SCAN_STACK_USE_ASYNC)
+      {
+        scanner_add_async_literal (context_p, scanner_context_p);
       }
 
       arrow_source_p = NULL;

--- a/tests/jerry/es.next/regression-test-issue-4924.js
+++ b/tests/jerry/es.next/regression-test-issue-4924.js
@@ -1,0 +1,45 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+try {
+    eval(`async((a))`);
+    assert(false);
+}
+catch (e) {
+    assert(e instanceof ReferenceError);
+}
+
+try {
+    eval(`async(async((async((a)))))`);
+    assert(false);
+}
+catch (e) {
+    assert(e instanceof ReferenceError);
+}
+
+try {
+    eval(`async((a)`);
+    assert(false);
+}
+catch (e) {
+    assert(e instanceof SyntaxError);
+}
+
+try {
+    eval(`async((a)))`);
+    assert(false);
+}
+catch (e) {
+    assert(e instanceof SyntaxError);
+}


### PR DESCRIPTION
Scan 'async' literal with different depth of brackets

This patch fixes #4924.
This patch fixes #4748.

JerryScript-DCO-1.0-Signed-off-by: Martin Negyokru negyokru@inf.u-szeged.hu
