### PR TITLE
Fix parsing of invalid private class properties

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -405,7 +405,10 @@ static void
 parser_check_duplicated_private_field (parser_context_t *context_p, /**< context */
                                        uint8_t opts) /**< options */
 {
-  JERRY_ASSERT (context_p->token.type == LEXER_LITERAL);
+  if (context_p->token.type != LEXER_LITERAL)
+  {
+    parser_raise_error (context_p, PARSER_ERR_EXPRESSION_EXPECTED);
+  }
   JERRY_ASSERT (context_p->private_context_p);
   scanner_class_private_member_t *iter = context_p->private_context_p->members_p;
 

--- a/tests/jerry/fail/regression-test-issue-5141.js
+++ b/tests/jerry/fail/regression-test-issue-5141.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class C { #get [Symbol]; }

--- a/tools/cppcheck/suppressions-list
+++ b/tools/cppcheck/suppressions-list
@@ -31,7 +31,7 @@ shiftNegativeLHS:jerry-math/*.c
 shiftTooManyBits:jerry-core/*.c
 shiftTooManyBitsSigned:jerry-math/*.c
 signConversionCond:jerry-core/*.c
-uninitvar:jerry-core/parser/js/js-parser-expr.c:3420
+uninitvar:jerry-core/parser/js/js-parser-expr.c:3423
 uninitvar:tests/unit-core/test-api-objecttype.c:119
 unmatchedSuppression:jerry-core/*.inc.h
 unreadVariable:jerry-core/*.c


### PR DESCRIPTION
Raise syntax error instead of failing with an assert.

Fixes https://github.com/jerryscript-project/jerryscript/issues/5141