### PR TITLE
Update MbedOS, RIOT and ESP_IDF CI checkers

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -273,19 +273,17 @@ jobs:
           $RUNNER -q --jerry-tests --build-debug
           --buildoptions=--toolchain=cmake/toolchain_linux_aarch64.cmake,--linker-flag=-static
 
-# TODO: update to ubuntu-22.04
-#  MbedOS_K64F_Build_Test:
-#    runs-on: ubuntu-18.04 # needed due to ppa:team-gcc-arm-embedded/ppa
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions/setup-python@v2
-#        with:
-#          python-version: '3.8' # needed due to 'intelhex' module
-#      - run: sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
-#      - run: sudo apt update
-#      - run: sudo apt install gcc-arm-embedded python3-setuptools mercurial
-#      - run: make -f ./targets/os/mbedos/Makefile.travis install
-#      - run: make -f ./targets/os/mbedos/Makefile.travis script
+  MbedOS_K64F_Build_Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '>=3.6'
+      - run: sudo apt update
+      - run: sudo apt install gcc-arm-none-eabi ninja-build
+      - run: make -f ./targets/os/mbedos/Makefile.travis install
+      - run: make -f ./targets/os/mbedos/Makefile.travis script
 
   Zephyr_STM32F4_Build_Test:
     runs-on: ubuntu-latest
@@ -311,18 +309,15 @@ jobs:
       - run: make -f ./targets/os/nuttx/Makefile.travis install-noapt
       - run: make -f ./targets/os/nuttx/Makefile.travis script
 
-# TODO: update to ubuntu-22.04
-#  RIOT_STM32F4_Build_Test:
-#    runs-on: ubuntu-18.04 # needed due to ppa:team-gcc-arm-embedded/ppa
-#    env:
-#      CC: clang
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa
-#      - run: sudo apt update
-#      - run: sudo apt install clang gcc-arm-embedded gcc-multilib
-#      - run: make -f ./targets/os/riot/Makefile.travis install-noapt
-#      - run: make -f ./targets/os/riot/Makefile.travis script
+  RIOT_STM32F4_Build_Test:
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt -y install clang gcc-arm-none-eabi
+      - run: make -f ./targets/os/riot/Makefile.travis install-noapt
+      - run: make -f ./targets/os/riot/Makefile.travis script
 
   ESP8266_RTOS_SDK_Build_Test:
     runs-on: ubuntu-latest
@@ -334,15 +329,15 @@ jobs:
       - run: make -f ./targets/baremetal-sdk/espressif/esp8266-rtos-sdk/Makefile.travis install-noapt
       - run: make -f ./targets/baremetal-sdk/espressif/esp8266-rtos-sdk/Makefile.travis script
 
-#  ESP_IDF_Build_Test:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions/setup-python@v2
-#        with:
-#          python-version: '3.8'
-#      - run: make -f ./targets/baremetal-sdk/espressif/esp-idf/Makefile.travis install-noapt
-#      - run: make -f ./targets/baremetal-sdk/espressif/esp-idf/Makefile.travis script
+  ESP_IDF_Build_Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '==3.8'
+      - run: make -f ./targets/baremetal-sdk/espressif/esp-idf/Makefile.travis install-noapt
+      - run: make -f ./targets/baremetal-sdk/espressif/esp-idf/Makefile.travis script
 
   Notification:
     runs-on: ubuntu-latest

--- a/targets/baremetal-sdk/espressif/esp-idf/Makefile.travis
+++ b/targets/baremetal-sdk/espressif/esp-idf/Makefile.travis
@@ -27,8 +27,8 @@ install-apt-get-deps:
 
 # Fetch and extract Xtensa toolchain.
 install-xtensa-esp32-gcc:
-	wget https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch3/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch3-linux-amd64.tar.gz --no-check-certificate --directory-prefix /tmp
-	tar xvfz /tmp/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch3-linux-amd64.tar.gz --directory /tmp
+	wget https://github.com/espressif/crosstool-NG/releases/download/esp-2021r2-patch5/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch5-linux-amd64.tar.gz --no-check-certificate --directory-prefix /tmp
+	tar xvfz /tmp/xtensa-esp32-elf-gcc8_4_0-esp-2021r2-patch5-linux-amd64.tar.gz --directory /tmp
 
 # Fetch Espressif IoT Development Framework and install its dependencies.
 install-esp-idf:

--- a/targets/os/mbedos/Makefile
+++ b/targets/os/mbedos/Makefile
@@ -32,21 +32,18 @@ JERRY_HEAP_SIZE ?= 70
 
 define MBED_CLI_FLAGS
 	--clean
-	--build $(BUILD_DIR)
-	--source $(MBED_OS_DIR)
-	--source $(JERRY_ROOT_DIR)
-	--source $(JERRY_TARGET_DIR)
+	--mbed-os-path $(MBED_OS_DIR)
+	--program-path $(JERRY_ROOT_DIR)
 	--toolchain $(TOOLCHAIN)
-	--target $(BOARD)
-	--artifact-name mbedos
-	--macro JERRY_GLOBAL_HEAP_SIZE=$(JERRY_HEAP_SIZE)
+	--mbed-target $(BOARD)
+	--app-config $(JERRY_ROOT_DIR)/mbed_lib.json
 endef
 
 .PHONY: all
 all: .build
 
 .PHONY: clean
-clean: .mbedignore-remove
+clean: .extra-files-remove
 	rm -rf $(JERRY_ROOT_DIR)/build/mbed-os
 
 .PHONY: flash
@@ -57,17 +54,18 @@ flash: .mbed-set-flash-flag .build
 	$(eval MBED_CLI_FLAGS += --flash)
 
 .PHONY: .build
-.build: .mbedignore-copy .mbed-build .mbedignore-remove
+.build: .extra-files-copy .mbed-build .extra-files-remove
 
 .PHONY: .mbed-build
 .mbed-build:
-	mbed config -G MBED_OS_DIR $(MBED_OS_DIR)
-	mbed compile $(strip $(MBED_CLI_FLAGS))
+	mbed-tools compile $(strip $(MBED_CLI_FLAGS))
 
-.PHONY: .mbedignore-copy
-.mbedignore-copy:
+.PHONY: .extra-files-copy
+.extra-files-copy:
 	cp mbedignore.txt $(JERRY_ROOT_DIR)/.mbedignore
+	cp mbed_lib.json $(JERRY_ROOT_DIR)/mbed_lib.json
 
-.PHONY: .mbedignore-remove
-.mbedignore-remove:
+.PHONY: .extra-files-remove
+.extra-files-remove:
 	rm -f $(JERRY_ROOT_DIR)/.mbedignore
+	rm -f $(JERRY_ROOT_DIR)/mbed_lib.json

--- a/targets/os/mbedos/Makefile.travis
+++ b/targets/os/mbedos/Makefile.travis
@@ -22,12 +22,13 @@ all:
 ## Targets for installing build dependencies of the Mbed OS JerryScript target.
 
 install-mbedos:
-	git clone https://github.com/ARMmbed/mbed-os.git ../mbed-os -b mbed-os-6.15.0
+	git clone https://github.com/ARMmbed/mbed-os.git ../mbed-os -b mbed-os-6.17.0
 
 # Deploy Mbed and install Mbed Python dependencies.
 install-mbedos-deps:
-	pip install mbed-cli
-	pip install -r ../mbed-os/requirements.txt
+	pip3 install --upgrade pip
+	pip3 install mbed-tools setuptools
+	pip3 install -r ../mbed-os/requirements.txt
 
 install: install-mbedos install-mbedos-deps
 

--- a/targets/os/mbedos/mbed_lib.json
+++ b/targets/os/mbedos/mbed_lib.json
@@ -1,0 +1,4 @@
+{
+  "name": "jerry",
+  "macros": ["JERRY_GLOBAL_HEAP_SIZE=70"]
+}


### PR DESCRIPTION
Update MbedOS and RIOT CI checkers to use `gcc-arm-none-eabi` on top of ubuntu-latest

Upgrade to mbed-tools and mbed-os 6.17

Bump xtensa version to `2021r2-patch5` and re-enable `ESP_IDF_Build_Test`