### PR TITLE
Fix some style issues in debugger documentation

### DIFF
--- a/docs/07.DEBUGGER.md
+++ b/docs/07.DEBUGGER.md
@@ -100,7 +100,8 @@ typedef jerry_value_t
 (*jerry_debugger_wait_for_source_callback_t) (const jerry_char_t *source_name_p,
                                               size_t source_name_size,
                                               const jerry_char_t *source_p,
-                                              size_t source_size, void *user_p);
+                                              size_t source_size,
+                                              void *user_p);
 ```
 
 - `source_name_p` - source (usually a file) name of the source code
@@ -293,7 +294,8 @@ return value of the function.
 ```c
 jerry_debugger_wait_for_source_status_t
 jerry_debugger_wait_for_client_source (jerry_debugger_wait_for_source_callback_t callback_p,
-                                       void *user_p, jerry_value_t *return_value)
+                                       void *user_p,
+                                       jerry_value_t *return_value)
 ```
 
 **Example**
@@ -385,7 +387,7 @@ Sends the program's output to the debugger client.
 
 ```c
 void
-jerry_debugger_send_output (const jerry_char_t *buffer, jerry_size_t string_size)
+jerry_debugger_send_output (const jerry_char_t *buffer, jerry_size_t str_size)
 ```
 
 **Example**

--- a/docs/13.DEBUGGER-TRANSPORT.md
+++ b/docs/13.DEBUGGER-TRANSPORT.md
@@ -77,7 +77,8 @@ the `header_p->next_p->send()` method.
 
 ```c
 typedef bool (*jerry_debugger_transport_send_t) (struct jerry_debugger_transport_interface_t *header_p,
-                                                 uint8_t *message_p, size_t message_length);
+                                                 uint8_t *message_p,
+                                                 size_t message_length);
 ```
 
 ## jerry_debugger_transport_receive_t
@@ -107,8 +108,10 @@ will be the first item of the interface chain.
 
 ```c
 void jerry_debugger_transport_add (jerry_debugger_transport_header_t *header_p,
-                                   size_t send_message_header_size, size_t max_send_message_size,
-                                   size_t receive_message_header_size, size_t max_receive_message_size);
+                                   size_t send_message_header_size,
+                                   size_t max_send_message_size,
+                                   size_t receive_message_header_size,
+                                   size_t max_receive_message_size);
 ```
 
 - `header_p`: header of a transportation interface.


### PR DESCRIPTION
There was some style issues in debugger documentation. This patch fixes these issues.

JerryScript-DCO-1.0-Signed-off-by: Gergo Csizi gergocs@inf.u-szeged.hu