### PR TITLE
Fix: prevent stack overflow in scanner (Fixes #5249)

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -2360,6 +2360,11 @@ scanner_create_variables (parser_context_t *context_p, /**< context */
 
   literal.char_p = info_p->source_p - 1;
 
+  if (JERRY_UNLIKELY (info_p == NULL || info_p->type == SCANNER_TYPE_END)) /* check for end of scanner queue */
+  {
+    parser_raise_error (context_p, PARSER_ERR_UNEXPECTED_END); 
+  }
+
   while (next_data_p[0] != SCANNER_STREAM_TYPE_END)
   {
     uint32_t type = next_data_p[0] & SCANNER_STREAM_TYPE_MASK;


### PR DESCRIPTION
fixes #5249
Adds null/end check in js-scanner-util to prevent stack overflow.

Date:      Wed Sep 24 00:28:40 2025 -0400

 On branch fix/5249-stack-overflow
 Changes to be committed:
	modified:   jerry-core/parser/js/js-scanner-util.c

JerryScript-DCO-1.0-Signed-off-by: Harriet Zhu harrietzhu0115@gmail.com