### PR TITLE
Fix parsing class body that includes stray semicolon after a static block

### DIFF
--- a/jerry-core/parser/js/js-scanner.c
+++ b/jerry-core/parser/js/js-scanner.c
@@ -2700,6 +2700,12 @@ scanner_scan_all (parser_context_t *context_p) /**< context */
             identifier_found = true;
           }
 
+          if (context_p->token.type == LEXER_SEMICOLON)
+          {
+            scanner_context.mode = SCAN_MODE_CLASS_BODY;
+            continue;
+          }
+
           if (!identifier_found)
           {
             scanner_raise_error (context_p);
@@ -2726,12 +2732,6 @@ scanner_scan_all (parser_context_t *context_p) /**< context */
           {
             scanner_push_class_field_initializer (context_p, &scanner_context);
             break;
-          }
-
-          if (context_p->token.type == LEXER_SEMICOLON)
-          {
-            scanner_context.mode = SCAN_MODE_CLASS_BODY;
-            continue;
           }
 
           if (context_p->token.type != LEXER_RIGHT_BRACE && !(context_p->token.flags & LEXER_WAS_NEWLINE))

--- a/tests/jerry/regression-test-issue-5114.js
+++ b/tests/jerry/regression-test-issue-5114.js
@@ -1,0 +1,19 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class c {
+    static {
+    }
+    ;
+}


### PR DESCRIPTION
Fixes https://github.com/jerryscript-project/jerryscript/issues/5114