### PR TITLE
Run doctest code snippets instead of compiling them, where possible.

### DIFF
--- a/docs/02.API-REFERENCE.md
+++ b/docs/02.API-REFERENCE.md
@@ -3906,7 +3906,7 @@ jerry_on_throw (jerry_throw_cb_t throw_cb,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"
@@ -3974,7 +3974,7 @@ bool jerry_exception_is_captured (jerry_value_t value);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"
@@ -4040,7 +4040,7 @@ void jerry_exception_allow_capture (jerry_value_t value, bool should_capture);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"
@@ -4847,7 +4847,7 @@ jerry_value_t jerry_module_link (const jerry_value_t module_val,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # (test="link")
 
 ```c
 #include <jerryscript.h>
@@ -4926,7 +4926,7 @@ jerry_value_t jerry_module_evaluate (const jerry_value_t module_val);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -4987,7 +4987,7 @@ jerry_module_state_t jerry_module_state (const jerry_value_t module_val);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5048,7 +5048,7 @@ void jerry_module_on_state_changed (jerry_module_state_changed_cb_t callback,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5126,7 +5126,7 @@ void jerry_module_on_import_meta (jerry_module_import_meta_cb_t callback,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5204,7 +5204,7 @@ size_t jerry_module_request_count (const jerry_value_t module_val);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5276,7 +5276,7 @@ jerry_value_t jerry_module_request (const jerry_value_t module_val, size_t reque
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5344,7 +5344,7 @@ jerry_value_t jerry_module_namespace (const jerry_value_t module_val);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5412,7 +5412,7 @@ jerry_module_on_import (jerry_module_import_cb_t callback_p,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5544,7 +5544,7 @@ jerry_native_module (jerry_native_module_evaluate_cb_t callback,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5607,7 +5607,7 @@ jerry_native_module_get (const jerry_value_t native_module_val,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -5668,7 +5668,7 @@ jerry_value_t jerry_native_module_set (const jerry_value_t native_module_val,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include <jerryscript.h>
@@ -12240,7 +12240,7 @@ jerry_arraybuffer_has_buffer (const jerry_value_t value);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"
@@ -12306,7 +12306,7 @@ jerry_arraybuffer_heap_allocation_limit (const jerry_length_t allocation_limit);
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"
@@ -12382,7 +12382,7 @@ jerry_arraybuffer_allocator (jerry_arraybuffer_allocate_cb_t allocate_callback,
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"

--- a/docs/14.EXT-REFERENCE-HANDLE-SCOPE.md
+++ b/docs/14.EXT-REFERENCE-HANDLE-SCOPE.md
@@ -11,7 +11,7 @@ JerryScript only supports a single nested hierarchy of scopes. There is only one
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"
@@ -55,7 +55,7 @@ It is necessary in common cases that a handle has to be promote to outer scope a
 
 **Example**
 
-[doctest]: # (test="compile")
+[doctest]: # ()
 
 ```c
 #include "jerryscript.h"


### PR DESCRIPTION
Code have `main` entrypoint should be `run` or 'link', not 'compile'

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
