### PR TITLE
Add stack-overflow check to 'lexer_construct_function_object'

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -2799,6 +2799,12 @@ uint16_t
 lexer_construct_function_object (parser_context_t *context_p, /**< context */
                                  uint32_t extra_status_flags) /**< extra status flags */
 {
+#if (JERRY_STACK_LIMIT != 0)
+  if (JERRY_UNLIKELY (ecma_get_current_stack_usage () > CONFIG_MEM_STACK_LIMIT))
+  {
+    parser_raise_error (context_p, PARSER_ERR_STACK_OVERFLOW);
+  }
+#endif /* JERRY_STACK_LIMIT != 0 */
   ecma_compiled_code_t *compiled_code_p;
   lexer_literal_t *literal_p;
   uint16_t result_index;

--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2505,6 +2505,13 @@ parser_parse_source (void *source_p, /**< source code */
     jcontext_raise_exception (ECMA_VALUE_NULL);
     return NULL;
   }
+#if (JERRY_STACK_LIMIT != 0)
+  if (context.error == PARSER_ERR_STACK_OVERFLOW)
+  {
+    ecma_raise_standard_error (JERRY_ERROR_RANGE, ECMA_ERR_MAXIMUM_CALL_STACK_SIZE_EXCEEDED);
+    return NULL;
+  }
+#endif /* JERRY_STACK_LIMIT != 0 */
 
 #if JERRY_ERROR_MESSAGES
   ecma_string_t *err_str_p;

--- a/jerry-core/parser/js/parser-errors.h
+++ b/jerry-core/parser/js/parser-errors.h
@@ -32,7 +32,10 @@ typedef enum
   /** @endcond */
   PARSER_ERR_OUT_OF_MEMORY,
   PARSER_ERR_INVALID_REGEXP,
-  PARSER_ERR_NO_ERROR
+#if (JERRY_STACK_LIMIT != 0)
+  PARSER_ERR_STACK_OVERFLOW,
+#endif /* JERRY_STACK_LIMIT != 0 */
+  PARSER_ERR_NO_ERROR,
 } parser_error_msg_t;
 
 const lit_utf8_byte_t* parser_get_error_utf8 (uint32_t id);


### PR DESCRIPTION
This patch fixes #4887.

JerryScript-DCO-1.0-Signed-off-by: Martin Negyokru negyokru@inf.u-szeged.hu
