### PR TITLE
Fix gc of async destructuring assignments of strings

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -742,7 +742,11 @@ ecma_gc_mark_executable_object (ecma_object_t *object_p) /**< object */
 
         do
         {
-          ecma_gc_set_object_visited (ecma_get_object_from_value (*(--context_top_p)));
+          --context_top_p;
+          if (ecma_is_value_object (*context_top_p))
+          {
+            ecma_gc_set_object_visited (ecma_get_object_from_value (*context_top_p));
+          }
         } while (context_top_p > last_item_p);
 
         continue;

--- a/tests/jerry/regression-test-issue-5089.js
+++ b/tests/jerry/regression-test-issue-5089.js
@@ -1,0 +1,27 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+async function test1() {
+    var a;
+    ({k: a = await 1} = "XY");
+}
+test1();
+gc();
+
+async function test2() {
+    var a;
+    [a = await 1] = "";
+}
+test2();
+gc();


### PR DESCRIPTION
This fixes #5089

When garbage collection is running on a paused async function that includes destructuring assignments of strings, the string can be a direct string, and not an object, which cannot be marked as visited, as it does not have a visited flag.