### PR TITLE
Fix rare crash caused by get method of proxy object

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -171,7 +171,7 @@ jobs:
       - run: >-
           $RUNNER -q --jerry-tests
           --buildoptions=--stack-limit=0,--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--system-allocator=on,--linker-flag=-fuse-ld=gold
-          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js
+          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js,regression-test-issue-5101.js
 
   ASAN_Tests_Debug:
     runs-on: ubuntu-latest
@@ -187,7 +187,7 @@ jobs:
       - run: >-
           $RUNNER -q --jerry-tests --build-debug
           --buildoptions=--stack-limit=0,--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--system-allocator=on,--linker-flag=-fuse-ld=gold
-          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js
+          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js,regression-test-issue-5101.js
 
   UBSAN_Tests:
     runs-on: ubuntu-latest

--- a/jerry-core/ecma/operations/ecma-function-object.c
+++ b/jerry-core/ecma/operations/ecma-function-object.c
@@ -1010,6 +1010,8 @@ ecma_op_function_call_constructor (vm_frame_ctx_shared_args_t *shared_args_p, /*
                                    ecma_object_t *scope_p, /**< lexical environment to use */
                                    ecma_value_t this_binding) /**< value of 'ThisBinding' */
 {
+  ECMA_CHECK_STACK_USAGE ();
+
   shared_args_p->header.status_flags |= VM_FRAME_CTX_SHARED_NON_ARROW_FUNC;
 
   ecma_value_t ret_value;
@@ -1079,6 +1081,8 @@ ecma_op_function_call_simple (ecma_object_t *func_obj_p, /**< Function object */
                               uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_FUNCTION);
+
+  ECMA_CHECK_STACK_USAGE ();
 
   vm_frame_ctx_shared_args_t shared_args;
   shared_args.header.status_flags = VM_FRAME_CTX_SHARED_HAS_ARG_LIST;
@@ -1205,6 +1209,8 @@ ecma_op_function_call_native_built_in (ecma_object_t *func_obj_p, /**< Function 
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_BUILT_IN_FUNCTION);
 
+  ECMA_CHECK_STACK_USAGE ();
+
 #if JERRY_BUILTIN_REALMS
   ecma_global_object_t *saved_global_object_p = JERRY_CONTEXT (global_object_p);
 
@@ -1234,6 +1240,8 @@ ecma_op_function_call_native (ecma_object_t *func_obj_p, /**< Function object */
                               uint32_t arguments_list_len) /**< length of arguments list */
 {
   JERRY_ASSERT (ecma_get_object_type (func_obj_p) == ECMA_OBJECT_TYPE_NATIVE_FUNCTION);
+
+  ECMA_CHECK_STACK_USAGE ();
 
   ecma_native_function_t *native_function_p = (ecma_native_function_t *) func_obj_p;
 

--- a/jerry-core/ecma/operations/ecma-proxy-object.c
+++ b/jerry-core/ecma/operations/ecma-proxy-object.c
@@ -1170,7 +1170,9 @@ ecma_proxy_object_get (ecma_object_t *obj_p, /**< proxy object */
   ecma_value_t args[] = { proxy_obj_p->target, prop_value, receiver };
 
   /* 9. */
+  ecma_ref_object (obj_p);
   ecma_value_t trap_result = ecma_op_function_call (func_obj_p, handler, args, 3);
+  ecma_deref_object (obj_p);
 
   ecma_deref_object (func_obj_p);
 

--- a/tests/jerry/regression-test-issue-5101.js
+++ b/tests/jerry/regression-test-issue-5101.js
@@ -1,0 +1,32 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var iter = 100;
+async function f0() {
+    iter--;
+    function f6() {
+        return f0;
+    }
+    var proxy_handler = {
+        "get": f0,
+    };
+
+    f0.__proto__ = new Proxy(f6, proxy_handler);
+
+    if ((iter >= 0)) {
+        var v12 = f0();
+    }
+    return f0;
+}
+f0();


### PR DESCRIPTION
This fixes #5101
In rare cases the proxy object could get used after being incorrectly removed by the gc

Add stack checks to the start of all function calls

A Regression test is not included because I was unable to reproduce the crash with code that would be readable / easy to understand, only with a marginally simplified version of the example code given in the original issue, and @zherczeg advised against including it:
```js
async function f0() {
    function f6() {
        return f0;
    }
    var proxy_handler = {
        "get": f0,
    };

    f0.__proto__ = new Proxy(f6, proxy_handler);
    var v12 = f0();
    return f0;
}
f0();
```
However I can include it anyways if requested.