### PR TITLE
build: fix rpath settings for macOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ set(ENABLE_LTO                ON  CACHE BOOL "Enable LTO build?")
 set(ENABLE_STRIP              ON  CACHE BOOL "Enable stripping all symbols from release binary?")
 set(ENABLE_COMPILE_COMMANDS   ON  CACHE BOOL "Enable generating compile_commands.json?")
 
+if (APPLE)
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
+
 if(USING_MSVC)
   set(ENABLE_STATIC_CRT         OFF CACHE BOOL "Enable MSVC static CRT?")
 endif()


### PR DESCRIPTION
👋 seeing some rpath issue when building [jerryscript 3.0.0](https://github.com/Homebrew/homebrew-core/pull/201692), updating the rpath settings for macos builds.