### PR TITLE
CMake update cmake_minimum_required (VERSION 3.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project (Jerry C)
 
 if(NOT DEFINED PYTHON)

--- a/jerry-core/CMakeLists.txt
+++ b/jerry-core/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 set(JERRY_CORE_NAME jerry-core)
 project (${JERRY_CORE_NAME} C)
 

--- a/jerry-ext/CMakeLists.txt
+++ b/jerry-ext/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 set(JERRY_EXT_NAME jerry-ext)
 project (${JERRY_EXT_NAME} C)
 

--- a/jerry-main/CMakeLists.txt
+++ b/jerry-main/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project (jerry-main C)
 
 # Optional build settings

--- a/jerry-math/CMakeLists.txt
+++ b/jerry-math/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 set(JERRY_MATH_NAME jerry-math)
 project (${JERRY_MATH_NAME} C)
 

--- a/jerry-port/CMakeLists.txt
+++ b/jerry-port/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 set(JERRY_PORT_NAME jerry-port)
 project (${JERRY_PORT_NAME} C)
 

--- a/tests/unit-core/CMakeLists.txt
+++ b/tests/unit-core/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project (unit-core C)
 
 if (NOT IS_ABSOLUTE ${FEATURE_PROFILE})

--- a/tests/unit-doc/CMakeLists.txt
+++ b/tests/unit-doc/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project (unit-doc C)
 find_package(PythonInterp REQUIRED)
 

--- a/tests/unit-ext/CMakeLists.txt
+++ b/tests/unit-ext/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project (unit-ext C)
 
 set(INCLUDE_UNIT_EXT ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tests/unit-ext/module/CMakeLists.txt
+++ b/tests/unit-ext/module/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 set(JERRYX_MODULE_UNITTEST_NAME unit-test-jerry-module)
 project (${JERRYX_MODULE_UNITTEST_NAME} C)
 

--- a/tests/unit-math/CMakeLists.txt
+++ b/tests/unit-math/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project (unit-math C)
 
 # Unit tests main modules


### PR DESCRIPTION
```
CMake Deprecation Warning at jerry-port/CMakeLists.txt:15 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
```
JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
