### PR TITLE
The fail test cases are not reliably checked, fixes the import of "../es.next" first

### DIFF
--- a/tests/jerry/fail/module-002.mjs
+++ b/tests/jerry/fail/module-002.mjs
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 
-import { , as b } from "../es.next/module-export-01.mjs";
+import { , as b } from "../module-export-01.mjs";

--- a/tests/jerry/fail/module-003.mjs
+++ b/tests/jerry/fail/module-003.mjs
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 
-import , as b from "../es.next/module-export-01.mjs";
+import , as b from "../module-export-01.mjs";

--- a/tests/jerry/fail/module-004.mjs
+++ b/tests/jerry/fail/module-004.mjs
@@ -13,4 +13,4 @@
  * limitations under the License.
  */
 
-import { b as , } from "../es.next/module-export-01.mjs";
+import { b as , } from "../module-export-01.mjs";

--- a/tests/jerry/fail/module-005.mjs
+++ b/tests/jerry/fail/module-005.mjs
@@ -14,4 +14,4 @@
  */
 
 /* Named imports must be in a NamedImports block. */
-import b as , from "../es.next/module-export-01.mjs";
+import b as , from "../module-export-01.mjs";

--- a/tests/jerry/fail/module-010.mjs
+++ b/tests/jerry/fail/module-010.mjs
@@ -14,4 +14,4 @@
  */
 
 /* Can't have duplicate local bindings */
-import { c as a, d as a } from "../es.next/module-export-01.mjs";
+import { c as a, d as a } from "../module-export-01.mjs";

--- a/tests/jerry/fail/module-014.mjs
+++ b/tests/jerry/fail/module-014.mjs
@@ -15,5 +15,5 @@
 
 /* Import/export statements must be in the global scope. */
 if (true) {
-  import { c } from "../es.next/module-export-01.mjs";
+  import { c } from "../module-export-01.mjs";
 }

--- a/tests/jerry/fail/module-015.mjs
+++ b/tests/jerry/fail/module-015.mjs
@@ -15,5 +15,5 @@
 
 /* Import/export statements must be in the global scope. */
 function someFunction() {
-  import { c } from "../es.next/module-export-01.mjs";
+  import { c } from "../module-export-01.mjs";
 }

--- a/tests/jerry/fail/module-016.mjs
+++ b/tests/jerry/fail/module-016.mjs
@@ -14,4 +14,4 @@
  */
 
 /* Import/export statements must be in the global scope. */
-eval ('import { c } from "../es.next/module-export-01.mjs";');
+eval ('import { c } from "../module-export-01.mjs";');

--- a/tests/jerry/fail/module-017.mjs
+++ b/tests/jerry/fail/module-017.mjs
@@ -14,4 +14,4 @@
  */
 
 /* NamedImports must always be followed by a FromClause. */
-import { b }, from "../es.next/module-export-01.mjs"
+import { b }, from "../module-export-01.mjs"

--- a/tests/jerry/fail/module-018.mjs
+++ b/tests/jerry/fail/module-018.mjs
@@ -14,4 +14,4 @@
  */
 
 /* An import statement can have either a NameSpaceImport or NamedIpmorts */
-import * as mod, { b } from "../es.next/module-export-01.mjs"
+import * as mod, { b } from "../module-export-01.mjs"

--- a/tests/jerry/fail/module-020.mjs
+++ b/tests/jerry/fail/module-020.mjs
@@ -14,4 +14,4 @@
  */
 
 /* '*' is not valid inside NamedImports. */
-import { *, d } from "../es.next/module-imported-01.mjs"
+import { *, d } from "../module-imported-01.mjs"

--- a/tests/jerry/fail/module-021.mjs
+++ b/tests/jerry/fail/module-021.mjs
@@ -14,5 +14,5 @@
  */
 
 /* Can't have duplicated local bindings. */
-import { b } from "../es.next/module-export-01.mjs"
-import { b } from "../es.next/module-export-02.mjs"
+import { b } from "../module-export-01.mjs"
+import { b } from "../module-export-02.mjs"

--- a/tests/jerry/fail/module-022.mjs
+++ b/tests/jerry/fail/module-022.mjs
@@ -14,4 +14,4 @@
  */
 
 /* FromClause must follow an ImportClause. */
-import from "../es.next/module-export-02.mjs"
+import from "../module-export-02.mjs"

--- a/tests/jerry/fail/module-023.mjs
+++ b/tests/jerry/fail/module-023.mjs
@@ -14,4 +14,4 @@
  */
 
 /* Namespace imports must have a local name. */
-import * from "../es.next/module-export-01.mjs"
+import * from "../module-export-01.mjs"

--- a/tests/jerry/fail/module-024.mjs
+++ b/tests/jerry/fail/module-024.mjs
@@ -15,4 +15,4 @@
 
 export function ns() {}
 /* Duplicated export. */
-export * as ns from "../es.next/module-export-fail-test.mjs"
+export * as ns from "../module-export-fail-test.mjs"

--- a/tests/jerry/fail/module-025.mjs
+++ b/tests/jerry/fail/module-025.mjs
@@ -14,4 +14,4 @@
  */
 
 /* Indirect exports must be checked if they are resolvable. */
-export { l } from "../es.next/module-export-01.mjs"
+export { l } from "../module-export-01.mjs"

--- a/tests/jerry/fail/module-028.mjs
+++ b/tests/jerry/fail/module-028.mjs
@@ -14,4 +14,4 @@
  */
 
 /* Ambiguous import */
-import { x } from "../es.next/module-export-05.mjs"
+import { x } from "../module-export-05.mjs"

--- a/tests/jerry/fail/module-029.mjs
+++ b/tests/jerry/fail/module-029.mjs
@@ -14,4 +14,4 @@
  */
 
 /* Import/export statements must be in the global scope. */
-Function('','import { c } from "../es.next/module-export-01.mjs";')
+Function('','import { c } from "../module-export-01.mjs";')

--- a/tests/jerry/fail/module-030.mjs
+++ b/tests/jerry/fail/module-030.mjs
@@ -14,4 +14,4 @@
  */
 
 /* No default export found. */
-import def from "../es.next/module-export-06.mjs"
+import def from "../module-export-06.mjs"

--- a/tests/jerry/fail/module-032.mjs
+++ b/tests/jerry/fail/module-032.mjs
@@ -14,4 +14,4 @@
  */
 
 let a;
-import { a } from "../es.next/module-export-fail-test.mjs";
+import { a } from "../module-export-fail-test.mjs";

--- a/tests/jerry/fail/module-033.mjs
+++ b/tests/jerry/fail/module-033.mjs
@@ -14,4 +14,4 @@
  */
 
 var a;
-import { a } from "../es.next/module-export-fail-test.mjs";
+import { a } from "../module-export-fail-test.mjs";

--- a/tests/jerry/fail/module-034.mjs
+++ b/tests/jerry/fail/module-034.mjs
@@ -13,5 +13,5 @@
  * limitations under the License.
  */
 
-import { a } from "../es.next/module-export-fail-test.mjs";
+import { a } from "../module-export-fail-test.mjs";
 class a {};

--- a/tests/jerry/fail/module-035.mjs
+++ b/tests/jerry/fail/module-035.mjs
@@ -13,5 +13,5 @@
  * limitations under the License.
  */
 
-import { a } from "../es.next/module-export-fail-test.mjs";
+import { a } from "../module-export-fail-test.mjs";
 function a() {}

--- a/tests/jerry/fail/regression-test-issue-2896.js
+++ b/tests/jerry/fail/regression-test-issue-2896.js
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 export {} from "dummy.mjs";
-export {} from "../es.next/module-export-04.mjs";
+export {} from "../module-export-04.mjs";


### PR DESCRIPTION
…/es.next" first

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
