### PR TITLE
Minor fix to ensure Python 3 support in the debugger

### DIFF
--- a/jerry-debugger/jerry_client_websocket.py
+++ b/jerry-debugger/jerry_client_websocket.py
@@ -90,7 +90,7 @@ class WebSocket:
         """ Send message. """
         message = struct.pack(byte_order + "BBI",
                               WEBSOCKET_BINARY_FRAME | WEBSOCKET_FIN_BIT,
-                              WEBSOCKET_FIN_BIT + struct.unpack(byte_order + "B", packed_data[0].to_bytes())[0],
+                              WEBSOCKET_FIN_BIT + struct.unpack(byte_order + "B", packed_data[0:1])[0],
                               0) + packed_data[1:]
 
         self.__send_data(message)


### PR DESCRIPTION
The default value for length parameter in to_bytes was added in Python version 3.11. This small fix ensures the compatibility with older Python3 versions.
