### PR TITLE
Fix: prevent stack overflow in scanner (Fixes #5247)

### DIFF
--- a/jerry-core/parser/js/js-scanner-util.c
+++ b/jerry-core/parser/js/js-scanner-util.c
@@ -2033,6 +2033,11 @@ scanner_is_context_needed (parser_context_t *context_p, /**< context */
   uint32_t scope_stack_reg_top =
     (check_type != PARSER_CHECK_GLOBAL_CONTEXT ? context_p->scope_stack_reg_top : 1); /* block result */
 
+  if (JERRY_UNLIKELY (info_p == NULL || info_p->type == SCANNER_TYPE_END)) /* check for end of scanner queue */
+  {
+    parser_raise_error (context_p, PARSER_ERR_UNEXPECTED_END);
+  }
+
   while (data_p[0] != SCANNER_STREAM_TYPE_END)
   {
     uint8_t data = data_p[0];


### PR DESCRIPTION
Fix: prevent stack overflow in scanner (Fixes #5247)
Date:      Wed Sep 24 00:44:06 2025 -0400

 On branch fix/5247-stack-overflow
 Changes to be committed:
	modified:   jerry-core/parser/js/js-scanner-util.c

JerryScript-DCO-1.0-Signed-off-by: Harriet Zhu harrietzhu0115@gmail.com