### PR TITLE
Replace global inclusions with local ones, because with the amalgam.p…

### DIFF
--- a/jerry-core/api/jerry-module.c
+++ b/jerry-core/api/jerry-module.c
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
-#include <lit-magic-strings.h>
-#include <lit-strings.h>
+#include "lit-magic-strings.h"
+#include "lit-strings.h"
 
 #include "jerryscript-core.h"
 #include "jerryscript-port.h"

--- a/jerry-core/jrt/jrt-logging.c
+++ b/jerry-core/jrt/jrt-logging.c
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-#include <jrt.h>
+#include "jrt.h"
 
 static jerry_log_level_t jerry_log_level = JERRY_LOG_LEVEL_ERROR;
 


### PR DESCRIPTION
Replace global inclusions with local ones, because with the amalgam.py tool they were added and this leads to compile error.