### PR TITLE
Introduce JERRY_ZSTR_ARG macro to avoid call strlen on string literal.

### DIFF
--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -118,18 +118,6 @@ void jerry_port_log (const char *message_p);
 
 ```c
 /**
- * Print a single character to standard output.
- *
- * This port function is never called from jerry-core directly, it is only used by jerry-ext components to print
- * information.
- *
- * @param byte: the byte to print.
- */
-void jerry_port_print_byte (jerry_char_t byte);
-```
-
-```c
-/**
  * Print a buffer to standard output
  *
  * This port function is never called from jerry-core directly, it is only used by jerry-ext components to print

--- a/docs/10.EXT-REFERENCE-HANDLER.md
+++ b/docs/10.EXT-REFERENCE-HANDLER.md
@@ -351,15 +351,14 @@ jerryx_handler_gc (const jerry_value_t func_obj_val, const jerry_value_t this_p,
 **Summary**
 
 Provide a `print` implementation for scripts. The routine converts all of its
-arguments to strings and outputs them char-by-char using
-`jerry_port_print_byte`. The NULL character is output as "\u0000",
-other characters are output bytewise.
+arguments to strings and outputs them by using `jerry_port_print_buffer`.
+The NULL character is output as "\u0000", other characters are output bytewise.
 
 *Note*: This implementation does not use standard C `printf` to print its
 output. This allows more flexibility but also extends the core JerryScript
 engine port API. Applications that want to use `jerryx_handler_print` must
 ensure that their port implementation also provides
-`jerry_port_print_byte`.
+`jerry_port_print_buffer`.
 
 **Prototype**
 
@@ -379,7 +378,7 @@ jerryx_handler_print (const jerry_value_t func_obj_val, const jerry_value_t this
 **See also**
 
 - [jerryx_register_global](#jerryx_register_global)
-- [jerry_port_print_byte](05.PORT-API.md#jerry_port_print_char)
+- [jerry_port_print_buffer](05.PORT-API.md#jerry_port_print_buffer)
 
 
 # Handler registration helper

--- a/docs/16.MIGRATION-GUIDE.md
+++ b/docs/16.MIGRATION-GUIDE.md
@@ -770,3 +770,4 @@ In this section the new API functions are listed.
 - [`jerry_port_get_current_context`](05.PORT-API.md#jerry_port_get_current_context)
 - [`jerry_port_fatal`](05.PORT-API.md#jerry_port_fatal)
 - [`jerry_port_sleep`](05.PORT-API.md#jerry_port_sleep)
+- [`jerry_port_print_byte`](05.PORT-API.md#jerry_port_print_byte)

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -143,16 +143,6 @@ void jerry_port_context_free (void);
 void jerry_port_log (const char *message_p);
 
 /**
- * Print a single character to standard output.
- *
- * This port function is never called from jerry-core directly, it is only used by jerry-ext components to print
- * information.
- *
- * @param byte: the byte to print.
- */
-void jerry_port_print_byte (jerry_char_t byte);
-
-/**
  * Print a buffer to standard output
  *
  * This port function is never called from jerry-core directly, it is only used by jerry-ext components to print

--- a/jerry-core/include/jerryscript-types.h
+++ b/jerry-core/include/jerryscript-types.h
@@ -857,6 +857,11 @@ typedef void (*jerry_arraybuffer_free_cb_t) (jerry_arraybuffer_type_t buffer_typ
                                              void *user_p);
 
 /**
+ * Helper to expand string literal to [string pointer, string size] argument pair.
+ */
+#define JERRY_ZSTR_ARG(str) ((const jerry_char_t *) (str)), ((jerry_size_t) (sizeof (str) - 1))
+
+/**
  * @}
  */
 

--- a/jerry-ext/include/jerryscript-ext/print.h
+++ b/jerry-ext/include/jerryscript-ext/print.h
@@ -22,9 +22,7 @@
 JERRY_C_API_BEGIN
 
 jerry_value_t jerryx_print_value (const jerry_value_t value);
-void jerryx_print_byte (jerry_char_t ch);
 void jerryx_print_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size);
-void jerryx_print_string (const char *str_p);
 void jerryx_print_backtrace (unsigned depth);
 void jerryx_print_unhandled_exception (jerry_value_t exception);
 void jerryx_print_unhandled_rejection (jerry_value_t exception);

--- a/jerry-ext/include/jerryscript-ext/repl.h
+++ b/jerry-ext/include/jerryscript-ext/repl.h
@@ -20,7 +20,7 @@
 
 JERRY_C_API_BEGIN
 
-void jerryx_repl (const char* prompt_p);
+void jerryx_repl (const jerry_char_t *prompt_p, jerry_size_t prompt_size);
 
 JERRY_C_API_END
 

--- a/jerry-ext/util/handlers.c
+++ b/jerry-ext/util/handlers.c
@@ -25,9 +25,9 @@
  * Provide a 'print' implementation for scripts.
  *
  * The routine converts all of its arguments to strings and outputs them
- * char-by-char using jerry_port_print_byte.
+ * by using jerry_port_print_buffer.
  *
- * The NUL character is output as "\u0000", other characters are output
+ * The NULL character is output as "\u0000", other characters are output
  * bytewise.
  *
  * Note:
@@ -35,7 +35,7 @@
  *      output. This allows more flexibility but also extends the core
  *      JerryScript engine port API. Applications that want to use
  *      `jerryx_handler_print` must ensure that their port implementation also
- *      provides `jerry_port_print_byte`.
+ *      provides `jerry_port_print_buffer`.
  *
  * @return undefined - if all arguments could be converted to strings,
  *         error - otherwise.
@@ -51,7 +51,7 @@ jerryx_handler_print (const jerry_call_info_t *call_info_p, /**< call informatio
   {
     if (index > 0)
     {
-      jerryx_print_byte (' ');
+      jerryx_print_buffer (JERRY_ZSTR_ARG (" "));
     }
 
     jerry_value_t result = jerryx_print_value (args_p[index]);
@@ -62,7 +62,7 @@ jerryx_handler_print (const jerry_call_info_t *call_info_p, /**< call informatio
     }
   }
 
-  jerryx_print_byte ('\n');
+  jerryx_print_buffer (JERRY_ZSTR_ARG ("\n"));
   return jerry_undefined ();
 } /* jerryx_handler_print */
 

--- a/jerry-ext/util/print.c
+++ b/jerry-ext/util/print.c
@@ -61,7 +61,7 @@ jerryx_buffered_print (uint32_t value, void *user_p)
     jerryx_print_buffer (buffer_p->data, buffer_p->index);
     buffer_p->index = 0;
 
-    jerryx_print_string ("\\u0000");
+    jerryx_print_buffer (JERRY_ZSTR_ARG ("\\u0000"));
     return;
   }
 
@@ -112,20 +112,6 @@ jerryx_print_value (const jerry_value_t value)
 } /* jerryx_print */
 
 /**
- * Print a character to standard output, also sending it to the debugger, if connected.
- *
- * @param ch: input character
- */
-void
-jerryx_print_byte (jerry_char_t byte)
-{
-  jerry_port_print_byte (byte);
-#if JERRY_DEBUGGER
-  jerry_debugger_send_output (&byte, 1);
-#endif /* JERRY_DEBUGGER */
-} /* jerryx_print_char */
-
-/**
  * Print a buffer to standard output, also sending it to the debugger, if connected.
  *
  * @param buffer_p: inptut string buffer
@@ -139,24 +125,6 @@ jerryx_print_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size)
   jerry_debugger_send_output (buffer_p, buffer_size);
 #endif /* JERRY_DEBUGGER */
 } /* jerryx_print_buffer */
-
-/**
- * Print a zero-terminated string to standard output, also sending it to the debugger, if connected.
- *
- * @param buffer_p: inptut string buffer
- * @param buffer_size: size of the string
- */
-void
-jerryx_print_string (const char *str_p)
-{
-  const jerry_char_t *buffer_p = (jerry_char_t *) str_p;
-  jerry_size_t buffer_size = (jerry_size_t) (strlen (str_p));
-
-  jerry_port_print_buffer (buffer_p, buffer_size);
-#if JERRY_DEBUGGER
-  jerry_debugger_send_output (buffer_p, buffer_size);
-#endif /* JERRY_DEBUGGER */
-} /* jerryx_print_string */
 
 /**
  * Print backtrace as log messages up to a specific depth.

--- a/jerry-ext/util/repl.c
+++ b/jerry-ext/util/repl.c
@@ -24,13 +24,13 @@
 #include "jerryscript-ext/print.h"
 
 void
-jerryx_repl (const char *prompt_p)
+jerryx_repl (const jerry_char_t *prompt_p, jerry_size_t prompt_size)
 {
   jerry_value_t result;
 
   while (true)
   {
-    jerryx_print_string (prompt_p);
+    jerryx_print_buffer (prompt_p, prompt_size);
     fflush (stdout);
 
     jerry_size_t length;
@@ -38,7 +38,7 @@ jerryx_repl (const char *prompt_p)
 
     if (line_p == NULL)
     {
-      jerryx_print_byte ('\n');
+      jerryx_print_buffer (JERRY_ZSTR_ARG ("\n"));
       return;
     }
 
@@ -80,7 +80,7 @@ jerryx_repl (const char *prompt_p)
       goto exception;
     }
 
-    jerryx_print_byte ('\n');
+    jerryx_print_buffer (JERRY_ZSTR_ARG ("\n"));
 
     jerry_value_free (result);
     result = jerry_run_jobs ();

--- a/jerry-main/main-desktop.c
+++ b/jerry-main/main-desktop.c
@@ -222,8 +222,14 @@ restart:
   }
   else if (arguments.source_count == 0)
   {
-    const char *prompt_p = (arguments.option_flags & OPT_FLAG_NO_PROMPT) ? "" : "jerry> ";
-    jerryx_repl (prompt_p);
+    if ((arguments.option_flags & OPT_FLAG_NO_PROMPT))
+    {
+      jerryx_repl (JERRY_ZSTR_ARG (""));
+    }
+    else
+    {
+      jerryx_repl (JERRY_ZSTR_ARG ("jerry> "));
+    }
   }
 
   result = jerry_run_jobs ();

--- a/jerry-port/common/jerry-port-io.c
+++ b/jerry-port/common/jerry-port-io.c
@@ -28,29 +28,11 @@ jerry_port_log (const char *message_p) /**< message */
   fputs (message_p, stderr);
 } /* jerry_port_log */
 
-/**
- * Default implementation of jerry_port_print_byte. Uses 'putchar' to
- * print a single character to standard output.
- */
 void JERRY_ATTR_WEAK
-jerry_port_print_byte (jerry_char_t byte) /**< the character to print */
+jerry_port_print_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size)
 {
-  putchar (byte);
-} /* jerry_port_print_byte */
-
-/**
- * Default implementation of jerry_port_print_buffer. Uses 'jerry_port_print_byte' to
- * print characters of the input buffer.
- */
-void JERRY_ATTR_WEAK
-jerry_port_print_buffer (const jerry_char_t *buffer_p, /**< string buffer */
-                         jerry_size_t buffer_size) /**< string size*/
-{
-  for (jerry_size_t i = 0; i < buffer_size; i++)
-  {
-    jerry_port_print_byte (buffer_p[i]);
-  }
-} /* jerry_port_print_byte */
+  fwrite (buffer_p, 1, buffer_size, stdout);
+} /* jerry_port_print_buffer */
 
 /**
  * Read a line from standard input as a zero-terminated string.

--- a/targets/os/nuttx/jerry-main.c
+++ b/targets/os/nuttx/jerry-main.c
@@ -206,7 +206,7 @@ jerry_main (int argc, char *argv[])
 
   if (files_counter == 0)
   {
-    jerryx_repl ("jerry> ");
+    jerryx_repl (JERRY_ZSTR_ARG ("jerry> "));
   }
   else
   {

--- a/targets/os/zephyr/src/jerry-main.c
+++ b/targets/os/zephyr/src/jerry-main.c
@@ -49,7 +49,7 @@ main (void)
   jerry_init (JERRY_INIT_EMPTY);
   jerryx_register_global ("print", jerryx_handler_print);
 
-  jerryx_repl ("js> ");
+  jerryx_repl (JERRY_ZSTR_ARG ("js> "));
 
   jerry_cleanup ();
 } /* main */


### PR DESCRIPTION
Currently `jerryx_print_string ("\\u0000")` are implementd with

```
void
jerryx_print_string (const char *str_p)
{
  const jerry_char_t *buffer_p = (jerry_char_t *) str_p;
  jerry_size_t buffer_size = (jerry_size_t) (strlen (str_p));

  jerry_port_print_buffer (buffer_p, buffer_size);
#if JERRY_DEBUGGER
  jerry_debugger_send_output (buffer_p, buffer_size);
#endif /* JERRY_DEBUGGER */
} /* jerryx_print_string */

```

So indeed "\\u0000" is not output before MR, after this MR, jerryx_print_string is removed, and `jerryx_print_string ("\\u0000")` replaced with `jerryx_print_buffer (JERRY_ZSTR_ARG ("\\u0000"));`, so the string "\\u0000" is output to console after this MR.

* replace usage of jerryx_print_byte with jerryx_print_buffer.

So we only need implement `jerry_port_print_buffer`, reduce the code size and port api list

Partially fixes #4979

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com