### PR TITLE
 The skipping of null values during array processing has been removed

### DIFF
--- a/jerry-core/vm/opcodes.c
+++ b/jerry-core/vm/opcodes.c
@@ -326,11 +326,6 @@ opfunc_append_to_spread_array (ecma_value_t *stack_top_p, /**< current stack top
 
   for (uint32_t i = 0, idx = old_length; i < values_length; i++, idx++)
   {
-    if (ecma_is_value_array_hole (stack_top_p[i]))
-    {
-      continue;
-    }
-
     if (stack_top_p[i] == ECMA_VALUE_SPREAD_ELEMENT)
     {
       i++;

--- a/tests/jerry/array-concat.js
+++ b/tests/jerry/array-concat.js
@@ -1,0 +1,26 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This test will not pass on FLOAT32 due to precision issues
+
+var a;
+var foo = function(it) {
+    a = [...it, , ];
+};
+var array = [1, 2];
+foo(array);
+assert (a.length == 3);
+assert (a[0] == 1);
+assert (a[1] == 2);
+assert (a[2] == undefined);


### PR DESCRIPTION
This patch fixes https://github.com/jerryscript-project/jerryscript/issues/5026
Signevior of skipping null values during array processing, which was inconsistent with the mainstream js engine behavior, has been removed.

JerryScript-DCO-1.0-Signed-off-by: tangbin 2387440390@qq.com
