### PR TITLE
Fix Assertion '!jcontext_has_pending_exception ()' failed

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-regexp-prototype.c
@@ -498,6 +498,7 @@ ecma_builtin_regexp_prototype_match_all (ecma_object_t *regexp_obj_p, /**< this 
     ecma_deref_ecma_string (str_p);
     ecma_deref_ecma_string (flags);
     ecma_deref_object (matcher_obj_p);
+    return set;
   }
 
   uint16_t parsed_flag;

--- a/tests/jerry/regression-test-issue-5139.js
+++ b/tests/jerry/regression-test-issue-5139.js
@@ -1,0 +1,29 @@
+/* Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function check_syntax_error (script)
+{
+  try
+  {
+    eval (script);
+    assert (false);
+  }
+  catch (e)
+  {
+    assert (e instanceof TypeError);
+  }
+}
+
+check_syntax_error("var t = Function( );t[Symbol.species] = Object;var e = new Proxy({ constructor:t}, {set:function( ){ }} );RegExp.prototype[Symbol.matchAll].call(e);")


### PR DESCRIPTION
This patch fixes https://github.com/jerryscript-project/jerryscript/issues/5069
There is a very obvious problem there. When an anomaly is detected, it is not thrown out in time.