### PR TITLE
Reduce or even remove the usage of strlen in jerry-core and ext by improve the jerry port api

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -193,11 +193,12 @@ void jerry_port_line_free (jerry_char_t *buffer_p);
  *
  * @param path_p: zero-terminated string containing the input path
  * @param path_size: size of the input path string in bytes, excluding terminating zero
+ * @param out_size_p: The normalized path's size in bytes.
  *
  * @return buffer with the normalized path if the operation is successful,
  *         NULL otherwise
  */
-jerry_char_t *jerry_port_path_normalize (const jerry_char_t *path_p, jerry_size_t path_size);
+jerry_char_t *jerry_port_path_normalize (const jerry_char_t *path_p, jerry_size_t path_size, jerry_size_t *out_size_p);
 ```
 
 ```c
@@ -211,31 +212,43 @@ void jerry_port_path_free (jerry_char_t *path_p);
 
 ```c
 /**
- * Get the offset of the basename component in the input path.
+ * Check if a char of a path is a path separator.
  *
- * The implementation should return the offset of the first character after the last path separator found in the path.
- * This is used by the caller to split the path into a directory name and a file name.
+ * @param path_c: The char to check
  *
- * @param path_p: input zero-terminated path string
- *
- * @return offset of the basename component in the input path
+ * @return if a char of a path is a path separator.
  */
-jerry_size_t jerry_port_path_base (const jerry_char_t *path_p);
+bool jerry_port_path_is_separator (jerry_char_t path_c);
 ```
 
 ```c
 /**
- * Open a source file and read its contents into a buffer.
+ * Evalute the length of root component of a path
+ *
+ * @param path_p: input zero-terminated path string
+ * @param path_size: length of the path string
+ *
+ * @return length of root component of a path if it's a absolute path
+ *         0 otherwise
+ */
+jerry_size_t jerry_port_path_root (const jerry_char_t *path_p, jerry_size_t path_size);
+```
+
+```c
+/**
+ * Open a source file and read the content into a buffer.
  *
  * When the source file is no longer needed by the caller, the returned pointer will be passed to
  * `jerry_port_source_free`, which can be used to finalize the buffer.
  *
  * @param file_name_p: Path that points to the source file in the filesystem.
+ * @param file_name_size length of source file path
  * @param out_size_p: The opened file's size in bytes.
  *
  * @return pointer to the buffer which contains the content of the file.
  */
-jerry_char_t *jerry_port_source_read (const char *file_name_p, jerry_size_t *out_size_p);
+jerry_char_t *
+jerry_port_source_read (const jerry_char_t *file_name_p, jerry_size_t file_name_size, jerry_size_t *out_size_p);
 ```
 
 ```c

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -217,11 +217,12 @@ void jerry_port_line_free (jerry_char_t *buffer_p);
  *
  * @param path_p: zero-terminated string containing the input path
  * @param path_size: size of the input path string in bytes, excluding terminating zero
+ * @param out_size_p: The normalized path's size in bytes.
  *
  * @return buffer with the normalized path if the operation is successful,
  *         NULL otherwise
  */
-jerry_char_t *jerry_port_path_normalize (const jerry_char_t *path_p, jerry_size_t path_size);
+jerry_char_t *jerry_port_path_normalize (const jerry_char_t *path_p, jerry_size_t path_size, jerry_size_t *out_size_p);
 
 /**
  * Free a path buffer returned by jerry_port_path_normalize.
@@ -231,16 +232,24 @@ jerry_char_t *jerry_port_path_normalize (const jerry_char_t *path_p, jerry_size_
 void jerry_port_path_free (jerry_char_t *path_p);
 
 /**
- * Get the offset of the basename component in the input path.
+ * Check if a char of a path is a path separator.
  *
- * The implementation should return the offset of the first character after the last path separator found in the path.
- * This is used by the caller to split the path into a directory name and a file name.
+ * @param path_c: The char to check
+ *
+ * @return if a char of a path is a path separator.
+ */
+bool jerry_port_path_is_separator (jerry_char_t path_c);
+
+/**
+ * Evalute the length of root component of a path
  *
  * @param path_p: input zero-terminated path string
+ * @param path_size: length of the path string
  *
- * @return offset of the basename component in the input path
+ * @return length of root component of a path if it's a absolute path
+ *         0 otherwise
  */
-jerry_size_t jerry_port_path_base (const jerry_char_t *path_p);
+jerry_size_t jerry_port_path_root (const jerry_char_t *path_p, jerry_size_t path_size);
 
 /**
  * Open a source file and read the content into a buffer.
@@ -249,11 +258,13 @@ jerry_size_t jerry_port_path_base (const jerry_char_t *path_p);
  * `jerry_port_source_free`, which can be used to finalize the buffer.
  *
  * @param file_name_p: Path that points to the source file in the filesystem.
+ * @param file_name_size length of source file path
  * @param out_size_p: The opened file's size in bytes.
  *
  * @return pointer to the buffer which contains the content of the file.
  */
-jerry_char_t *jerry_port_source_read (const char *file_name_p, jerry_size_t *out_size_p);
+jerry_char_t *
+jerry_port_source_read (const jerry_char_t *file_name_p, jerry_size_t file_name_size, jerry_size_t *out_size_p);
 
 /**
  * Free a source file buffer.

--- a/jerry-ext/include/jerryscript-ext/sources.h
+++ b/jerry-ext/include/jerryscript-ext/sources.h
@@ -20,10 +20,10 @@
 
 JERRY_C_API_BEGIN
 
-jerry_value_t jerryx_source_parse_script (const char* path);
-jerry_value_t jerryx_source_exec_script (const char* path);
-jerry_value_t jerryx_source_exec_module (const char* path);
-jerry_value_t jerryx_source_exec_snapshot (const char* path, size_t function_index);
+jerry_value_t jerryx_source_parse_script (const jerry_char_t* path_p, jerry_size_t path_size);
+jerry_value_t jerryx_source_exec_script (const jerry_char_t* path_p, jerry_size_t path_size);
+jerry_value_t jerryx_source_exec_module (const jerry_char_t* path_p, jerry_size_t path_size);
+jerry_value_t jerryx_source_exec_snapshot (const jerry_char_t* path_p, jerry_size_t path_size, size_t function_index);
 jerry_value_t jerryx_source_exec_stdin (void);
 
 JERRY_C_API_END

--- a/jerry-ext/util/print.c
+++ b/jerry-ext/util/print.c
@@ -263,7 +263,8 @@ jerryx_print_unhandled_exception (jerry_value_t exception) /**< exception value 
       *path_str_end_p = '\0';
 
       jerry_size_t source_size;
-      jerry_char_t *source_p = jerry_port_source_read (path_str_p, &source_size);
+      jerry_size_t path_size = (jerry_size_t) (path_str_end_p - path_str_p);
+      jerry_char_t *source_p = jerry_port_source_read ((const jerry_char_t *) path_str_p, path_size, &source_size);
 
       /* Revert the error message. */
       *path_str_end_p = ':';

--- a/jerry-ext/util/sources.c
+++ b/jerry-ext/util/sources.c
@@ -27,10 +27,10 @@
 #include "jerryscript-ext/print.h"
 
 jerry_value_t
-jerryx_source_parse_script (const char *path_p)
+jerryx_source_parse_script (const jerry_char_t *path_p, jerry_size_t path_size)
 {
   jerry_size_t source_size;
-  jerry_char_t *source_p = jerry_port_source_read (path_p, &source_size);
+  jerry_char_t *source_p = jerry_port_source_read (path_p, path_size, &source_size);
 
   if (source_p == NULL)
   {
@@ -46,8 +46,7 @@ jerryx_source_parse_script (const char *path_p)
 
   jerry_parse_options_t parse_options;
   parse_options.options = JERRY_PARSE_HAS_SOURCE_NAME;
-  parse_options.source_name =
-    jerry_string ((const jerry_char_t *) path_p, (jerry_size_t) strlen (path_p), JERRY_ENCODING_UTF8);
+  parse_options.source_name = jerry_string (path_p, path_size, JERRY_ENCODING_UTF8);
 
   jerry_value_t result = jerry_parse (source_p, source_size, &parse_options);
 
@@ -58,9 +57,9 @@ jerryx_source_parse_script (const char *path_p)
 } /* jerryx_source_parse_script */
 
 jerry_value_t
-jerryx_source_exec_script (const char *path_p)
+jerryx_source_exec_script (const jerry_char_t *path_p, jerry_size_t path_size)
 {
-  jerry_value_t result = jerryx_source_parse_script (path_p);
+  jerry_value_t result = jerryx_source_parse_script (path_p, path_size);
 
   if (!jerry_value_is_exception (result))
   {
@@ -73,10 +72,9 @@ jerryx_source_exec_script (const char *path_p)
 } /* jerryx_source_exec_script */
 
 jerry_value_t
-jerryx_source_exec_module (const char *path_p)
+jerryx_source_exec_module (const jerry_char_t *path_p, jerry_size_t path_size)
 {
-  jerry_value_t specifier =
-    jerry_string ((const jerry_char_t *) path_p, (jerry_size_t) strlen (path_p), JERRY_ENCODING_UTF8);
+  jerry_value_t specifier = jerry_string (path_p, path_size, JERRY_ENCODING_UTF8);
   jerry_value_t referrer = jerry_undefined ();
 
   jerry_value_t module = jerry_module_resolve (specifier, referrer, NULL);
@@ -110,10 +108,10 @@ jerryx_source_exec_module (const char *path_p)
 } /* jerryx_source_exec_module */
 
 jerry_value_t
-jerryx_source_exec_snapshot (const char *path_p, size_t function_index)
+jerryx_source_exec_snapshot (const jerry_char_t *path_p, jerry_size_t path_size, size_t function_index)
 {
   jerry_size_t source_size;
-  jerry_char_t *source_p = jerry_port_source_read (path_p, &source_size);
+  jerry_char_t *source_p = jerry_port_source_read (path_p, path_size, &source_size);
 
   if (source_p == NULL)
   {

--- a/jerry-main/main-desktop.c
+++ b/jerry-main/main-desktop.c
@@ -129,18 +129,19 @@ restart:
   for (uint32_t source_index = 0; source_index < arguments.source_count; source_index++)
   {
     main_source_t *source_file_p = sources_p + source_index;
-    const char *file_path_p = argv[source_file_p->path_index];
+    const jerry_char_t *file_path_p = (const jerry_char_t *) argv[source_file_p->path_index];
+    jerry_size_t file_path_size = (jerry_size_t) strlen ((const char *) file_path_p);
 
     switch (source_file_p->type)
     {
       case SOURCE_MODULE:
       {
-        result = jerryx_source_exec_module (file_path_p);
+        result = jerryx_source_exec_module (file_path_p, file_path_size);
         break;
       }
       case SOURCE_SNAPSHOT:
       {
-        result = jerryx_source_exec_snapshot (file_path_p, source_file_p->snapshot_index);
+        result = jerryx_source_exec_snapshot (file_path_p, file_path_size, source_file_p->snapshot_index);
         break;
       }
       default:
@@ -149,11 +150,11 @@ restart:
 
         if ((arguments.option_flags & OPT_FLAG_PARSE_ONLY) != 0)
         {
-          result = jerryx_source_parse_script (file_path_p);
+          result = jerryx_source_parse_script (file_path_p, file_path_size);
         }
         else
         {
-          result = jerryx_source_exec_script (file_path_p);
+          result = jerryx_source_exec_script (file_path_p, file_path_size);
         }
 
         break;

--- a/jerry-port/unix/jerry-port-unix-fs.c
+++ b/jerry-port/unix/jerry-port-unix-fs.c
@@ -20,22 +20,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-/**
- * Normalize a file path using realpath.
- *
- * @param path_p: input path
- * @param path_size: input path size
- *
- * @return a newly allocated buffer with the normalized path if the operation is successful,
- *         NULL otherwise
- */
 jerry_char_t *
-jerry_port_path_normalize (const jerry_char_t *path_p, /**< input path */
-                           jerry_size_t path_size) /**< size of the path */
+jerry_port_path_normalize (const jerry_char_t *path_p, jerry_size_t path_size, jerry_size_t *out_size_p)
 {
   (void) path_size;
 
-  return (jerry_char_t *) realpath ((char *) path_p, NULL);
+  char *full_path_p = realpath ((char *) path_p, NULL);
+  /* TODO: implement realpath properly */
+  if (full_path_p != NULL)
+  {
+    *out_size_p = (jerry_size_t) strlen (full_path_p);
+  }
+  else
+  {
+    *out_size_p = 0;
+  }
+  return (jerry_char_t *) full_path_p;
 } /* jerry_port_path_normalize */
 
 /**
@@ -46,18 +46,5 @@ jerry_port_path_free (jerry_char_t *path_p)
 {
   free (path_p);
 } /* jerry_port_path_free */
-
-/**
- * Computes the end of the directory part of a path.
- *
- * @return end of the directory part of a path.
- */
-jerry_size_t JERRY_ATTR_WEAK
-jerry_port_path_base (const jerry_char_t *path_p) /**< path */
-{
-  const jerry_char_t *basename_p = (jerry_char_t *) strrchr ((char *) path_p, '/') + 1;
-
-  return (jerry_size_t) (basename_p - path_p);
-} /* jerry_port_get_directory_end */
 
 #endif /* defined(__unix__) || defined(__APPLE__) */

--- a/jerry-port/win/jerry-port-win-fs.c
+++ b/jerry-port/win/jerry-port-win-fs.c
@@ -20,6 +20,115 @@
 #include <stdlib.h>
 #include <string.h>
 
+bool
+jerry_port_path_is_separator (jerry_char_t path_c)
+{
+  if (path_c == '/' || path_c == '\\')
+  {
+    return true;
+  }
+  return false;
+} /* jerry_port_path_is_separator */
+
+jerry_size_t
+jerry_port_path_root (const jerry_char_t *path_p, jerry_size_t path_size)
+{
+  if (path_p == NULL)
+  {
+    return 0;
+  }
+
+  if (path_size == 0)
+  {
+    return 0;
+  }
+
+  /* Path size >= 1 */
+  jerry_char_t path0 = path_p[0];
+  bool path0_is_separator = jerry_port_path_is_separator (path0);
+  if (path_size == 1)
+  {
+    return path0_is_separator ? 1 : 0;
+  }
+
+  /* Path size >= 2 */
+  if ((path0 >= 'a' && path0 >= 'z' || path0 >= 'A' && path0 >= 'Z') && path0 == ':')
+  {
+    /* It's `c:` `d:` `D:` */
+    if (path_size == 2)
+    {
+      return 2;
+    }
+    /* path size >= 3, C:\, c:/ style root path */
+    if (jerry_port_path_is_separator (path_p[2]))
+    {
+      return 3;
+    }
+    /* Path with invalid windows root such as C:t C:0 */
+    return 0;
+  }
+  if (!path0_is_separator)
+  {
+    /* not a absolute path */
+    return 0;
+  }
+
+  if (!jerry_port_path_is_separator (path_p[1]))
+  {
+    /* It's a absolute path with a single leading separator */
+    return 1;
+  }
+
+  /**
+   * Path is a UNC path, maybe
+   *  Device path sucg as `\\?\` or `\\.\`
+   *  UNC network share path such as `\\localhost\c$` `\\localhost\c$\`
+   */
+  if (path_size == 2)
+  {
+    /* `\\`, `//`, `/\`, `\/` is not a absolute path on win32 */
+    return 2;
+  }
+
+  /* Path size >= 3 */
+  if (path_p[2] == '?' || path_p[2] == '.')
+  {
+    if (path_size > 3 && jerry_port_path_is_separator (path_p[3]))
+    {
+      /* Device path prefix "\\.\" or "\\?\" */
+      return 4;
+    }
+  }
+  /* UNC network share path */
+  jerry_size_t path_i = 2;
+  /* Skipping the UNC domain name or server name */
+  while (path_i < path_size && !jerry_port_path_is_separator (path_p[path_i]))
+  {
+    ++path_i;
+  }
+  /* Skipping all the path separators */
+  while (path_i < path_size && jerry_port_path_is_separator (path_p[path_i]))
+  {
+    ++path_i;
+  }
+  /* Skipping the UNC share name */
+  while (path_i < path_size && !jerry_port_path_is_separator (path_p[path_i]))
+  {
+    ++path_i;
+  }
+
+  /**
+   * There might be a separator at the network share root path end,
+   * include that as well, it will mark the path as absolute, such as
+   * `\\localhost\c$\`
+   */
+  if (path_i < path_size && jerry_port_path_is_separator (path_p[path_i]))
+  {
+    ++path_i;
+  }
+  return path_i;
+} /* jerry_port_path_root */
+
 /**
  * Normalize a file path.
  *
@@ -27,12 +136,13 @@
  *         NULL otherwise
  */
 jerry_char_t *
-jerry_port_path_normalize (const jerry_char_t *path_p, /**< input path */
-                           jerry_size_t path_size) /**< size of the path */
+jerry_port_path_normalize (const jerry_char_t *path_p, jerry_size_t path_size, jerry_size_t *out_size_p)
 {
   (void) path_size;
 
-  return (jerry_char_t *) _fullpath (NULL, path_p, _MAX_PATH);
+  char *full_path_p = _fullpath (NULL, path_p, _MAX_PATH);
+  *out_size_p = (jerry_size_t) strlen (full_path_p);
+  return (jerry_char_t *) full_path_p;
 } /* jerry_port_path_normalize */
 
 /**
@@ -43,30 +153,5 @@ jerry_port_path_free (jerry_char_t *path_p)
 {
   free (path_p);
 } /* jerry_port_path_free */
-
-/**
- * Get the end of the directory part of the input path.
- *
- * @param path_p: input zero-terminated path string
- *
- * @return offset of the directory end in the input path string
- */
-jerry_size_t
-jerry_port_path_base (const jerry_char_t *path_p)
-{
-  const jerry_char_t *end_p = path_p + strlen ((const char *) path_p);
-
-  while (end_p > path_p)
-  {
-    if (end_p[-1] == '/' || end_p[-1] == '\\')
-    {
-      return (jerry_size_t) (end_p - path_p);
-    }
-
-    end_p--;
-  }
-
-  return 0;
-} /* jerry_port_path_base */
 
 #endif /* defined(_WIN32) */

--- a/targets/os/nuttx/jerry-main.c
+++ b/targets/os/nuttx/jerry-main.c
@@ -212,7 +212,7 @@ jerry_main (int argc, char *argv[])
   {
     for (i = 0; i < files_counter; i++)
     {
-      ret_value = jerryx_source_exec_script (file_names[i]);
+      ret_value = jerryx_source_exec_script (file_names[i], strlen (file_names[i]));
       if (jerry_value_is_exception (ret_value))
       {
         ret_code = JERRY_STANDALONE_EXIT_CODE_FAIL;


### PR DESCRIPTION

Using consistence const jerry_char_t* path_p, jerry_size_t path_size for all path handling.

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
