### PR TITLE
Fix the return type of 'jerry_string_substr'.

### DIFF
--- a/jerry-core/include/jerryscript-core.h
+++ b/jerry-core/include/jerryscript-core.h
@@ -450,7 +450,7 @@ void *jerry_string_user_ptr (const jerry_value_t value, bool *is_external);
  * @defgroup jerry-api-string-op Operations
  * @{
  */
-jerry_size_t jerry_string_substr (const jerry_value_t value, jerry_length_t start, jerry_length_t end);
+jerry_value_t jerry_string_substr (const jerry_value_t value, jerry_length_t start, jerry_length_t end);
 jerry_size_t jerry_string_to_buffer (const jerry_value_t value,
                                      jerry_encoding_t encoding,
                                      jerry_char_t *buffer_p,

--- a/tests/unit-core/test-api-strings.c
+++ b/tests/unit-core/test-api-strings.c
@@ -159,6 +159,22 @@ main (void)
     jerry_value_free (test_str);
   }
 
+  /* Test jerry_string_substr */
+  {
+    jerry_value_t test_str = jerry_string_sz ("Hello World!");
+    jerry_value_t expected_str = jerry_string_sz ("Hello");
+
+    // Read the string into a byte buffer.
+    jerry_value_t sub_str = jerry_string_substr (test_str, 0, 5);
+
+    TEST_ASSERT (!strict_equals (sub_str, test_str));
+    TEST_ASSERT (strict_equals (sub_str, expected_str));
+
+    jerry_value_free (sub_str);
+    jerry_value_free (expected_str);
+    jerry_value_free (test_str);
+  }
+
   jerry_cleanup ();
 
   return 0;


### PR DESCRIPTION
Also added new unit test to test basic functionality of 'jerry_string_substr'.

JerryScript-DCO-1.0-Signed-off-by: Laszlo Lango laszlo.lango@h-lab.eu
