### PR TITLE
Fix logging related issues

### DIFF
--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -300,6 +300,7 @@ set(SOURCE_CORE_FILES
   jmem/jmem-heap.c
   jmem/jmem-poolman.c
   jrt/jrt-fatals.c
+  jrt/jrt-logging.c
   lit/lit-char-helpers.c
   lit/lit-magic-strings.c
   lit/lit-strings.c

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -169,7 +169,6 @@ struct jerry_context_t
   uint32_t lit_magic_string_ex_count; /**< external magic strings count */
   uint32_t jerry_init_flags; /**< run-time configuration flags */
   uint32_t status_flags; /**< run-time flags (the top 8 bits are used for passing class parsing options) */
-  jerry_log_level_t log_level; /**< current log level */
 
 #if (JERRY_GC_MARK_LIMIT != 0)
   uint32_t ecma_gc_mark_recursion_limit; /**< GC mark recursion limit */

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -738,32 +738,20 @@ jmem_heap_stats_print (void)
 
   JERRY_DEBUG_MSG ("Heap stats:\n");
 #if !JERRY_SYSTEM_ALLOCATOR
-  JERRY_DEBUG_MSG ("  Heap size = %zu bytes\n", heap_stats->size);
+  JERRY_DEBUG_MSG ("  Heap size = %u bytes\n", (unsigned) heap_stats->size);
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
-  JERRY_DEBUG_MSG ("  Allocated = %zu bytes\n"
-                   "  Peak allocated = %zu bytes\n"
-                   "  Waste = %zu bytes\n"
-                   "  Peak waste = %zu bytes\n"
-                   "  Allocated byte code data = %zu bytes\n"
-                   "  Peak allocated byte code data = %zu bytes\n"
-                   "  Allocated string data = %zu bytes\n"
-                   "  Peak allocated string data = %zu bytes\n"
-                   "  Allocated object data = %zu bytes\n"
-                   "  Peak allocated object data = %zu bytes\n"
-                   "  Allocated property data = %zu bytes\n"
-                   "  Peak allocated property data = %zu bytes\n",
-                   heap_stats->allocated_bytes,
-                   heap_stats->peak_allocated_bytes,
-                   heap_stats->waste_bytes,
-                   heap_stats->peak_waste_bytes,
-                   heap_stats->byte_code_bytes,
-                   heap_stats->peak_byte_code_bytes,
-                   heap_stats->string_bytes,
-                   heap_stats->peak_string_bytes,
-                   heap_stats->object_bytes,
-                   heap_stats->peak_object_bytes,
-                   heap_stats->property_bytes,
-                   heap_stats->peak_property_bytes);
+  JERRY_DEBUG_MSG ("  Allocated = %u bytes\n", (unsigned) heap_stats->allocated_bytes);
+  JERRY_DEBUG_MSG ("  Peak allocated = %u bytes\n", (unsigned) heap_stats->peak_allocated_bytes);
+  JERRY_DEBUG_MSG ("  Waste = %u bytes\n", (unsigned) heap_stats->waste_bytes);
+  JERRY_DEBUG_MSG ("  Peak waste = %u bytes\n", (unsigned) heap_stats->peak_waste_bytes);
+  JERRY_DEBUG_MSG ("  Allocated byte code data = %u bytes\n", (unsigned) heap_stats->byte_code_bytes);
+  JERRY_DEBUG_MSG ("  Peak allocated byte code data = %u bytes\n", (unsigned) heap_stats->peak_byte_code_bytes);
+  JERRY_DEBUG_MSG ("  Allocated string data = %u bytes\n", (unsigned) heap_stats->string_bytes);
+  JERRY_DEBUG_MSG ("  Peak allocated string data = %u bytes\n", (unsigned) heap_stats->peak_string_bytes);
+  JERRY_DEBUG_MSG ("  Allocated object data = %u bytes\n", (unsigned) heap_stats->object_bytes);
+  JERRY_DEBUG_MSG ("  Peak allocated object data = %u bytes\n", (unsigned) heap_stats->peak_object_bytes);
+  JERRY_DEBUG_MSG ("  Allocated property data = %u bytes\n", (unsigned) heap_stats->property_bytes);
+  JERRY_DEBUG_MSG ("  Peak allocated property data = %u bytes\n", (unsigned) heap_stats->peak_property_bytes);
 } /* jmem_heap_stats_print */
 
 /**

--- a/jerry-core/jrt/jrt-logging.c
+++ b/jerry-core/jrt/jrt-logging.c
@@ -1,0 +1,40 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jrt.h>
+
+static jerry_log_level_t jerry_log_level = JERRY_LOG_LEVEL_ERROR;
+
+/**
+ * Get current log level
+ *
+ * @return log level
+ */
+jerry_log_level_t
+jerry_jrt_get_log_level (void)
+{
+  return jerry_log_level;
+} /* jerry_jrt_get_log_level */
+
+/**
+ * Set log level
+ *
+ * @param level: new log level
+ */
+void
+jerry_jrt_set_log_level (jerry_log_level_t level)
+{
+  jerry_log_level = level;
+} /* jerry_jrt_set_log_level */

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -117,6 +117,9 @@ void JERRY_ATTR_NORETURN jerry_unreachable (const char *file, const char *functi
  */
 void JERRY_ATTR_NORETURN jerry_fatal (jerry_fatal_code_t code);
 
+jerry_log_level_t jerry_jrt_get_log_level (void);
+void jerry_jrt_set_log_level (jerry_log_level_t level);
+
 /*
  * Logging
  */


### PR DESCRIPTION
PR #4907 moved the log level into the engine context, however this caused
issues with logging without the engine being initialized. This commit
reverts the log level to be a static variable.

This commit also implements missing format specifiers for jerry_log.