### PR TITLE
Drop JERRY_FEATURE_CPOINTER_32_BIT

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -146,7 +146,6 @@ this value can only be returned by the [jerry_error_type](#jerry_error_type).
 
 Possible compile time enabled feature types:
 
- - JERRY_FEATURE_CPOINTER_32_BIT - 32 bit compressed pointers
  - JERRY_FEATURE_ERROR_MESSAGES - error messages
  - JERRY_FEATURE_JS_PARSER - js-parser
  - JERRY_FEATURE_HEAP_STATS - memory statistics

--- a/jerry-core/api/jerryscript.c
+++ b/jerry-core/api/jerryscript.c
@@ -1693,9 +1693,6 @@ jerry_feature_enabled (const jerry_feature_t feature) /**< feature to check */
   JERRY_ASSERT (feature < JERRY_FEATURE__COUNT);
 
   return (false
-#if JERRY_CPOINTER_32_BIT
-          || feature == JERRY_FEATURE_CPOINTER_32_BIT
-#endif /* JERRY_CPOINTER_32_BIT */
 #if JERRY_ERROR_MESSAGES
           || feature == JERRY_FEATURE_ERROR_MESSAGES
 #endif /* JERRY_ERROR_MESSAGES */

--- a/jerry-core/include/jerryscript-types.h
+++ b/jerry-core/include/jerryscript-types.h
@@ -74,7 +74,6 @@ typedef enum
  */
 typedef enum
 {
-  JERRY_FEATURE_CPOINTER_32_BIT, /**< 32 bit compressed pointers */
   JERRY_FEATURE_ERROR_MESSAGES, /**< error messages */
   JERRY_FEATURE_JS_PARSER, /**< js-parser */
   JERRY_FEATURE_HEAP_STATS, /**< memory statistics */


### PR DESCRIPTION
There is no usage of JERRY_FEATURE_CPOINTER_32_BIT at runtime and there is no need use it at runtime