### PR TITLE
chore: allow CMake though to 3.10

### DIFF
--- a/targets/baremetal-sdk/espressif/CMakeLists.txt
+++ b/targets/baremetal-sdk/espressif/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.10)
 
 set(SDKCONFIG ${CMAKE_BINARY_DIR}/sdkconfig)
 # Workaround to generate sdkconfig into the build directory.

--- a/targets/baremetal-sdk/espressif/main/CMakeLists.txt
+++ b/targets/baremetal-sdk/espressif/main/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.10)
 
 # Set JerryScript variables
 set(JERRY_ROOT_DIR ${PROJECT_DIR}/../../..)


### PR DESCRIPTION
This is allows the build with cmake-4.0.0 without deprecation warnings.

use min...max syntax to allow build with newer cmake. ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

Fixes:
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.