### PR TITLE
Fix: avoid 1B OOB read at EOF after class static block (Fixes #5254)

### DIFF
--- a/jerry-core/parser/js/js-parser-expr.c
+++ b/jerry-core/parser/js/js-parser-expr.c
@@ -857,8 +857,15 @@ parser_parse_class_body (parser_context_t *context_p, /**< context */
 
           parser_stack_push (context_p, &range.start_location, sizeof (scanner_location_t));
           fields_size += sizeof (scanner_location_t);
-
-          lexer_consume_next_character (context_p);
+          
+          if (JERRY_UNLIKELY(context_p->source_p >= context_p->source_end_p))  
+          {
+            parser_raise_error (context_p, PARSER_ERR_PROPERTY_IDENTIFIER_EXPECTED);
+          }
+          else
+          {
+            lexer_consume_next_character (context_p);
+          }
         }
         else if (lexer_consume_assign (context_p))
         {


### PR DESCRIPTION
When a class static block ends at EOF (no trailing newline), the caller unconditionally consumed the next char after '}', causing a 1-byte OOB read in lexer_consume_next_character. Guard at the call site and raise the same parse error the next stage expects.

JerryScript-DCO-1.0-Signed-off-by: Harriet Zhu harrietzhu0115@gmail.com

**PLEASE REMOVE THIS TEMPLATE BEFORE SUBMITTING**
