### PR TITLE
Update clang-format

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -16,19 +16,17 @@ jobs:
         with:
           python-version: '3.10'
       - run: sudo apt update
-# TODO: update checkers to current versions available in ubuntu 22.04
-#      - run: sudo apt install clang-format-10 python-serial
-      - run: sudo apt install pylint doxygen cppcheck
+      - run: sudo apt install pylint doxygen cppcheck clang-format-15
       - run: $RUNNER --check-signed-off=gh-actions
         if: ${{ always() }}
       - run: $RUNNER --check-doxygen
         if: ${{ always() }}
-#      - run: $RUNNER --check-format
-#        if: ${{ always() }}
+      - run: $RUNNER --check-format
+        if: ${{ always() }}
       - run: $RUNNER --check-license
         if: ${{ always() }}
-#      - run: $RUNNER --check-strings
-#        if: ${{ always() }}
+      - run: $RUNNER --check-strings
+        if: ${{ always() }}
       - run: $RUNNER --check-pylint
         if: ${{ always() }}
       - run: $RUNNER --check-cppcheck

--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -92,7 +92,6 @@ typedef struct
   bool class_found;
 } snapshot_globals_t;
 
-
 /**
  * Write data into the specified buffer.
  *

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers.h
@@ -261,8 +261,7 @@ ecma_value_t ecma_builtin_helper_error_dispatch_call (jerry_error_t error_type,
 typedef ecma_value_t (*ecma_builtin_helper_sort_compare_fn_t) (ecma_value_t lhs, /**< left value */
                                                                ecma_value_t rhs, /**< right value */
                                                                ecma_value_t compare_func, /**< compare function */
-                                                               ecma_object_t *array_buffer_p /**< arrayBuffer */
-                                                               );
+                                                               ecma_object_t *array_buffer_p /**< arrayBuffer */);
 
 ecma_value_t ecma_builtin_helper_array_merge_sort_helper (ecma_value_t *array_p,
                                                           uint32_t length,

--- a/jerry-core/ecma/operations/ecma-objects.c
+++ b/jerry-core/ecma/operations/ecma-objects.c
@@ -1850,9 +1850,9 @@ ecma_op_object_get_own_property_descriptor (ecma_object_t *object_p, /**< the ob
       prop_desc_p->value = property_ref.virtual_value;
     }
 
-    prop_desc_p->flags |= (JERRY_PROP_IS_VALUE_DEFINED | JERRY_PROP_IS_WRITABLE_DEFINED);
-    prop_desc_p->flags = (uint16_t) (
-      prop_desc_p->flags | (ecma_is_property_writable (property) ? JERRY_PROP_IS_WRITABLE : JERRY_PROP_NO_OPTS));
+    prop_desc_p->flags |=
+      (uint16_t) (JERRY_PROP_IS_VALUE_DEFINED | JERRY_PROP_IS_WRITABLE_DEFINED
+                  | (ecma_is_property_writable (property) ? JERRY_PROP_IS_WRITABLE : JERRY_PROP_NO_OPTS));
   }
   else
   {

--- a/jerry-core/include/jerryscript-compiler.h
+++ b/jerry-core/include/jerryscript-compiler.h
@@ -64,9 +64,9 @@ JERRY_C_API_BEGIN
 /*
  * Compiler-specific macros relevant for Microsoft Visual C/C++ Compiler.
  */
-#define JERRY_ATTR_DEPRECATED __declspec(deprecated)
-#define JERRY_ATTR_NOINLINE   __declspec(noinline)
-#define JERRY_ATTR_NORETURN   __declspec(noreturn)
+#define JERRY_ATTR_DEPRECATED __declspec (deprecated)
+#define JERRY_ATTR_NOINLINE   __declspec (noinline)
+#define JERRY_ATTR_NORETURN   __declspec (noreturn)
 
 /*
  * Microsoft Visual C/C++ Compiler doesn't support for VLA, using _alloca

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -217,7 +217,7 @@ void jerry_jrt_set_log_level (jerry_log_level_t level);
  */
 #if defined(__clang__) || defined(__GNUC__)
 /* Clang/GCC will not tail call given inline volatile assembly. */
-#define JERRY_BLOCK_TAIL_CALL_OPTIMIZATION() __asm__ __volatile__("")
+#define JERRY_BLOCK_TAIL_CALL_OPTIMIZATION() __asm__ __volatile__ ("")
 #else /* !defined(__clang__) && !defined(__GNUC__) */
 /* On GCC 10.x this version also works. */
 #define JERRY_BLOCK_TAIL_CALL_OPTIMIZATION()                 \

--- a/jerry-ext/include/jerryscript-ext/module.h
+++ b/jerry-ext/include/jerryscript-ext/module.h
@@ -62,10 +62,10 @@ typedef struct jerryx_native_module_t
 #pragma section(".CRT$XCU", read)
 #pragma section(".CRT$XTU", read)
 
-#define JERRYX_MSVC_FUNCTION_ON_SECTION(sec_name, f)                               \
-  static void f (void);                                                            \
-  __pragma (JERRYX_MSVC_INCLUDE_SYM (f##_section)) __declspec(allocate (sec_name)) \
-    JERRYX_MSCV_EXTERN_C void (*f##_section) (void) = f;                           \
+#define JERRYX_MSVC_FUNCTION_ON_SECTION(sec_name, f)                                \
+  static void f (void);                                                             \
+  __pragma (JERRYX_MSVC_INCLUDE_SYM (f##_section)) __declspec (allocate (sec_name)) \
+    JERRYX_MSCV_EXTERN_C void (*f##_section) (void) = f;                            \
   static void f (void)
 
 #define JERRYX_MODULE_CONSTRUCTOR(f) JERRYX_MSVC_FUNCTION_ON_SECTION (".CRT$XCU", f)

--- a/jerry-main/benchmark/main-benchmark.c
+++ b/jerry-main/benchmark/main-benchmark.c
@@ -162,19 +162,19 @@ run (void)
 #endif /* !(defined ( __linux__) && __linux__) */
 
 #if defined(__x86_64__)
-#define STACK_SAVE(TARGET)                          \
-  {                                                 \
-    __asm volatile("mov %%rsp, %0" : "=m"(TARGET)); \
+#define STACK_SAVE(TARGET)                           \
+  {                                                  \
+    __asm volatile ("mov %%rsp, %0" : "=m"(TARGET)); \
   }
 #elif defined(__i386__)
-#define STACK_SAVE(TARGET)                          \
-  {                                                 \
-    __asm volatile("mov %%esp, %0" : "=m"(TARGET)); \
+#define STACK_SAVE(TARGET)                           \
+  {                                                  \
+    __asm volatile ("mov %%esp, %0" : "=m"(TARGET)); \
   }
 #elif defined(__arm__)
-#define STACK_SAVE(TARGET)                       \
-  {                                              \
-    __asm volatile("mov %0, sp" : "=r"(TARGET)); \
+#define STACK_SAVE(TARGET)                        \
+  {                                               \
+    __asm volatile ("mov %0, sp" : "=r"(TARGET)); \
   }
 #else /* !defined (__x86_64__) && !defined (__i386__) && !defined (__arm__) */
 #error "Unsupported stack measurement target!"

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -30,7 +30,7 @@ RE_DIRECTIVE_COMMENT = re.compile(r"^#\s*(else|endif)$", re.MULTILINE)
 RE_FUNCTION_NAME_COMMENT = re.compile(
     r"^\}(?!(?:\s\/\*\s\w+\s\*\/$|\s?\w*;))", re.MULTILINE)
 
-CLANG_FORMAT_MIN_VERSION = 10
+CLANG_FORMAT_MIN_VERSION = 15
 
 FOLDERS = ["jerry-core",
            "jerry-ext",


### PR DESCRIPTION
In this patch:
- Bump minimum clang-format version to 15 (the previously used 10 is not in the ubuntu-22.04 repo)
- Reformat several files
- Re-enable format and strings CI checkers


