### PR TITLE
Fix arguments object in eval-ed functions in static class initializers

### DIFF
--- a/jerry-core/parser/js/js-scanner-internal.h
+++ b/jerry-core/parser/js/js-scanner-internal.h
@@ -125,6 +125,8 @@ typedef enum
 #if JERRY_DEBUGGER
   SCANNER_CONTEXT_DEBUGGER_ENABLED = (1 << 1), /**< debugger is enabled */
 #endif /* JERRY_DEBUGGER */
+  SCANNER_CONTEXT_RESTORE_INSIDE_CLASS_FIELD_FLAG =
+    (1 << 2), /**< restore the PARSER_INSIDE_CLASS_FIELD flag of the main context */
 } scanner_context_flags_t;
 
 /**

--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -1534,6 +1534,11 @@ scanner_scan_statement (parser_context_t *context_p, /**< context */
     }
     case LEXER_KEYW_FUNCTION:
     {
+      if (context_p->status_flags & PARSER_INSIDE_CLASS_FIELD)
+      {
+        scanner_context_p->status_flags |= SCANNER_CONTEXT_RESTORE_INSIDE_CLASS_FIELD_FLAG;
+        context_p->status_flags &= (uint32_t) ~(PARSER_INSIDE_CLASS_FIELD);
+      }
       uint16_t status_flags = SCANNER_LITERAL_POOL_FUNCTION | SCANNER_LITERAL_POOL_FUNCTION_STATEMENT;
 
       if (scanner_context_p->async_source_p != NULL)
@@ -2014,6 +2019,12 @@ scanner_scan_statement_end (parser_context_t *context_p, /**< context */
         if (type != LEXER_RIGHT_BRACE)
         {
           break;
+        }
+
+        if (scanner_context_p->status_flags & SCANNER_CONTEXT_RESTORE_INSIDE_CLASS_FIELD_FLAG)
+        {
+          context_p->status_flags |= PARSER_INSIDE_CLASS_FIELD;
+          scanner_context_p->status_flags &= (uint16_t) ~(SCANNER_CONTEXT_RESTORE_INSIDE_CLASS_FIELD_FLAG);
         }
 
         if (context_p->stack_top_uint8 != SCAN_STACK_CLASS_STATEMENT)

--- a/tests/jerry/regression-test-issue-5117.js
+++ b/tests/jerry/regression-test-issue-5117.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class Outer {
+    static {
+        eval(`
+            function staticfunc() {
+                arguments;
+            }
+
+            class Inner {
+            }
+        `);
+    }
+}


### PR DESCRIPTION
This patch fixes https://github.com/jerryscript-project/jerryscript/issues/5117 and https://github.com/jerryscript-project/jerryscript/issues/5119