### PR TITLE
Fix arrow function parsing

### DIFF
--- a/jerry-core/parser/js/js-parser.c
+++ b/jerry-core/parser/js/js-parser.c
@@ -2829,6 +2829,7 @@ parser_parse_arrow_function (parser_context_t *context_p, /**< context */
   JERRY_ASSERT (context_p->token.type == LEXER_ARROW);
 
   lexer_next_token (context_p);
+  bool next_token_needed = false;
 
   if (context_p->token.type == LEXER_LEFT_BRACE)
   {
@@ -2839,7 +2840,7 @@ parser_parse_arrow_function (parser_context_t *context_p, /**< context */
 
     /* Unlike normal function, arrow functions consume their close brace. */
     JERRY_ASSERT (context_p->token.type == LEXER_RIGHT_BRACE);
-    lexer_next_token (context_p);
+    next_token_needed = true;
   }
   else
   {
@@ -2877,6 +2878,11 @@ parser_parse_arrow_function (parser_context_t *context_p, /**< context */
 #endif /* JERRY_PARSER_DUMP_BYTE_CODE */
 
   parser_restore_context (context_p, &saved_context);
+
+  if (next_token_needed)
+  {
+    lexer_next_token (context_p);
+  }
 
   return compiled_code_p;
 } /* parser_parse_arrow_function */

--- a/tests/jerry/fail/regression-test-issue-5085.js
+++ b/tests/jerry/fail/regression-test-issue-5085.js
@@ -1,0 +1,17 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+async () => {}
+await Symbol;
+class B{}


### PR DESCRIPTION
This patch fixes #5085

JerryScript-DCO-1.0-Signed-off-by: Mate Tokodi mate.tokodi@szteszoftver.hu