### PR TITLE
Put reference on executable object's this_binding to avoid unwanted f…

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -171,7 +171,7 @@ jobs:
       - run: >-
           $RUNNER -q --jerry-tests
           --buildoptions=--stack-limit=0,--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--system-allocator=on,--linker-flag=-fuse-ld=gold
-          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js,regression-test-issue-5101.js
+          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4870.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js,regression-test-issue-5101.js
 
   ASAN_Tests_Debug:
     runs-on: ubuntu-latest
@@ -187,7 +187,7 @@ jobs:
       - run: >-
           $RUNNER -q --jerry-tests --build-debug
           --buildoptions=--stack-limit=0,--compile-flag=-fsanitize=address,--compile-flag=-m32,--compile-flag=-fno-omit-frame-pointer,--compile-flag=-fno-common,--compile-flag=-O2,--debug,--system-allocator=on,--linker-flag=-fuse-ld=gold
-          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js,regression-test-issue-5101.js
+          --skip-list=parser-oom.js,parser-oom2.js,stack-limit.js,regression-test-issue-4870.js,regression-test-issue-4901.js,regression-test-issue-4848.js,regression-test-issue-4890.js,regression-test-issue-2190.js,regression-test-issue-2258-2963.js,regression-test-issue-2448.js,regression-test-issue-2905.js,regression-test-issue-3785.js,proxy-evil-recursion.js,regression-test-issue-5101.js
 
   UBSAN_Tests:
     runs-on: ubuntu-latest

--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -737,6 +737,7 @@ opfunc_resume_executable_object (vm_executable_object_t *executable_object_p, /*
     ecma_ref_if_object (*register_p++);
   }
 
+  ecma_ref_if_object (executable_object_p->frame_ctx.this_binding);
   ecma_ref_if_object (executable_object_p->iterator);
 
   JERRY_ASSERT (ECMA_EXECUTABLE_OBJECT_IS_SUSPENDED (executable_object_p));
@@ -770,6 +771,7 @@ opfunc_resume_executable_object (vm_executable_object_t *executable_object_p, /*
 
     /* All resources are released. */
     executable_object_p->extended_object.u.cls.u2.executable_obj_flags |= ECMA_EXECUTABLE_OBJECT_COMPLETED;
+    ecma_deref_if_object (executable_object_p->frame_ctx.this_binding);
     return result;
   }
 
@@ -798,6 +800,7 @@ opfunc_resume_executable_object (vm_executable_object_t *executable_object_p, /*
     ecma_deref_if_object (*register_p++);
   }
 
+  ecma_deref_if_object (executable_object_p->frame_ctx.this_binding);
   ecma_deref_if_object (executable_object_p->iterator);
 
   return result;

--- a/tests/jerry/es.next/regression-test-issue-4870.js
+++ b/tests/jerry/es.next/regression-test-issue-4870.js
@@ -1,0 +1,87 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+async function f() {
+    let arr = [0.000000];
+    let fuzz_v152 = arr;
+    let fuzz_v159 = fuzz_v152.__proto__;
+    fuzz_v152.valueOf = function* (fuzz_v166, fuzz_v167) {
+        while (arr) {
+        }
+        var fuzz_v172 = ~f;
+        arr >>= [1.100000];
+        return fuzz_v167;
+    };
+    arr.includes(arr, [340282346638528859811704183484516925440.000000], arr);
+    delete [10];
+    let fuzz_v253 = f.__proto__;
+    let fuzz_v256 = {
+        "D5FP8": f
+    };
+    arr["map"](f, new Object(true));
+    arr.flat();
+    let fuzz_v69 = false;
+    await this;
+    await f;
+    var fuzz_v43 = arr -= new Date(new String({
+        "findIndex": arr
+    }));
+    await this;
+    let fuzz_v286 = Symbol.reject();
+    await f;
+    await new Promise(f);
+    await new Promise(async function* (fuzz_v80) {
+        var fuzz_v82 = new Uint32Array(fuzz_v80, arr, [1.100000], fuzz_v80, fuzz_v80);
+        let fuzz_v96 = fuzz_v82.__proto__;
+        this.length = 4;
+    });
+    await new Promise(async function* (fuzz_v138, fuzz_v139) {
+        fuzz_v138.__proto__ = fuzz_v139;
+        let fuzz_v147 = function* (fuzz_v149, fuzz_v150, fuzz_v151, fuzz_v152) {
+            let fuzz_v165 = Reflect.apply(fuzz_v152, {
+                "findIndex": fuzz_v150
+            }, [{}]);
+            switch ({
+                includes: fuzz_v138,
+                set valueOf(fuzz_v175) {
+                    fuzz_v150.valueOf = fuzz_v175;
+                    return;
+                }
+            }) {
+                case [1.100000]:
+                    throw arr;
+                    break;
+                case 5643033980980220.000000:
+                    let fuzz_v203 = String.prototype.trim.call(new String());
+                    break;
+                default:
+                    fuzz_v43.valueOf = fuzz_v150;
+            }
+            let fuzz_v214 = fuzz_v69;
+            let fuzz_v223 = Number.isInteger(2147483648);
+        };
+        var fuzz_v228 = f;
+        delete f.__proto__;
+        let fuzz_v237 = {};
+    });
+    await new Promise(f);
+    await new Promise(async function* (fuzz_v269, fuzz_v270, fuzz_v271) {
+        class fuzz_class273 extends f {
+
+        }
+        return arr;
+    });
+    await new Promise(fuzz_v286);
+}
+f(f, f);


### PR DESCRIPTION
…rees before exiting execution

This patch fixes #4870.

The implementation is based on PR #4966, only resolved the conflicts and applied requested changes.

Co-authored-by: Martin Negyokru negyokru@inf.u-szeged.hu
JerryScript-DCO-1.0-Signed-off-by: Gergo Csizi gergocs@inf.u-szeged.hu