### PR TITLE
Fix the private field crash for the Array object.

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -919,6 +919,11 @@ opfunc_private_method_or_accessor_add (ecma_object_t *class_object_p, /**< the f
 
     JERRY_ASSERT (prop_name_p->u.hash & ECMA_SYMBOL_FLAG_PRIVATE_INSTANCE_METHOD);
 
+    if (ecma_op_object_is_fast_array (this_obj_p))
+    {
+      ecma_fast_array_convert_to_normal (this_obj_p);
+    }
+
     prop_p = ecma_find_named_property (this_obj_p, prop_name_p);
     ecma_object_t *method_p = ecma_get_object_from_value (method);
 
@@ -1368,6 +1373,11 @@ opfunc_private_field_add (ecma_value_t base, /**< base object */
   ecma_object_t *obj_p = ecma_get_object_from_value (base);
   ecma_string_t *prop_name_p = ecma_get_string_from_value (property);
   ecma_string_t *private_key_p = NULL;
+
+  if (ecma_op_object_is_fast_array (obj_p))
+  {
+    ecma_fast_array_convert_to_normal (obj_p);
+  }
 
   ecma_property_t *prop_p = opfunc_find_private_element (obj_p, prop_name_p, &private_key_p, false);
 

--- a/tests/jerry/private_fields.js
+++ b/tests/jerry/private_fields.js
@@ -327,3 +327,26 @@ class O {
 var var16 = new O();
 var16.b();
 assert(var16.c() == 12);
+
+// Private fields are accessible in Array object
+class P extends Array {
+  #a = 1;
+  b() {
+    return this.#a;
+  }
+}
+
+var var17 = new P();
+assert(var17.b() == 1);
+
+class Q extends Array {
+  #a() {
+    return 1;
+  }
+  b() {
+    return this.#a();
+  }
+}
+
+var var18 = new Q();
+assert(var18.b() == 1);

--- a/tests/jerry/regression-test-issue-5097.js
+++ b/tests/jerry/regression-test-issue-5097.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class Foo extends ([]).constructor {
+    #g;
+}
+
+new Foo();

--- a/tests/jerry/regression-test-issue-5100.js
+++ b/tests/jerry/regression-test-issue-5100.js
@@ -1,0 +1,21 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class Foo extends Array {
+    #x() {
+    }
+}
+
+var bar = new Foo();
+bar[0] = 1;

--- a/tests/jerry/regression-test-issue-5138.js
+++ b/tests/jerry/regression-test-issue-5138.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class C1 extends Array{
+    #test() {
+    }
+}
+new C1()


### PR DESCRIPTION
Fix the private field crash in the Array object mentioned in 
https://github.com/jerryscript-project/jerryscript/issues/5138
