### PR TITLE
Fixed the issue where gc was triggered during the attribute search pr…

### DIFF
--- a/jerry-core/ecma/base/ecma-gc.c
+++ b/jerry-core/ecma/base/ecma-gc.c
@@ -2109,6 +2109,7 @@ ecma_gc_free_object (ecma_object_t *object_p) /**< object to free */
 void
 ecma_gc_run (void)
 {
+  JERRY_CONTEXT(running_gc_count)++;
 #if (JERRY_GC_MARK_LIMIT != 0)
   JERRY_ASSERT (JERRY_CONTEXT (ecma_gc_mark_recursion_limit) == JERRY_GC_MARK_LIMIT);
 #endif /* (JERRY_GC_MARK_LIMIT != 0) */
@@ -2235,6 +2236,7 @@ ecma_gc_run (void)
   /* Free RegExp bytecodes stored in cache */
   re_cache_gc ();
 #endif /* JERRY_BUILTIN_REGEXP */
+  JERRY_CONTEXT(running_gc_count)--;
 } /* ecma_gc_run */
 
 /**

--- a/jerry-core/ecma/base/ecma-helpers.c
+++ b/jerry-core/ecma/base/ecma-helpers.c
@@ -729,7 +729,7 @@ ecma_find_named_property (ecma_object_t *obj_p, /**< object to find property in 
   }
 
 #if JERRY_PROPERTY_HASHMAP
-  if (steps >= (ECMA_PROPERTY_HASMAP_MINIMUM_SIZE / 2))
+  if (steps >= (ECMA_PROPERTY_HASMAP_MINIMUM_SIZE / 2) && JERRY_CONTEXT(running_gc_count) == 0)
   {
     ecma_property_hashmap_create (obj_p);
   }

--- a/jerry-core/jcontext/jcontext.h
+++ b/jerry-core/jcontext/jcontext.h
@@ -156,6 +156,7 @@ struct jerry_context_t
   jerry_external_string_free_cb_t external_string_free_callback_p; /**< free callback for external strings */
   void *error_object_created_callback_user_p; /**< user pointer for error_object_update_callback_p */
   jerry_error_object_created_cb_t error_object_created_callback_p; /**< decorator callback for Error objects */
+  uint32_t running_gc_count; /**< The current status of gc */
   size_t ecma_gc_objects_number; /**< number of currently allocated objects */
   size_t ecma_gc_new_objects; /**< number of newly allocated objects since last GC session */
   size_t jmem_heap_allocated_size; /**< size of allocated regions */

--- a/jerry-core/jmem/jmem-heap.c
+++ b/jerry-core/jmem/jmem-heap.c
@@ -103,6 +103,7 @@ jmem_heap_init (void)
   JMEM_VALGRIND_NOACCESS_SPACE (JERRY_HEAP_CONTEXT (area), JMEM_HEAP_AREA_SIZE);
 
 #endif /* !JERRY_SYSTEM_ALLOCATOR */
+  JERRY_CONTEXT(running_gc_count) = 0;
   JMEM_HEAP_STAT_INIT ();
 } /* jmem_heap_init */
 

--- a/tests/jerry/gc-hashmap.js
+++ b/tests/jerry/gc-hashmap.js
@@ -1,0 +1,22 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+var a = [ ];
+for (var v = 0; v < 256; v++)
+{
+    var n = Object.create(null);
+    a.push(n, a);
+    n = new WeakSet(a);
+    n.o = 1;
+}


### PR DESCRIPTION
This patch fixes https://github.com/jerryscript-project/jerryscript/issues/5084
During the property search process, a gc was triggered. During the gc process, ecma_property_hashmap_create (obj_p) was triggered again on the original object, which led to the final problem. In my personal understanding, the properties of the object should not be modified during the gc process. So, problems can be avoided by adding variables to the context to monitor the status of the gc.
JerryScript-DCO-1.0-Signed-off-by: tangbin 2387440390@qq.com

