### PR TITLE
When the eval is either a non-string or empty, clear the local state to prevent contamination of the next parsing unit

### DIFF
--- a/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-global.c
@@ -88,6 +88,7 @@ ecma_builtin_global_object_eval (ecma_value_t x) /**< routine's first argument *
   if (JERRY_UNLIKELY (!ecma_is_value_string (x)))
   {
     /* step 1 */
+    ECMA_CLEAR_LOCAL_PARSE_OPTS ();
     return ecma_copy_value (x);
   }
 

--- a/jerry-core/ecma/operations/ecma-eval.c
+++ b/jerry-core/ecma/operations/ecma-eval.c
@@ -50,6 +50,7 @@ ecma_op_eval (ecma_value_t source_code, /**< source code */
 
   if (ecma_is_value_magic_string (source_code, LIT_MAGIC_STRING__EMPTY))
   {
+    ECMA_CLEAR_LOCAL_PARSE_OPTS ();
     return ECMA_VALUE_UNDEFINED;
   }
 

--- a/tests/jerry/eval-lexical-env.js
+++ b/tests/jerry/eval-lexical-env.js
@@ -1,0 +1,16 @@
+// Copyright JS Foundation and other contributors, http://js.foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+function i(a, b = eval()){eval()};
+i(i("a"), eval("var a"));


### PR DESCRIPTION
This patch fixes https://github.com/jerryscript-project/jerryscript/issues/5058

JerryScript-DCO-1.0-Signed-off-by: tangbin 2387440390@qq.com