### PR TITLE
Fix the access error caused when a class is implemented to be empty

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -1088,7 +1088,7 @@ parser_parse_class (parser_context_t *context_p, /**< context */
     }
   }
 
-  if (class_name_index != PARSER_INVALID_LITERAL_INDEX)
+  if (class_name_index != PARSER_INVALID_LITERAL_INDEX && context_p->scope_stack_p != NULL)
   {
     if (JERRY_UNLIKELY (context_p->scope_stack_top >= context_p->scope_stack_size))
     {

--- a/tests/jerry/class-empty-context.js
+++ b/tests/jerry/class-empty-context.js
@@ -1,0 +1,15 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class v0 {v1 = class v2 {  }}


### PR DESCRIPTION
This patch fixes https://github.com/jerryscript-project/jerryscript/issues/5061
Fix the access error caused when a class is implemented to be empty

JerryScript-DCO-1.0-Signed-off-by: tangbin 2387440390@qq.com

