### PR TITLE
Update and fix some issues in EXT-REFERENCE documentation

### DIFF
--- a/docs/09.EXT-REFERENCE-ARG.md
+++ b/docs/09.EXT-REFERENCE-ARG.md
@@ -361,6 +361,28 @@ jerryx_arg_transform_array (const jerry_value_t array_val,
 
 - [jerryx_arg_array](#jerryx_arg_array)
 
+## jerryx_arg_transform_optional
+
+**Summary**
+
+The common function to deal with optional arguments. The core transform function is provided by argument `func`.
+
+**Prototype**
+
+```c
+jerry_value_t jerryx_arg_transform_optional (jerryx_arg_js_iterator_t *js_arg_iter_p,
+                                             const jerryx_arg_t *c_arg_p,
+                                             jerryx_arg_transform_func_t func);
+```
+
+ - `js_arg_iter_p` - the JS arg iterator.
+ - `c_arg_p` - the native arg.
+ - `func` - the core transform function.
+ - return value - a `jerry_value_t` representing `undefined` if all validators passed or an `Error` if a validator failed.
+
+**See also**
+
+- [jerryx_arg_transform_func_t](#jerryx_arg_transform_func_t)
 
 # Helpers for commonly used validations
 
@@ -577,11 +599,11 @@ User should prepare the `jerryx_arg_object_props_t` instance, and pass it to thi
 
 ```c
 static inline jerryx_arg_t
-jerryx_arg_object_properties (const jerryx_arg_object_props_t *object_props_p,
+jerryx_arg_object_properties (const jerryx_arg_object_props_t *obj_prop_p,
                               jerryx_arg_optional_t opt_flag);
 ```
  - return value - the created `jerryx_arg_t` instance.
- - `object_props_p` - provides information for properties transform.
+ - `obj_prop_p` - provides information for properties transform.
  - `opt_flag` - whether the argument is optional.
 
 **Example**
@@ -753,6 +775,23 @@ my_external_handler (const jerry_value_t function_obj,
 - [jerryx_arg_transform_object_properties](#jerryx_arg_transform_object_properties)
 
 # Functions to create custom validations
+
+## jerryx_arg_ignore
+
+**Summary**
+
+Create a jerryx_arg_t instance for ignored argument.
+
+**Prototype**
+
+```c
+static inline jerryx_arg_t jerryx_arg_ignore (void);
+```
+ - return value - the created `jerryx_arg_t` instance.
+
+**See also**
+
+- [jerryx_arg_t](#jerryx_arg_t)
 
 ## jerryx_arg_custom
 

--- a/docs/10.EXT-REFERENCE-HANDLER.md
+++ b/docs/10.EXT-REFERENCE-HANDLER.md
@@ -24,7 +24,7 @@ The engine must be initialized before specifying the `jerry_value_t` in the stru
 typedef struct {
   const char *name;
   jerry_value_t value;
-} jerryx_function_list_entry;
+} jerryx_property_entry;
 ```
 
 **See also**

--- a/docs/12.EXT-REFERENCE-MODULE.md
+++ b/docs/12.EXT-REFERENCE-MODULE.md
@@ -63,7 +63,7 @@ to `jerryx_module_resolve` with a module name whose canonical name matches an al
 ```c
 jerry_value_t
 jerryx_module_resolve (const jerry_value_t name,
-                       const jerryx_module_resolver_t *resolvers_p,
+                       const jerryx_module_resolver_t **resolvers_p,
                        size_t resolver_count);
 ```
 
@@ -84,7 +84,7 @@ Remove a module from the current context's cache, or clear the cache entirely.
 ```c
 void
 jerryx_module_clear_cache (const jerry_value_t name,
-                           const jerryx_module_resolver_t *resolvers_p,
+                           const jerryx_module_resolver_t **resolvers_p,
                            size_t resolver_count);
 ```
 

--- a/jerry-ext/include/jerryscript-ext/arg.h
+++ b/jerry-ext/include/jerryscript-ext/arg.h
@@ -167,7 +167,7 @@ static inline jerryx_arg_t
 jerryx_arg_native_pointer (void **dest, const jerry_object_native_info_t *info_p, jerryx_arg_optional_t opt_flag);
 static inline jerryx_arg_t jerryx_arg_ignore (void);
 static inline jerryx_arg_t jerryx_arg_custom (void *dest, uintptr_t extra_info, jerryx_arg_transform_func_t func);
-static inline jerryx_arg_t jerryx_arg_object_properties (const jerryx_arg_object_props_t *object_props_p,
+static inline jerryx_arg_t jerryx_arg_object_properties (const jerryx_arg_object_props_t *obj_prop_p,
                                                          jerryx_arg_optional_t opt_flag);
 static inline jerryx_arg_t jerryx_arg_array (const jerryx_arg_array_items_t *array_items_p,
                                              jerryx_arg_optional_t opt_flag);

--- a/jerry-ext/include/jerryscript-ext/arg.impl.h
+++ b/jerry-ext/include/jerryscript-ext/arg.impl.h
@@ -347,7 +347,7 @@ jerryx_arg_custom (void *dest, /**< pointer to the native argument where the res
  * @return a jerryx_arg_t instance.
  */
 static inline jerryx_arg_t
-jerryx_arg_object_properties (const jerryx_arg_object_props_t *object_props, /**< pointer to object property mapping */
+jerryx_arg_object_properties (const jerryx_arg_object_props_t *obj_prop_p, /**< pointer to object property mapping */
                               jerryx_arg_optional_t opt_flag) /**< whether the argument is optional */
 {
   jerryx_arg_transform_func_t func;
@@ -361,7 +361,7 @@ jerryx_arg_object_properties (const jerryx_arg_object_props_t *object_props, /**
     func = jerryx_arg_transform_object_props;
   }
 
-  return (jerryx_arg_t){ .func = func, .dest = NULL, .extra_info = (uintptr_t) object_props };
+  return (jerryx_arg_t){ .func = func, .dest = NULL, .extra_info = (uintptr_t) obj_prop_p };
 } /* jerryx_arg_object_properties */
 
 /**

--- a/jerry-ext/include/jerryscript-ext/module.h
+++ b/jerry-ext/include/jerryscript-ext/module.h
@@ -161,12 +161,12 @@ extern jerryx_module_resolver_t jerryx_module_native_resolver;
  * loaded if it is found.
  */
 jerry_value_t
-jerryx_module_resolve (const jerry_value_t name, const jerryx_module_resolver_t **resolvers, size_t count);
+jerryx_module_resolve (const jerry_value_t name, const jerryx_module_resolver_t **resolvers_p, size_t count);
 
 /**
  * Delete a module from the cache or, if name has the JavaScript value of undefined, clear the entire cache.
  */
-void jerryx_module_clear_cache (const jerry_value_t name, const jerryx_module_resolver_t **resolvers, size_t count);
+void jerryx_module_clear_cache (const jerry_value_t name, const jerryx_module_resolver_t **resolvers_p, size_t count);
 
 JERRY_C_API_END
 


### PR DESCRIPTION
There was some issues and typos in the EXT-REFERENCE documentation. This patch fixes these issues and typos.

JerryScript-DCO-1.0-Signed-off-by: Gergo Csizi gergocs@inf.u-szeged.hu
