### PR TITLE
Fix CI for macos-latest

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -57,7 +57,7 @@ jobs:
       - run: $RUNNER -q --jerry-tests --buildoptions=--compile-flag=-m32,--cpointer-32bit=on --build-debug
 
   OSX_x86-64_Build_Correctness_Unit_Tests:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4
@@ -67,7 +67,7 @@ jobs:
       - run: $RUNNER -q --unittests
 
   OSX_x86-64_Build_Correctness_Unit_Tests_Debug:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v4

--- a/tests/unit-math/CMakeLists.txt
+++ b/tests/unit-math/CMakeLists.txt
@@ -30,6 +30,9 @@ foreach(SOURCE_UNIT_TEST_MAIN ${SOURCE_UNIT_TEST_MAIN_MODULES})
   add_executable(${TARGET_NAME} ${SOURCE_UNIT_TEST_MAIN})
   set_property(TARGET ${TARGET_NAME} PROPERTY LINK_FLAGS "${LINKER_FLAGS_COMMON}")
   set_property(TARGET ${TARGET_NAME} PROPERTY RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests")
+  if("${PLATFORM}" STREQUAL "DARWIN")
+    set_property(TARGET ${TARGET_NAME} PROPERTY COMPILE_OPTIONS "-Wno-literal-range")
+  endif()
 
   target_link_libraries(${TARGET_NAME} jerry-math)
 


### PR DESCRIPTION
Add a non-inlineable function for negating a number on macos, bacause due to a compiler bug `r = -r` was being optimized out, resulting in some modulo operations failing such as `-1 % -1` or `-1 % 1`.

Disable `-Wliteral-range` for `test-math.c` on macos, because it was falsely raised for `isnan`, `isinf`, and `isfinite` macros.