### PR TITLE
Fix heap buffer overflow

### DIFF
--- a/jerry-core/api/jerry-snapshot.c
+++ b/jerry-core/api/jerry-snapshot.c
@@ -1582,6 +1582,10 @@ jerry_get_literals_from_snapshot (const uint32_t *snapshot_p, /**< input snapsho
   jerry_char_t *const buffer_start_p = lit_buf_p;
   jerry_char_t *const buffer_end_p = lit_buf_p + lit_buf_size;
 
+  JMEM_CHECK_ARRAY_SIZE_AND_THROW(literal_count, ecma_string_t *, \
+    ecma_collection_destroy(lit_pool_p)                           \
+  );
+
   JMEM_DEFINE_LOCAL_ARRAY (literal_array, literal_count, ecma_string_t *);
   lit_utf8_size_t literal_idx = 0;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-array-prototype.c
@@ -1064,6 +1064,10 @@ ecma_builtin_array_prototype_object_sort (ecma_value_t this_arg, /**< this argum
 
   ecma_value_t ret_value = ECMA_VALUE_ERROR;
   uint32_t copied_num = 0;
+
+  JMEM_CHECK_ARRAY_SIZE_AND_THROW(defined_prop_count, ecma_value_t, \
+    ecma_collection_free(array_index_props_p)                       \
+  );
   JMEM_DEFINE_LOCAL_ARRAY (values_buffer, defined_prop_count, ecma_value_t);
 
   ecma_value_t *buffer_p = array_index_props_p->buffer_p;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-function-prototype.c
@@ -232,6 +232,9 @@ ecma_builtin_function_prototype_object_apply (ecma_object_t *func_obj_p, /**< th
 
   /* 6. */
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
+
+  JMEM_CHECK_ARRAY_SIZE_AND_THROW(length, ecma_value_t, \
+  );
   JMEM_DEFINE_LOCAL_ARRAY (arguments_list_p, length, ecma_value_t);
   ecma_length_t index = 0;
 

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-sort.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-helpers-sort.c
@@ -84,6 +84,9 @@ ecma_builtin_helper_array_merge_sort_helper (ecma_value_t *array_p, /**< array t
                                              ecma_object_t *array_buffer_p) /**< arrayBuffer */
 {
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
+
+  JMEM_CHECK_ARRAY_SIZE_AND_THROW(length, ecma_value_t, \
+  );
   JMEM_DEFINE_LOCAL_ARRAY (dest_array_p, length, ecma_value_t);
 
   ecma_value_t *temp_p;

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-json.c
@@ -1726,6 +1726,13 @@ ecma_builtin_json_stringify (ecma_value_t arg1, /**< value */
     }
     else
     {
+      JMEM_CHECK_ARRAY_SIZE_AND_THROW(num_of_spaces, char, \
+        ecma_free_value(space);                            \
+        if (context.property_list_p != NULL)               \
+        {                                                  \
+          ecma_collection_free(context.property_list_p);   \
+        }                                                  \
+      );
       JMEM_DEFINE_LOCAL_ARRAY (space_buff, num_of_spaces, char);
 
       memset (space_buff, LIT_CHAR_SP, (size_t) num_of_spaces);

--- a/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
+++ b/jerry-core/ecma/builtin-objects/ecma-builtin-object.c
@@ -832,6 +832,10 @@ ecma_builtin_object_object_define_properties (ecma_object_t *obj_p, /**< routine
   ecma_value_t *buffer_p = prop_names_p->buffer_p;
 
   /* 4. */
+  JMEM_CHECK_ARRAY_SIZE_AND_THROW(prop_names_p->item_count, ecma_property_descriptor_t, \
+    ecma_collection_free(prop_names_p);                                                 \
+    ecma_deref_object(props_p)                                                          \
+  );
   JMEM_DEFINE_LOCAL_ARRAY (property_descriptors, prop_names_p->item_count, ecma_property_descriptor_t);
   uint32_t property_descriptor_number = 0;
   ecma_collection_t *enum_prop_names = ecma_new_collection ();

--- a/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
+++ b/jerry-core/ecma/builtin-objects/typedarray/ecma-builtin-typedarray-prototype.c
@@ -1245,6 +1245,9 @@ ecma_builtin_typedarray_prototype_sort (ecma_value_t this_arg, /**< this argumen
   }
 
   ecma_value_t ret_value = ECMA_VALUE_EMPTY;
+
+  JMEM_CHECK_ARRAY_SIZE_AND_THROW(info_p->length, ecma_value_t, \
+  );
   JMEM_DEFINE_LOCAL_ARRAY (values_buffer, info_p->length, ecma_value_t);
 
   uint32_t buffer_index = 0;

--- a/jerry-core/jmem/jmem.h
+++ b/jerry-core/jmem/jmem.h
@@ -18,6 +18,8 @@
 
 #include "jrt.h"
 
+#include <limits.h>
+
 /** \addtogroup mem Memory allocation
  * @{
  *
@@ -190,6 +192,20 @@ void jmem_heap_stats_print (void);
 
 jmem_cpointer_t JERRY_ATTR_PURE jmem_compress_pointer (const void *pointer_p);
 void *JERRY_ATTR_PURE jmem_decompress_pointer (uintptr_t compressed_pointer);
+
+#if JERRY_CPOINTER_32_BIT
+
+#define JMEM_CHECK_ARRAY_SIZE_AND_THROW(number, type, finalize) \
+if (UINT_MAX / sizeof(type) < (size_t)(number)) {               \
+  finalize;                                                     \
+  return ecma_raise_range_error(ECMA_ERR_INVALID_ARRAY_LENGTH); \
+}
+
+#else /* JERRY_CPOINTER_32_BIT */
+
+#define JMEM_CHECK_ARRAY_SIZE_AND_THROW(number, type, finalize)
+
+#endif /* JERRY_CPOINTER_32_BIT */
 
 /**
  * Define a local array variable and allocate memory for the array on the heap.


### PR DESCRIPTION
This patch fixes #5067

Test case
```
a = new Int16Array ( 1073741825 ) . sort ( ) ; 
```

