### PR TITLE
Rename jerry_port_log to jerry_port_log_buffer for reduce strlen usage

### DIFF
--- a/docs/01.CONFIGURATION.md
+++ b/docs/01.CONFIGURATION.md
@@ -155,7 +155,7 @@ Enabling this feature provides detailed error messages where available, like lin
 
 ### Logging
 
-This option can be used to enable log messages during runtime. When enabled the engine will use the `jerry_port_log` port API function to print relevant log messages.
+This option can be used to enable log messages during runtime. When enabled the engine will use the `jerry_port_log_buffer` port API function to print relevant log messages.
 This feature is disabled by default.
 
 | Options |                                              |

--- a/docs/05.PORT-API.md
+++ b/docs/05.PORT-API.md
@@ -120,9 +120,10 @@ void jerry_port_context_free (void);
  * The implementation can decide whether error and debug messages are logged to
  * the console, or saved to a database or to a file.
  *
- * @param message_p: the message to log.
+ * @param buffer_p: input buffer
+ * @param buffer_size: data size
  */
-void jerry_port_log (const char *message_p);
+void jerry_port_log_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size);
 ```
 
 ```c

--- a/jerry-core/include/jerryscript-compiler.h
+++ b/jerry-core/include/jerryscript-compiler.h
@@ -197,6 +197,13 @@ void *__cdecl _alloca (size_t _Size);
 #endif /* !JERRY_VLA */
 
 /**
+ * Helper to make sure unused parameters, variables, or expressions trigger no compiler warning.
+ */
+#ifndef JERRY_UNUSED
+#define JERRY_UNUSED(x) ((void) (x))
+#endif /* !JERRY_UNUSED */
+
+/**
  * @}
  */
 

--- a/jerry-core/include/jerryscript-port.h
+++ b/jerry-core/include/jerryscript-port.h
@@ -144,9 +144,10 @@ void jerry_port_context_free (void);
  * The implementation can decide whether error and debug messages are logged to
  * the console, or saved to a database or to a file.
  *
- * @param message_p: the message to log.
+ * @param buffer_p: input buffer that is a zero-terminated UTF-8 string
+ * @param buffer_size: data size
  */
-void jerry_port_log (const char *message_p);
+void jerry_port_log_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size);
 
 /**
  * Print a buffer to standard output

--- a/jerry-core/jrt/jrt.h
+++ b/jerry-core/jrt/jrt.h
@@ -30,11 +30,6 @@
  */
 #define JERRY_BITSINBYTE 8
 
-/*
- * Make sure unused parameters, variables, or expressions trigger no compiler warning.
- */
-#define JERRY_UNUSED(x) ((void) (x))
-
 #define JERRY_UNUSED_1(_1)                             JERRY_UNUSED (_1)
 #define JERRY_UNUSED_2(_1, _2)                         JERRY_UNUSED (_1), JERRY_UNUSED_1 (_2)
 #define JERRY_UNUSED_3(_1, _2, _3)                     JERRY_UNUSED (_1), JERRY_UNUSED_2 (_2, _3)

--- a/jerry-core/parser/js/common.c
+++ b/jerry-core/parser/js/common.c
@@ -65,11 +65,7 @@ static void
 util_print_chars (const uint8_t *char_p, /**< character pointer */
                   size_t size) /**< size */
 {
-  while (size > 0)
-  {
-    JERRY_DEBUG_MSG ("%c", *char_p++);
-    size--;
-  }
+  JERRY_DEBUG_MSG ("%.*s", (int) size, char_p);
 } /* util_print_chars */
 
 /**
@@ -81,7 +77,7 @@ util_print_number (ecma_number_t num_p) /**< number to print */
   lit_utf8_byte_t str_buf[ECMA_MAX_CHARS_IN_STRINGIFIED_NUMBER];
   lit_utf8_size_t str_size = ecma_number_to_utf8_string (num_p, str_buf, sizeof (str_buf));
   str_buf[str_size] = 0;
-  JERRY_DEBUG_MSG ("%s", str_buf);
+  JERRY_DEBUG_MSG ("%.*s", (int) str_size, str_buf);
 } /* util_print_number */
 
 #if JERRY_BUILTIN_BIGINT

--- a/jerry-ext/common/jext-common.h
+++ b/jerry-ext/common/jext-common.h
@@ -23,11 +23,6 @@
 #include "jerryscript.h"
 
 /*
- * Make sure unused parameters, variables, or expressions trigger no compiler warning.
- */
-#define JERRYX_UNUSED(x) ((void) (x))
-
-/*
  * Asserts
  *
  * Warning:
@@ -70,7 +65,7 @@ void JERRY_ATTR_NORETURN jerry_unreachable (const char *file, const char *functi
   {                      \
     if (false)           \
     {                    \
-      JERRYX_UNUSED (x); \
+      JERRY_UNUSED (x);  \
     }                    \
   } while (0)
 

--- a/jerry-ext/debugger/debugger-common.c
+++ b/jerry-ext/debugger/debugger-common.c
@@ -35,7 +35,7 @@ jerryx_debugger_after_connect (bool success) /**< tells whether the connection
     jerry_debugger_transport_close ();
   }
 #else /* !(defined (JERRY_DEBUGGER) && (JERRY_DEBUGGER == 1)) */
-  JERRYX_UNUSED (success);
+  JERRY_UNUSED (success);
 #endif /* defined (JERRY_DEBUGGER) && (JERRY_DEBUGGER == 1) */
 } /* jerryx_debugger_after_connect */
 

--- a/jerry-ext/debugger/debugger-serial.c
+++ b/jerry-ext/debugger/debugger-serial.c
@@ -402,7 +402,7 @@ jerryx_debugger_serial_create (const char *config) /**< specify the configuratio
 bool
 jerryx_debugger_serial_create (const char *config)
 {
-  JERRYX_UNUSED (config);
+  JERRY_UNUSED (config);
   return false;
 } /* jerryx_debugger_serial_create */
 

--- a/jerry-ext/debugger/debugger-tcp.c
+++ b/jerry-ext/debugger/debugger-tcp.c
@@ -399,7 +399,7 @@ jerryx_debugger_tcp_create (uint16_t port) /**< listening port */
 bool
 jerryx_debugger_tcp_create (uint16_t port)
 {
-  JERRYX_UNUSED (port);
+  JERRY_UNUSED (port);
   return false;
 } /* jerryx_debugger_tcp_create */
 

--- a/jerry-port/common/jerry-port-io.c
+++ b/jerry-port/common/jerry-port-io.c
@@ -19,14 +19,11 @@
 
 #include "jerryscript-port.h"
 
-/**
- * Default implementation of jerry_port_log. Prints log messages to stderr.
- */
 void JERRY_ATTR_WEAK
-jerry_port_log (const char *message_p) /**< message */
+jerry_port_log_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size)
 {
-  fputs (message_p, stderr);
-} /* jerry_port_log */
+  fwrite (buffer_p, 1, buffer_size, stderr);
+} /* jerry_port_log_buffer */
 
 void JERRY_ATTR_WEAK
 jerry_port_print_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size)

--- a/targets/baremetal-sdk/espressif/main/jerry-port.c
+++ b/targets/baremetal-sdk/espressif/main/jerry-port.c
@@ -31,10 +31,10 @@
 static const char ESP_JS_TAG[] = "JS";
 
 void
-jerry_port_log (const char *message_p)
+jerry_port_log_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size)
 {
-  ESP_LOGI (ESP_JS_TAG, "%s", message_p);
-} /* jerry_port_log */
+  ESP_LOGI (ESP_JS_TAG, "%s", buffer_p);
+} /* jerry_port_log_buffer */
 
 void
 jerry_port_fatal (jerry_fatal_code_t code)

--- a/targets/os/mbedos/jerry-port.cpp
+++ b/targets/os/mbedos/jerry-port.cpp
@@ -27,19 +27,19 @@ jerry_port_fatal (jerry_fatal_code_t code)
 } /* jerry_port_fatal */
 
 void
-jerry_port_log (const char *message_p)
+jerry_port_log_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size)
 {
-  while (*message_p != '\0')
+  for (jerry_size_t i = 0; i < buffer_size; ++i)
   {
-    if (*message_p == '\n')
+    if (buffer_p[i] == '\n')
     {
       /* add CR for proper display in serial monitors */
       fputc ('\r', stderr);
     }
 
-    fputc (*message_p++, stderr);
+    fputc (buffer_p[i], stderr);
   }
-} /* jerry_port_log */
+} /* jerry_port_log_buffer */
 
 int32_t
 jerry_port_local_tza (double unix_ms)

--- a/targets/os/nuttx/jerry-port.c
+++ b/targets/os/nuttx/jerry-port.c
@@ -20,10 +20,11 @@
 #include "jerryscript-port.h"
 
 void
-jerry_port_log (const char *message_p)
+jerry_port_log_buffer (const jerry_char_t *buffer_p, jerry_size_t buffer_size)
 {
-  (void) message_p;
-} /* jerry_port_log */
+  JERRY_UNUSED (buffer_p);
+  JERRY_UNUSED (buffer_size);
+} /* jerry_port_log_buffer */
 
 jerry_char_t *
 jerry_port_line_read (jerry_size_t *out_size_p)

--- a/tests/unit-core/test-common.h
+++ b/tests/unit-core/test-common.h
@@ -25,8 +25,6 @@
 
 #include "jerryscript-port.h"
 
-#define JERRY_UNUSED(x) ((void) (x))
-
 #define TEST_ASSERT(x)                                           \
   do                                                             \
   {                                                              \

--- a/tests/unit-ext/test-common.h
+++ b/tests/unit-ext/test-common.h
@@ -20,8 +20,6 @@
 
 #define ARRAY_SIZE(array) ((unsigned long) (sizeof (array) / sizeof ((array)[0])))
 
-#define JERRY_UNUSED(x) ((void) (x))
-
 #define TEST_ASSERT(x)                                           \
   do                                                             \
   {                                                              \


### PR DESCRIPTION
Add buffer_size parameter for function jerry_port_log_buffer, so that jerry_port_log_buffer won't need calculate strlen when printing

Optimize util_print_chars use %.*s so that the number of strlen call is reduced.

JerryScript-DCO-1.0-Signed-off-by: Yonggang Luo luoyonggang@gmail.com
