### PR TITLE
fix heap-buffer-overflow in lexer_compare_identifier_to_char

### DIFF
--- a/jerry-core/parser/js/js-lexer.c
+++ b/jerry-core/parser/js/js-lexer.c
@@ -3322,7 +3322,7 @@ lexer_compare_identifier_to_chars (const uint8_t *left_p, /**< left identifier *
 {
   uint8_t utf8_buf[6];
 
-  do
+  while (size > 0)
   {
     if (*left_p == *right_p)
     {
@@ -3362,7 +3362,7 @@ lexer_compare_identifier_to_chars (const uint8_t *left_p, /**< left identifier *
         return false;
       }
     } while (--escape_size > 0);
-  } while (size > 0);
+  }
 
   return true;
 } /* lexer_compare_identifier_to_chars */

--- a/tests/jerry/class_static_async_function.js
+++ b/tests/jerry/class_static_async_function.js
@@ -1,0 +1,24 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function check_syntax_error(code) {
+    try {
+      eval(code)
+      assert(false)
+    } catch (e) {
+      assert(e instanceof SyntaxError)
+    }
+  }
+  
+check_syntax_error("class C {#static async''");


### PR DESCRIPTION
This patch fixes https://github.com/jerryscript-project/jerryscript/issues/5066
There is a problem there. When size is passed to 0 in lexer_compare_identifier_to_char, because of do while(size > 0) and the size type is uint, it will cause an unexpected loop and result in heap overflow
